### PR TITLE
feat(tournée): arrangement quotidien intelligent « Choisie pour vous » (Story 22.3)

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Tournée",
+      "summary": "Ta Tournée se complète chaque jour avec des sections « Choisie pour vous », à partir des thèmes et sources que tu suis. Un tap sur le badge explique le pourquoi ; tu peux garder ou retirer, et tout désactiver d'un switch."
+    },
+    {
       "tag": "Sources",
       "summary": "Des sources spécialisées sur chacun de tes sujets dès l'inscription."
     },

--- a/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
+++ b/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
@@ -17,6 +17,59 @@ import '../../feed/models/content_model.dart';
 /// réutilisant le payload [FeedThemeSection] (champs `sourceId`/`sourceLogoUrl`).
 enum SectionKind { essentiel, bonnes, theme, veille, source }
 
+/// Origine d'une section de la Tournée du jour (Story 22.3).
+///
+/// `validated` = section **dédiée** (favori épinglé / source Essentiel /
+/// veille) — toujours rendue, jamais masquée par l'algo. `suggested` = section
+/// « Choisie pour vous » qui remplit un slot restant, issue d'un thème/source
+/// que l'utilisateur suit déjà mais n'a pas épinglé. Défaut `validated` →
+/// rétro-compat des payloads/sections qui ne portent pas le champ.
+enum SectionOrigin { validated, suggested }
+
+/// Une puce de transparence d'une suggestion (miroir de `ScoreContribution`
+/// côté backend, cf. `schemas/content.py`). Story 22.3.
+class SuggestionContribution {
+  final String label;
+  final double points;
+  final String? pillar;
+
+  const SuggestionContribution({
+    required this.label,
+    this.points = 0,
+    this.pillar,
+  });
+
+  factory SuggestionContribution.fromJson(Map<String, dynamic> json) {
+    return SuggestionContribution(
+      label: (json['label'] as String?) ?? '',
+      points: (json['points'] as num?)?.toDouble() ?? 0,
+      pillar: json['pillar'] as String?,
+    );
+  }
+}
+
+/// Raison « Pourquoi cette section ? » d'une suggestion (Story 22.3).
+///
+/// `label` = la contribution dominante (titre de la sheet) ; `breakdown` =
+/// 2-3 puces honnêtes construites côté backend depuis les seules composantes
+/// réellement présentes (préférence déclarée / lue + N articles + variété).
+class SuggestionReason {
+  final String label;
+  final List<SuggestionContribution> breakdown;
+
+  const SuggestionReason({required this.label, this.breakdown = const []});
+
+  factory SuggestionReason.fromJson(Map<String, dynamic> json) {
+    return SuggestionReason(
+      label: (json['label'] as String?) ?? '',
+      breakdown: ((json['breakdown'] as List?) ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(SuggestionContribution.fromJson)
+          .toList(growable: false),
+    );
+  }
+}
+
 /// Stable identity for a section across rebuilds.
 ///
 /// Used as a key for per-section UI/dérivations (ordre tournée, dédup…) so
@@ -270,6 +323,13 @@ class FeedThemeSection extends FluxSection {
   /// the "Chargement…" label and ignore taps.
   final bool isLoadingMore;
 
+  /// Story 22.3 — origine de la section. `suggested` ⇒ section « Choisie pour
+  /// vous » (badge + « i » explicatif, dismiss/promotion). Défaut `validated`.
+  final SectionOrigin origin;
+
+  /// Raison de transparence (non null seulement quand [origin] est `suggested`).
+  final SuggestionReason? reason;
+
   const FeedThemeSection({
     required super.kind,
     required super.label,
@@ -283,12 +343,17 @@ class FeedThemeSection extends FluxSection {
     this.currentPage = 1,
     this.hasMore = true,
     this.isLoadingMore = false,
+    this.origin = SectionOrigin.validated,
+    this.reason,
     super.blurb,
     super.illustrationAsset,
   });
 
   @override
   int get totalCount => items.length;
+
+  /// Raccourci : la section est une suggestion « Choisie pour vous ».
+  bool get isSuggested => origin == SectionOrigin.suggested;
 
   FeedThemeSection copyWith({
     List<Content>? items,
@@ -314,6 +379,11 @@ class FeedThemeSection extends FluxSection {
       currentPage: currentPage ?? this.currentPage,
       hasMore: hasMore ?? this.hasMore,
       isLoadingMore: isLoadingMore ?? this.isLoadingMore,
+      // Story 22.3 — origin/reason doivent survivre au dédup/filtre/loadMore
+      // (même piège que coreVisibleCount ci-dessus) : un copyWith qui les
+      // perdrait retirerait le badge « Choisie pour vous » au 1ᵉʳ recompose.
+      origin: origin,
+      reason: reason,
       blurb: blurb,
       illustrationAsset: illustrationAsset,
     );

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -132,6 +132,10 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   // Tournée »), résolues depuis `userSourcesStateProvider.favorites` +
   // catalogue `userSourcesProvider`. Composées entre les thèmes et la veille.
   List<FeedThemeSection> _sources = const [];
+  // Story 22.3 — sections « Choisie pour vous » (suggérées), résolues depuis le
+  // payload `getTopThemes` (`origin=="suggested"`), best-first par daily_rank.
+  // Remplissent les slots restants APRÈS les validées ; jamais une validée.
+  List<FeedThemeSection> _suggested = const [];
   // Dernières sources favorites (sourceId+position) rendues — sert au listener
   // `userSourcesStateProvider` pour ne refetch que sur un vrai changement.
   List<SourceFavoriteRef> _lastSourceFavorites = const [];
@@ -440,9 +444,10 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     final favoriteSources = _pickFavoriteSources();
     _lastSourceFavorites = favoriteSources;
 
-    // Sections thèmes/sources vidées d'abord — peuplées en phase 2 si fetch.
+    // Sections thèmes/sources/suggérées vidées d'abord — peuplées en phase 2 si fetch.
     _themes = const [];
     _sources = const [];
+    _suggested = const [];
     _closingDismissed = await _loadClosingDismissedForToday();
     unawaited(_purgeOldPrefsKeys());
 
@@ -466,8 +471,10 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       state = AsyncData(_compose(isSerene));
     }
 
-    // Phase 2 — fan-out thèmes + sources, puis recompose avec le set complet
-    // (réutilise exactement le pattern de _refetchThemesOnly/_refetchSourcesOnly).
+    // Phase 2 — fan-out thèmes + sources + suggérées « Choisie pour vous », puis
+    // recompose avec le set complet (réutilise le pattern de
+    // _refetchThemesOnly/_refetchSourcesOnly).
+    final suggestions = [for (final t in topThemes) if (t.isSuggested) t];
     final fetched = await Future.wait([
       _fetchThemeSections(
         favorites,
@@ -475,9 +482,11 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
         isExplicitFavorite: !picked.isFallback,
       ),
       _fetchSourceSections(favoriteSources, isSerene),
+      _fetchSuggestedSections(suggestions, isSerene),
     ]);
     _themes = fetched[0];
     _sources = fetched[1];
+    _suggested = fetched[2];
 
     return _compose(isSerene);
   }
@@ -659,7 +668,9 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
           sectionByKey[key]!,
     ];
     final finalSections = _capSectionsToFit(
-      _dedupeSectionsInOrder(_filterSections(rawOrdered)),
+      _dropEmptySuggested(
+        _dedupeSectionsInOrder(_filterSections(rawOrdered)),
+      ),
       usableHeight,
     );
     final grilleSlotIndex = _resolveGrilleSlotIndex(
@@ -683,6 +694,18 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   /// No-op conservé comme seam (appelé par [_compose]).
   FluxSection _fitHeroSection(FluxSection essentiel, double? usableHeight) {
     return essentiel;
+  }
+
+  /// Story 22.3 — retire les sections **suggérées** vidées par le dédup
+  /// inter-sections (tous leurs articles déjà vus plus haut). Une « Choisie
+  /// pour vous » sans article ne doit jamais afficher un bandeau + badge
+  /// orphelins (contrairement aux sections validées source/veille qui rendent
+  /// un empty-state assumé).
+  List<FluxSection> _dropEmptySuggested(List<FluxSection> sections) {
+    return [
+      for (final s in sections)
+        if (!(s is FeedThemeSection && s.isSuggested && s.items.isEmpty)) s,
+    ];
   }
 
   /// Caps each downstream section's `coreVisibleCount` to what fits the usable
@@ -1181,6 +1204,8 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     required bool isExplicitFavorite,
     String? themeSlug,
     String? customTopicId,
+    SectionOrigin origin = SectionOrigin.validated,
+    SuggestionReason? reason,
   }) {
     final items = feed?.items ?? const <Content>[];
     if (!isExplicitFavorite && items.length < 2) return null;
@@ -1198,6 +1223,8 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       customTopicId: customTopicId,
       items: items,
       hasMore: hasMore,
+      origin: origin,
+      reason: reason,
     );
   }
 
@@ -1263,22 +1290,16 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       if (customized || hasSourceFav || veilleRef != null) {
         themeRefs = const [];
       } else {
-        // Fallback fresh accounts : top-themes pondérés puis macro canoniques.
+        // Story 22.3 — fini le triplet codé en dur (tech/env/science) : un
+        // compte peu configuré est désormais complété par les sections
+        // « Choisie pour vous » (suggestions backend, jamais hors préférences),
+        // pas par des macro-thèmes statiques. On ne garde ici que les thèmes
+        // réellement **validés** et pondérés (`origin=="validated"`) ; les
+        // suggérées du même payload transitent par `_fetchSuggestedSections`.
         final valid = topFallback
-            .where((t) => themeMap.containsKey(t.interestSlug))
+            .where((t) => !t.isSuggested && themeMap.containsKey(t.interestSlug))
             .map<FavoriteRef>((t) => ThemeFavoriteRef(slug: t.interestSlug))
             .toList();
-        // Pad with canonical macro themes the user is missing — order: tech,
-        // environment, science (matches the backend backfill list).
-        const canonical = [fallbackTheme1, fallbackTheme2, 'science'];
-        final present =
-            valid.whereType<ThemeFavoriteRef>().map((r) => r.slug).toSet();
-        for (final slug in canonical) {
-          if (valid.length >= _kMaxFavoriteSections) break;
-          if (present.contains(slug)) continue;
-          valid.add(ThemeFavoriteRef(slug: slug));
-          present.add(slug);
-        }
         themeRefs = valid.take(_kMaxFavoriteSections).toList(growable: false);
         isFallback = themeRefs.isNotEmpty;
       }
@@ -1502,6 +1523,8 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   FeedThemeSection? _buildSourceSection({
     required FeedResponse? feed,
     required Source source,
+    SectionOrigin origin = SectionOrigin.validated,
+    SuggestionReason? reason,
   }) {
     final items = feed?.items ?? const <Content>[];
     final hasMore = _themeHasMore(
@@ -1517,7 +1540,132 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       sourceLogoUrl: source.logoUrl,
       items: items,
       hasMore: hasMore,
+      origin: origin,
+      reason: reason,
     );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Sections « Choisie pour vous » (Story 22.3).
+  // ---------------------------------------------------------------------------
+
+  /// Clé `sectionKey`-compatible d'une suggestion backend (`theme:`/`source:`).
+  String _suggestionKey(TopTheme s) =>
+      s.kind == 'source' && s.sourceId != null
+          ? tourneeSourceKey(s.sourceId!)
+          : tourneeThemeKey(s.interestSlug);
+
+  /// Résout chaque suggestion (`origin=="suggested"`) en section, en fetchant le
+  /// même top classé que les sections validées (`personalized:true`, hérite du
+  /// mode serein). Filtre amont les suggestions déjà masquées (dismiss) ou
+  /// vivant en onglet Flâner — évite des round-trips inutiles. Les suggestions
+  /// dont le feed du jour revient **vide** sont droppées (jour pauvre → moins de
+  /// suggestions, jamais d'empty-state « Choisie pour vous »).
+  Future<List<FeedThemeSection>> _fetchSuggestedSections(
+    List<TopTheme> suggestions,
+    bool isSerene,
+  ) async {
+    if (suggestions.isEmpty) return const [];
+    final tournee = ref.read(tourneeOrderPrefsProvider);
+    final flanerKeys = ref.read(tabOrderPrefsProvider).toSet();
+    final usable = [
+      for (final s in suggestions)
+        if (!tournee.hiddenKeys.contains(_suggestionKey(s)) &&
+            !flanerKeys.contains(_suggestionKey(s)))
+          s,
+    ];
+    if (usable.isEmpty) return const [];
+
+    final catalog =
+        ref.read(userSourcesProvider).valueOrNull ?? const <Source>[];
+    final sourceById = {for (final s in catalog) s.id: s};
+
+    final feeds = await Future.wait(
+      usable.map((s) {
+        if (s.kind == 'source' && s.sourceId != null) {
+          return _fetchOneSource(s.sourceId!, isSerene);
+        }
+        return _fetchOneTheme(ThemeFavoriteRef(slug: s.interestSlug), isSerene);
+      }),
+    );
+
+    // Réutilise les builders validés ([_buildSourceSection]/[_buildThemeSection])
+    // en ne surchargeant que `origin`/`reason`. Une suggestion dont le feed du
+    // jour est vide est droppée ici (jamais d'empty-state « Choisie pour vous » ;
+    // `isExplicitFavorite: true` empêche le builder thème de re-couper sous 2).
+    final sections = <FeedThemeSection>[];
+    for (var i = 0; i < usable.length; i++) {
+      final s = usable[i];
+      final feed = feeds[i];
+      if ((feed?.items ?? const <Content>[]).isEmpty) continue;
+      final FeedThemeSection? section;
+      if (s.kind == 'source' && s.sourceId != null) {
+        final src = sourceById[s.sourceId!];
+        if (src == null) continue;
+        section = _buildSourceSection(
+          feed: feed,
+          source: src,
+          origin: SectionOrigin.suggested,
+          reason: s.reason,
+        );
+      } else {
+        final visual = visualFor(s.interestSlug);
+        section = _buildThemeSection(
+          feed: feed,
+          label: visual.label,
+          accent: visual.accent,
+          isExplicitFavorite: true,
+          themeSlug: s.interestSlug,
+          origin: SectionOrigin.suggested,
+          reason: s.reason,
+        );
+      }
+      if (section != null) sections.add(section);
+    }
+    return sections;
+  }
+
+  /// Retire une suggestion de la Tournée (dismiss). Mémoire **locale** via
+  /// `hiddenKeys` (réversible, pas de pollution de l'algo global) ; le listener
+  /// `tourneeOrderPrefsProvider` recompose et la suivante (si une suggestion
+  /// avait été coupée par le cap) remonte gratuitement.
+  Future<void> dismissSuggestion(FeedThemeSection section) async {
+    final key = sectionKey(section);
+    await ref.read(tourneeOrderPrefsProvider.notifier).setHidden(key, true);
+  }
+
+  /// Promeut une suggestion en favori dédié (réutilise le chemin favori
+  /// existant). La section repassera `origin="validated"` au prochain load et
+  /// sortira du pool suggéré. Les listeners `userInterests`/`userSources`
+  /// recomposent la Tournée.
+  Future<void> promoteSuggestion(FeedThemeSection section) async {
+    await ref.read(tourneeOrderPrefsProvider.notifier).markCustomized();
+    try {
+      if (section.kind == SectionKind.source && section.sourceId != null) {
+        await ref
+            .read(userSourcesStateProvider.notifier)
+            .setSourceState(section.sourceId!, InterestState.favorite);
+        await _appendTourneeOrder(tourneeSourceKey(section.sourceId!));
+      } else if (section.themeSlug != null) {
+        await ref
+            .read(userInterestsProvider.notifier)
+            .setInterestState(
+              ThemeFavoriteRef(slug: section.themeSlug!),
+              InterestState.favorite,
+            );
+        await _appendTourneeOrder(tourneeThemeKey(section.themeSlug!));
+      }
+    } catch (e) {
+      debugPrint('FluxContinu: promoteSuggestion failed: $e');
+    }
+  }
+
+  Future<void> _appendTourneeOrder(String key) async {
+    final order = ref.read(tourneeOrderPrefsProvider).order;
+    if (order.contains(key)) return;
+    await ref
+        .read(tourneeOrderPrefsProvider.notifier)
+        .setOrder([...order, key]);
   }
 
   Map<String, FluxSection> _tourneeSectionByKey() {
@@ -1531,7 +1679,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       for (final key in ref.read(tabOrderPrefsProvider))
         if (key.startsWith('theme:')) key,
     };
-    return {
+    final map = <String, FluxSection>{
       if (_actusDuJour != null) kTourneeActusKey: _actusDuJour!,
       if (_bonnes != null) kTourneeBonnesKey: _bonnes!,
       for (final section in _themes)
@@ -1539,6 +1687,15 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
           sectionKey(section): section,
       for (final section in _sources) sectionKey(section): section,
     };
+    // Story 22.3 — sections suggérées : ajoutées seulement si la clé n'est pas
+    // déjà prise par une validée (`putIfAbsent` ⇒ une validée l'emporte
+    // toujours, p.ex. après une promotion) et pas routée vers Flâner.
+    for (final section in _suggested) {
+      final key = sectionKey(section);
+      if (flanerThemeKeys.contains(key)) continue;
+      map.putIfAbsent(key, () => section);
+    }
+    return map;
   }
 
   /// Liste ordonnée des clés sous "L'Essentiel du jour" : éditorial, Grille,
@@ -1567,6 +1724,19 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     final orderedThemeKeys =
         customized ? themeKeys : _biasThemeKeysByMostFollowed(themeKeys);
     final favoriteKeys = [...orderedThemeKeys, ...sourceKeys, ...veilleKeys];
+    // Story 22.3 — clés des sections « Choisie pour vous », best-first par
+    // daily_rank (`_suggested` arrive déjà trié du backend). Insérées APRÈS les
+    // validées (jamais devant) et dédupliquées contre elles : un compte
+    // non-personnalisé les voit après ses favoris ; un compte personnalisé les
+    // verra reléguées en fin par `applyOrder` (ordre manuel sticky) → coupées en
+    // premier par le cap. Filtrées des `hiddenKeys` plus bas (dismiss respecté).
+    final favoriteKeySet = favoriteKeys.toSet();
+    final suggestedKeys = [
+      for (final section in _suggested)
+        if (sectionByKey.containsKey(sectionKey(section)) &&
+            !favoriteKeySet.contains(sectionKey(section)))
+          sectionKey(section),
+    ];
     final useSereneDefault = isSerene && !customized;
     // La Grille n'est PAS réordonnable par l'utilisateur (cf. modal « Mes
     // favoris ») : on l'exclut d'`applyOrder` et on l'épingle juste après les
@@ -1577,11 +1747,13 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
         ? <String>[
             kTourneeBonnesKey,
             ...favoriteKeys,
+            ...suggestedKeys,
             kTourneeActusKey,
           ]
         : <String>[
             kTourneeActusKey,
             ...favoriteKeys,
+            ...suggestedKeys,
             kTourneeBonnesKey,
           ];
     final availableKeys = [

--- a/apps/mobile/lib/features/flux_continu/providers/tournee_smart_arrangement_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/tournee_smart_arrangement_provider.dart
@@ -1,0 +1,86 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/auth/auth_state.dart';
+import '../../digest/providers/digest_provider.dart'
+    show digestRepositoryProvider;
+import 'flux_continu_provider.dart';
+
+/// Clé de préférence serveur de l'arrangement intelligent (Story 22.3).
+/// Absence = activé (default-ON sans migration) ; seul `"false"` désactive.
+const String kTourneeSmartArrangementKey = 'tournee_smart_arrangement';
+
+/// État du switch « Suggestions du facteur » (sections « Choisie pour vous »).
+class TourneeSmartArrangementState {
+  final bool enabled;
+  final bool isLoading;
+
+  const TourneeSmartArrangementState({
+    this.enabled = true,
+    this.isLoading = true,
+  });
+
+  TourneeSmartArrangementState copyWith({bool? enabled, bool? isLoading}) {
+    return TourneeSmartArrangementState(
+      enabled: enabled ?? this.enabled,
+      isLoading: isLoading ?? this.isLoading,
+    );
+  }
+}
+
+/// Switch global « Suggestions du facteur » exposé dans « Composer ma Tournée ».
+///
+/// Le backend lit la préférence serveur `tournee_smart_arrangement` pour
+/// (dés)activer l'arrangement intelligent ; ce provider en est le miroir
+/// mobile (lecture initiale + écriture). Rebuild propre quand l'utilisateur
+/// authentifié change (logout → autre compte), comme `sereinToggleProvider`.
+final tourneeSmartArrangementProvider = StateNotifierProvider<
+    TourneeSmartArrangementNotifier, TourneeSmartArrangementState>((ref) {
+  ref.watch(authStateProvider.select((s) => s.user?.id));
+  return TourneeSmartArrangementNotifier(ref).._init();
+});
+
+class TourneeSmartArrangementNotifier
+    extends StateNotifier<TourneeSmartArrangementState> {
+  final Ref _ref;
+
+  TourneeSmartArrangementNotifier(this._ref)
+      : super(const TourneeSmartArrangementState());
+
+  Future<void> _init() async {
+    try {
+      final prefs = await _ref.read(digestRepositoryProvider).getPreferences();
+      final entry = prefs.firstWhere(
+        (p) => p['preference_key'] == kTourneeSmartArrangementKey,
+        orElse: () => const <String, String>{},
+      );
+      // Absence (clé jamais écrite) = activé ; seul "false" désactive.
+      final enabled = entry['preference_value'] != 'false';
+      state = TourneeSmartArrangementState(enabled: enabled, isLoading: false);
+    } catch (_) {
+      // Échec réseau → on assume le défaut (activé) sans bloquer l'UI.
+      state =
+          const TourneeSmartArrangementState(enabled: true, isLoading: false);
+    }
+  }
+
+  /// Bascule instantanée : l'UI flippe tout de suite, la préférence est
+  /// persistée en arrière-plan, puis la Tournée est recalculée pour faire
+  /// (dis)paraître les sections « Choisie pour vous ».
+  Future<void> toggle() async {
+    final next = !state.enabled;
+    state = state.copyWith(enabled: next);
+    unawaited(HapticFeedback.lightImpact());
+    try {
+      await _ref.read(digestRepositoryProvider).updatePreference(
+            key: kTourneeSmartArrangementKey,
+            value: next.toString(),
+          );
+    } catch (_) {
+      // Silencieux : retenté à la prochaine session.
+    }
+    _ref.invalidate(fluxContinuProvider);
+  }
+}

--- a/apps/mobile/lib/features/flux_continu/repositories/flux_continu_repository.dart
+++ b/apps/mobile/lib/features/flux_continu/repositories/flux_continu_repository.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/api/api_client.dart';
 import '../../../core/api/providers.dart';
 import '../../feed/models/content_model.dart';
+import '../models/flux_continu_models.dart';
 
 /// One entry of `GET /api/users/top-themes`.
 ///
@@ -16,17 +17,50 @@ class TopTheme {
   final double weight;
   final int articleCount;
 
+  /// Story 22.3 — discriminant de slot : `"theme"` (défaut, rétro-compat),
+  /// `"veille"` ou `"source"`. Pour `"source"`, [sourceId] est rempli et le
+  /// mobile route vers `/api/feed?source_id=` au lieu de `?theme=`.
+  final String kind;
+  final String? sourceId;
+
+  /// `"validated"` (défaut, rétro-compat) ou `"suggested"` (section
+  /// « Choisie pour vous »).
+  final String origin;
+
+  /// Ordre du jour calculé par le backend (validées d'abord, puis suggérées
+  /// best-first). Sert à ordonner les suggérées entre elles.
+  final int dailyRank;
+
+  /// Raison de transparence — non null seulement quand [origin] == suggested.
+  final SuggestionReason? reason;
+
   const TopTheme({
     required this.interestSlug,
     required this.weight,
     this.articleCount = 0,
+    this.kind = 'theme',
+    this.sourceId,
+    this.origin = 'validated',
+    this.dailyRank = 0,
+    this.reason,
   });
 
+  /// Raccourci : ce slot est une section « Choisie pour vous ».
+  bool get isSuggested => origin == 'suggested';
+
   factory TopTheme.fromJson(Map<String, dynamic> json) {
+    final rawReason = json['reason'];
     return TopTheme(
       interestSlug: (json['interest_slug'] as String?) ?? '',
       weight: (json['weight'] as num?)?.toDouble() ?? 0.0,
       articleCount: (json['article_count'] as num?)?.toInt() ?? 0,
+      kind: (json['kind'] as String?) ?? 'theme',
+      sourceId: json['source_id'] as String?,
+      origin: (json['origin'] as String?) ?? 'validated',
+      dailyRank: (json['daily_rank'] as num?)?.toInt() ?? 0,
+      reason: rawReason is Map<String, dynamic>
+          ? SuggestionReason.fromJson(rawReason)
+          : null,
     );
   }
 
@@ -34,6 +68,10 @@ class TopTheme {
     'interest_slug': interestSlug,
     'weight': weight,
     'article_count': articleCount,
+    'kind': kind,
+    'source_id': sourceId,
+    'origin': origin,
+    'daily_rank': dailyRank,
   };
 }
 

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -20,6 +20,7 @@ import '../../../core/nudges/widgets/feed_nudge_anchors.dart';
 import '../../../core/orchestration/first_impression_orchestrator.dart';
 import '../../../core/providers/analytics_provider.dart';
 import '../../../core/providers/navigation_providers.dart';
+import '../../../core/ui/notification_service.dart';
 import '../../custom_topics/widgets/topic_chip.dart';
 import '../../digest/models/digest_models.dart';
 import '../../feed/models/content_model.dart';
@@ -48,6 +49,7 @@ import '../widgets/geoloc_prompt_banner.dart';
 import '../widgets/section_banner.dart';
 import '../widgets/section_block.dart';
 import '../widgets/sticky_tab_bar.dart';
+import '../widgets/suggestion_reason_sheet.dart';
 import '../../grille/widgets/grille_cta_card.dart';
 
 /// Scroll offset at which the AppBar is swapped with the sticky tab bar.
@@ -666,6 +668,29 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
         .then((_) => _restoreLastDedicatedSection());
   }
 
+  /// Story 22.3 — ouvre la sheet « Pourquoi cette section ? » d'une suggestion
+  /// « Choisie pour vous ». Les actions garder/retirer délèguent au notifier
+  /// (promotion en favori / dismiss local), avec confirmation discrète.
+  void _openSuggestionSheet(
+    BuildContext context,
+    FeedThemeSection section,
+    FluxContinuNotifier notifier,
+  ) {
+    showSuggestionReasonSheet(
+      context,
+      sectionTitle: section.label,
+      reason: section.reason,
+      onKeep: () async {
+        await notifier.promoteSuggestion(section);
+        NotificationService.showSuccess('Ajoutée à tes favoris');
+      },
+      onDismiss: () async {
+        await notifier.dismissSuggestion(section);
+        NotificationService.showSuccess('Suggestion retirée');
+      },
+    );
+  }
+
   /// Opens the dedicated full-page view for a [DigestTopicSection]
   /// (Actus du jour, Bonnes Nouvelles). Mirrors [_openThemeSection].
   void _openDigestSection(BuildContext context, DigestTopicSection section) {
@@ -1246,6 +1271,10 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       }
       final section = state.sections[i];
       final isFavorite = _isFavoriteSection(section);
+      // Story 22.3 — une section suggérée ne porte pas l'étoile « favori »
+      // (elle se gère via son badge « Choisie pour vous » + sheet), pour ne pas
+      // confondre les deux affordances.
+      final isSuggested = section is FeedThemeSection && section.isSuggested;
       // Mode personnalisé : préfixe l'inline « Gérer / Tes N favoris » au-dessus
       // du `SectionBlock`, à l'intérieur du subtree mesuré → l'inline fait
       // partie du bloc de snap de cette section (cf. [inlineTargetIndex]).
@@ -1283,8 +1312,12 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
                         : null,
                     onSwipeConversion: _recordSwipeConversion,
                     onLongPressConversion: _recordLongPressConversion,
-                    onTapFavorite: isFavorite
+                    onTapFavorite: isFavorite && !isSuggested
                         ? () => showTourneeComposerSheet(context)
+                        : null,
+                    // Story 22.3 — badge « Choisie pour vous » → sheet explicative.
+                    onTapSuggestionInfo: isSuggested
+                        ? () => _openSuggestionSheet(context, section, notifier)
                         : null,
                     // Story 23.4 — bouton réglages (tune) sur la section veille →
                     // ouvre la config en édition. Réutilisé par le CTA d'état vide.

--- a/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
@@ -23,6 +23,7 @@ import '../../sources/widgets/source_logo_avatar.dart';
 import '../../veille/providers/veille_active_config_provider.dart';
 import '../../veille/providers/veille_themes_provider.dart';
 import '../providers/tournee_order_prefs_provider.dart' hide applyOrder;
+import '../providers/tournee_smart_arrangement_provider.dart';
 import '../utils/theme_color_mapping.dart';
 import 'choice_tile.dart';
 
@@ -848,6 +849,9 @@ class _ManageFavoritesContentState
                 const SizedBox(height: FacteurSpacing.space4),
                 _SectionLabel(label: 'GÉRER', colors: colors),
                 const SizedBox(height: 4),
+                // Story 22.3 — switch discret « Suggestions du facteur » : active
+                // ou non les sections « Choisie pour vous » de la Tournée.
+                const _SmartArrangementSwitch(),
                 ChoiceTile(
                   icon: Icons.rss_feed,
                   accent: colors.sectionVeille1,
@@ -1537,6 +1541,74 @@ class _SectionLabel extends StatelessWidget {
         const SizedBox(width: 6),
         Text('· $counter', style: labelStyle?.copyWith(letterSpacing: 0.2)),
       ],
+    );
+  }
+}
+
+/// Story 22.3 — switch discret « Suggestions du facteur » : active/désactive
+/// les sections « Choisie pour vous » de la Tournée (préférence serveur
+/// `tournee_smart_arrangement`, default-ON). Calqué sur [ChoiceTile].
+class _SmartArrangementSwitch extends ConsumerWidget {
+  const _SmartArrangementSwitch();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+    final state = ref.watch(tourneeSmartArrangementProvider);
+    final accent = colors.primary;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+      child: Row(
+        children: [
+          Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: accent.withValues(alpha: 0.12),
+            ),
+            alignment: Alignment.center,
+            child: Icon(
+              PhosphorIcons.sparkle(PhosphorIconsStyle.fill),
+              color: accent,
+              size: 20,
+            ),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Suggestions du facteur',
+                  style: textTheme.bodyLarge?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: colors.textPrimary,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  'Complète ta Tournée avec des thèmes et sources que tu suis.',
+                  style: textTheme.bodySmall?.copyWith(
+                    color: colors.textTertiary,
+                    height: 1.35,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          Switch.adaptive(
+            value: state.enabled,
+            onChanged: state.isLoading
+                ? null
+                : (_) => ref
+                    .read(tourneeSmartArrangementProvider.notifier)
+                    .toggle(),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
@@ -51,6 +51,15 @@ class SectionBanner extends StatelessWidget {
   /// est câblé.
   final int hiddenCount;
 
+  /// Story 22.3 — quand true, le banner pose un badge « Choisie pour vous »
+  /// au-dessus du titre, tappable via [onTapInfo] (ouvre la sheet « Pourquoi
+  /// cette section ? »). Signale une section suggérée par le facteur.
+  final bool suggested;
+
+  /// Tap sur le badge « Choisie pour vous » → sheet explicative + actions
+  /// (garder / retirer). Null hors sections suggérées.
+  final VoidCallback? onTapInfo;
+
   const SectionBanner({
     super.key,
     required this.title,
@@ -63,6 +72,8 @@ class SectionBanner extends StatelessWidget {
     this.logoUrl,
     this.onTap,
     this.hiddenCount = 0,
+    this.suggested = false,
+    this.onTapInfo,
   });
 
   double _trailingControlReserve() {
@@ -186,6 +197,10 @@ class SectionBanner extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       mainAxisSize: MainAxisSize.min,
                       children: [
+                        if (suggested) ...[
+                          _SuggestedBadge(accent: accent, onTap: onTapInfo),
+                          const SizedBox(height: 8),
+                        ],
                         _AccentDash(accent: accent, large: large),
                         Padding(
                           padding: EdgeInsets.only(
@@ -343,6 +358,66 @@ class _SettingsButton extends StatelessWidget {
             semanticLabel: 'Réglages de ma veille',
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// Story 22.3 — pastille « Choisie pour vous » posée au-dessus du titre d'une
+/// section suggérée. Tappable : ouvre la sheet « Pourquoi cette section ? ». Le
+/// « i » signale l'affordance d'explication (transparence totale, PO).
+class _SuggestedBadge extends StatelessWidget {
+  final Color accent;
+  final VoidCallback? onTap;
+
+  const _SuggestedBadge({required this.accent, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final badge = Container(
+      padding: const EdgeInsets.fromLTRB(8, 4, 7, 4),
+      decoration: BoxDecoration(
+        color: accent.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: accent.withValues(alpha: 0.34), width: 0.8),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            PhosphorIcons.sparkle(PhosphorIconsStyle.fill),
+            size: 11,
+            color: accent,
+          ),
+          const SizedBox(width: 5),
+          Text(
+            'Choisie pour vous',
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 0.1,
+              color: accent,
+            ),
+          ),
+          if (onTap != null) ...[
+            const SizedBox(width: 5),
+            Icon(
+              PhosphorIcons.info(PhosphorIconsStyle.bold),
+              size: 12,
+              color: accent.withValues(alpha: 0.85),
+            ),
+          ],
+        ],
+      ),
+    );
+    if (onTap == null) return badge;
+    return Semantics(
+      button: true,
+      label: 'Pourquoi cette section est proposée',
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: badge,
       ),
     );
   }

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -58,6 +58,11 @@ class SectionBlock extends StatelessWidget {
   /// (spécifique veille). Câblé uniquement pour les sections thème.
   final VoidCallback? onAddSources;
 
+  /// Story 22.3 — tap sur le badge « Choisie pour vous » d'une section
+  /// suggérée → ouvre la sheet « Pourquoi cette section ? ». Câblé uniquement
+  /// pour les sections `origin == suggested` (cf. flux_continu_screen).
+  final VoidCallback? onTapSuggestionInfo;
+
   const SectionBlock({
     super.key,
     required this.section,
@@ -76,6 +81,7 @@ class SectionBlock extends StatelessWidget {
     this.onTapSettings,
     this.onAddSources,
     this.onSeeAll,
+    this.onTapSuggestionInfo,
   });
 
   @override
@@ -119,6 +125,9 @@ class SectionBlock extends StatelessWidget {
           onTapSettings: onTapSettings,
           onTap: onSeeAll,
           hiddenCount: hiddenCount,
+          // Story 22.3 — badge « Choisie pour vous » sur les sections suggérées.
+          suggested: section is FeedThemeSection && section.isSuggested,
+          onTapInfo: onTapSuggestionInfo,
         ),
         ...cards,
         const SizedBox(height: 16),

--- a/apps/mobile/lib/features/flux_continu/widgets/suggestion_reason_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/suggestion_reason_sheet.dart
@@ -1,0 +1,226 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+import '../models/flux_continu_models.dart';
+
+/// Story 22.3 — sheet « Pourquoi cette section ? » d'une suggestion « Choisie
+/// pour vous ». Transparence totale (PO) : le headline = la raison dominante,
+/// les puces = le breakdown honnête servi par le backend (préférence déclarée /
+/// lue + N articles + variété). Deux actions : garder (promotion en favori) ou
+/// retirer (dismiss, mémoire locale). Pas d'em-dash dans la copy (règle PO).
+Future<void> showSuggestionReasonSheet(
+  BuildContext context, {
+  required String sectionTitle,
+  required SuggestionReason? reason,
+  required Future<void> Function() onKeep,
+  required Future<void> Function() onDismiss,
+}) {
+  return showModalBottomSheet<void>(
+    context: context,
+    backgroundColor: Colors.transparent,
+    isScrollControlled: true,
+    enableDrag: true,
+    isDismissible: true,
+    barrierColor: Colors.black.withValues(alpha: 0.5),
+    builder: (ctx) => ClipRect(
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 6, sigmaY: 6),
+        child: _SuggestionReasonContent(
+          sectionTitle: sectionTitle,
+          reason: reason,
+          onKeep: onKeep,
+          onDismiss: onDismiss,
+        ),
+      ),
+    ),
+  );
+}
+
+class _SuggestionReasonContent extends StatelessWidget {
+  final String sectionTitle;
+  final SuggestionReason? reason;
+  final Future<void> Function() onKeep;
+  final Future<void> Function() onDismiss;
+
+  const _SuggestionReasonContent({
+    required this.sectionTitle,
+    required this.reason,
+    required this.onKeep,
+    required this.onDismiss,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+    final bullets = reason?.breakdown ?? const <SuggestionContribution>[];
+
+    return SafeArea(
+      top: false,
+      child: Container(
+        decoration: BoxDecoration(
+          color: colors.backgroundSecondary,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+        ),
+        padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Handle cosmétique + bouton fermer.
+            Stack(
+              alignment: Alignment.center,
+              children: [
+                Container(
+                  width: 40,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: colors.textTertiary.withValues(alpha: 0.3),
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: IconButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    icon: Icon(Icons.close, color: colors.textTertiary),
+                    tooltip: 'Fermer',
+                    visualDensity: VisualDensity.compact,
+                    constraints: const BoxConstraints(
+                      minWidth: 36,
+                      minHeight: 36,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: FacteurSpacing.space2),
+
+            Row(
+              children: [
+                Icon(
+                  PhosphorIcons.sparkle(PhosphorIconsStyle.fill),
+                  size: 16,
+                  color: colors.primary,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Pourquoi cette section ?',
+                    style: textTheme.displaySmall?.copyWith(
+                      fontSize: 20,
+                      fontWeight: FontWeight.w700,
+                      color: colors.textPrimary,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 6),
+            Text(
+              'Choisie pour vous dans « $sectionTitle », toujours à partir de '
+              'tes préférences.',
+              style: textTheme.bodySmall?.copyWith(
+                color: colors.textTertiary,
+                height: 1.4,
+              ),
+            ),
+
+            if (reason != null && reason!.label.isNotEmpty) ...[
+              const SizedBox(height: FacteurSpacing.space4),
+              Text(
+                reason!.label,
+                style: textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w700,
+                  color: colors.textPrimary,
+                ),
+              ),
+            ],
+
+            const SizedBox(height: FacteurSpacing.space3),
+            for (final c in bullets)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.only(top: 5),
+                      child: Container(
+                        width: 6,
+                        height: 6,
+                        decoration: BoxDecoration(
+                          color: colors.primary.withValues(alpha: 0.65),
+                          shape: BoxShape.circle,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Text(
+                        c.label,
+                        style: textTheme.bodyMedium?.copyWith(
+                          color: colors.textSecondary,
+                          height: 1.4,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+            const SizedBox(height: FacteurSpacing.space4),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                onPressed: () {
+                  HapticFeedback.selectionClick();
+                  Navigator.of(context).pop();
+                  // Fire-and-forget : l'appelant (écran) attend et confirme.
+                  onKeep();
+                },
+                icon: Icon(
+                  PhosphorIcons.star(PhosphorIconsStyle.fill),
+                  size: 16,
+                ),
+                label: const Text('Garder dans mes favoris'),
+                style: FilledButton.styleFrom(
+                  minimumSize: const Size.fromHeight(50),
+                  backgroundColor: colors.primary,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(FacteurRadius.small),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            SizedBox(
+              width: double.infinity,
+              child: TextButton.icon(
+                onPressed: () {
+                  HapticFeedback.selectionClick();
+                  Navigator.of(context).pop();
+                  // Fire-and-forget : l'appelant (écran) attend et confirme.
+                  onDismiss();
+                },
+                icon: Icon(
+                  PhosphorIcons.minusCircle(PhosphorIconsStyle.regular),
+                  size: 16,
+                  color: colors.textSecondary,
+                ),
+                label: Text(
+                  'Retirer cette suggestion',
+                  style: TextStyle(color: colors.textSecondary),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/test/features/feed/widgets/pin_subjects_sheet_test.dart
+++ b/apps/mobile/test/features/feed/widgets/pin_subjects_sheet_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:facteur/config/theme.dart';
 import 'package:facteur/features/digest/providers/serein_toggle_provider.dart';
+import 'package:facteur/features/flux_continu/providers/tournee_smart_arrangement_provider.dart';
 import 'package:facteur/features/feed/widgets/pin_subjects_sheet.dart';
 import 'package:facteur/features/grille/models/grille_models.dart';
 import 'package:facteur/features/grille/providers/grille_provider.dart';
@@ -120,6 +121,9 @@ Widget _sheetHost(UserInterestsState interests, Widget child) => ProviderScope(
         veilleActiveConfigProvider.overrideWith(() => _StubVeille()),
         grilleRepositoryProvider.overrideWithValue(_NoGrille()),
         sereinToggleProvider.overrideWith((ref) => _StubSerein(ref)),
+        tourneeSmartArrangementProvider.overrideWith(
+          (ref) => TourneeSmartArrangementNotifier(ref),
+        ),
       ],
       child: MaterialApp(
         theme: ThemeData(
@@ -184,7 +188,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Mes favoris'), findsOneWidget);
-      expect(find.text('TES ONGLETS POUR EXPLORER'), findsOneWidget);
+      expect(find.text('ONGLETS DE TA PAGE FLÂNER'), findsOneWidget);
       // Porte Flâner ⇒ segment « Sujets » présélectionné : le sujet suivi est
       // proposé à l'épinglage.
       expect(find.text('Climat'), findsOneWidget);

--- a/apps/mobile/test/features/flux_continu/models/flux_continu_models_test.dart
+++ b/apps/mobile/test/features/flux_continu/models/flux_continu_models_test.dart
@@ -119,10 +119,10 @@ void main() {
     });
 
     test('uses source:<id> for source sections', () {
-      final src = FeedThemeSection(
+      const src = FeedThemeSection(
         kind: SectionKind.source,
         label: 'Le Monde',
-        accent: const Color(0xFF8E44AD),
+        accent: Color(0xFF8E44AD),
         coreVisibleCount: 3,
         sourceId: 'src-uuid',
         sourceLogoUrl: 'https://logo.test/x.png',
@@ -268,6 +268,79 @@ void main() {
     test('returns null for an unknown current key', () {
       final a = themeSection(slug: 'tech');
       expect(nextSectionAfter([a], 'theme:nope'), isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Story 22.3 — suggestions « Choisie pour vous »
+  // ---------------------------------------------------------------------------
+
+  group('FeedThemeSection origin/reason (Story 22.3)', () {
+    test('default origin is validated and reason is null', () {
+      final s = themeSection(slug: 'tech');
+      expect(s.origin, SectionOrigin.validated);
+      expect(s.reason, isNull);
+      expect(s.isSuggested, isFalse);
+    });
+
+    test('suggested section carries origin + reason', () {
+      const reason = SuggestionReason(
+        label: 'Tu suis ce thème',
+        breakdown: [SuggestionContribution(label: 'Tu suis ce thème')],
+      );
+      const s = FeedThemeSection(
+        kind: SectionKind.theme,
+        label: 'Tech',
+        accent: Color(0xFF000000),
+        coreVisibleCount: 3,
+        themeSlug: 'tech',
+        items: [],
+        origin: SectionOrigin.suggested,
+        reason: reason,
+      );
+      expect(s.isSuggested, isTrue);
+      expect(s.reason, same(reason));
+    });
+
+    test('copyWith preserves origin + reason (badge survives recompose)', () {
+      const reason = SuggestionReason(label: 'Sources fiables');
+      const s = FeedThemeSection(
+        kind: SectionKind.source,
+        label: 'Le Monde',
+        accent: Color(0xFF000000),
+        coreVisibleCount: 3,
+        sourceId: 'sid',
+        items: [],
+        origin: SectionOrigin.suggested,
+        reason: reason,
+      );
+      final copy = s.copyWith(items: const []);
+      expect(copy.origin, SectionOrigin.suggested);
+      expect(copy.reason, same(reason));
+      expect(copy.isSuggested, isTrue);
+    });
+  });
+
+  group('SuggestionReason.fromJson (Story 22.3)', () {
+    test('parses label + breakdown', () {
+      final r = SuggestionReason.fromJson({
+        'label': 'Tu suis ce thème',
+        'breakdown': [
+          {'label': 'Tu suis ce thème', 'points': 100, 'pillar': 'pertinence'},
+          {'label': '5 articles récents', 'points': 50, 'pillar': 'fraicheur'},
+        ],
+      });
+      expect(r.label, 'Tu suis ce thème');
+      expect(r.breakdown, hasLength(2));
+      expect(r.breakdown.first.label, 'Tu suis ce thème');
+      expect(r.breakdown.first.pillar, 'pertinence');
+      expect(r.breakdown[1].points, 50);
+    });
+
+    test('tolerates missing breakdown', () {
+      final r = SuggestionReason.fromJson({'label': 'Varié pour aujourd\'hui'});
+      expect(r.label, 'Varié pour aujourd\'hui');
+      expect(r.breakdown, isEmpty);
     });
   });
 }

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
@@ -280,10 +280,12 @@ void main() {
 
   group('FluxContinuNotifier — favorites-driven theme sections', () {
     test(
-      '0 favorites + empty top-themes fallback → 3 canonical themes fetched',
+      // Story 22.3 — le fallback canonique (tech/environment/science) codé en
+      // dur a été supprimé : un compte 0 favori + top-themes vide ne fetche
+      // plus aucun thème (le padding vient désormais des suggestions backend).
+      '0 favorites + empty top-themes → no canonical theme fetched',
       () async {
         SharedPreferences.setMockInitialValues(<String, Object>{});
-        // Digest absent, feed absent → only the theme fetches matter.
         when(
           () => feedRepo.getFeed(
             page: any(named: 'page'),
@@ -294,12 +296,57 @@ void main() {
           ),
         ).thenAnswer((_) async => _feedResponseWith(3));
 
-        final container = makeContainer(); // 0 favorites in stub
+        final container = makeContainer(); // 0 favorites, top-themes vide
         addTearDown(container.dispose);
 
         await settle(container);
 
-        // 3 fallback canonical theme fetches (tech, environment, science).
+        // Plus de fetch canonique : aucune section thème n'est fetchée.
+        verifyNever(
+          () => feedRepo.getFeed(
+            page: any(named: 'page'),
+            limit: any(named: 'limit'),
+            theme: any(named: 'theme'),
+            serein: any(named: 'serein'),
+            personalized: any(named: 'personalized'),
+          ),
+        );
+      },
+    );
+
+    test(
+      // Story 22.3 — une suggestion « Choisie pour vous » (origin=suggested)
+      // remplit un slot : son feed est fetché et la section porte le badge.
+      '0 favorites + a suggested top-theme → suggested theme fetched',
+      () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        when(() => fluxRepo.getTopThemes()).thenAnswer(
+          (_) async => const [
+            TopTheme(
+              interestSlug: 'science',
+              weight: 1.0,
+              articleCount: 5,
+              origin: 'suggested',
+              dailyRank: 0,
+              reason: SuggestionReason(label: 'Tu suis ce thème'),
+            ),
+          ],
+        );
+        when(
+          () => feedRepo.getFeed(
+            page: any(named: 'page'),
+            limit: any(named: 'limit'),
+            theme: any(named: 'theme'),
+            serein: any(named: 'serein'),
+            personalized: any(named: 'personalized'),
+          ),
+        ).thenAnswer((_) async => _feedResponseWith(3));
+
+        final container = makeContainer();
+        addTearDown(container.dispose);
+
+        final state = await settle(container);
+
         final captured = verify(
           () => feedRepo.getFeed(
             page: any(named: 'page'),
@@ -309,7 +356,15 @@ void main() {
             personalized: any(named: 'personalized'),
           ),
         ).captured;
-        expect(captured, containsAll(['tech', 'environment', 'science']));
+        expect(captured, contains('science'));
+
+        final suggested = state.sections
+            .whereType<FeedThemeSection>()
+            .where((s) => s.isSuggested)
+            .toList();
+        expect(suggested, hasLength(1));
+        expect(suggested.first.themeSlug, 'science');
+        expect(suggested.first.reason?.label, 'Tu suis ce thème');
       },
     );
 

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_tournee_order_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_tournee_order_test.dart
@@ -816,16 +816,12 @@ void main() {
 
   group('fallback canonique gaté (Tournée bugs E2E)', () {
     test(
-        '0 favori + customized=false + 0 source/veille ⇒ fallback canonique '
-        '(compte neuf)', () async {
-      // Prefs vides (setUp) → customized=false → compte réellement neuf.
-      stubFeed(
-        themeIds: {
-          'tech': ['a', 'b'],
-          'environment': ['a', 'b'],
-          'science': ['a', 'b'],
-        },
-      );
+        // Story 22.3 — le triplet canonique codé en dur a été retiré : un
+        // compte neuf sans top-themes ne voit plus tech/environment/science
+        // injectés (le padding vient des suggestions « Choisie pour vous »).
+        '0 favori + customized=false + 0 source/veille + top-themes vide ⇒ '
+        'pas de fallback canonique', () async {
+      stubFeed();
       final container = await buildContainer(
         interests: _interestsState(),
         sourcesState: _sourcesState(),
@@ -840,9 +836,41 @@ void main() {
           .toList();
       expect(
         slugs,
-        containsAll(['tech', 'environment', 'science']),
-        reason: 'un compte neuf garde sa Tournée par défaut',
+        isEmpty,
+        reason: 'plus de triplet canonique codé en dur (Story 22.3)',
       );
+    });
+
+    test(
+        // Story 22.3 — un compte neuf est désormais complété par les sections
+        // suggérées (origin=suggested) servies par le backend, badgées.
+        '0 favori + suggestions backend ⇒ sections « Choisie pour vous »',
+        () async {
+      when(() => fluxRepo.getTopThemes()).thenAnswer(
+        (_) async => const [
+          TopTheme(
+            interestSlug: 'tech',
+            weight: 1.0,
+            articleCount: 4,
+            origin: 'suggested',
+            reason: SuggestionReason(label: 'Tu suis ce thème'),
+          ),
+        ],
+      );
+      stubFeed(themeIds: {'tech': ['a', 'b']});
+      final container = await buildContainer(
+        interests: _interestsState(),
+        sourcesState: _sourcesState(),
+        catalog: const [],
+      );
+      addTearDown(container.dispose);
+
+      await settle(container);
+      final suggested = favoriteSections(container)
+          .where((s) => s.isSuggested)
+          .toList();
+      expect(suggested, hasLength(1));
+      expect(suggested.first.themeSlug, 'tech');
     });
 
     test(

--- a/apps/mobile/test/features/flux_continu/repositories/top_theme_parsing_test.dart
+++ b/apps/mobile/test/features/flux_continu/repositories/top_theme_parsing_test.dart
@@ -1,0 +1,63 @@
+import 'package:facteur/features/flux_continu/repositories/flux_continu_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Story 22.3 — `TopTheme.fromJson` parse les champs additifs (origin / kind /
+/// source_id / daily_rank / reason) tout en restant rétro-compatible avec les
+/// payloads pré-22.3 (défauts `theme` / `validated`).
+void main() {
+  group('TopTheme.fromJson (Story 22.3)', () {
+    test('legacy payload defaults to validated theme', () {
+      final t = TopTheme.fromJson({
+        'interest_slug': 'tech',
+        'weight': 1.5,
+        'article_count': 3,
+      });
+      expect(t.interestSlug, 'tech');
+      expect(t.kind, 'theme');
+      expect(t.origin, 'validated');
+      expect(t.isSuggested, isFalse);
+      expect(t.sourceId, isNull);
+      expect(t.reason, isNull);
+      expect(t.dailyRank, 0);
+    });
+
+    test('parses a suggested theme with reason + daily_rank', () {
+      final t = TopTheme.fromJson({
+        'interest_slug': 'science',
+        'weight': 1.0,
+        'article_count': 7,
+        'kind': 'theme',
+        'origin': 'suggested',
+        'daily_rank': 2,
+        'reason': {
+          'label': 'Tu suis ce thème',
+          'breakdown': [
+            {'label': 'Tu suis ce thème', 'points': 100, 'pillar': 'pertinence'},
+            {'label': '7 articles récents', 'points': 60, 'pillar': 'fraicheur'},
+          ],
+        },
+      });
+      expect(t.isSuggested, isTrue);
+      expect(t.dailyRank, 2);
+      expect(t.reason, isNotNull);
+      expect(t.reason!.label, 'Tu suis ce thème');
+      expect(t.reason!.breakdown, hasLength(2));
+    });
+
+    test('parses a suggested source with source_id', () {
+      final t = TopTheme.fromJson({
+        'interest_slug': 'politics',
+        'weight': 1.0,
+        'article_count': 5,
+        'kind': 'source',
+        'source_id': 'abc-123',
+        'origin': 'suggested',
+        'daily_rank': 1,
+        'reason': {'label': 'Tu suis cette source', 'breakdown': <dynamic>[]},
+      });
+      expect(t.kind, 'source');
+      expect(t.sourceId, 'abc-123');
+      expect(t.isSuggested, isTrue);
+    });
+  });
+}

--- a/apps/mobile/test/features/flux_continu/widgets/manage_favorites_sheet_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/manage_favorites_sheet_test.dart
@@ -5,6 +5,7 @@
 import 'package:facteur/config/routes.dart';
 import 'package:facteur/config/theme.dart';
 import 'package:facteur/features/digest/providers/serein_toggle_provider.dart';
+import 'package:facteur/features/flux_continu/providers/tournee_smart_arrangement_provider.dart';
 import 'package:facteur/features/flux_continu/widgets/manage_favorites_sheet.dart';
 import 'package:facteur/features/grille/models/grille_models.dart';
 import 'package:facteur/features/grille/providers/grille_provider.dart';
@@ -176,6 +177,9 @@ Future<({_SpyInterestsNotifier interests, _SpySourcesNotifier sources})>
         ),
         sereinToggleProvider.overrideWith(
           (ref) => _StubSereinToggleNotifier(ref, false),
+        ),
+        tourneeSmartArrangementProvider.overrideWith(
+          (ref) => TourneeSmartArrangementNotifier(ref),
         ),
       ],
       child: _wrap(
@@ -504,6 +508,9 @@ void main() {
           sereinToggleProvider.overrideWith(
             (ref) => _StubSereinToggleNotifier(ref, false),
           ),
+        tourneeSmartArrangementProvider.overrideWith(
+          (ref) => TourneeSmartArrangementNotifier(ref),
+        ),
         ],
         child: MaterialApp.router(
           theme: ThemeData(

--- a/apps/mobile/test/features/flux_continu/widgets/personalisation_cta_card_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/personalisation_cta_card_test.dart
@@ -4,6 +4,7 @@ import 'package:facteur/config/theme.dart';
 import 'package:facteur/core/nudges/nudge_ids.dart';
 import 'package:facteur/features/digest/providers/serein_toggle_provider.dart';
 import 'package:facteur/features/flux_continu/providers/personalisation_cta_provider.dart';
+import 'package:facteur/features/flux_continu/providers/tournee_smart_arrangement_provider.dart';
 import 'package:facteur/features/flux_continu/widgets/personalisation_cta_card.dart';
 import 'package:facteur/features/grille/providers/grille_provider.dart';
 import 'package:facteur/features/grille/repositories/grille_repository.dart';
@@ -85,6 +86,9 @@ void main() {
           veilleActiveConfigProvider.overrideWith(() => _StubVeille()),
           grilleRepositoryProvider.overrideWithValue(_FakeGrilleRepository()),
           sereinToggleProvider.overrideWith((ref) => _StubSerein(ref)),
+          tourneeSmartArrangementProvider.overrideWith(
+            (ref) => TourneeSmartArrangementNotifier(ref),
+          ),
         ],
         child: MaterialApp(
           theme: ThemeData(

--- a/apps/mobile/test/features/flux_continu/widgets/tournee_composer_sheet_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/tournee_composer_sheet_test.dart
@@ -3,6 +3,7 @@
 // La couverture détaillée du contenu vit dans `manage_favorites_sheet_test.dart`.
 import 'package:facteur/config/theme.dart';
 import 'package:facteur/features/digest/providers/serein_toggle_provider.dart';
+import 'package:facteur/features/flux_continu/providers/tournee_smart_arrangement_provider.dart';
 import 'package:facteur/features/flux_continu/widgets/tournee_composer_sheet.dart';
 import 'package:facteur/features/grille/models/grille_models.dart';
 import 'package:facteur/features/grille/providers/grille_provider.dart';
@@ -78,6 +79,9 @@ Widget _host(Widget child) => ProviderScope(
         veilleActiveConfigProvider.overrideWith(() => _StubVeille()),
         grilleRepositoryProvider.overrideWithValue(_NoGrille()),
         sereinToggleProvider.overrideWith((ref) => _StubSerein(ref)),
+        tourneeSmartArrangementProvider.overrideWith(
+          (ref) => TourneeSmartArrangementNotifier(ref),
+        ),
       ],
       child: MaterialApp(
         theme: ThemeData(extensions: [FacteurPalettes.light]),

--- a/docs/stories/core/22.3.tournee-arrangement-intelligent.md
+++ b/docs/stories/core/22.3.tournee-arrangement-intelligent.md
@@ -1,0 +1,151 @@
+# Story 22.3 — Tournée du jour : arrangement quotidien intelligent (« Choisie pour vous »)
+
+> **Type** : Feature
+> **Statut** : En cours
+> **Branche** : `boujonlaurin-dotcom/tournee-auto-populate-sections` → `main`
+> **Épopée** : 22 — Tournée du jour / Essentiel
+
+---
+
+## Contexte
+
+La Tournée du jour est aujourd'hui **statique** : elle affiche les favoris épinglés
+(`UserFavoriteInterest`, cap 7) dans un ordre fixe, complété pour les comptes neufs par un
+fallback **codé en dur** (`const canonical = [tech, environment, science]` dans
+`flux_continu_provider.dart`). Rien ne varie d'un jour à l'autre, rien ne tient compte du
+contenu réellement disponible, et un thème/source que l'user **suit** (sans l'avoir épinglé)
+ne remonte jamais.
+
+**Objectif** (recadré PO) : une option **activée par défaut** qui transforme la Tournée en un
+**arrangement quotidien intelligent** par-dessus la configuration que l'utilisateur a **déjà
+déclarée**. Ce n'est PAS un moteur de découverte qui injecte des thèmes étrangers : la
+« surprise » = **diversité + variation jour après jour** dans la sélection et l'ordre des
+éléments, **toujours issus des préférences réelles**.
+
+Point ajouté par le PO : un **switch clair et discret** dans la modal « Composer ma Tournée »
+pour activer/désactiver facilement les suggestions personnalisées du facteur.
+
+---
+
+## Décisions PO (actées, non re-questionnables)
+
+- **Pool = univers déjà configuré** : thèmes/sources suivis mais non épinglés, + élargissement
+  **doux** (sources on-thème quand le compte est peu configuré). **Jamais hors préférences réelles.**
+- **Périmètre = thèmes ET sources**.
+- **Variation quotidienne** sur la sélection + l'ordre des suggérées, mais les sections dédiées
+  ne sont **JAMAIS masquées** (invariant dur).
+- **Plafond suggestions = 4** sections « Choisie pour vous » max (`TOURNEE_SUGGEST_SUBCAP`).
+- **Rejet d'une suggestion = mémoire locale** (`hiddenKeys`, pas de migration).
+- **Transparence totale** : chaque suggérée porte un badge « Choisie pour vous » + un « i »
+  honnête sur le pourquoi.
+- **Pas d'em-dash** dans la copy user-facing (règle PO).
+- **Curseur scoring = Fidèle** (70 % préférences réelles) ; surprise = variation, pas découverte.
+
+---
+
+## Conception backend (PR 1 — déployable seul, zéro migration)
+
+### Nouveau service `TourneeSuggester`
+`packages/api/app/services/recommendation/tournee_suggester.py`. `get_top_themes()` devient un
+orchestrateur fin : il calcule `validated` (logique actuelle), puis appelle
+`TourneeSuggester(db).arrange(user_id, validated_keys, sub_cap)` qui :
+
+1. **Construit le pool candidat** issu du déclaré : thèmes `UserInterest` suivis non présents
+   dans `validated`, sources `UserSource` suivies (state `followed`, donc non-favorites/déjà
+   rendues). **Élargissement doux** si le pool < `sub_cap` : sources curées dont le `theme`
+   est un thème suivi (préférence déclarée via le thème).
+2. **Filtres durs** : exclut muted (`UserPersonalization.muted_themes/muted_sources`, états
+   `hidden`), et tout candidat sous le **plancher de contenu** (`recent_count <
+   TOURNEE_SUGGEST_CONTENT_FLOOR`, fenêtre 14 j).
+3. **Score quotidien** normalisé 0–1, majoritairement préférences réelles :
+   `daily_score = 0.40*explicit + 0.30*measured + 0.20*quantity + 0.10*quality`.
+4. **Variation quotidienne** : `compute_seed(user_id, "daily")` + `randomized_sort`
+   (température 0.10) → stable le jour, varié le lendemain. Réutilise le pattern
+   `topic_selector.py` / digest.
+5. **Raison de transparence** par suggérée : `TopThemeReason{label, breakdown:[ScoreContribution]}`
+   uniquement depuis les composantes réellement > 0. **Invariant testé : aucune suggérée sans
+   breakdown.**
+
+Constantes ajoutées dans `scoring_config.py::ScoringWeights` (source unique) : `TOURNEE_SUGGEST_*`.
+
+### Contrat API (additif, rétro-compatible)
+`TopThemeResponse` gagne : `kind` accepte `"source"`, `source_id`, `origin` (`validated` défaut),
+`daily_rank`, `reason`. `origin="validated"` par défaut → anciens clients/payloads inchangés.
+Les suggérées de type source arrivent dans la même liste `get_top_themes` (`kind="source"`,
+`source_id` rempli).
+
+### Persistance — zéro migration
+- **Toggle défaut-ON** : `"tournee_smart_arrangement"` ajouté à `ALLOWED_PREFERENCE_KEYS`.
+  Absence = ON ; l'algo ne tourne pas seulement si la valeur stockée est `"false"`.
+- **Rejet** : `hiddenKeys` (SharedPreferences) côté client.
+- **Promotion** : chemin favori existant (étoile) → la section repasse `origin="validated"`.
+
+---
+
+## Conception mobile (PR 2)
+
+1. **Validées d'abord** (résolues comme aujourd'hui, toujours rendues, jamais masquées).
+2. **Suggérées ensuite** : remplissent `min(sub_cap, slots restants)` depuis les
+   `origin=="suggested"` (déjà best-first du backend), en filtrant `hiddenKeys` + clés validées.
+   **Supprime le `const canonical` codé en dur.**
+3. `FeedThemeSection` gagne `origin` + `reason` (additifs, défaut null, portés par `copyWith`).
+4. `SectionBanner` : badge « Choisie pour vous » + « i » → bottom-sheet « Pourquoi cette
+   section ? » (headline = `reason.label`, 2-3 puces depuis `reason.breakdown`).
+5. **Dismiss** → `setHidden('theme:<slug>'|'source:<id>', true)` + recompose (le suivant remonte).
+   **Promotion** ⭐ → chemin favori existant.
+6. **Switch global** dans « Composer ma Tournée » (`manage_favorites_sheet.dart`), **défaut ON** →
+   `PUT /users/preferences tournee_smart_arrangement`. OFF = aucune suggérée (legacy).
+
+---
+
+## Cas limites & garde-fous
+
+- **7 favoris validés** : `remaining=0` → aucune suggérée, Tournée identique à aujourd'hui.
+- **Jour pauvre** : `CONTENT_FLOOR` coupe les pools vides → moins de sections, pas d'empty-state.
+- **Mode serein** : les suggérées héritent du filtrage serein au fetch (`_fetchOneTheme(isSerene)`).
+- **Anti-désorientation** : seed daily, `hiddenKeys` persistant, validées jamais sous les suggérées.
+- **Anti-boîte-noire** : toute `origin="suggested"` a un `reason` non vide et **vrai** (assertion + test).
+
+---
+
+## Tâches
+
+### PR 1 — Backend (livrée)
+- [x] `scoring_config.py` : constantes `TOURNEE_SUGGEST_*`
+- [x] `tournee_suggester.py` : service `TourneeSuggester.arrange()`
+- [x] `routers/users.py` : `TopThemeResponse` étendu + `TopThemeReason` + orchestration `get_top_themes`
+- [x] `user_service.py` : `ALLOWED_PREFERENCE_KEYS += tournee_smart_arrangement`
+- [x] `tests/services/test_tournee_suggester.py` (8) + `tests/routers/test_top_themes_suggestions.py` (4)
+
+### PR 2 — Mobile (livrée)
+- [x] `flux_continu_repository.dart` : `TopTheme.fromJson` (origin/kind/source_id/daily_rank/reason)
+- [x] `flux_continu_models.dart` : `SectionOrigin` + `SuggestionReason` sur `FeedThemeSection` (+copyWith)
+- [x] `flux_continu_provider.dart` : composition suggérées + suppression `const canonical` + dismiss/promote
+- [x] `section_banner.dart` : badge « Choisie pour vous » + « i »
+- [x] `suggestion_reason_sheet.dart` : bottom-sheet « Pourquoi cette section ? » (garder / retirer)
+- [x] `tournee_smart_arrangement_provider.dart` + switch dans `manage_favorites_sheet.dart`
+- [x] tests modèles/parsing + provider (composition/suggestion) + harnais sheets mis à jour
+- [ ] Playwright E2E (à lancer via `/validate-feature` avant `/go`)
+
+---
+
+## Décisions d'implémentation (notes)
+
+- **Ordre des validées non réordonné par l'algo** : par prudence anti-désorientation, le mobile
+  garde l'ordre existant des sections dédiées ; `daily_rank` ne sert qu'à ordonner les suggérées
+  entre elles. La variation quotidienne porte sur la **sélection + l'ordre des suggérées**, ce qui
+  satisfait l'invariant « validées jamais sous les suggérées, jamais masquées ».
+- **Promotion via la sheet** (bouton « Garder dans mes favoris »), pas via l'étoile : l'étoile est
+  masquée sur les suggérées pour ne pas confondre les deux affordances.
+- **Suggérées vides droppées** : une suggestion dont le feed du jour (24 h, sources suivies) ou le
+  dédup inter-sections vide la liste n'affiche jamais un bandeau + badge orphelins.
+
+## Fichiers modifiés
+
+**Backend** : `scoring_config.py`, `tournee_suggester.py` (nouveau), `routers/users.py`,
+`user_service.py` ; tests `test_tournee_suggester.py` (nouveau), `test_top_themes_suggestions.py` (nouveau).
+
+**Mobile** : `flux_continu_models.dart`, `flux_continu_repository.dart`, `flux_continu_provider.dart`,
+`section_banner.dart`, `section_block.dart`, `flux_continu_screen.dart`,
+`suggestion_reason_sheet.dart` (nouveau), `manage_favorites_sheet.dart`,
+`tournee_smart_arrangement_provider.dart` (nouveau) ; tests modèles/repo/provider + harnais sheets.

--- a/packages/api/app/routers/users.py
+++ b/packages/api/app/routers/users.py
@@ -25,6 +25,7 @@ _perf_logger = structlog.get_logger("streak_perf")
 from app.database import get_db
 from app.dependencies import get_current_user_id
 from app.models.user import UserProfile
+from app.schemas.content import ScoreContribution
 from app.schemas.streak import StreakResponse
 from app.schemas.user import (
     AlgorithmProfileResponse,
@@ -301,19 +302,41 @@ async def update_preference(
     return PreferenceUpdateResponse(success=True, key=data.key, value=data.value)
 
 
+class TopThemeReason(BaseModel):
+    """Raison de transparence d'une section « Choisie pour vous » (Story 22.3).
+
+    `label` = la contribution dominante ; `breakdown` = 2-3 puces honnêtes
+    construites depuis les seules composantes réellement présentes. Réutilise la
+    shape `ScoreContribution` du feed/digest (cf. `schemas/content.py`).
+    """
+
+    label: str
+    breakdown: list[ScoreContribution] = []
+
+
 class TopThemeResponse(BaseModel):
     """Un slot de la Tournée du jour.
 
     Pour `kind="veille"`, `interest_slug` est le `theme_id` (slug parent) de la
     `VeilleConfig` et `veille_config_id` est rempli — le mobile dispatche alors
     vers `/api/veille/feed` au lieu de `/api/feed?theme=`.
+
+    Story 22.3 — champs additifs rétro-compatibles : `origin="validated"` par
+    défaut (anciens payloads/clients inchangés) ; les sections « Choisie pour
+    vous » arrivent avec `origin="suggested"`, un `reason` non vide, et un
+    `daily_rank` d'ordre du jour. Une suggestion **source** porte `kind="source"`
+    + `source_id` (le mobile route alors vers `/api/feed?source_id=`).
     """
 
     interest_slug: str
     weight: float
     article_count: int = 0
-    kind: Literal["theme", "veille"] = "theme"
+    kind: Literal["theme", "veille", "source"] = "theme"
     veille_config_id: UUID | None = None
+    source_id: UUID | None = None
+    origin: Literal["validated", "suggested"] = "validated"
+    daily_rank: int = 0
+    reason: TopThemeReason | None = None
 
 
 @router.get("/top-themes", response_model=list[TopThemeResponse])
@@ -426,7 +449,7 @@ async def get_top_themes(
             out.append(
                 TopThemeResponse(interest_slug=slug, weight=1.5, article_count=0)
             )
-        return out[:FAVORITE_CAP]
+        return await _arrange_tournee(db, user_uuid, out[:FAVORITE_CAP])
 
     # Fallback : sort weight desc, exclure les thèmes sans article 14j.
     service = UserService(db)
@@ -447,7 +470,7 @@ async def get_top_themes(
     theme_counts = {row[0]: row[1] for row in count_rows}
 
     themes = sorted(interests, key=lambda i: i.weight, reverse=True)
-    return [
+    validated = [
         TopThemeResponse(
             interest_slug=i.interest_slug,
             weight=i.weight,
@@ -456,6 +479,72 @@ async def get_top_themes(
         for i in themes
         if theme_counts.get(i.interest_slug, 0) > 0
     ][:FAVORITE_CAP]
+    return await _arrange_tournee(db, user_uuid, validated)
+
+
+async def _smart_arrangement_enabled(db: AsyncSession, user_uuid: UUID) -> bool:
+    """Toggle « Choisie pour vous » (Story 22.3).
+
+    Absence de la préférence = activé (default-ON sans migration) ; seule la
+    valeur stockée `"false"` désactive l'arrangement intelligent.
+    """
+    from app.models.user import UserPreference
+
+    value = await db.scalar(
+        sa_select(UserPreference.preference_value).where(
+            UserPreference.user_id == user_uuid,
+            UserPreference.preference_key == "tournee_smart_arrangement",
+        )
+    )
+    return value != "false"
+
+
+async def _arrange_tournee(
+    db: AsyncSession,
+    user_uuid: UUID,
+    validated: list[TopThemeResponse],
+) -> list[TopThemeResponse]:
+    """Affecte les `daily_rank` aux validées et complète les slots restants par
+    des sections « Choisie pour vous » (Story 22.3).
+
+    Les validées gardent leur ordre d'entrée (jamais réordonnées/masquées ici) ;
+    les suggérées remplissent `min(SUBCAP, slots restants)` derrière elles, déjà
+    triées best-first pour aujourd'hui par `TourneeSuggester`. No-op si le toggle
+    est off, s'il ne reste aucun slot, ou si le pool est vide (jour pauvre).
+    """
+    from app.constants import FAVORITE_CAP
+
+    for rank, item in enumerate(validated):
+        item.daily_rank = rank
+
+    remaining = FAVORITE_CAP - len(validated)
+    if remaining <= 0 or not await _smart_arrangement_enabled(db, user_uuid):
+        return validated
+
+    from app.services.recommendation.scoring_config import ScoringWeights
+    from app.services.recommendation.tournee_suggester import TourneeSuggester
+
+    sub_cap = min(ScoringWeights.TOURNEE_SUGGEST_SUBCAP, remaining)
+    validated_slugs = {item.interest_slug for item in validated if item.interest_slug}
+    suggestions = await TourneeSuggester(db).arrange(
+        user_uuid, validated_slugs, sub_cap
+    )
+    rank = len(validated)
+    for s in suggestions:
+        validated.append(
+            TopThemeResponse(
+                interest_slug=s.slug or "",
+                weight=1.0,
+                article_count=s.recent_count,
+                kind="source" if s.kind == "source" else "theme",
+                source_id=s.source_id,
+                origin="suggested",
+                daily_rank=rank,
+                reason=TopThemeReason(label=s.reason_label, breakdown=s.breakdown),
+            )
+        )
+        rank += 1
+    return validated
 
 
 # ─── Account deletion ────────────────────────────────────────────────────────

--- a/packages/api/app/services/recommendation/scoring_config.py
+++ b/packages/api/app/services/recommendation/scoring_config.py
@@ -397,3 +397,43 @@ class ScoringWeights:
 
     # Minimum articles sharing an entity to form an entity CTA group.
     MIN_FOR_ENTITY_GROUPING = 5
+
+    # --- TOURNÉE SMART ARRANGEMENT (Story 22.3 — « Choisie pour vous ») ---
+    # Arrangement quotidien intelligent par-dessus la config déclarée : les
+    # sections « Choisie pour vous » remplissent les slots restants de la Tournée
+    # avec des thèmes/sources suivis-mais-non-épinglés (jamais hors préférences).
+    # Curseur « Fidèle » : majoritairement préférences réelles, la « surprise » =
+    # variation quotidienne (seed daily + Gumbel basse température), pas découverte.
+
+    # Poids du blend `daily_score` (0–1). Doivent sommer à 1.0.
+    #   explicit : 1.0 si le candidat est directement suivi / déclaré à l'onboarding.
+    #   measured : poids interest/subtopic appris + affinité source (0–1).
+    #   quantity : log-saturé sur le nb d'articles récents (rareté → moins).
+    #   quality  : moyenne reliability des sources du thème (signal qualité).
+    TOURNEE_SUGGEST_W_EXPLICIT = 0.40
+    TOURNEE_SUGGEST_W_MEASURED = 0.30
+    TOURNEE_SUGGEST_W_QUANTITY = 0.20
+    TOURNEE_SUGGEST_W_QUALITY = 0.10
+
+    # Composante `explicit` d'un candidat issu de l'élargissement doux (source
+    # on-thème non directement suivie) : plus faible qu'un suivi direct (1.0).
+    TOURNEE_SUGGEST_SOFT_EXPLICIT = 0.5
+
+    # Plancher de contenu : un candidat avec moins de N articles récents (14 j)
+    # est écarté (jour pauvre → moins de suggestions, jamais d'empty-state suggéré).
+    TOURNEE_SUGGEST_CONTENT_FLOOR = 3
+
+    # Saturation log de la composante `quantity` : au-delà, le nb d'articles
+    # n'augmente plus le score (évite qu'un thème bavard domine).
+    TOURNEE_SUGGEST_QUANTITY_SATURATION = 60.0
+
+    # Température Gumbel de la variation quotidienne (basse : ordre stable le
+    # jour, varié le lendemain, sans réordonner brutalement).
+    TOURNEE_SUGGEST_TEMPERATURE = 0.10
+
+    # Plafond de sections « Choisie pour vous » (thèmes + sources confondus).
+    TOURNEE_SUGGEST_SUBCAP = 4
+
+    # Fenêtre de récence (jours) du comptage d'articles par candidat (aligné
+    # sur le filtre 14 j du fallback `get_top_themes`).
+    TOURNEE_SUGGEST_RECENCY_DAYS = 14

--- a/packages/api/app/services/recommendation/tournee_suggester.py
+++ b/packages/api/app/services/recommendation/tournee_suggester.py
@@ -1,0 +1,463 @@
+"""Arrangement quotidien intelligent de la Tournée du jour (Story 22.3).
+
+Construit les sections « Choisie pour vous » : thèmes / sources que l'utilisateur
+**suit déjà** mais n'a **pas épinglés**, sélectionnés et ordonnés chaque jour par
+un blend de signaux (préférence déclarée, poids appris, quantité de contenu
+frais, qualité des sources), avec une variation quotidienne déterministe.
+
+Invariants produit (PO) :
+- Jamais de thème **hors préférences réelles** : la « surprise » = variation, pas
+  découverte. L'élargissement « doux » reste borné aux sources dont le thème
+  primaire est un thème déjà déclaré par l'utilisateur.
+- Les sections **dédiées** (validées) ne passent jamais ici ; elles sont
+  résolues en amont par `get_top_themes` et ne sont jamais masquées.
+- Chaque suggérée porte une **raison vraie** (breakdown non vide construit à
+  partir des seules composantes réellement > 0) : anti-boîte-noire testé.
+
+Réutilise le pattern de variation déterministe de `topic_selector.py` / digest
+(`compute_seed` + `randomized_sort`, basse température) pour un ordre stable dans
+la journée et varié le lendemain.
+"""
+
+import math
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+import structlog
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.content import Content
+from app.models.enums import InterestState, ReliabilityScore
+from app.models.source import Source, UserSource
+from app.models.user import UserInterest
+from app.models.user_personalization import UserPersonalization
+from app.schemas.content import ScoreContribution
+from app.services.recommendation.randomization import compute_seed, randomized_sort
+from app.services.recommendation.scoring_config import ScoringWeights
+
+logger = structlog.get_logger(__name__)
+
+# Reliability → score qualité 0–1. On **lit** la colonne `reliability_score`
+# (pas de recalcul du FQS) et on la projette sur une échelle continue.
+_RELIABILITY_QUALITY: dict[ReliabilityScore, float] = {
+    ReliabilityScore.HIGH: 1.0,
+    ReliabilityScore.MIXED: 0.6,
+    ReliabilityScore.MEDIUM: 0.5,
+    ReliabilityScore.LOW: 0.2,
+    ReliabilityScore.UNKNOWN: 0.4,
+}
+_DEFAULT_QUALITY = 0.4
+
+
+@dataclass
+class TourneeSuggestion:
+    """Une section « Choisie pour vous » candidate, scorée pour aujourd'hui."""
+
+    key: str  # "theme:<slug>" | "source:<id>"
+    kind: str  # "theme" | "source"
+    slug: str | None  # slug thème (thème direct, ou thème primaire d'une source)
+    source_id: UUID | None
+    label_name: str  # nom d'affichage (libellé thème ou nom de source)
+    recent_count: int
+    is_soft: bool  # issu de l'élargissement doux (source on-thème non suivie)
+
+    # Composantes normalisées 0–1 du blend `daily_score`.
+    explicit: float = 0.0
+    measured: float = 0.0
+    quantity: float = 0.0
+    quality: float = 0.0
+    daily_score: float = 0.0
+
+    reason_label: str = ""
+    breakdown: list[ScoreContribution] = field(default_factory=list)
+
+
+class TourneeSuggester:
+    """Orchestre la construction des suggestions « Choisie pour vous ».
+
+    `arrange()` est le seul point d'entrée : il prend l'ensemble des slugs de
+    thèmes **déjà validés** (rendus comme sections dédiées) pour ne jamais les
+    re-suggérer, et un `sub_cap` = nombre de slots restants dans la Tournée.
+    """
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def arrange(
+        self,
+        user_id: UUID,
+        validated_theme_slugs: set[str],
+        sub_cap: int,
+    ) -> list[TourneeSuggestion]:
+        """Retourne au plus `sub_cap` suggestions, best-first pour aujourd'hui.
+
+        Pipeline : pool (déclaré) → filtres durs (muted + plancher contenu) →
+        score quotidien → variation déterministe → cap. Liste vide si rien ne
+        passe (jour pauvre, 7 favoris, compte vide) : jamais d'empty-state suggéré.
+        """
+        if sub_cap <= 0:
+            return []
+
+        candidates = await self._build_pool(user_id, validated_theme_slugs, sub_cap)
+        if not candidates:
+            return []
+
+        for c in candidates:
+            c.daily_score = (
+                ScoringWeights.TOURNEE_SUGGEST_W_EXPLICIT * c.explicit
+                + ScoringWeights.TOURNEE_SUGGEST_W_MEASURED * c.measured
+                + ScoringWeights.TOURNEE_SUGGEST_W_QUANTITY * c.quantity
+                + ScoringWeights.TOURNEE_SUGGEST_W_QUALITY * c.quality
+            )
+            self._build_reason(c)
+
+        # Variation quotidienne : seed daily (stable le jour, varié le lendemain).
+        seed = compute_seed(str(user_id), granularity="daily")
+        wrapped = [(c, c.daily_score) for c in candidates]
+        randomized = randomized_sort(
+            wrapped,
+            temperature=ScoringWeights.TOURNEE_SUGGEST_TEMPERATURE,
+            seed=seed,
+        )
+        ordered = [c for c, _ in randomized][:sub_cap]
+
+        logger.info(
+            "tournee_suggestions_arranged",
+            user_id=str(user_id),
+            pool=len(candidates),
+            returned=len(ordered),
+            sub_cap=sub_cap,
+            themes=sum(1 for c in ordered if c.kind == "theme"),
+            sources=sum(1 for c in ordered if c.kind == "source"),
+        )
+        return ordered
+
+    # ── Pool ────────────────────────────────────────────────────────────────
+
+    async def _build_pool(
+        self,
+        user_id: UUID,
+        validated_theme_slugs: set[str],
+        sub_cap: int,
+    ) -> list[TourneeSuggestion]:
+        """Construit le pool candidat issu du **déclaré**, filtres durs inclus.
+
+        Les lectures ci-dessous sont indépendantes mais restent **séquentielles** :
+        elles partagent l'`AsyncSession` du request scope, qui n'autorise pas de
+        statements concurrents. Ne pas les `asyncio.gather` sans connexions
+        dédiées (ça lèverait `InterfaceError: another operation is in progress`).
+        """
+        muted_themes, muted_sources = await self._load_muted(user_id)
+
+        # Thèmes suivis (state followed), non validés, non mutés.
+        interest_rows = (
+            await self.db.execute(
+                select(UserInterest.interest_slug, UserInterest.weight).where(
+                    UserInterest.user_id == user_id,
+                    UserInterest.state == InterestState.FOLLOWED,
+                )
+            )
+        ).all()
+        followed_themes: dict[str, float] = {
+            row.interest_slug: row.weight or 1.0 for row in interest_rows
+        }
+        # Tous les thèmes déclarés (validés + suivis) — cible de l'élargissement doux.
+        declared_theme_slugs = validated_theme_slugs | set(followed_themes)
+
+        # Sources suivies (state followed) : candidates directes (les favorites
+        # sont déjà rendues comme sections dédiées côté mobile).
+        followed_source_ids = set(
+            (
+                await self.db.execute(
+                    select(UserSource.source_id).where(
+                        UserSource.user_id == user_id,
+                        UserSource.state == InterestState.FOLLOWED,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        # Catalogue sources actives (1 requête) : qualité par thème + résolution.
+        source_rows = (
+            await self.db.execute(
+                select(
+                    Source.id,
+                    Source.name,
+                    Source.theme,
+                    Source.reliability_score,
+                    Source.is_curated,
+                ).where(Source.is_active)
+            )
+        ).all()
+        source_by_id = {row.id: row for row in source_rows}
+        theme_quality = self._theme_quality_map(source_rows)
+
+        # Affinité source apprise (0–1) — réutilise la logique de reco.
+        affinity = await self._source_affinity(user_id)
+
+        theme_candidates: list[TourneeSuggestion] = []
+        for slug, weight in followed_themes.items():
+            if slug in validated_theme_slugs or slug in muted_themes:
+                continue
+            theme_candidates.append(
+                TourneeSuggestion(
+                    key=f"theme:{slug}",
+                    kind="theme",
+                    slug=slug,
+                    source_id=None,
+                    label_name=slug,
+                    recent_count=0,
+                    is_soft=False,
+                    explicit=1.0,
+                    measured=_clamp01(weight - 1.0),
+                    quality=theme_quality.get(slug, _DEFAULT_QUALITY),
+                )
+            )
+
+        source_candidates: list[TourneeSuggestion] = []
+        for sid in followed_source_ids:
+            if sid in muted_sources:
+                continue
+            row = source_by_id.get(sid)
+            if row is None:
+                continue
+            source_candidates.append(
+                self._source_candidate(row, affinity, is_soft=False)
+            )
+
+        # Élargissement doux : si le pool est sous le cap, on complète avec des
+        # sources **curées** dont le thème primaire est un thème déjà déclaré
+        # (préférence réelle via le thème), non suivies, non mutées.
+        soft_candidates: list[TourneeSuggestion] = []
+        if len(theme_candidates) + len(source_candidates) < sub_cap:
+            already = followed_source_ids | muted_sources
+            soft_limit = max(sub_cap * 2, 4)
+            for row in source_rows:
+                if len(soft_candidates) >= soft_limit:
+                    break
+                if not row.is_curated:
+                    continue
+                if row.theme not in declared_theme_slugs:
+                    continue
+                if row.id in already:
+                    continue
+                soft_candidates.append(
+                    self._source_candidate(row, affinity, is_soft=True)
+                )
+
+        candidates = theme_candidates + source_candidates + soft_candidates
+        if not candidates:
+            return []
+
+        # Comptes de contenu récent (plancher dur). Deux requêtes groupées.
+        await self._attach_recent_counts(candidates)
+
+        floor = ScoringWeights.TOURNEE_SUGGEST_CONTENT_FLOOR
+        kept: list[TourneeSuggestion] = []
+        saturation = ScoringWeights.TOURNEE_SUGGEST_QUANTITY_SATURATION
+        for c in candidates:
+            if c.recent_count < floor:
+                continue
+            c.quantity = _log_saturate(c.recent_count, saturation)
+            kept.append(c)
+        return kept
+
+    async def _load_muted(self, user_id: UUID) -> tuple[set[str], set[UUID]]:
+        perso = await self.db.scalar(
+            select(UserPersonalization).where(UserPersonalization.user_id == user_id)
+        )
+        if perso is None:
+            return set(), set()
+        return set(perso.muted_themes or []), set(perso.muted_sources or [])
+
+    def _source_candidate(
+        self, row, affinity: dict[UUID, float], *, is_soft: bool
+    ) -> TourneeSuggestion:
+        quality = _RELIABILITY_QUALITY.get(row.reliability_score, _DEFAULT_QUALITY)
+        return TourneeSuggestion(
+            key=f"source:{row.id}",
+            kind="source",
+            slug=row.theme,
+            source_id=row.id,
+            label_name=row.name,
+            recent_count=0,
+            is_soft=is_soft,
+            explicit=ScoringWeights.TOURNEE_SUGGEST_SOFT_EXPLICIT if is_soft else 1.0,
+            measured=affinity.get(row.id, 0.0),
+            quality=quality,
+        )
+
+    def _theme_quality_map(self, source_rows) -> dict[str, float]:
+        """Qualité moyenne (reliability) des sources actives, par thème."""
+        sums: dict[str, float] = {}
+        counts: dict[str, int] = {}
+        for row in source_rows:
+            if not row.theme:
+                continue
+            q = _RELIABILITY_QUALITY.get(row.reliability_score, _DEFAULT_QUALITY)
+            sums[row.theme] = sums.get(row.theme, 0.0) + q
+            counts[row.theme] = counts.get(row.theme, 0) + 1
+        return {t: sums[t] / counts[t] for t in sums}
+
+    async def _source_affinity(self, user_id: UUID) -> dict[UUID, float]:
+        """Affinité source apprise (0–1). Best-effort : `{}` si indisponible."""
+        try:
+            from app.services.recommendation_service import RecommendationService
+
+            return await RecommendationService(self.db)._compute_source_affinity(
+                user_id
+            )
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.warning("tournee_source_affinity_failed", error=str(exc))
+            return {}
+
+    async def _attach_recent_counts(self, candidates: list[TourneeSuggestion]) -> None:
+        cutoff = datetime.now(UTC) - timedelta(
+            days=ScoringWeights.TOURNEE_SUGGEST_RECENCY_DAYS
+        )
+        theme_slugs = [c.slug for c in candidates if c.kind == "theme" and c.slug]
+        source_ids = [c.source_id for c in candidates if c.kind == "source"]
+
+        theme_counts: dict[str, int] = {}
+        if theme_slugs:
+            rows = (
+                await self.db.execute(
+                    select(Content.theme, func.count(Content.id))
+                    .where(
+                        Content.theme.in_(theme_slugs),
+                        Content.published_at >= cutoff,
+                    )
+                    .group_by(Content.theme)
+                )
+            ).all()
+            theme_counts = {row[0]: row[1] for row in rows}
+
+        source_counts: dict[UUID, int] = {}
+        if source_ids:
+            rows = (
+                await self.db.execute(
+                    select(Content.source_id, func.count(Content.id))
+                    .where(
+                        Content.source_id.in_(source_ids),
+                        Content.published_at >= cutoff,
+                    )
+                    .group_by(Content.source_id)
+                )
+            ).all()
+            source_counts = {row[0]: row[1] for row in rows}
+
+        for c in candidates:
+            if c.kind == "theme":
+                c.recent_count = theme_counts.get(c.slug, 0)
+            else:
+                c.recent_count = source_counts.get(c.source_id, 0)
+
+    # ── Transparence ──────────────────────────────────────────────────────────
+
+    def _build_reason(self, c: TourneeSuggestion) -> None:
+        """Construit `reason_label` + `breakdown` depuis les composantes > 0.
+
+        Invariant : le breakdown n'est **jamais vide** (au pire la seule
+        « Varié pour aujourd'hui »), et chaque puce reflète une composante
+        réellement présente — pas de raison fabriquée.
+        """
+        contribs: list[tuple[float, ScoreContribution]] = []
+
+        if c.explicit > 0:
+            if c.kind == "source" and not c.is_soft:
+                label = "Tu suis cette source"
+            elif c.is_soft:
+                label = "Sur un thème que tu suis"
+            else:
+                label = "Tu suis ce thème"
+            weighted = ScoringWeights.TOURNEE_SUGGEST_W_EXPLICIT * c.explicit
+            contribs.append(
+                (
+                    weighted,
+                    ScoreContribution(
+                        label=label,
+                        points=round(c.explicit * 100, 1),
+                        is_positive=True,
+                        pillar="pertinence",
+                    ),
+                )
+            )
+
+        if c.measured > 0:
+            weighted = ScoringWeights.TOURNEE_SUGGEST_W_MEASURED * c.measured
+            contribs.append(
+                (
+                    weighted,
+                    ScoreContribution(
+                        label="Tu lis souvent ce genre de contenu",
+                        points=round(c.measured * 100, 1),
+                        is_positive=True,
+                        pillar="pertinence",
+                    ),
+                )
+            )
+
+        if c.recent_count > 0:
+            weighted = ScoringWeights.TOURNEE_SUGGEST_W_QUANTITY * c.quantity
+            article_word = "article" if c.recent_count == 1 else "articles"
+            contribs.append(
+                (
+                    weighted,
+                    ScoreContribution(
+                        label=f"{c.recent_count} {article_word} récents",
+                        points=round(c.quantity * 100, 1),
+                        is_positive=True,
+                        pillar="fraicheur",
+                    ),
+                )
+            )
+
+        if c.quality > 0:
+            weighted = ScoringWeights.TOURNEE_SUGGEST_W_QUALITY * c.quality
+            contribs.append(
+                (
+                    weighted,
+                    ScoreContribution(
+                        label="Sources fiables",
+                        points=round(c.quality * 100, 1),
+                        is_positive=True,
+                        pillar="qualite",
+                    ),
+                )
+            )
+
+        # Tri par contribution pondérée décroissante : le label dominant en tête.
+        contribs.sort(key=lambda x: x[0], reverse=True)
+        breakdown = [contrib for _, contrib in contribs]
+
+        # Miroir du « Hasard pour diversifier » du digest (points=0, transparence).
+        breakdown.append(
+            ScoreContribution(
+                label="Varié pour aujourd'hui",
+                points=0,
+                is_positive=True,
+                pillar="diversite",
+            )
+        )
+
+        c.breakdown = breakdown
+        c.reason_label = breakdown[0].label
+
+
+def _clamp01(value: float) -> float:
+    if value < 0:
+        return 0.0
+    if value > 1:
+        return 1.0
+    return value
+
+
+def _log_saturate(count: int, saturation: float) -> float:
+    """Quantité log-saturée 0–1 : `log1p(count) / log1p(saturation)`, plafonné."""
+    if count <= 0:
+        return 0.0
+    return _clamp01(math.log1p(count) / math.log1p(saturation))

--- a/packages/api/app/services/user_service.py
+++ b/packages/api/app/services/user_service.py
@@ -44,6 +44,10 @@ ALLOWED_PREFERENCE_KEYS: frozenset[str] = frozenset(
         "independence_pref",
         "swipe_liked_count",
         "swipe_disliked_count",
+        # Story 22.3 — arrangement intelligent de la Tournée (« Choisie pour
+        # vous »). Absence = activé ; seul "false" désactive (default-ON sans
+        # migration). Toggle exposé dans « Composer ma Tournée ».
+        "tournee_smart_arrangement",
     }
 )
 

--- a/packages/api/tests/routers/test_top_themes_suggestions.py
+++ b/packages/api/tests/routers/test_top_themes_suggestions.py
@@ -1,0 +1,239 @@
+"""Tests d'intégration `GET /api/users/top-themes` — sections « Choisie pour
+vous » (Story 22.3).
+
+Vérifie l'orchestration : daily_rank sur les validées, suggérées appended avec
+`origin="suggested"` + `reason` + `daily_rank`, gating via la préférence
+`tournee_smart_arrangement`, et rétro-compat des défauts.
+"""
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.database import get_db
+from app.dependencies import get_current_user_id
+from app.main import app
+from app.models.content import Content
+from app.models.enums import (
+    ContentType,
+    InterestState,
+    ReliabilityScore,
+    SourceType,
+)
+from app.models.source import Source, UserSource
+from app.models.user import UserInterest, UserPreference, UserProfile
+from app.models.user_favorites import UserFavoriteInterest
+
+
+def _source(name: str, theme: str) -> Source:
+    return Source(
+        id=uuid4(),
+        name=name,
+        url=f"https://example.com/{uuid4()}",
+        feed_url=f"https://example.com/{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme=theme,
+        is_active=True,
+        is_curated=True,
+        reliability_score=ReliabilityScore.HIGH,
+    )
+
+
+def _content(source_id, theme: str, days_ago: int) -> Content:
+    return Content(
+        id=uuid4(),
+        source_id=source_id,
+        title="Article",
+        url=f"https://example.com/{uuid4()}",
+        guid=str(uuid4()),
+        published_at=datetime.now(UTC) - timedelta(days=days_ago),
+        content_type=ContentType.ARTICLE,
+        theme=theme,
+    )
+
+
+@pytest_asyncio.fixture
+async def configured_user(db_session):
+    """User avec 1 favori (tech) + thème suivi 'science' alimenté en contenu."""
+    user_id = uuid4()
+    db_session.add(UserProfile(user_id=user_id, onboarding_completed=True))
+    for slug in ("tech", "science"):
+        db_session.add(
+            UserInterest(
+                user_id=user_id,
+                interest_slug=slug,
+                weight=1.0,
+                state=InterestState.FOLLOWED,
+            )
+        )
+    # tech est épinglé (favori) → section validée.
+    db_session.add(
+        UserFavoriteInterest(user_id=user_id, position=0, interest_slug="tech")
+    )
+    # science a du contenu récent → candidat suggéré.
+    src = _source("Science Source", "science")
+    db_session.add(src)
+    await db_session.flush()
+    for d in range(5):
+        db_session.add(_content(src.id, "science", days_ago=d))
+    await db_session.commit()
+
+    async def _fake_user():
+        return str(user_id)
+
+    async def _fake_db():
+        yield db_session
+
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+    try:
+        yield user_id
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.mark.asyncio
+async def test_appends_suggestion_with_origin_reason_rank(configured_user):
+    """La validée (tech) reste origin=validated ; science arrive suggested."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/users/top-themes")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    validated = [t for t in body if t["origin"] == "validated"]
+    suggested = [t for t in body if t["origin"] == "suggested"]
+    assert [t["interest_slug"] for t in validated] == ["tech"]
+    assert validated[0]["daily_rank"] == 0
+    assert validated[0]["reason"] is None  # rétro-compat : pas de reason sur validée
+
+    assert any(t["interest_slug"] == "science" for t in suggested)
+    science = next(t for t in suggested if t["interest_slug"] == "science")
+    assert science["reason"] is not None
+    assert science["reason"]["label"]
+    assert len(science["reason"]["breakdown"]) >= 1
+    assert science["daily_rank"] == 1  # juste après la validée
+
+
+@pytest.mark.asyncio
+async def test_disabled_via_preference(configured_user, db_session):
+    """`tournee_smart_arrangement="false"` → aucune suggérée."""
+    db_session.add(
+        UserPreference(
+            user_id=configured_user,
+            preference_key="tournee_smart_arrangement",
+            preference_value="false",
+        )
+    )
+    await db_session.commit()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/users/top-themes")
+    body = resp.json()
+    assert all(t["origin"] == "validated" for t in body)
+    assert [t["interest_slug"] for t in body] == ["tech"]
+
+
+@pytest.mark.asyncio
+async def test_seven_favorites_leaves_no_room(db_session):
+    """7 favoris validés → aucun slot restant → aucune suggérée."""
+    user_id = uuid4()
+    db_session.add(UserProfile(user_id=user_id, onboarding_completed=True))
+    slugs = ["tech", "science", "society", "culture", "economy", "politics", "sport"]
+    for pos, slug in enumerate(slugs):
+        db_session.add(
+            UserFavoriteInterest(user_id=user_id, position=pos, interest_slug=slug)
+        )
+        db_session.add(
+            UserInterest(
+                user_id=user_id,
+                interest_slug=slug,
+                weight=1.0,
+                state=InterestState.FOLLOWED,
+            )
+        )
+    # Une source suivie qui pourrait être suggérée s'il restait de la place.
+    src = _source("Extra", "international")
+    db_session.add(src)
+    await db_session.flush()
+    for d in range(5):
+        db_session.add(_content(src.id, "international", days_ago=d))
+    db_session.add(
+        UserSource(
+            user_id=user_id,
+            source_id=src.id,
+            is_custom=False,
+            state=InterestState.FOLLOWED,
+        )
+    )
+    await db_session.commit()
+
+    async def _fake_user():
+        return str(user_id)
+
+    async def _fake_db():
+        yield db_session
+
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/api/users/top-themes")
+        body = resp.json()
+        assert len(body) == 7
+        assert all(t["origin"] == "validated" for t in body)
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.mark.asyncio
+async def test_source_suggestion_serialization(db_session):
+    """Une source suggérée porte kind=source + source_id dans le payload JSON."""
+    user_id = uuid4()
+    db_session.add(UserProfile(user_id=user_id, onboarding_completed=True))
+    db_session.add(
+        UserFavoriteInterest(user_id=user_id, position=0, interest_slug="tech")
+    )
+    src = _source("Mediapart", "politics")
+    db_session.add(src)
+    await db_session.flush()
+    for d in range(6):
+        db_session.add(_content(src.id, "politics", days_ago=d))
+    db_session.add(
+        UserSource(
+            user_id=user_id,
+            source_id=src.id,
+            is_custom=False,
+            state=InterestState.FOLLOWED,
+        )
+    )
+    await db_session.commit()
+
+    async def _fake_user():
+        return str(user_id)
+
+    async def _fake_db():
+        yield db_session
+
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/api/users/top-themes")
+        body = resp.json()
+        sources = [t for t in body if t["kind"] == "source"]
+        assert len(sources) == 1
+        assert sources[0]["source_id"] == str(src.id)
+        assert sources[0]["origin"] == "suggested"
+        assert sources[0]["reason"] is not None
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)

--- a/packages/api/tests/services/test_tournee_suggester.py
+++ b/packages/api/tests/services/test_tournee_suggester.py
@@ -1,0 +1,291 @@
+"""Tests du `TourneeSuggester` — arrangement intelligent de la Tournée (Story 22.3).
+
+Couvre : exclusion validées + muted, plancher de contenu, correction de la
+raison (breakdown vrai, label dominant, aucune suggérée sans breakdown),
+déterminisme du seed, capacité (sub_cap), et suggestions source + élargissement
+doux.
+
+DB locale : `DATABASE_URL` → facteur_test (54322), cf. conftest.
+"""
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from app.models.content import Content
+from app.models.enums import ContentType, InterestState, ReliabilityScore, SourceType
+from app.models.source import Source, UserSource
+from app.models.user import UserInterest, UserProfile
+from app.models.user_personalization import UserPersonalization
+from app.services.recommendation.scoring_config import ScoringWeights
+from app.services.recommendation.tournee_suggester import TourneeSuggester
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _source(
+    name: str,
+    theme: str,
+    *,
+    curated: bool = True,
+    reliability: ReliabilityScore = ReliabilityScore.HIGH,
+) -> Source:
+    return Source(
+        id=uuid4(),
+        name=name,
+        url=f"https://example.com/{uuid4()}",
+        feed_url=f"https://example.com/{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme=theme,
+        is_active=True,
+        is_curated=curated,
+        reliability_score=reliability,
+    )
+
+
+def _content(source_id, theme: str, *, days_ago: int = 1) -> Content:
+    return Content(
+        id=uuid4(),
+        source_id=source_id,
+        title="Article",
+        url=f"https://example.com/{uuid4()}",
+        guid=str(uuid4()),
+        published_at=datetime.now(UTC) - timedelta(days=days_ago),
+        content_type=ContentType.ARTICLE,
+        theme=theme,
+    )
+
+
+async def _seed_theme_content(db, theme: str, n: int) -> Source:
+    """Crée une source curée + `n` articles récents pour un thème."""
+    src = _source(f"src-{theme}", theme)
+    db.add(src)
+    await db.flush()
+    for i in range(n):
+        db.add(_content(src.id, theme, days_ago=i % 7))
+    await db.flush()
+    return src
+
+
+async def _make_user(db) -> UserProfile:
+    profile = UserProfile(user_id=uuid4(), onboarding_completed=True)
+    db.add(profile)
+    await db.flush()
+    return profile
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_excludes_validated_and_muted(db_session):
+    """Un thème validé (déjà rendu) ou muté n'est jamais suggéré."""
+    user = await _make_user(db_session)
+    uid = user.user_id
+    # 3 thèmes suivis, tous avec du contenu.
+    for theme in ("tech", "science", "sport"):
+        await _seed_theme_content(
+            db_session, theme, ScoringWeights.TOURNEE_SUGGEST_CONTENT_FLOOR + 2
+        )
+        db_session.add(
+            UserInterest(
+                user_id=uid,
+                interest_slug=theme,
+                weight=1.0,
+                state=InterestState.FOLLOWED,
+            )
+        )
+    # science est muté.
+    db_session.add(
+        UserPersonalization(user_id=uid, muted_themes=["science"], muted_sources=[])
+    )
+    await db_session.flush()
+
+    # tech est déjà validé → exclu. science muté → exclu. Reste sport.
+    suggestions = await TourneeSuggester(db_session).arrange(
+        uid, validated_theme_slugs={"tech"}, sub_cap=4
+    )
+    theme_slugs = {s.slug for s in suggestions if s.kind == "theme"}
+    assert "tech" not in theme_slugs
+    assert "science" not in theme_slugs
+    assert "sport" in theme_slugs
+
+
+@pytest.mark.asyncio
+async def test_content_floor_excludes_sparse_themes(db_session):
+    """Un thème suivi sous le plancher de contenu est écarté."""
+    user = await _make_user(db_session)
+    uid = user.user_id
+    # tech : sous le plancher (floor-1). science : au-dessus.
+    await _seed_theme_content(
+        db_session, "tech", ScoringWeights.TOURNEE_SUGGEST_CONTENT_FLOOR - 1
+    )
+    await _seed_theme_content(
+        db_session, "science", ScoringWeights.TOURNEE_SUGGEST_CONTENT_FLOOR + 3
+    )
+    for theme in ("tech", "science"):
+        db_session.add(
+            UserInterest(
+                user_id=uid,
+                interest_slug=theme,
+                weight=1.0,
+                state=InterestState.FOLLOWED,
+            )
+        )
+    await db_session.flush()
+
+    suggestions = await TourneeSuggester(db_session).arrange(
+        uid, validated_theme_slugs=set(), sub_cap=4
+    )
+    theme_slugs = {s.slug for s in suggestions if s.kind == "theme"}
+    assert "tech" not in theme_slugs  # sous le floor
+    assert "science" in theme_slugs
+
+
+@pytest.mark.asyncio
+async def test_reason_breakdown_is_true_and_never_empty(db_session):
+    """Chaque suggérée a un breakdown non vide, vrai, avec label dominant."""
+    user = await _make_user(db_session)
+    uid = user.user_id
+    n = ScoringWeights.TOURNEE_SUGGEST_CONTENT_FLOOR + 4
+    await _seed_theme_content(db_session, "tech", n)
+    db_session.add(
+        UserInterest(
+            user_id=uid, interest_slug="tech", weight=1.0, state=InterestState.FOLLOWED
+        )
+    )
+    await db_session.flush()
+
+    suggestions = await TourneeSuggester(db_session).arrange(
+        uid, validated_theme_slugs=set(), sub_cap=4
+    )
+    assert suggestions, "tech devrait être suggéré"
+    for s in suggestions:
+        # Invariant anti-boîte-noire : jamais de suggérée sans breakdown.
+        assert s.breakdown, "aucune suggérée sans breakdown"
+        assert s.reason_label
+        assert s.reason_label == s.breakdown[0].label  # dominant en tête
+        labels = [c.label for c in s.breakdown]
+        # La quantité réelle est reflétée (n articles), et la diversité est la
+        # dernière puce (miroir « Hasard pour diversifier »).
+        assert any("article" in label for label in labels)
+        assert s.breakdown[-1].label == "Varié pour aujourd'hui"
+    tech = next(s for s in suggestions if s.slug == "tech")
+    assert any("thème" in c.label for c in tech.breakdown)  # explicit présent
+
+
+@pytest.mark.asyncio
+async def test_deterministic_within_day(db_session):
+    """Même user + même jour → même ordre (seed daily)."""
+    user = await _make_user(db_session)
+    uid = user.user_id
+    for theme in ("tech", "science", "sport", "culture", "economy"):
+        await _seed_theme_content(
+            db_session, theme, ScoringWeights.TOURNEE_SUGGEST_CONTENT_FLOOR + 2
+        )
+        db_session.add(
+            UserInterest(
+                user_id=uid,
+                interest_slug=theme,
+                weight=1.0,
+                state=InterestState.FOLLOWED,
+            )
+        )
+    await db_session.flush()
+
+    first = await TourneeSuggester(db_session).arrange(uid, set(), sub_cap=4)
+    second = await TourneeSuggester(db_session).arrange(uid, set(), sub_cap=4)
+    assert [s.key for s in first] == [s.key for s in second]
+
+
+@pytest.mark.asyncio
+async def test_sub_cap_zero_returns_empty(db_session):
+    """sub_cap <= 0 (Tournée pleine) → aucune suggestion."""
+    user = await _make_user(db_session)
+    await _seed_theme_content(db_session, "tech", 5)
+    db_session.add(
+        UserInterest(
+            user_id=user.user_id,
+            interest_slug="tech",
+            weight=1.0,
+            state=InterestState.FOLLOWED,
+        )
+    )
+    await db_session.flush()
+    assert (
+        await TourneeSuggester(db_session).arrange(user.user_id, set(), sub_cap=0) == []
+    )
+
+
+@pytest.mark.asyncio
+async def test_sub_cap_limits_count(db_session):
+    """Le nombre de suggérées ne dépasse jamais sub_cap."""
+    user = await _make_user(db_session)
+    uid = user.user_id
+    for theme in ("tech", "science", "sport", "culture", "economy", "politics"):
+        await _seed_theme_content(
+            db_session, theme, ScoringWeights.TOURNEE_SUGGEST_CONTENT_FLOOR + 2
+        )
+        db_session.add(
+            UserInterest(
+                user_id=uid,
+                interest_slug=theme,
+                weight=1.0,
+                state=InterestState.FOLLOWED,
+            )
+        )
+    await db_session.flush()
+    suggestions = await TourneeSuggester(db_session).arrange(uid, set(), sub_cap=2)
+    assert len(suggestions) == 2
+
+
+@pytest.mark.asyncio
+async def test_followed_source_is_suggested(db_session):
+    """Une source suivie (non favorite) avec du contenu devient une suggérée."""
+    user = await _make_user(db_session)
+    uid = user.user_id
+    src = _source("Le Monde", "society")
+    db_session.add(src)
+    await db_session.flush()
+    for i in range(ScoringWeights.TOURNEE_SUGGEST_CONTENT_FLOOR + 2):
+        db_session.add(_content(src.id, "society", days_ago=i % 5))
+    db_session.add(
+        UserSource(
+            user_id=uid, source_id=src.id, is_custom=False, state=InterestState.FOLLOWED
+        )
+    )
+    await db_session.flush()
+
+    suggestions = await TourneeSuggester(db_session).arrange(uid, set(), sub_cap=4)
+    src_suggestions = [s for s in suggestions if s.kind == "source"]
+    assert len(src_suggestions) == 1
+    s = src_suggestions[0]
+    assert s.source_id == src.id
+    assert s.key == f"source:{src.id}"
+    assert any("source" in c.label for c in s.breakdown)
+
+
+@pytest.mark.asyncio
+async def test_soft_expansion_curated_on_followed_theme(db_session):
+    """Pool maigre → élargissement doux : source curée sur un thème suivi."""
+    user = await _make_user(db_session)
+    uid = user.user_id
+    # Thème suivi tech, MAIS aucun contenu pour le thème (donc pas de candidat
+    # thème direct) — seule une source curée tech avec du contenu existe.
+    src = _source("Tech Source", "tech")
+    db_session.add(src)
+    await db_session.flush()
+    for i in range(ScoringWeights.TOURNEE_SUGGEST_CONTENT_FLOOR + 2):
+        db_session.add(_content(src.id, "tech", days_ago=i % 5))
+    db_session.add(
+        UserInterest(
+            user_id=uid, interest_slug="tech", weight=1.0, state=InterestState.FOLLOWED
+        )
+    )
+    await db_session.flush()
+
+    suggestions = await TourneeSuggester(db_session).arrange(uid, set(), sub_cap=4)
+    soft = [s for s in suggestions if s.kind == "source" and s.is_soft]
+    assert soft, "la source curée on-thème devrait être suggérée en doux"
+    assert any("thème que tu suis" in c.label for c in soft[0].breakdown)


### PR DESCRIPTION
## Quoi

La Tournée du jour était **statique** : favoris épinglés dans un ordre fixe, complétés pour les comptes neufs par un triplet **codé en dur** (`const canonical = [tech, environment, science]`). Cette PR la transforme en un **arrangement quotidien intelligent** par-dessus la config que l'utilisateur a **déjà déclarée** : des sections « Choisie pour vous » remplissent les slots restants à partir des thèmes/sources **suivis mais non épinglés**, jamais hors préférences réelles. La « surprise » = diversité + variation jour après jour, pas un moteur de découverte.

Feature activée par défaut, avec un **switch discret** dans « Composer ma Tournée » pour la désactiver.

## Pourquoi

Rien ne variait d'un jour à l'autre, rien ne tenait compte du contenu réellement disponible, et un thème/source **suivi** (non épinglé) ne remontait jamais. Le fallback macro-thèmes statique injectait du contenu non choisi sur les comptes peu configurés.

## Comment ça marche

**Backend (additif, zéro migration)**
- Nouveau `TourneeSuggester.arrange()` : pool issu du déclaré (suivis non épinglés + élargissement doux aux sources curées on-thème) → filtres durs (muted + plancher de contenu 14 j) → blend `daily_score` (40 % explicit / 30 % measured / 20 % quantity / 10 % quality) → variation déterministe (`compute_seed` + `randomized_sort`, réutilise le pattern digest) → cap 4.
- `TopThemeResponse` étendu rétro-compatible : `kind="source"`, `source_id`, `origin` (`validated` défaut), `daily_rank`, `reason`. `get_top_themes` funnel les deux chemins via `_arrange_tournee`.
- Toggle **default-ON** sans migration : `tournee_smart_arrangement` dans `ALLOWED_PREFERENCE_KEYS` ; seule la valeur `"false"` désactive.
- Transparence : chaque suggérée porte un `reason` **vrai** (breakdown depuis les seules composantes > 0). Invariant testé : aucune suggérée sans breakdown.

**Mobile**
- Suppression du `const canonical` codé en dur.
- `FeedThemeSection` porte `origin` + `reason` ; badge « Choisie pour vous » + « i » → sheet « Pourquoi cette section ? » (garder en favori / retirer).
- Switch global dans « Composer ma Tournée » (miroir de `sereinToggleProvider`).
- Validées jamais masquées ni reléguées sous les suggérées ; dismiss = mémoire locale (`hiddenKeys`) ; suggérées vidées par le dédup inter-sections droppées (pas de bandeau orphelin).

## Comment ça a été vérifié

- [x] Backend `pytest` : suite complète **1810 passed**, dont **12 nouveaux** (`test_tournee_suggester` + `test_top_themes_suggestions`)
- [x] `flutter test` : tous les tests `flux_continu` + sheets verts ; suite mobile sans **nouvel** échec (les ~22 échecs restants sont pré-existants, Hive/Supabase non init, hors périmètre)
- [x] `flutter analyze` propre sur les fichiers touchés
- [x] `/simplify` passé (réutilisation des builders de section + garde-fou efficacité)
- [ ] Playwright E2E : **non exécuté** — à lancer via `/validate-feature` (étape QA web séparée) avant déploiement, feature très visuelle

## Zones à risque

- `GET /top-themes` (hot path) : +1 requête de toggle par appel, + le coût du suggester quand des slots restent (gaté : no-op si Tournée pleine ou toggle off).
- Composition des sections Tournée (`flux_continu_provider`) : ordering validées/suggérées, dédup, `_dropEmptySuggested`.
- `TopThemeResponse` : champs additifs `origin="validated"` par défaut → anciens clients/payloads inchangés.

## Notes
- **Pas de migration Alembic** (toggle = préférence existante, champs API additifs).
- Story : `docs/stories/core/22.3.tournee-arrangement-intelligent.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
