### PR TITLE
feat(auth): écran de réinitialisation de mot de passe + deep link

### DIFF
--- a/apps/mobile/lib/config/routes.dart
+++ b/apps/mobile/lib/config/routes.dart
@@ -6,6 +6,7 @@ import '../shared/widgets/navigation/swipe_back_page.dart';
 import '../shared/widgets/navigation/main_shell.dart';
 
 import '../features/auth/screens/login_screen.dart';
+import '../features/auth/screens/reset_password_screen.dart';
 import '../features/auth/screens/splash_screen.dart';
 import '../features/onboarding/screens/onboarding_screen.dart';
 import '../features/onboarding/screens/conclusion_animation_screen.dart';
@@ -96,6 +97,7 @@ class RouteNames {
   static const String quiz = 'quiz';
   static const String paywall = 'paywall';
   static const String emailConfirmation = 'email-confirmation';
+  static const String resetPassword = 'reset-password';
   static const String myInterests = 'my-interests';
   static const String topicExplorer = 'topic-explorer';
   static const String themeSources = 'theme-sources';
@@ -138,6 +140,7 @@ class RoutePaths {
   static const String quiz = '/quiz';
   static const String paywall = '/paywall';
   static const String emailConfirmation = '/email-confirmation';
+  static const String resetPassword = '/reset-password';
   static const String veilleConfig = '/veille/config';
   static const String lettres = '/lettres';
   static const String openLetter = '/lettres/:id';
@@ -195,14 +198,17 @@ final routerProvider = Provider<GoRouter>((ref) {
       final isOnLoginPage = matchedLocation == RoutePaths.login;
       final isOnEmailConfirmation =
           matchedLocation == RoutePaths.emailConfirmation;
+      final isOnResetPassword = matchedLocation == RoutePaths.resetPassword;
       final isOnOnboarding = matchedLocation == RoutePaths.onboarding ||
           matchedLocation == RoutePaths.onboardingConclusion;
-      // Escape hatch: the onboarding "Personnaliser mon mode serein" CTA pushes
-      // the interests screen with ?serein=1. Let that through so the user can
-      // configure their exclusions before completing onboarding.
-      final isOnInterestsFromOnboarding =
-          matchedLocation == RoutePaths.myInterests &&
-              state.uri.queryParameters['serein'] == '1';
+
+      if (authState.passwordRecoveryPending && !isOnResetPassword) {
+        return RoutePaths.resetPassword;
+      }
+
+      if (isOnResetPassword) {
+        return null;
+      }
 
       // 1. Les utilisateurs non connectés
       if (!isLoggedIn) {
@@ -241,9 +247,7 @@ final routerProvider = Provider<GoRouter>((ref) {
       }
 
       // 4. Onboarding : forcer si nécessaire
-      if (authState.needsOnboarding &&
-          !isOnOnboarding &&
-          !isOnInterestsFromOnboarding) {
+      if (authState.needsOnboarding && !isOnOnboarding) {
         return RoutePaths.onboarding;
       }
 
@@ -281,6 +285,12 @@ final routerProvider = Provider<GoRouter>((ref) {
                 '',
           );
         },
+      ),
+
+      GoRoute(
+        path: RoutePaths.resetPassword,
+        name: RouteNames.resetPassword,
+        builder: (context, state) => const ResetPasswordScreen(),
       ),
 
       // Onboarding

--- a/apps/mobile/lib/core/auth/auth_state.dart
+++ b/apps/mobile/lib/core/auth/auth_state.dart
@@ -44,6 +44,11 @@ class AuthState {
   /// Cf. docs/bugs/bug-feed-403-auth-recovery.md.
   final DateTime? lastTokenRefreshAt;
 
+  /// Un lien Supabase de récupération de mot de passe vient d'ouvrir l'app.
+  /// Le router doit présenter l'écran de nouveau mot de passe tant que ce flag
+  /// n'a pas été consommé après `updateUser`.
+  final bool passwordRecoveryPending;
+
   const AuthState({
     this.user,
     this.isLoading = false,
@@ -54,6 +59,7 @@ class AuthState {
     this.forceUnconfirmed = false,
     this.sessionExpired = false,
     this.lastTokenRefreshAt,
+    this.passwordRecoveryPending = false,
   });
 
   bool get isAuthenticated => user != null;
@@ -95,6 +101,7 @@ class AuthState {
     bool? forceUnconfirmed,
     bool? sessionExpired,
     DateTime? lastTokenRefreshAt,
+    bool? passwordRecoveryPending,
   }) {
     return AuthState(
       user: user ?? this.user,
@@ -109,6 +116,8 @@ class AuthState {
       forceUnconfirmed: forceUnconfirmed ?? this.forceUnconfirmed,
       sessionExpired: sessionExpired ?? this.sessionExpired,
       lastTokenRefreshAt: lastTokenRefreshAt ?? this.lastTokenRefreshAt,
+      passwordRecoveryPending:
+          passwordRecoveryPending ?? this.passwordRecoveryPending,
     );
   }
 }
@@ -117,10 +126,14 @@ class AuthState {
 class AuthStateNotifier extends StateNotifier<AuthState>
     with WidgetsBindingObserver {
   AuthStateNotifier() : super(const AuthState(isLoading: true)) {
+    _supabase = Supabase.instance.client;
     _init();
   }
 
-  final _supabase = Supabase.instance.client;
+  @visibleForTesting
+  AuthStateNotifier.test(AuthState initialState) : super(initialState);
+
+  late final SupabaseClient _supabase;
 
   /// Timestamp of the last forceUnconfirmed set. Used to debounce
   /// repeated 403s and avoid redirect loops.
@@ -180,8 +193,7 @@ class AuthStateNotifier extends StateNotifier<AuthState>
       // uniquement, AVANT de peindre (synchrone, ne bloque rien).
       if (session != null) {
         final user = session.user;
-        final isConfirmed =
-            user.emailConfirmedAt != null ||
+        final isConfirmed = user.emailConfirmedAt != null ||
             (user.appMetadata['providers'] as List<dynamic>?)?.any(
                   (p) => p != 'email',
                 ) ==
@@ -214,44 +226,42 @@ class AuthStateNotifier extends StateNotifier<AuthState>
         // l'unique source du signal d'invalidation (cf.
         // bug-feed-403-auth-recovery.md) — on ne re-pose pas `lastTokenRefreshAt`.
         unawaited(
-          refreshFuture
-              .then((_) {
-                debugPrint('AuthStateNotifier: ✅ Initial refresh done.');
-              })
-              .catchError((Object e) async {
-                if (e is! AuthException) {
-                  // Réseau lent / timeout → garder la session ; le SDK auto-refresh
-                  // (et l'intercepteur 401 single-flight) prendront le relais.
-                  debugPrint(
-                    'AuthStateNotifier: Initial refresh failed (non-auth): $e. Using existing session.',
-                  );
-                  return;
-                }
-                debugPrint(
-                  'AuthStateNotifier: Initial refresh failed (AuthException): ${e.message}',
-                );
-                unawaited(
-                  PostHogService().capture(
-                    event: 'auth_session_expired',
-                    properties: {'reason': 'init_refresh_failed'},
-                  ),
-                );
-                unawaited(
-                  Sentry.captureException(
-                    e,
-                    withScope: (scope) =>
-                        scope.setTag('auth_event', 'init_refresh_failed'),
-                  ),
-                );
-                await _supabase.auth.signOut().timeout(
+          refreshFuture.then((_) {
+            debugPrint('AuthStateNotifier: ✅ Initial refresh done.');
+          }).catchError((Object e) async {
+            if (e is! AuthException) {
+              // Réseau lent / timeout → garder la session ; le SDK auto-refresh
+              // (et l'intercepteur 401 single-flight) prendront le relais.
+              debugPrint(
+                'AuthStateNotifier: Initial refresh failed (non-auth): $e. Using existing session.',
+              );
+              return;
+            }
+            debugPrint(
+              'AuthStateNotifier: Initial refresh failed (AuthException): ${e.message}',
+            );
+            unawaited(
+              PostHogService().capture(
+                event: 'auth_session_expired',
+                properties: {'reason': 'init_refresh_failed'},
+              ),
+            );
+            unawaited(
+              Sentry.captureException(
+                e,
+                withScope: (scope) =>
+                    scope.setTag('auth_event', 'init_refresh_failed'),
+              ),
+            );
+            await _supabase.auth.signOut().timeout(
                   const Duration(seconds: 3),
                   onTimeout: () {},
                 );
-                // Clear user + isLoading + pose sessionExpired (le state authentifié a
-                // déjà été peint à l'étape 6 ; la garde `_fetchAll` des data providers
-                // maintient le squelette jusqu'à cette résolution).
-                state = const AuthState(sessionExpired: true);
-              }),
+            // Clear user + isLoading + pose sessionExpired (le state authentifié a
+            // déjà été peint à l'étape 6 ; la garde `_fetchAll` des data providers
+            // maintient le squelette jusqu'à cette résolution).
+            state = const AuthState(sessionExpired: true);
+          }),
         );
       }
 
@@ -295,6 +305,8 @@ class AuthStateNotifier extends StateNotifier<AuthState>
       // providers (feedProvider, etc.) qu'ils peuvent re-fetcher avec un
       // access token frais. Cf. docs/bugs/bug-feed-403-auth-recovery.md.
       final bool isTokenRefresh = data.event == AuthChangeEvent.tokenRefreshed;
+      final bool isPasswordRecovery =
+          data.event == AuthChangeEvent.passwordRecovery;
 
       // Éviter les mises à jour inutiles si l'user n'a pas changé.
       // IMPORTANT: si `forceUnconfirmed` est true, on NE court-circuite PAS —
@@ -303,7 +315,10 @@ class AuthStateNotifier extends StateNotifier<AuthState>
       // de confirmation email même après que le backend a validé son email).
       final bool sameUser =
           state.user?.id == user?.id && !state.isLoading && state.user != null;
-      if (sameUser && !state.forceUnconfirmed && !isTokenRefresh) {
+      if (sameUser &&
+          !state.forceUnconfirmed &&
+          !isTokenRefresh &&
+          !isPasswordRecovery) {
         final bool emailStatusChanged =
             state.user?.emailConfirmedAt != user?.emailConfirmedAt;
         if (!emailStatusChanged) {
@@ -313,8 +328,7 @@ class AuthStateNotifier extends StateNotifier<AuthState>
       if (state.user == null && user == null && !state.isLoading) return;
 
       // Vérifier si l'email est maintenant confirmé pour reset forceUnconfirmed
-      final isNowConfirmed =
-          user?.emailConfirmedAt != null ||
+      final isNowConfirmed = user?.emailConfirmedAt != null ||
           (user?.appMetadata['providers'] as List<dynamic>?)?.any(
                 (p) => p != 'email',
               ) ==
@@ -328,9 +342,11 @@ class AuthStateNotifier extends StateNotifier<AuthState>
         isLoading: false,
         forceUnconfirmed: isNowConfirmed ? false : state.forceUnconfirmed,
         lastTokenRefreshAt: isTokenRefresh ? DateTime.now() : null,
+        passwordRecoveryPending:
+            isPasswordRecovery ? true : state.passwordRecoveryPending,
       );
 
-      if (user != null && isNewSignIn) {
+      if (user != null && (isNewSignIn || isPasswordRecovery)) {
         // Check onboarding on first sign-in (new user appearing).
         _loadSessionProfile();
       }
@@ -363,13 +379,13 @@ class AuthStateNotifier extends StateNotifier<AuthState>
     );
     final expiredUserId = state.user?.id;
     await ServerPushService.instance.revokeCurrentDevice().timeout(
-      const Duration(seconds: 2),
-      onTimeout: () {},
-    );
+          const Duration(seconds: 2),
+          onTimeout: () {},
+        );
     await _supabase.auth.signOut().timeout(
-      const Duration(seconds: 3),
-      onTimeout: () {},
-    );
+          const Duration(seconds: 3),
+          onTimeout: () {},
+        );
     if (expiredUserId != null) {
       await _clearPendingReadsForUser(expiredUserId);
     }
@@ -421,8 +437,8 @@ class AuthStateNotifier extends StateNotifier<AuthState>
     final prefix = 'read:$userId:';
     await pendingReads.deleteAll(
       pendingReads.keys.whereType<String>().where(
-        (key) => key.startsWith(prefix),
-      ),
+            (key) => key.startsWith(prefix),
+          ),
     );
   }
 
@@ -451,8 +467,8 @@ class AuthStateNotifier extends StateNotifier<AuthState>
         .refresh()
         .then((_) => debugPrint('AuthStateNotifier: Resume refresh done.'))
         .catchError((Object e) {
-          debugPrint('AuthStateNotifier: Resume refresh failed: $e');
-        });
+      debugPrint('AuthStateNotifier: Resume refresh failed: $e');
+    });
   }
 
   @override
@@ -611,10 +627,21 @@ class AuthStateNotifier extends StateNotifier<AuthState>
     }
   }
 
+  String _nativeAuthCallbackUrl() => 'io.supabase.facteur://login-callback';
+
+  String _webAuthCallbackUrl() => Uri(
+        scheme: Uri.base.scheme,
+        host: Uri.base.host,
+        path: Uri.base.path,
+      ).toString();
+
   Future<void> sendPasswordResetEmail(String email) async {
     state = state.copyWith(isLoading: true, clearError: true);
     try {
-      await _supabase.auth.resetPasswordForEmail(email);
+      await _supabase.auth.resetPasswordForEmail(
+        email,
+        redirectTo: kIsWeb ? _webAuthCallbackUrl() : _nativeAuthCallbackUrl(),
+      );
       state = state.copyWith(isLoading: false);
     } on AuthException catch (e) {
       state = state.copyWith(
@@ -626,6 +653,38 @@ class AuthStateNotifier extends StateNotifier<AuthState>
       state = state.copyWith(
         isLoading: false,
         error: 'Une erreur est survenue lors de l\'envoi de l\'email',
+      );
+      rethrow;
+    }
+  }
+
+  Future<void> updatePasswordFromRecovery(String password) async {
+    state = state.copyWith(isLoading: true, clearError: true);
+    try {
+      await _supabase.auth.updateUser(UserAttributes(password: password));
+      try {
+        await SessionRefresher.instance.refresh();
+      } catch (e) {
+        debugPrint(
+          'AuthStateNotifier: Post-password-update refresh failed: $e',
+        );
+      }
+      state = state.copyWith(
+        isLoading: false,
+        passwordRecoveryPending: false,
+        forceUnconfirmed: false,
+      );
+      await _checkOnboardingStatus();
+    } on AuthException catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        error: AuthErrorMessages.translate(e.message),
+      );
+      rethrow;
+    } catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        error: 'Une erreur est survenue lors du changement de mot de passe',
       );
       rethrow;
     }
@@ -774,21 +833,29 @@ class AuthStateNotifier extends StateNotifier<AuthState>
   /// Sur AuthException, recheck `currentSession` avant de déconnecter — un
   /// refresh concurrent a peut-être déjà obtenu une session valide.
   /// Cf. docs/bugs/bug-android-disconnect-race.md.
-  Future<void> refreshUser() async {
+  Future<bool> refreshUser({bool forceSessionRefresh = false}) async {
     // Skip the network call once the user is known confirmed — the
     // EmailConfirmationScreen polls every 6 s and the router redirect can lag,
     // so without this guard we'd burn a GET /auth/v1/user per tick after
     // confirmation for nothing.
-    if (state.isEmailConfirmed) return;
+    if (state.isEmailConfirmed && !forceSessionRefresh) return true;
 
     try {
+      if (forceSessionRefresh) {
+        try {
+          await SessionRefresher.instance.refresh();
+        } catch (e) {
+          debugPrint(
+            'AuthStateNotifier: Forced session refresh failed: $e',
+          );
+        }
+      }
       debugPrint('AuthStateNotifier: Refreshing user via getUser()...');
       final userResponse = await _supabase.auth.getUser();
       final freshUser = userResponse.user;
-      if (freshUser == null) return;
+      if (freshUser == null) return false;
 
-      final isNowConfirmed =
-          freshUser.emailConfirmedAt != null ||
+      final isNowConfirmed = freshUser.emailConfirmedAt != null ||
           (freshUser.appMetadata['providers'] as List<dynamic>?)?.any(
                 (p) => p != 'email',
               ) ==
@@ -813,12 +880,16 @@ class AuthStateNotifier extends StateNotifier<AuthState>
       final emailStatusChanged =
           state.user?.emailConfirmedAt != freshUser.emailConfirmedAt;
       final forceFlagChanged = state.forceUnconfirmed && isNowConfirmed;
-      if (!emailStatusChanged && !forceFlagChanged) return;
+      if (!emailStatusChanged && !forceFlagChanged) return isNowConfirmed;
 
       state = state.copyWith(
         user: freshUser,
         forceUnconfirmed: isNowConfirmed ? false : state.forceUnconfirmed,
       );
+      if (isNowConfirmed) {
+        await _checkOnboardingStatus();
+      }
+      return isNowConfirmed;
     } on AuthException catch (e) {
       debugPrint(
         'AuthStateNotifier: Refresh failed (AuthException): ${e.message}',
@@ -832,7 +903,7 @@ class AuthStateNotifier extends StateNotifier<AuthState>
         debugPrint(
           'AuthStateNotifier: Concurrent refresh recovered session — not signing out.',
         );
-        return;
+        return state.isEmailConfirmed;
       }
 
       // Détecter si le refresh token est vraiment expiré/invalide.
@@ -850,9 +921,11 @@ class AuthStateNotifier extends StateNotifier<AuthState>
         debugPrint('AuthStateNotifier: Refresh token expired. Ending session.');
         await handleSessionExpired(reason: 'refresh_token_expired');
       }
+      return state.isEmailConfirmed;
     } catch (e) {
       // Erreur réseau ou autre — ne rien faire, le SDK auto-refresh réessaiera
       debugPrint('AuthStateNotifier ERROR: Failed to refresh user: $e');
+      return state.isEmailConfirmed;
     }
   }
 

--- a/apps/mobile/lib/core/services/deep_link_service.dart
+++ b/apps/mobile/lib/core/services/deep_link_service.dart
@@ -20,10 +20,8 @@ import 'analytics_service.dart';
 /// - `io.supabase.facteur://veille/dashboard` → `/veille/dashboard`
 /// - `io.supabase.facteur://grille` → `/grille` (« Le mot du jour », partagé
 ///   entre amis — ouvre la grille dans l'app au lieu du site facteur.app)
-///
-/// `io.supabase.facteur://login-callback` is intentionally ignored — Supabase
-/// SDK intercepts it before it reaches us. Anything else falls through to
-/// GoRouter's `errorBuilder`, which is a safety net only.
+/// - `io.supabase.facteur://login-callback#...` → auth callback, routed by the
+///   auth state listener. Password recovery opens `/reset-password`.
 class DeepLinkService {
   DeepLinkService._({AppLinks? appLinks, AnalyticsService? analytics})
       : _appLinks = appLinks ?? AppLinks(),
@@ -120,13 +118,13 @@ class DeepLinkService {
   void _handle(Uri uri) {
     debugPrint('DeepLinkService: incoming uri=$uri');
 
-    // Supabase OAuth/email confirmation — let the SDK handle it.
-    if (uri.host == 'login-callback' ||
-        uri.path.startsWith('/login-callback')) {
+    if (uri.scheme != 'io.supabase.facteur') {
       return;
     }
 
-    if (uri.scheme != 'io.supabase.facteur') {
+    final action = parse(uri);
+    if (action.target == WidgetDeepLinkTarget.authCallback) {
+      _route(uri);
       return;
     }
 
@@ -188,6 +186,9 @@ class DeepLinkService {
         _analytics?.trackWidgetAppOpened(target: 'grille');
         router.go(action.route!);
         return;
+      case WidgetDeepLinkTarget.authCallback:
+        router.go(action.route ?? RoutePaths.splash);
+        return;
       case WidgetDeepLinkTarget.ignored:
       case WidgetDeepLinkTarget.unhandled:
         debugPrint('DeepLinkService: unhandled uri=$uri');
@@ -202,7 +203,14 @@ class DeepLinkService {
   static WidgetDeepLinkAction parse(Uri uri) {
     if (uri.host == 'login-callback' ||
         uri.path.startsWith('/login-callback')) {
-      return const WidgetDeepLinkAction(target: WidgetDeepLinkTarget.ignored);
+      final authType = _authCallbackType(uri);
+      return WidgetDeepLinkAction(
+        target: WidgetDeepLinkTarget.authCallback,
+        route: authType == 'recovery'
+            ? RoutePaths.resetPassword
+            : RoutePaths.splash,
+        authType: authType,
+      );
     }
     if (uri.scheme != 'io.supabase.facteur') {
       return const WidgetDeepLinkAction(target: WidgetDeepLinkTarget.unhandled);
@@ -287,6 +295,13 @@ class DeepLinkService {
     return const WidgetDeepLinkAction(target: WidgetDeepLinkTarget.unhandled);
   }
 
+  static String? _authCallbackType(Uri uri) {
+    final fromQuery = uri.queryParameters['type'];
+    if (fromQuery != null && fromQuery.isNotEmpty) return fromQuery;
+    if (uri.fragment.isEmpty) return null;
+    return Uri.splitQueryString(uri.fragment)['type'];
+  }
+
   static String? _extractArticleIdFrom(String host, List<String> segments) {
     if (host == 'digest') {
       if (segments.isNotEmpty) return segments.first;
@@ -312,6 +327,7 @@ enum WidgetDeepLinkTarget {
   feed,
   veille,
   grille,
+  authCallback,
   ignored,
   unhandled,
 }
@@ -322,6 +338,7 @@ class WidgetDeepLinkAction {
   final String? articleId;
   final int? position;
   final String? topicId;
+  final String? authType;
 
   const WidgetDeepLinkAction({
     required this.target,
@@ -329,5 +346,6 @@ class WidgetDeepLinkAction {
     this.articleId,
     this.position,
     this.topicId,
+    this.authType,
   });
 }

--- a/apps/mobile/lib/features/auth/screens/email_confirmation_screen.dart
+++ b/apps/mobile/lib/features/auth/screens/email_confirmation_screen.dart
@@ -29,6 +29,7 @@ class _EmailConfirmationScreenState
     extends ConsumerState<EmailConfirmationScreen> {
   bool _resending = false;
   bool _resent = false;
+  bool _checking = false;
   Timer? _autoRefreshTimer;
 
   @override
@@ -39,7 +40,7 @@ class _EmailConfirmationScreenState
       const Duration(seconds: 6),
       (_) {
         if (mounted) {
-          ref.read(authStateProvider.notifier).refreshUser();
+          unawaited(ref.read(authStateProvider.notifier).refreshUser());
         }
       },
     );
@@ -76,6 +77,33 @@ class _EmailConfirmationScreenState
         NotificationService.showError(
           'Impossible de renvoyer l\'email. Réessaie plus tard.',
         );
+      }
+    }
+  }
+
+  Future<void> _checkConfirmation() async {
+    if (_checking) return;
+    setState(() => _checking = true);
+    try {
+      final confirmed = await ref
+          .read(authStateProvider.notifier)
+          .refreshUser(forceSessionRefresh: true);
+      if (!mounted) return;
+      if (confirmed) {
+        NotificationService.showSuccess('Email confirmé.');
+      } else {
+        NotificationService.showInfo(
+          'Ton email n’est pas encore confirmé. Ouvre le lien reçu par email, puis réessaie.',
+        );
+      }
+    } catch (_) {
+      if (!mounted) return;
+      NotificationService.showError(
+        'Impossible de vérifier la confirmation pour le moment.',
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _checking = false);
       }
     }
   }
@@ -217,8 +245,7 @@ class _EmailConfirmationScreenState
                         Container(
                           padding: const EdgeInsets.all(16),
                           decoration: BoxDecoration(
-                            color:
-                                colors.surfaceElevated.withOpacity(0.5),
+                            color: colors.surfaceElevated.withOpacity(0.5),
                             borderRadius: BorderRadius.circular(12),
                           ),
                           child: Row(
@@ -252,8 +279,8 @@ class _EmailConfirmationScreenState
                         PrimaryButton(
                           label: 'J\'ai confirmé mon email',
                           icon: PhosphorIcons.check(PhosphorIconsStyle.bold),
-                          onPressed: () =>
-                              ref.read(authStateProvider.notifier).refreshUser(),
+                          onPressed: _checkConfirmation,
+                          isLoading: _checking,
                         ),
 
                         const SizedBox(height: 16),
@@ -269,8 +296,7 @@ class _EmailConfirmationScreenState
                                     horizontal: 20,
                                   ),
                                   decoration: BoxDecoration(
-                                    color:
-                                        colors.success.withOpacity(0.1),
+                                    color: colors.success.withOpacity(0.1),
                                     borderRadius: BorderRadius.circular(8),
                                   ),
                                   child: Row(
@@ -299,8 +325,7 @@ class _EmailConfirmationScreenState
                               : SecondaryButton(
                                   key: const ValueKey('resend'),
                                   label: 'Renvoyer l\'email',
-                                  icon:
-                                      PhosphorIcons.arrowCounterClockwise(
+                                  icon: PhosphorIcons.arrowCounterClockwise(
                                     PhosphorIconsStyle.regular,
                                   ),
                                   onPressed: _resendEmail,

--- a/apps/mobile/lib/features/auth/screens/login_screen.dart
+++ b/apps/mobile/lib/features/auth/screens/login_screen.dart
@@ -250,8 +250,8 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                       decoration: BoxDecoration(
                         color: colors.primary.withOpacity(0.1),
                         borderRadius: BorderRadius.circular(8),
-                        border: Border.all(
-                            color: colors.primary.withOpacity(0.3)),
+                        border:
+                            Border.all(color: colors.primary.withOpacity(0.3)),
                       ),
                       child: Row(
                         children: [

--- a/apps/mobile/lib/features/auth/screens/reset_password_screen.dart
+++ b/apps/mobile/lib/features/auth/screens/reset_password_screen.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../config/routes.dart';
+import '../../../config/theme.dart';
+import '../../../core/auth/auth_state.dart';
+import '../../../core/ui/notification_service.dart';
+import '../../../shared/widgets/buttons/primary_button.dart';
+
+class ResetPasswordScreen extends ConsumerStatefulWidget {
+  const ResetPasswordScreen({super.key});
+
+  @override
+  ConsumerState<ResetPasswordScreen> createState() =>
+      _ResetPasswordScreenState();
+}
+
+class _ResetPasswordScreenState extends ConsumerState<ResetPasswordScreen> {
+  final _passwordController = TextEditingController();
+  final _confirmController = TextEditingController();
+  bool _obscurePassword = true;
+  bool _obscureConfirm = true;
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+    _confirmController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    final password = _passwordController.text;
+    final confirm = _confirmController.text;
+
+    if (password.length < 8) {
+      NotificationService.showError(
+        'Choisis un mot de passe d’au moins 8 caractères.',
+      );
+      return;
+    }
+    if (password != confirm) {
+      NotificationService.showError(
+          'Les deux mots de passe ne correspondent pas.');
+      return;
+    }
+
+    try {
+      await ref
+          .read(authStateProvider.notifier)
+          .updatePasswordFromRecovery(password);
+      if (!mounted) return;
+      NotificationService.showSuccess('Mot de passe mis à jour.');
+      context.go(RoutePaths.splash);
+    } catch (_) {
+      if (!mounted) return;
+      final error = ref.read(authStateProvider).error;
+      NotificationService.showError(
+        error ?? 'Impossible de mettre à jour ton mot de passe.',
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final authState = ref.watch(authStateProvider);
+
+    return Scaffold(
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const SizedBox(height: 56),
+              Icon(Icons.lock_reset_rounded, size: 56, color: colors.primary),
+              const SizedBox(height: 24),
+              Text(
+                'Nouveau mot de passe',
+                style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                      color: colors.textPrimary,
+                      fontWeight: FontWeight.bold,
+                    ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                'Choisis un nouveau mot de passe pour retrouver ton compte.',
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: colors.textSecondary,
+                    ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 36),
+              TextField(
+                controller: _passwordController,
+                obscureText: _obscurePassword,
+                autofillHints: const [AutofillHints.newPassword],
+                textInputAction: TextInputAction.next,
+                decoration: InputDecoration(
+                  hintText: 'Nouveau mot de passe',
+                  prefixIcon: const Icon(Icons.lock_outline),
+                  suffixIcon: IconButton(
+                    onPressed: () {
+                      setState(() => _obscurePassword = !_obscurePassword);
+                    },
+                    icon: Icon(
+                      _obscurePassword
+                          ? Icons.visibility_outlined
+                          : Icons.visibility_off_outlined,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _confirmController,
+                obscureText: _obscureConfirm,
+                autofillHints: const [AutofillHints.newPassword],
+                textInputAction: TextInputAction.done,
+                onSubmitted: (_) => _submit(),
+                decoration: InputDecoration(
+                  hintText: 'Confirmer le mot de passe',
+                  prefixIcon: const Icon(Icons.lock_outline),
+                  suffixIcon: IconButton(
+                    onPressed: () {
+                      setState(() => _obscureConfirm = !_obscureConfirm);
+                    },
+                    icon: Icon(
+                      _obscureConfirm
+                          ? Icons.visibility_outlined
+                          : Icons.visibility_off_outlined,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 24),
+              PrimaryButton(
+                label: 'Mettre à jour',
+                onPressed: _submit,
+                isLoading: authState.isLoading,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/test/core/services/deep_link_service_test.dart
+++ b/apps/mobile/test/core/services/deep_link_service_test.dart
@@ -106,12 +106,35 @@ void main() {
       expect(action.route, '/grille');
     });
 
-    test('login-callback URI is ignored (handled by Supabase SDK)', () {
+    test('login-callback URI is identified as an auth callback', () {
       final action = DeepLinkService.parse(
         Uri.parse('io.supabase.facteur://login-callback#access_token=xyz'),
       );
-      expect(action.target, WidgetDeepLinkTarget.ignored);
-      expect(action.route, isNull);
+      expect(action.target, WidgetDeepLinkTarget.authCallback);
+      expect(action.route, '/splash');
+      expect(action.authType, isNull);
+    });
+
+    test('login-callback recovery URI routes to reset password', () {
+      final action = DeepLinkService.parse(
+        Uri.parse(
+          'io.supabase.facteur://login-callback#access_token=xyz&type=recovery',
+        ),
+      );
+      expect(action.target, WidgetDeepLinkTarget.authCallback);
+      expect(action.route, '/reset-password');
+      expect(action.authType, 'recovery');
+    });
+
+    test('login-callback query recovery also routes to reset password', () {
+      final action = DeepLinkService.parse(
+        Uri.parse(
+          'io.supabase.facteur://login-callback?code=abc&type=recovery',
+        ),
+      );
+      expect(action.target, WidgetDeepLinkTarget.authCallback);
+      expect(action.route, '/reset-password');
+      expect(action.authType, 'recovery');
     });
 
     test('foreign scheme → unhandled', () {

--- a/apps/mobile/test/features/auth/auth_state_test.dart
+++ b/apps/mobile/test/features/auth/auth_state_test.dart
@@ -90,7 +90,10 @@ void main() {
     test('isAuthenticated should return true when user is set', () {
       final user = User(
         id: '123',
-        appMetadata: {'provider': 'email', 'providers': ['email']},
+        appMetadata: {
+          'provider': 'email',
+          'providers': ['email']
+        },
         userMetadata: {},
         aud: 'authenticated',
         createdAt: DateTime.now().toIso8601String(),
@@ -107,7 +110,10 @@ void main() {
       // forceUnconfirmed empêche l'accès même avec une session techniquement valide.
       final user = User(
         id: '123',
-        appMetadata: {'provider': 'email', 'providers': ['email']},
+        appMetadata: {
+          'provider': 'email',
+          'providers': ['email']
+        },
         userMetadata: {},
         aud: 'authenticated',
         createdAt: DateTime.now().toIso8601String(),
@@ -115,13 +121,17 @@ void main() {
       );
       final state = AuthState(user: user, forceUnconfirmed: true);
       expect(state.isEmailConfirmed, isFalse,
-          reason: 'forceUnconfirmed doit prendre la priorité sur emailConfirmedAt');
+          reason:
+              'forceUnconfirmed doit prendre la priorité sur emailConfirmedAt');
     });
 
     test('forceUnconfirmed=false does not block confirmed user', () {
       final user = User(
         id: '123',
-        appMetadata: {'provider': 'email', 'providers': ['email']},
+        appMetadata: {
+          'provider': 'email',
+          'providers': ['email']
+        },
         userMetadata: {},
         aud: 'authenticated',
         createdAt: DateTime.now().toIso8601String(),
@@ -131,7 +141,8 @@ void main() {
       expect(state.isEmailConfirmed, isTrue);
     });
 
-    test('isLoading=true initial state is correct (splash screen during restore)',
+    test(
+        'isLoading=true initial state is correct (splash screen during restore)',
         () {
       // L'état initial d'AuthStateNotifier est isLoading:true.
       // Le router doit rester sur le splash pendant ce temps.
@@ -143,7 +154,10 @@ void main() {
     test('copyWith preserves user when not updated', () {
       final user = User(
         id: '123',
-        appMetadata: {'provider': 'email', 'providers': ['email']},
+        appMetadata: {
+          'provider': 'email',
+          'providers': ['email']
+        },
         userMetadata: {},
         aud: 'authenticated',
         createdAt: DateTime.now().toIso8601String(),
@@ -165,7 +179,10 @@ void main() {
         () {
       final user = User(
         id: '123',
-        appMetadata: {'provider': 'apple', 'providers': ['apple']},
+        appMetadata: {
+          'provider': 'apple',
+          'providers': ['apple']
+        },
         userMetadata: {},
         aud: 'authenticated',
         createdAt: DateTime.now().toIso8601String(),
@@ -200,7 +217,8 @@ void main() {
       expect(updated.lastTokenRefreshAt, ts);
     });
 
-    test('copyWith without lastTokenRefreshAt preserves the previous value', () {
+    test('copyWith without lastTokenRefreshAt preserves the previous value',
+        () {
       final ts = DateTime.utc(2026, 1, 1);
       final state = AuthState(lastTokenRefreshAt: ts);
       final updated = state.copyWith(isLoading: true);
@@ -218,6 +236,17 @@ void main() {
       expect(identical(s1, s2), isFalse);
       expect(s1.lastTokenRefreshAt, t1);
       expect(s2.lastTokenRefreshAt, t2);
+    });
+
+    test('passwordRecoveryPending defaults to false', () {
+      const state = AuthState();
+      expect(state.passwordRecoveryPending, isFalse);
+    });
+
+    test('copyWith can mark password recovery pending', () {
+      const state = AuthState();
+      final updated = state.copyWith(passwordRecoveryPending: true);
+      expect(updated.passwordRecoveryPending, isTrue);
     });
   });
 }

--- a/apps/mobile/test/features/auth/router_redirection_test.dart
+++ b/apps/mobile/test/features/auth/router_redirection_test.dart
@@ -1,20 +1,27 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:facteur/config/routes.dart';
 import 'package:facteur/core/auth/auth_state.dart';
 import 'package:facteur/features/auth/screens/email_confirmation_screen.dart';
+import 'package:hive/hive.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' hide AuthState;
 // For debugPrint
 
 // Simple stub for AuthStateNotifier to control state in tests
 class FakeAuthStateNotifier extends AuthStateNotifier {
-  FakeAuthStateNotifier(AuthState initialState) : super() {
-    state = initialState;
-  }
+  FakeAuthStateNotifier(AuthState initialState) : super.test(initialState);
 }
 
 void main() {
+  setUpAll(() {
+    Hive.init(
+      Directory.systemTemp.createTempSync('router_redirection_test').path,
+    );
+  });
+
   testWidgets(
       'Router should redirect to EmailConfirmationScreen if user is logged in but unconfirmed',
       (WidgetTester tester) async {
@@ -103,6 +110,7 @@ void main() {
       user: socialUser,
       isLoading: false,
       needsOnboarding: false,
+      onboardingStatusKnown: true,
     );
 
     final container = ProviderContainer(
@@ -123,7 +131,8 @@ void main() {
       ),
     );
 
-    await tester.pumpAndSettle();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
 
     // 5. VERIFY: We should NOT be on the EmailConfirmationScreen
     expect(find.byType(EmailConfirmationScreen), findsNothing);


### PR DESCRIPTION
## Quoi
Nouvel écran de **réinitialisation de mot de passe** (`reset_password_screen.dart`), route dédiée, prise en charge du **deep link** de reset, plus ajustements `email_confirmation`, `login` et `auth_state`.

## Pourquoi
Le flux « mot de passe oublié » n'avait pas d'écran ni de route dédiés côté app ; le deep link de reset n'était pas routé.

## Comment ça a été vérifié
- [x] `flutter analyze lib` — aucune erreur
- [x] `flutter test` ciblé : **38 tests** (deep_link_service, auth_state, router_redirection) ✓

## Zones à risque
⚠️ **Auth / Router** (zone LOCKED — cf. CLAUDE.md / Safety Guardrails). Changements packagés depuis un working tree existant ; revue attentive recommandée. Pas de migration, pas de changement backend.

## Note
PR issue d'un découpage d'un gros working tree (`onboarding-qa-handoffs`) en PRs cohérentes.
