### PR TITLE
feat(sources+onboarding): fiche source repensée + intégration onboarding

### DIFF
--- a/apps/mobile/lib/features/onboarding/data/source_recommender.dart
+++ b/apps/mobile/lib/features/onboarding/data/source_recommender.dart
@@ -4,12 +4,7 @@ import '../../../config/topic_labels.dart';
 import '../../sources/models/source_model.dart';
 
 /// Category of a recommended source.
-enum SourceCategory {
-  matched,
-  perspective,
-  gem,
-  catalog,
-}
+enum SourceCategory { matched, perspective, gem, catalog }
 
 /// Type of recommendation tag displayed on a source card.
 enum RecommendationTagType {
@@ -73,10 +68,10 @@ class SourceRecommendation {
 
   /// IDs that should be pre-selected.
   Set<String> get preselectedIds => {
-        ...specialists.map((r) => r.source.id),
-        ...matched.map((r) => r.source.id),
-        ...gems.map((r) => r.source.id),
-      };
+    ...specialists.map((r) => r.source.id),
+    ...matched.map((r) => r.source.id),
+    ...gems.map((r) => r.source.id),
+  };
 
   const SourceRecommendation({
     required this.matched,
@@ -197,13 +192,15 @@ class SourceRecommender {
         continue;
       }
       final result = tagResults[source.id]!;
-      matchedSources.add(RecommendedSource(
-        source: source,
-        category: SourceCategory.matched,
-        tags: result.tags,
-        reason: result.reason,
-        score: scored[source.id] ?? 0,
-      ));
+      matchedSources.add(
+        RecommendedSource(
+          source: source,
+          category: SourceCategory.matched,
+          tags: result.tags,
+          reason: result.reason,
+          score: scored[source.id] ?? 0,
+        ),
+      );
       usedIds.add(source.id);
     }
 
@@ -242,30 +239,40 @@ class SourceRecommender {
     }
 
     // 4. Catalog: everything else, alphabetical
-    final catalogSources = curated
-        .where((s) => !usedIds.contains(s.id))
-        .toList()
-      ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+    final catalogSources =
+        curated.where((s) => !usedIds.contains(s.id)).toList()..sort(
+          (a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()),
+        );
 
     final catalogRecommended = catalogSources
-        .map((s) => RecommendedSource(
-              source: s,
-              category: SourceCategory.catalog,
-              reason: '',
-            ))
+        .map(
+          (s) => RecommendedSource(
+            source: s,
+            category: SourceCategory.catalog,
+            reason: '',
+          ),
+        )
         .toList();
 
-    // Tag « Similaire à {nom} » : raccroche chaque reco (matched / perspective /
-    // gems) à la meilleure source aimée AU SWIPE partageant thème + (tier ou
-    // biais). Pas le catalogue (déjà replié), pas les sources déjà suivies.
-    final likedSources =
-        curated.where((s) => likedSet.contains(s.id)).toList();
+    // Tag « Similaire à {nom} » : raccroche quelques recos à une source aimée
+    // AU SWIPE, seulement quand aucune raison plus spécifique n'est déjà
+    // affichée. Pas le catalogue (déjà replié), pas les sources déjà suivies.
+    final likedSources = curated.where((s) => likedSet.contains(s.id)).toList();
+    final similarTagCounts = <String, int>{};
 
     List<RecommendedSource> withSimilarTag(List<RecommendedSource> list) {
       if (likedSources.isEmpty) return list;
       return list.map((r) {
-        final tag = _similarTag(r.source, likedSources);
-        if (tag == null) return r;
+        if (_hasSpecificTag(r.tags)) return r;
+        final anchor = _similarAnchor(r.source, likedSources);
+        if (anchor == null) return r;
+        final count = similarTagCounts[anchor.id] ?? 0;
+        if (count >= 2) return r;
+        similarTagCounts[anchor.id] = count + 1;
+        final tag = RecommendationTag(
+          label: 'Similaire à ${anchor.name}',
+          type: RecommendationTagType.similar,
+        );
         return RecommendedSource(
           source: r.source,
           category: r.category,
@@ -283,6 +290,15 @@ class SourceRecommender {
       catalog: catalogRecommended,
       specialists: withSimilarTag(specialistSources),
     );
+  }
+
+  static bool _hasSpecificTag(List<RecommendationTag> tags) {
+    return tags.any((t) {
+      return t.type == RecommendationTagType.specialist ||
+          t.type == RecommendationTagType.topic ||
+          t.type == RecommendationTagType.antiBruit ||
+          t.type == RecommendationTagType.fiable;
+    });
   }
 
   /// Garantit ≥1 carte « spécialiste » par subtopic sélectionné. Un subtopic est
@@ -314,74 +330,86 @@ class SourceRecommender {
 
     for (final sub in selectedSubtopics) {
       if (covered.contains(sub)) continue;
-      final candidates = allCurated
-          .where((s) => !taken.contains(s.id) && s.granularTopics.contains(sub))
-          .toList()
-        ..sort((a, b) {
-          final ad = a.granularTopics.isNotEmpty && a.granularTopics.first == sub
-              ? 1
-              : 0;
-          final bd = b.granularTopics.isNotEmpty && b.granularTopics.first == sub
-              ? 1
-              : 0;
-          if (ad != bd) return bd - ad; // spécialité dominante d'abord
-          final byScore = (scored[b.id] ?? 0).compareTo(scored[a.id] ?? 0);
-          if (byScore != 0) return byScore;
-          final aRel = a.reliabilityScore == 'high' ? 1 : 0;
-          final bRel = b.reliabilityScore == 'high' ? 1 : 0;
-          if (aRel != bRel) return bRel - aRel;
-          return b.articles30d.compareTo(a.articles30d);
-        });
+      final candidates =
+          allCurated
+              .where(
+                (s) => !taken.contains(s.id) && s.granularTopics.contains(sub),
+              )
+              .toList()
+            ..sort((a, b) {
+              final ad =
+                  a.granularTopics.isNotEmpty && a.granularTopics.first == sub
+                  ? 1
+                  : 0;
+              final bd =
+                  b.granularTopics.isNotEmpty && b.granularTopics.first == sub
+                  ? 1
+                  : 0;
+              if (ad != bd) return bd - ad; // spécialité dominante d'abord
+              final byScore = (scored[b.id] ?? 0).compareTo(scored[a.id] ?? 0);
+              if (byScore != 0) return byScore;
+              final aRel = a.reliabilityScore == 'high' ? 1 : 0;
+              final bRel = b.reliabilityScore == 'high' ? 1 : 0;
+              if (aRel != bRel) return bRel - aRel;
+              return b.articles30d.compareTo(a.articles30d);
+            });
       if (candidates.isEmpty) continue;
       final best = candidates.first;
       taken.add(best.id);
       covered.add(sub);
-      result.add(RecommendedSource(
-        source: best,
-        category: SourceCategory.matched,
-        tags: [
-          RecommendationTag(
-            label: 'Spécialisé en ${getTopicLabel(sub)}',
-            type: RecommendationTagType.specialist,
-          ),
-        ],
-        reason: 'Parce que vous suivez ${getTopicLabel(sub)}',
-        score: scored[best.id] ?? 0,
-      ));
+      result.add(
+        RecommendedSource(
+          source: best,
+          category: SourceCategory.matched,
+          tags: [
+            RecommendationTag(
+              label: 'Spécialisé en ${getTopicLabel(sub)}',
+              type: RecommendationTagType.specialist,
+            ),
+          ],
+          reason: 'Parce que vous suivez ${getTopicLabel(sub)}',
+          score: scored[best.id] ?? 0,
+        ),
+      );
     }
     return result;
   }
 
-  /// Cherche la meilleure source aimée au swipe « similaire » à [s] : partage un
-  /// thème (principal ou secondaire) **et** (même `sourceTier` **ou** même
-  /// `biasStance` connu). Départage par `followerCount` desc. Renvoie le tag
-  /// `'Similaire à {nom}'` ou `null` si aucune ancre.
-  static RecommendationTag? _similarTag(
-    Source s,
-    List<Source> likedSources,
-  ) {
+  /// Cherche la meilleure source aimée au swipe « similaire » à [s]. Deux
+  /// signaux partagés sont requis parmi thème, sujet granulaire, tier et biais
+  /// connu. Départage par `followerCount` desc.
+  static Source? _similarAnchor(Source s, List<Source> likedSources) {
     Set<String> themesOf(Source x) => {
-          if (x.theme != null) x.theme!,
-          ...x.secondaryThemes,
-        };
+      if (x.theme != null) x.theme!,
+      ...x.secondaryThemes,
+    };
 
     final sThemes = themesOf(s);
     Source? best;
     for (final liked in likedSources) {
       if (liked.id == s.id) continue;
-      if (sThemes.intersection(themesOf(liked)).isEmpty) continue;
-      final sameTierOrBias = s.sourceTier == liked.sourceTier ||
-          (s.biasStance != 'unknown' && s.biasStance == liked.biasStance);
-      if (!sameTierOrBias) continue;
+      var sharedSignals = 0;
+      if (sThemes.intersection(themesOf(liked)).isNotEmpty) {
+        sharedSignals++;
+      }
+      if (s.granularTopics
+          .toSet()
+          .intersection(liked.granularTopics.toSet())
+          .isNotEmpty) {
+        sharedSignals++;
+      }
+      if (s.sourceTier == liked.sourceTier) {
+        sharedSignals++;
+      }
+      if (s.biasStance != 'unknown' && s.biasStance == liked.biasStance) {
+        sharedSignals++;
+      }
+      if (sharedSignals < 2) continue;
       if (best == null || liked.followerCount > best.followerCount) {
         best = liked;
       }
     }
-    if (best == null) return null;
-    return RecommendationTag(
-      label: 'Similaire à ${best.name}',
-      type: RecommendationTagType.similar,
-    );
+    return best;
   }
 
   static _ScoreResult _scoreSource({
@@ -409,10 +437,12 @@ class SourceRecommender {
         bestReasonScore = 3;
         bestReason = getTopicLabel(source.theme!);
       }
-      tags.add(RecommendationTag(
-        label: getTopicLabel(source.theme!),
-        type: RecommendationTagType.topic,
-      ));
+      tags.add(
+        RecommendationTag(
+          label: getTopicLabel(source.theme!),
+          type: RecommendationTagType.topic,
+        ),
+      );
     }
 
     // Secondary themes match (+1 each)
@@ -423,11 +453,14 @@ class SourceRecommender {
           bestReason = getTopicLabel(t);
         }
         // Only add tag for first secondary theme to avoid clutter
-        if (tags.where((t) => t.type == RecommendationTagType.topic).length < 2) {
-          tags.add(RecommendationTag(
-            label: getTopicLabel(t),
-            type: RecommendationTagType.topic,
-          ));
+        if (tags.where((t) => t.type == RecommendationTagType.topic).length <
+            2) {
+          tags.add(
+            RecommendationTag(
+              label: getTopicLabel(t),
+              type: RecommendationTagType.topic,
+            ),
+          );
         }
       }
     }
@@ -436,33 +469,38 @@ class SourceRecommender {
     // top share après le re-tag backend) ∈ sujets choisis. Cœur de l'effet wow.
     final String? specialistSlug =
         source.granularTopics.isNotEmpty &&
-                subtopics.contains(source.granularTopics.first)
-            ? source.granularTopics.first
-            : null;
+            subtopics.contains(source.granularTopics.first)
+        ? source.granularTopics.first
+        : null;
     if (specialistSlug != null) {
-      tags.add(RecommendationTag(
-        label: 'Spécialisé en ${getTopicLabel(specialistSlug)}',
-        type: RecommendationTagType.specialist,
-      ));
+      tags.add(
+        RecommendationTag(
+          label: 'Spécialisé en ${getTopicLabel(specialistSlug)}',
+          type: RecommendationTagType.specialist,
+        ),
+      );
     }
 
     // Granular topics match subtopics (+2 each)
     for (final gt in source.granularTopics) {
       if (subtopics.contains(gt)) {
         score += 2;
-        if (2 > bestReasonScore) {
-          bestReasonScore = 2;
+        if (bestReasonScore <= 3) {
+          bestReasonScore = 4;
           bestReason = getTopicLabel(gt);
         }
         // La spécialité dominante est déjà badgée « Spécialisé en X » : on ne
         // double pas avec un tag thème générique.
         if (gt == specialistSlug) continue;
         // Add subtopic tag (prefer over theme if more specific)
-        if (tags.where((t) => t.type == RecommendationTagType.topic).length < 2) {
-          tags.add(RecommendationTag(
-            label: getTopicLabel(gt),
-            type: RecommendationTagType.topic,
-          ));
+        if (tags.where((t) => t.type == RecommendationTagType.topic).length <
+            2) {
+          tags.add(
+            RecommendationTag(
+              label: getTopicLabel(gt),
+              type: RecommendationTagType.topic,
+            ),
+          );
         }
       }
     }
@@ -529,19 +567,23 @@ class SourceRecommender {
     // Rule: source has high reliability OR is deep-tier (= analyses profondes)
     if (hasNoise &&
         (source.sourceTier == 'deep' || source.reliabilityScore == 'high')) {
-      tags.add(const RecommendationTag(
-        label: 'Anti-bruit',
-        type: RecommendationTagType.antiBruit,
-      ));
+      tags.add(
+        const RecommendationTag(
+          label: 'Anti-bruit',
+          type: RecommendationTagType.antiBruit,
+        ),
+      );
     }
 
     // Source fiable: user worried about bias → tag reliable sources
     // Rule: source has high reliability score
     if (hasBias && source.reliabilityScore == 'high') {
-      tags.add(const RecommendationTag(
-        label: 'Source fiable',
-        type: RecommendationTagType.fiable,
-      ));
+      tags.add(
+        const RecommendationTag(
+          label: 'Source fiable',
+          type: RecommendationTagType.fiable,
+        ),
+      );
     }
 
     // Serein: user worried about anxiety → tag sources with calm themes
@@ -549,10 +591,12 @@ class SourceRecommender {
     if (hasAnxiety &&
         source.theme != null &&
         _sereinThemes.contains(source.theme)) {
-      tags.add(const RecommendationTag(
-        label: 'Peu anxiogène',
-        type: RecommendationTagType.serein,
-      ));
+      tags.add(
+        const RecommendationTag(
+          label: 'Peu anxiogène',
+          type: RecommendationTagType.serein,
+        ),
+      );
     }
 
     final reason = bestReason.isNotEmpty
@@ -571,8 +615,9 @@ class SourceRecommender {
     final targetBiases = _oppositeBiases(matched.map((r) => r.source).toList());
 
     final candidates = allCurated
-        .where((s) =>
-            !usedIds.contains(s.id) && targetBiases.contains(s.biasStance))
+        .where(
+          (s) => !usedIds.contains(s.id) && targetBiases.contains(s.biasStance),
+        )
         .toList();
 
     // Sort by reliability (prefer 'high')
@@ -584,11 +629,13 @@ class SourceRecommender {
 
     return candidates
         .take(_maxPerspective)
-        .map((s) => RecommendedSource(
-              source: s,
-              category: SourceCategory.perspective,
-              reason: 'Pour voir un autre point de vue',
-            ))
+        .map(
+          (s) => RecommendedSource(
+            source: s,
+            category: SourceCategory.perspective,
+            reason: 'Pour voir un autre point de vue',
+          ),
+        )
         .toList();
   }
 
@@ -599,10 +646,12 @@ class SourceRecommender {
   }) {
     // Debug: help diagnose missing Pépites section
     final allDeep = allCurated.where((s) => s.sourceTier == 'deep').toList();
-    debugPrint('[SourceRecommender] _computeGems: '
-        '${allCurated.length} curated sources, '
-        '${allDeep.length} deep-tier sources '
-        '(${allDeep.map((s) => s.name).join(", ")})');
+    debugPrint(
+      '[SourceRecommender] _computeGems: '
+      '${allCurated.length} curated sources, '
+      '${allDeep.length} deep-tier sources '
+      '(${allDeep.map((s) => s.name).join(", ")})',
+    );
 
     final candidates = allCurated
         .where((s) => !usedIds.contains(s.id) && s.sourceTier == 'deep')
@@ -709,41 +758,40 @@ class SourceRecommender {
     final pickers = <void Function()>[
       // 1. Indépendant : forte indépendance ou posture alternative/spécialisée.
       () => pick(
-            SwipeAxisPole.independent,
-            (s) =>
-                (s.scoreIndependence ?? 0) >= 0.6 ||
-                s.biasStance == 'alternative' ||
-                s.biasStance == 'specialized',
-            (a, b) =>
-                (b.scoreIndependence ?? 0).compareTo(a.scoreIndependence ?? 0),
-          ),
+        SwipeAxisPole.independent,
+        (s) =>
+            (s.scoreIndependence ?? 0) >= 0.6 ||
+            s.biasStance == 'alternative' ||
+            s.biasStance == 'specialized',
+        (a, b) =>
+            (b.scoreIndependence ?? 0).compareTo(a.scoreIndependence ?? 0),
+      ),
       // 2. Fond : tier deep.
       () => pick(
-            SwipeAxisPole.deep,
-            (s) => s.sourceTier == 'deep',
-            byVolumeThenFollowers,
-          ),
+        SwipeAxisPole.deep,
+        (s) => s.sourceTier == 'deep',
+        byVolumeThenFollowers,
+      ),
       // 3. Référence établie : fiabilité haute + faible indépendance.
       () => pick(
-            SwipeAxisPole.established,
-            (s) =>
-                s.reliabilityScore == 'high' &&
-                (s.scoreIndependence ?? 1) <= 0.5,
-            (a, b) =>
-                (a.scoreIndependence ?? 1).compareTo(b.scoreIndependence ?? 1),
-          ),
+        SwipeAxisPole.established,
+        (s) =>
+            s.reliabilityScore == 'high' && (s.scoreIndependence ?? 1) <= 0.5,
+        (a, b) =>
+            (a.scoreIndependence ?? 1).compareTo(b.scoreIndependence ?? 1),
+      ),
       // 4. Actu directe : tier mainstream.
       () => pick(
-            SwipeAxisPole.mainstream,
-            (s) => s.sourceTier == 'mainstream',
-            byVolumeThenFollowers,
-          ),
+        SwipeAxisPole.mainstream,
+        (s) => s.sourceTier == 'mainstream',
+        byVolumeThenFollowers,
+      ),
       // 5. Perspective : bord opposé à la majorité matchée.
       () => pick(
-            SwipeAxisPole.perspective,
-            (s) => targetPerspectiveBiases.contains(s.biasStance),
-            byVolumeThenFollowers,
-          ),
+        SwipeAxisPole.perspective,
+        (s) => targetPerspectiveBiases.contains(s.biasStance),
+        byVolumeThenFollowers,
+      ),
     ];
 
     for (var round = 0; round < perPole; round++) {
@@ -761,9 +809,7 @@ class SourceRecommender {
       for (final s in fillers) {
         if (result.length >= maxCards) break;
         used.add(s.id);
-        result.add(
-          SpanningSource(source: s, pole: SwipeAxisPole.mainstream),
-        );
+        result.add(SpanningSource(source: s, pole: SwipeAxisPole.mainstream));
       }
     }
 

--- a/apps/mobile/lib/features/onboarding/onboarding_strings.dart
+++ b/apps/mobile/lib/features/onboarding/onboarding_strings.dart
@@ -24,8 +24,10 @@ class OnboardingStrings {
   static const String intro2Title = 'Ton hub d\'infos fiables.';
   static const String intro2Subtitle =
       'Facteur est une app Open-Source pour retrouver le plaisir de s\'informer.\n\nUn espace de confiance, qui mêle transparence, contrôle et sources de qualité.';
-  static const String intro2SubtitlePart1 = 'Facteur est une app Open-Source pour ';
-  static const String intro2SubtitleBold1 = 'retrouver le plaisir de s\'informer';
+  static const String intro2SubtitlePart1 =
+      'Facteur est une app Open-Source pour ';
+  static const String intro2SubtitleBold1 =
+      'retrouver le plaisir de s\'informer';
   static const String intro2SubtitlePart2 = '. Un espace de ';
   static const String intro2SubtitleBold2 = 'confiance';
   static const String intro2SubtitlePart3 = ', qui mêle ';
@@ -53,8 +55,7 @@ class OnboardingStrings {
       "Commençons par vous. \n\nQu'est-ce qui vous épuise le plus avec l'info ?";
   static const String q1Subtitle = '';
   static const String q1NoiseLabel = 'Le Bruit';
-  static const String q1NoiseSubtitle =
-      "Trop d'info. Impossible de bien trier";
+  static const String q1NoiseSubtitle = "Trop d'info. Impossible de bien trier";
   static const String q1BiasLabel = 'Les Biais';
   static const String q1BiasSubtitle = 'Je doute constamment de la neutralité';
   static const String q1AnxietyLabel = 'La négativité';
@@ -105,11 +106,12 @@ class OnboardingStrings {
   // Glisser à droite = ça m'intéresse ; gauche = pas pour moi.
   static const String swipeTitle = 'Quels médias suivre ?';
   static const String swipeSubtitle =
-      'Glissez à droite ceux qui vous parlent, à gauche les autres. '
-      'On ajuste vos suggestions en direct.';
+      'Glisse à droite ceux qui te parlent, à gauche les autres. '
+      'On ajuste tes suggestions en direct.';
   static const String swipeLikeHint = 'Ça m\'intéresse';
   static const String swipeSkipHint = 'Pas pour moi';
-  static const String swipeDoneButton = 'Voir mes sources';
+  static const String swipeUndoLabel = 'Revenir au dernier média';
+  static const String swipeDoneButton = 'Voir mes médias';
   // Compteur humanisé à 3 paliers selon l'avancement (current/total). Plus
   // présent qu'un sec « Carte X sur Y », sans em-dash (règle PO).
   static const String swipeProgressStart = 'Premières cartes (%d/%d)';
@@ -137,9 +139,9 @@ class OnboardingStrings {
   static const String swipeReliabilityUnknown = 'Non évaluée';
 
   // Moment de calibration en fin de tri + micro-indice pendant les swipes.
-  static const String swipeRefiningTitle = 'On affine vos sources…';
+  static const String swipeRefiningTitle = 'On affine tes médias…';
   static const String swipeRefiningSubtitle =
-      'On ajuste les suggestions à vos goûts.';
+      'On ajuste les suggestions à tes goûts.';
   static const String swipeCalibratingHint = 'On affine…';
 
   // Q8: Gamification
@@ -178,32 +180,29 @@ class OnboardingStrings {
   // Digest Mode
   static const String digestModeTitle =
       'Quel mode de récap quotidien préférez-vous ?';
-  static const String digestModeSubtitle =
-      'Vous pourrez changer à tout moment.';
+  static const String digestModeSubtitle = 'Tu pourras changer à tout moment.';
 
   // Digest Mode — Rester serein (rich subtitle parts)
   static const String digestModeSereinPart1 =
-      'Certains sujets peuvent être difficiles à lire. Activez le ';
+      'Certains sujets peuvent être difficiles à lire. Active le ';
   static const String digestModeSereinBold1 = 'mode serein';
   static const String digestModeSereinPart2 = ' pour ';
   static const String digestModeSereinBold2 = 'filtrer les contenus anxiogènes';
-  static const String digestModeSereinPart3 = '.\nVous pourrez ';
+  static const String digestModeSereinPart3 = '.\nTu pourras ';
   static const String digestModeSereinBold3 = 'changer d\'avis à tout moment';
   static const String digestModeSereinPart4 =
-      ' grâce au bouton dédié en haut de votre essentiel et du flux.';
+      ' grâce au bouton dédié en haut de ton essentiel et du flux.';
 
   // Réassurance affichée sous les choix du mode serein (sans tiret em).
   static const String digestModeAnytimeNote =
-      'Vous pourrez activer ou désactiver le mode serein à tout moment depuis Mes intérêts.';
+      'Tu pourras affiner ce qui te semble serein depuis les paramètres.';
 
   // Personalised serein CTA (shown on the DigestMode question).
-  static const String personalizeSereinCta =
-      'Personnaliser mon mode serein';
+  static const String personalizeSereinCta = 'Personnaliser mon mode serein';
 
   // Q10: Page sources « sur mesure »
   static const String sourcesSuggestionsTitle = 'Nos suggestions pour vous';
-  static const String sourcesAlreadyFollowTitle =
-      'Vous suivez déjà un média ?';
+  static const String sourcesAlreadyFollowTitle = 'Vous suivez déjà un média ?';
   static const String sourcesSeeAllCatalog = 'Voir tout le catalogue';
 
   // Q10: en-têtes des 4 blocs « sur mesure » (①②③④).
@@ -234,10 +233,9 @@ class OnboardingStrings {
   static const String q9Subtitle =
       'Basé sur vos réponses, voici les médias que Facteur vous recommande.';
   static const String q9SearchHint = 'Rechercher une source...';
-  static const String q9LoadingError = 'Erreur de chargement des sources';
-  static const String q9EmptyList = 'Aucune source disponible';
-  static const String q9NoMatch =
-      'Aucune source ne correspond à votre recherche';
+  static const String q9LoadingError = 'Erreur de chargement des médias';
+  static const String q9EmptyList = 'Aucun média disponible';
+  static const String q9NoMatch = 'Aucun média ne correspond à ta recherche';
 
   // Message de pré-sélection automatique
   static const String q9PreselectionTitle =
@@ -248,8 +246,7 @@ class OnboardingStrings {
       'Ajouter vos abonnements presse';
 
   // Carte d'ajout d'abonnement (style CTA Essentiel) sur la page sources.
-  static const String addSubscriptionCardTitle =
-      'Abonné à un média payant ?';
+  static const String addSubscriptionCardTitle = 'Abonné à un média payant ?';
   static const String addSubscriptionCardSubtitle =
       'Le Monde, Mediapart, L\'Équipe... Connectez vos abonnements pour lire '
       'les articles en entier, directement dans Facteur.';

--- a/apps/mobile/lib/features/onboarding/screens/questions/digest_mode_question.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/digest_mode_question.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
-import '../../../../config/routes.dart';
 import '../../../../config/serein_colors.dart';
 import '../../../../config/theme.dart';
 import '../../onboarding_strings.dart';
@@ -32,15 +30,12 @@ class DigestModeQuestion extends ConsumerWidget {
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
                   const SizedBox(height: FacteurSpacing.space8),
-
                   Text(
                     '🌿 Rester serein ?',
                     style: Theme.of(context).textTheme.displayLarge,
                     textAlign: TextAlign.center,
                   ),
-
                   const SizedBox(height: FacteurSpacing.space3),
-
                   Text.rich(
                     TextSpan(
                       style: Theme.of(context)
@@ -68,13 +63,13 @@ class DigestModeQuestion extends ConsumerWidget {
                     ),
                     textAlign: TextAlign.center,
                   ),
-
                   const SizedBox(height: FacteurSpacing.space8),
-
                   ElevatedButton.icon(
                     onPressed: () {
                       HapticFeedback.lightImpact();
-                      ref.read(onboardingProvider.notifier).selectDigestMode('serein');
+                      ref
+                          .read(onboardingProvider.notifier)
+                          .selectDigestMode('serein');
                     },
                     icon: Icon(SereinColors.sereinIcon, size: 18),
                     label: const Text('Oui, rester serein'),
@@ -87,13 +82,12 @@ class DigestModeQuestion extends ConsumerWidget {
                         fontWeight: FontWeight.w600,
                       ),
                       shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(FacteurRadius.large),
+                        borderRadius:
+                            BorderRadius.circular(FacteurRadius.large),
                       ),
                     ),
                   ),
-
                   const SizedBox(height: FacteurSpacing.space3),
-
                   OutlinedButton.icon(
                     onPressed: () {
                       HapticFeedback.lightImpact();
@@ -114,13 +108,12 @@ class DigestModeQuestion extends ConsumerWidget {
                         color: colors.textTertiary.withOpacity(0.3),
                       ),
                       shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(FacteurRadius.large),
+                        borderRadius:
+                            BorderRadius.circular(FacteurRadius.large),
                       ),
                     ),
                   ),
-
                   const SizedBox(height: FacteurSpacing.space4),
-
                   Text(
                     OnboardingStrings.digestModeAnytimeNote,
                     style: Theme.of(context)
@@ -129,36 +122,11 @@ class DigestModeQuestion extends ConsumerWidget {
                         ?.copyWith(color: colors.textTertiary),
                     textAlign: TextAlign.center,
                   ),
-
-                  const SizedBox(height: FacteurSpacing.space2),
-
-                  TextButton(
-                    onPressed: () {
-                      HapticFeedback.selectionClick();
-                      ref
-                          .read(onboardingProvider.notifier)
-                          .markDigestMode('serein');
-                      context.pushNamed(
-                        RouteNames.myInterests,
-                        queryParameters: const {'serein': '1'},
-                      );
-                    },
-                    child: Text(
-                      OnboardingStrings.personalizeSereinCta,
-                      style: TextStyle(
-                        color: SereinColors.sereinColor,
-                        fontWeight: FontWeight.w600,
-                        decoration: TextDecoration.underline,
-                      ),
-                    ),
-                  ),
-
                   const SizedBox(height: FacteurSpacing.space6),
                 ],
               ),
             ),
           ),
-
           DelayedContinueButton(
             visible: selectedMode != null,
             onPressed: () {

--- a/apps/mobile/lib/features/onboarding/screens/questions/sources_question.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/sources_question.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -9,6 +11,7 @@ import '../../../sources/models/source_model.dart';
 import '../../../sources/providers/sources_providers.dart';
 import '../../../sources/widgets/source_add_panel.dart';
 import '../../../sources/widgets/source_detail_modal.dart';
+import '../../../sources/widgets/source_logo_avatar.dart';
 import '../../data/source_recommender.dart';
 import '../../onboarding_strings.dart';
 import '../../providers/onboarding_proof_cache_provider.dart';
@@ -85,7 +88,12 @@ class _SourcesQuestionState extends ConsumerState<SourcesQuestion> {
       swipeDisliked: answers.swipeDisliked ?? const <String>[],
     );
     _recommendation = reco;
-    _suggestions = _computeSuggestions(reco, hasThemes: themes.isNotEmpty);
+    _suggestions = _computeSuggestions(
+      reco,
+      hasThemes: themes.isNotEmpty,
+      excludedIds: swipeLiked.toSet(),
+    );
+    _preloadSuggestionProfiles(_suggestions!);
 
     // Pré-sélection : top `_preselectLimit` des suggestions (déjà triées) +
     // toutes les sources swipées à droite (garanties cochées au reveal, même
@@ -116,14 +124,17 @@ class _SourcesQuestionState extends ConsumerState<SourcesQuestion> {
   List<RecommendedSource> _computeSuggestions(
     SourceRecommendation reco, {
     required bool hasThemes,
+    Set<String> excludedIds = const {},
   }) {
     final specialists = reco.specialists;
     if (hasThemes && (reco.matched.isNotEmpty || specialists.isNotEmpty)) {
-      final sorted = [...reco.matched]..sort((a, b) {
+      final sorted = [...reco.matched]
+        ..sort((a, b) {
           final byScore = b.score.compareTo(a.score);
           return byScore != 0 ? byScore : _byVolumeProxy(a, b);
         });
       return _dedupById([...specialists, ...sorted])
+          .where((r) => !excludedIds.contains(r.source.id))
           .take(_suggestionsLimit)
           .toList();
     }
@@ -135,8 +146,15 @@ class _SourcesQuestionState extends ConsumerState<SourcesQuestion> {
       ...reco.catalog,
     ]..sort(_byVolumeProxy);
     return _dedupById([...specialists, ...pool])
+        .where((r) => !excludedIds.contains(r.source.id))
         .take(_suggestionsLimit)
         .toList();
+  }
+
+  void _preloadSuggestionProfiles(List<RecommendedSource> suggestions) {
+    for (final r in suggestions.take(6)) {
+      ref.read(sourceProfileProvider(r.source.id).future).ignore();
+    }
   }
 
   /// Dédoublonne par `source.id` en conservant le premier passage (les
@@ -151,7 +169,8 @@ class _SourcesQuestionState extends ConsumerState<SourcesQuestion> {
   }
 
   /// Catalogue complet (toutes catégories confondues) pour « Voir tout ».
-  List<RecommendedSource> _fullCatalog(SourceRecommendation reco) => _dedupById([
+  List<RecommendedSource> _fullCatalog(SourceRecommendation reco) =>
+      _dedupById([
         ...reco.specialists,
         ...reco.matched,
         ...reco.perspective,
@@ -179,6 +198,7 @@ class _SourcesQuestionState extends ConsumerState<SourcesQuestion> {
         source: source,
         onToggleTrust: () => _toggleSource(source.id),
         isSelectedOverride: _selectedSourceIds.contains(source.id),
+        articleOpener: openSourceArticleOnRootNavigator,
       ),
     );
   }
@@ -202,7 +222,9 @@ class _SourcesQuestionState extends ConsumerState<SourcesQuestion> {
     if (sourceId == null || sourceId.isEmpty || sourceId == 'null') return;
 
     setState(() => _selectedSourceIds.add(sourceId));
-    ref.read(onboardingProofCacheProvider.notifier).update(
+    ref
+        .read(onboardingProofCacheProvider.notifier)
+        .update(
           (cache) => {
             ...cache,
             sourceId: SourceProofSeed(
@@ -310,6 +332,13 @@ class _SourcesQuestionState extends ConsumerState<SourcesQuestion> {
   ) {
     final colors = context.facteurColors;
     final suggestions = _suggestions ?? const <RecommendedSource>[];
+    final swipeLikedIds =
+        ref.read(onboardingProvider).answers.swipeLiked ?? const <String>[];
+    final alreadyAdded = [
+      for (final id in swipeLikedIds)
+        for (final source in allSources)
+          if (source.id == id) source,
+    ];
 
     return [
       Text(
@@ -320,12 +349,16 @@ class _SourcesQuestionState extends ConsumerState<SourcesQuestion> {
       const SizedBox(height: FacteurSpacing.space3),
       Text(
         OnboardingStrings.q9Subtitle,
-        style: Theme.of(context)
-            .textTheme
-            .bodyMedium
-            ?.copyWith(color: colors.textSecondary),
+        style: Theme.of(
+          context,
+        ).textTheme.bodyMedium?.copyWith(color: colors.textSecondary),
         textAlign: TextAlign.center,
       ),
+
+      if (alreadyAdded.isNotEmpty) ...[
+        const SizedBox(height: FacteurSpacing.space4),
+        _AlreadyAddedSources(sources: alreadyAdded),
+      ],
 
       // ① Suggestions sur mesure (top pré-cochées)
       if (suggestions.isNotEmpty) ...[
@@ -416,9 +449,9 @@ class _SourcesQuestionState extends ConsumerState<SourcesQuestion> {
               Expanded(
                 child: Text(
                   OnboardingStrings.sourcesAlreadyFollowTitle,
-                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                        fontWeight: FontWeight.w600,
-                      ),
+                  style: Theme.of(
+                    context,
+                  ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
                 ),
               ),
               AnimatedRotation(
@@ -449,6 +482,66 @@ class _SourcesQuestionState extends ConsumerState<SourcesQuestion> {
       // Autofocus seulement quand l'utilisateur vient de déplier le panneau.
       autoFocusSearch: _addPanelExpanded,
       onSourceAdded: _onSourceAdded,
+    );
+  }
+}
+
+class _AlreadyAddedSources extends StatelessWidget {
+  final List<Source> sources;
+
+  const _AlreadyAddedSources({required this.sources});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: FacteurSpacing.space4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Déjà ajoutées',
+            style: Theme.of(context).textTheme.titleSmall?.copyWith(
+              color: colors.textPrimary,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: FacteurSpacing.space2),
+          Wrap(
+            spacing: FacteurSpacing.space2,
+            runSpacing: FacteurSpacing.space2,
+            children: [
+              for (final source in sources)
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 8,
+                  ),
+                  decoration: BoxDecoration(
+                    color: colors.primary.withOpacity(0.08),
+                    borderRadius: BorderRadius.circular(FacteurRadius.medium),
+                    border: Border.all(color: colors.primary.withOpacity(0.18)),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      SourceLogoAvatar(source: source, size: 22, radius: 6),
+                      const SizedBox(width: 7),
+                      Text(
+                        source.name,
+                        style: Theme.of(context).textTheme.labelMedium
+                            ?.copyWith(
+                              color: colors.textPrimary,
+                              fontWeight: FontWeight.w600,
+                            ),
+                      ),
+                    ],
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
     );
   }
 }

--- a/apps/mobile/lib/features/onboarding/screens/questions/swipe_disambiguator_question.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/swipe_disambiguator_question.dart
@@ -42,6 +42,13 @@ class _VoteIntent {
   const _VoteIntent(this.card, this.liked);
 }
 
+/// Vote déjà appliqué, utilisé pour restaurer exactement la dernière carte.
+class _SwipeVote {
+  final SpanningSource card;
+  final bool liked;
+  const _SwipeVote({required this.card, required this.liked});
+}
+
 class _SwipeDisambiguatorQuestionState
     extends ConsumerState<SwipeDisambiguatorQuestion>
     with SingleTickerProviderStateMixin {
@@ -50,12 +57,14 @@ class _SwipeDisambiguatorQuestionState
   int _total = 0;
   final List<String> _liked = [];
   final List<String> _disliked = [];
+  final List<_SwipeVote> _voteHistory = [];
 
   /// Score net par pôle (alimente les chips de profil en direct).
   final Map<SwipeAxisPole, int> _poleScore = {};
 
   bool _completed = false;
   bool _hasInteracted = false;
+  bool _finishedSwipe = false;
 
   /// Moment « on affine vos sources » en fin de tri (overlay + délai).
   bool _refining = false;
@@ -122,6 +131,7 @@ class _SwipeDisambiguatorQuestionState
     );
     _queue = set.reversed.toList(); // dernier = première carte montrée
     _total = set.length;
+    _preloadTopProfiles();
 
     // Rien à montrer (catalogue indisponible / thèmes trop pauvres) → on saute
     // l'étape sans bloquer le parcours.
@@ -142,16 +152,14 @@ class _SwipeDisambiguatorQuestionState
 
     // Tri terminé : moment « on affine vos sources » (~1,4 s) avant de basculer.
     setState(() => _refining = true);
-    _refineTimer = Timer(
-      const Duration(milliseconds: 1400),
-      () {
-        if (!mounted) return;
-        _finishSwipe();
-      },
-    );
+    _refineTimer = Timer(const Duration(milliseconds: 1400), () {
+      if (!mounted) return;
+      _finishSwipe();
+    });
   }
 
   void _finishSwipe() {
+    _finishedSwipe = true;
     ref
         .read(onboardingProvider.notifier)
         .completeSwipe(List.of(_liked), List.of(_disliked));
@@ -161,13 +169,65 @@ class _SwipeDisambiguatorQuestionState
     HapticFeedback.lightImpact();
     setState(() {
       _hasInteracted = true;
+      _voteHistory.add(_SwipeVote(card: card, liked: liked));
       (liked ? _liked : _disliked).add(card.source.id);
       _poleScore[card.pole] = (_poleScore[card.pole] ?? 0) + (liked ? 1 : -1);
       _queue!.removeLast();
       _dragOffset = Offset.zero;
     });
+    _preloadTopProfiles();
     _flashCalibratingHint();
     if (_queue!.isEmpty) _complete();
+  }
+
+  bool get _canUndoSwipe => _voteHistory.isNotEmpty && !_finishedSwipe;
+
+  void _undoLastSwipe() {
+    if (!_canUndoSwipe) return;
+    HapticFeedback.selectionClick();
+
+    if (_slideController.isAnimating) {
+      _slideController.stop();
+    }
+    _slideController.reset();
+    _pendingVote = null;
+    _animFrom = Offset.zero;
+    _animTo = Offset.zero;
+    _refineTimer?.cancel();
+    _hintTimer?.cancel();
+
+    final vote = _voteHistory.removeLast();
+    final votedIds = vote.liked ? _liked : _disliked;
+    final index = votedIds.lastIndexOf(vote.card.source.id);
+    if (index != -1) {
+      votedIds.removeAt(index);
+    }
+
+    final reversedDelta = vote.liked ? -1 : 1;
+    final nextScore = (_poleScore[vote.card.pole] ?? 0) + reversedDelta;
+    if (nextScore == 0) {
+      _poleScore.remove(vote.card.pole);
+    } else {
+      _poleScore[vote.card.pole] = nextScore;
+    }
+
+    setState(() {
+      _completed = false;
+      _refining = false;
+      _hintVisible = false;
+      _dragOffset = Offset.zero;
+      _queue ??= <SpanningSource>[];
+      _queue!.add(vote.card);
+    });
+    _preloadTopProfiles();
+  }
+
+  void _preloadTopProfiles() {
+    final queue = _queue;
+    if (queue == null || queue.isEmpty) return;
+    for (final card in queue.reversed.take(3)) {
+      ref.read(sourceProfileProvider(card.source.id).future).ignore();
+    }
   }
 
   /// Fait apparaître brièvement le micro-indice « On affine… » après un vote.
@@ -220,8 +280,11 @@ class _SwipeDisambiguatorQuestionState
   }
 
   /// Projette la carte hors écran dans la direction du vote puis valide.
-  void _flingOut(SpanningSource card,
-      {required bool liked, double fromDy = -40}) {
+  void _flingOut(
+    SpanningSource card, {
+    required bool liked,
+    double fromDy = -40,
+  }) {
     if (_slideController.isAnimating) return;
     final dir = liked ? 1.0 : -1.0;
     _animateTo(
@@ -237,12 +300,12 @@ class _SwipeDisambiguatorQuestionState
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
-      builder: (sheetContext) => SourceDetailModal(
+      builder: (_) => SourceDetailModal(
         source: card.source,
         selectLabel: OnboardingStrings.swipeLikeHint,
         isSelectedOverride: _liked.contains(card.source.id),
+        articleOpener: openSourceArticleOnRootNavigator,
         onToggleTrust: () {
-          Navigator.of(sheetContext).pop();
           _flingOut(card, liked: true);
         },
       ),
@@ -269,8 +332,9 @@ class _SwipeDisambiguatorQuestionState
         final current = _total - remaining + 1;
 
         final content = Padding(
-          padding:
-              const EdgeInsets.symmetric(horizontal: FacteurSpacing.space6),
+          padding: const EdgeInsets.symmetric(
+            horizontal: FacteurSpacing.space6,
+          ),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
@@ -283,10 +347,9 @@ class _SwipeDisambiguatorQuestionState
               const SizedBox(height: FacteurSpacing.space3),
               Text(
                 OnboardingStrings.swipeSubtitle,
-                style: Theme.of(context)
-                    .textTheme
-                    .bodyMedium
-                    ?.copyWith(color: colors.textSecondary),
+                style: Theme.of(
+                  context,
+                ).textTheme.bodyMedium?.copyWith(color: colors.textSecondary),
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: FacteurSpacing.space2),
@@ -299,13 +362,9 @@ class _SwipeDisambiguatorQuestionState
                       ),
                   textAlign: TextAlign.center,
                 ),
-
               _buildCalibratingHint(context),
-
               Expanded(child: _buildCardArea(context, queue)),
-
               _buildTapHint(context, isFirstCard: remaining == _total),
-
               if (remaining > 0) ...[
                 _buildProfileInline(context),
                 _buildActions(context, queue.last),
@@ -337,9 +396,7 @@ class _SwipeDisambiguatorQuestionState
     } else {
       template = OnboardingStrings.swipeProgressMiddle;
     }
-    return template
-        .replaceFirst('%d', '$current')
-        .replaceFirst('%d', '$total');
+    return template.replaceFirst('%d', '$current').replaceFirst('%d', '$total');
   }
 
   /// Phrase inline « ce qu'on retient » placée *sous* le deck (au-dessus des
@@ -347,9 +404,8 @@ class _SwipeDisambiguatorQuestionState
   /// tant qu'aucun pôle n'est net-positif.
   Widget _buildProfileInline(BuildContext context) {
     final colors = context.facteurColors;
-    final activePoles = SwipeAxisPole.values
-        .where((p) => (_poleScore[p] ?? 0) > 0)
-        .toList();
+    final activePoles =
+        SwipeAxisPole.values.where((p) => (_poleScore[p] ?? 0) > 0).toList();
 
     return AnimatedSize(
       duration: const Duration(milliseconds: 220),
@@ -362,10 +418,9 @@ class _SwipeDisambiguatorQuestionState
               child: Text(
                 OnboardingStrings.swipeProfileInline +
                     activePoles.map(_poleLabel).join(', '),
-                style: Theme.of(context)
-                    .textTheme
-                    .bodySmall
-                    ?.copyWith(color: colors.textTertiary),
+                style: Theme.of(
+                  context,
+                ).textTheme.bodySmall?.copyWith(color: colors.textTertiary),
                 textAlign: TextAlign.center,
               ),
             ),
@@ -382,10 +437,9 @@ class _SwipeDisambiguatorQuestionState
         padding: const EdgeInsets.only(top: FacteurSpacing.space2),
         child: Text(
           OnboardingStrings.swipeCalibratingHint,
-          style: Theme.of(context)
-              .textTheme
-              .bodySmall
-              ?.copyWith(color: colors.textTertiary),
+          style: Theme.of(
+            context,
+          ).textTheme.bodySmall?.copyWith(color: colors.textTertiary),
           textAlign: TextAlign.center,
         ),
       ),
@@ -396,38 +450,42 @@ class _SwipeDisambiguatorQuestionState
   Widget _buildRefiningOverlay(BuildContext context) {
     final colors = context.facteurColors;
     return Positioned.fill(
-      child: AbsorbPointer(
-        child: ColoredBox(
-          color: colors.backgroundPrimary.withOpacity(0.96),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const CircularProgressIndicator(),
-              const SizedBox(height: FacteurSpacing.space6),
-              Text(
-                OnboardingStrings.swipeRefiningTitle,
-                style: Theme.of(context)
-                    .textTheme
-                    .titleMedium
-                    ?.copyWith(fontWeight: FontWeight.w700),
+      child: ColoredBox(
+        color: colors.backgroundPrimary.withOpacity(0.96),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const CircularProgressIndicator(),
+            const SizedBox(height: FacteurSpacing.space6),
+            Text(
+              OnboardingStrings.swipeRefiningTitle,
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: FacteurSpacing.space2),
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: FacteurSpacing.space6,
+              ),
+              child: Text(
+                OnboardingStrings.swipeRefiningSubtitle,
+                style: Theme.of(
+                  context,
+                ).textTheme.bodyMedium?.copyWith(color: colors.textSecondary),
                 textAlign: TextAlign.center,
               ),
-              const SizedBox(height: FacteurSpacing.space2),
-              Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: FacteurSpacing.space6,
-                ),
-                child: Text(
-                  OnboardingStrings.swipeRefiningSubtitle,
-                  style: Theme.of(context)
-                      .textTheme
-                      .bodyMedium
-                      ?.copyWith(color: colors.textSecondary),
-                  textAlign: TextAlign.center,
-                ),
+            ),
+            if (_canUndoSwipe) ...[
+              const SizedBox(height: FacteurSpacing.space6),
+              TextButton.icon(
+                onPressed: _undoLastSwipe,
+                icon: const Icon(Icons.undo_rounded, size: 18),
+                label: const Text(OnboardingStrings.swipeUndoLabel),
               ),
             ],
-          ),
+          ],
         ),
       ),
     );
@@ -447,7 +505,8 @@ class _SwipeDisambiguatorQuestionState
           for (var i = 0; i < queue.length; i++) {
             final card = queue[i];
             final depth = queue.length - 1 - i; // 0 = carte du dessus
-            if (depth > 2) continue; // ne rend que le dessus + 2 cartes derrière
+            if (depth > 2)
+              continue; // ne rend que le dessus + 2 cartes derrière
             final visual = SizedBox(
               width: constraints.maxWidth,
               child: _cardVisual(context, card),
@@ -488,10 +547,7 @@ class _SwipeDisambiguatorQuestionState
           }
           return Stack(
             alignment: Alignment.center,
-            children: [
-              ...backCards,
-              if (topCard != null) topCard,
-            ],
+            children: [...backCards, if (topCard != null) topCard],
           );
         },
       ),
@@ -567,19 +623,17 @@ class _SwipeDisambiguatorQuestionState
                   children: [
                     Text(
                       source.name,
-                      style: Theme.of(context)
-                          .textTheme
-                          .titleMedium
-                          ?.copyWith(fontWeight: FontWeight.w700),
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.w700,
+                          ),
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                     ),
                     Text(
                       source.getThemeLabel(),
-                      style: Theme.of(context)
-                          .textTheme
-                          .bodySmall
-                          ?.copyWith(color: colors.textSecondary),
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: colors.textSecondary,
+                          ),
                     ),
                   ],
                 ),
@@ -655,10 +709,9 @@ class _SwipeDisambiguatorQuestionState
         const SizedBox(width: FacteurSpacing.space2),
         Text(
           label,
-          style: Theme.of(context)
-              .textTheme
-              .bodySmall
-              ?.copyWith(color: colors.textSecondary),
+          style: Theme.of(
+            context,
+          ).textTheme.bodySmall?.copyWith(color: colors.textSecondary),
         ),
         Flexible(
           child: Text(
@@ -740,15 +793,17 @@ class _SwipeDisambiguatorQuestionState
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  Icon(Icons.touch_app_outlined,
-                      size: 14, color: colors.textTertiary),
+                  Icon(
+                    Icons.touch_app_outlined,
+                    size: 14,
+                    color: colors.textTertiary,
+                  ),
                   const SizedBox(width: 6),
                   Text(
                     OnboardingStrings.swipeTapHint,
-                    style: Theme.of(context)
-                        .textTheme
-                        .bodySmall
-                        ?.copyWith(color: colors.textTertiary),
+                    style: Theme.of(
+                      context,
+                    ).textTheme.bodySmall?.copyWith(color: colors.textTertiary),
                   ),
                 ],
               ),
@@ -758,23 +813,36 @@ class _SwipeDisambiguatorQuestionState
 
   Widget _buildActions(BuildContext context, SpanningSource top) {
     final colors = context.facteurColors;
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
+    return Column(
+      mainAxisSize: MainAxisSize.min,
       children: [
-        _actionButton(
-          context,
-          icon: Icons.close_rounded,
-          color: colors.textSecondary,
-          tooltip: OnboardingStrings.swipeSkipHint,
-          onTap: () => _flingOut(top, liked: false),
-        ),
-        const SizedBox(width: FacteurSpacing.space8),
-        _actionButton(
-          context,
-          icon: Icons.favorite_rounded,
-          color: colors.success,
-          tooltip: OnboardingStrings.swipeLikeHint,
-          onTap: () => _flingOut(top, liked: true),
+        if (_canUndoSwipe) ...[
+          TextButton.icon(
+            onPressed: _undoLastSwipe,
+            icon: const Icon(Icons.undo_rounded, size: 18),
+            label: const Text(OnboardingStrings.swipeUndoLabel),
+          ),
+          const SizedBox(height: FacteurSpacing.space2),
+        ],
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            _actionButton(
+              context,
+              icon: Icons.close_rounded,
+              color: colors.textSecondary,
+              tooltip: OnboardingStrings.swipeSkipHint,
+              onTap: () => _flingOut(top, liked: false),
+            ),
+            const SizedBox(width: FacteurSpacing.space8),
+            _actionButton(
+              context,
+              icon: Icons.favorite_rounded,
+              color: colors.success,
+              tooltip: OnboardingStrings.swipeLikeHint,
+              onTap: () => _flingOut(top, liked: true),
+            ),
+          ],
         ),
       ],
     );

--- a/apps/mobile/lib/features/onboarding/widgets/source_recommendation_card.dart
+++ b/apps/mobile/lib/features/onboarding/widgets/source_recommendation_card.dart
@@ -63,7 +63,8 @@ class SourceRecommendationCard extends StatelessWidget {
                     ? FacteurImage(
                         imageUrl: source.logoUrl!,
                         fit: BoxFit.cover,
-                        errorWidget: (_) => _buildLogoFallback(colors, source.name),
+                        errorWidget: (_) =>
+                            _buildLogoFallback(colors, source.name),
                       )
                     : _buildLogoFallback(colors, source.name),
               ),
@@ -81,13 +82,13 @@ class SourceRecommendationCard extends StatelessWidget {
                       Flexible(
                         child: Text(
                           source.name,
-                          style:
-                              Theme.of(context).textTheme.labelLarge?.copyWith(
-                                    color: colors.textPrimary,
-                                    fontWeight: isSelected
-                                        ? FontWeight.w600
-                                        : FontWeight.w500,
-                                  ),
+                          style: Theme.of(context).textTheme.labelLarge
+                              ?.copyWith(
+                                color: colors.textPrimary,
+                                fontWeight: isSelected
+                                    ? FontWeight.w600
+                                    : FontWeight.w500,
+                              ),
                           overflow: TextOverflow.ellipsis,
                         ),
                       ),
@@ -104,11 +105,11 @@ class SourceRecommendationCard extends StatelessWidget {
                         const SizedBox(width: 3),
                         Text(
                           source.getBiasLabel(),
-                          style:
-                              Theme.of(context).textTheme.labelSmall?.copyWith(
-                                    color: colors.textTertiary,
-                                    fontSize: 10,
-                                  ),
+                          style: Theme.of(context).textTheme.labelSmall
+                              ?.copyWith(
+                                color: colors.textTertiary,
+                                fontSize: 10,
+                              ),
                         ),
                       ],
                       // Badge format (non-article uniquement) : rend le format
@@ -136,13 +137,25 @@ class SourceRecommendationCard extends StatelessWidget {
                     Text(
                       recommendation.reason,
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color: colors.textTertiary,
-                            fontStyle: recommendation.category ==
-                                    SourceCategory.gem
-                                ? FontStyle.italic
-                                : FontStyle.normal,
-                          ),
+                        color: colors.textTertiary,
+                        fontStyle: recommendation.category == SourceCategory.gem
+                            ? FontStyle.italic
+                            : FontStyle.normal,
+                      ),
                       maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                  if (source.followerCount > 0) ...[
+                    const SizedBox(height: 3),
+                    Text(
+                      _followerLabel(source.followerCount),
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: colors.textTertiary,
+                        fontSize: 11,
+                        fontWeight: FontWeight.w500,
+                      ),
+                      maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                     ),
                   ],
@@ -184,6 +197,10 @@ class SourceRecommendationCard extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  String _followerLabel(int count) {
+    return 'Suivi par $count lecteur${count > 1 ? 's' : ''} Facteur';
   }
 
   /// Builds a fallback avatar with the source's initials.
@@ -232,8 +249,7 @@ class SourceRecommendationCard extends StatelessWidget {
       RecommendationTagType.specialist ||
       RecommendationTagType.similar ||
       RecommendationTagType.fiable ||
-      RecommendationTagType.antiBruit =>
-        true,
+      RecommendationTagType.antiBruit => true,
       _ => false,
     };
 
@@ -248,10 +264,10 @@ class SourceRecommendationCard extends StatelessWidget {
       child: Text(
         '$prefix${tag.label}',
         style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              color: highlighted ? colors.primary : colors.textSecondary,
-              fontSize: 11,
-              fontWeight: highlighted ? FontWeight.w600 : null,
-            ),
+          color: highlighted ? colors.primary : colors.textSecondary,
+          fontSize: 11,
+          fontWeight: highlighted ? FontWeight.w600 : null,
+        ),
       ),
     );
   }

--- a/apps/mobile/lib/features/sources/providers/sources_providers.dart
+++ b/apps/mobile/lib/features/sources/providers/sources_providers.dart
@@ -72,8 +72,10 @@ final smartSearchProvider =
 
 /// Couverture par thèmes d'une source (fiche source v2). Le cache de Riverpod
 /// évite un refetch quand la fiche se reconstruit (toggles trust/mute…).
-final sourceCoverageProvider =
-    FutureProvider.family<SourceCoverage, String>((ref, sourceId) async {
+final sourceCoverageProvider = FutureProvider.family<SourceCoverage, String>((
+  ref,
+  sourceId,
+) async {
   if (sourceId.isEmpty) {
     return const SourceCoverage(periodLabel: '', totalCount: 0);
   }
@@ -84,15 +86,24 @@ final sourceCoverageProvider =
 /// Profil unifié d'une source pour la fiche v3 : articles récents (Content
 /// complets), couverture par thèmes, volume et fréquence en un seul appel.
 /// `autoDispose` : libéré à la fermeture de la sheet.
-final sourceProfileProvider =
-    FutureProvider.family.autoDispose<SourceProfile, String>((
-  ref,
-  sourceId,
-) async {
-  if (sourceId.isEmpty) return const SourceProfile();
-  final repository = ref.watch(sourcesRepositoryProvider);
-  return repository.getSourceProfile(sourceId);
-});
+final sourceProfileProvider = FutureProvider.family
+    .autoDispose<SourceProfile, String>((ref, sourceId) async {
+      if (sourceId.isEmpty) return const SourceProfile();
+      final keepAlive = ref.keepAlive();
+      Timer? disposeTimer;
+      ref.onCancel(() {
+        disposeTimer = Timer(const Duration(minutes: 2), keepAlive.close);
+      });
+      ref.onResume(() {
+        disposeTimer?.cancel();
+        disposeTimer = null;
+      });
+      ref.onDispose(() {
+        disposeTimer?.cancel();
+      });
+      final repository = ref.watch(sourcesRepositoryProvider);
+      return repository.getSourceProfile(sourceId);
+    });
 
 final trendingSourcesProvider = FutureProvider<List<Source>>((ref) async {
   final repository = ref.watch(sourcesRepositoryProvider);

--- a/apps/mobile/lib/features/sources/utils/publication_frequency.dart
+++ b/apps/mobile/lib/features/sources/utils/publication_frequency.dart
@@ -1,7 +1,7 @@
 /// Humanise la fréquence de publication d'une source pour la fiche v3.
 ///
-/// Fonction **pure** : le chip horloge du header en dérive un libellé court
-/// (« ~100/jour », « quelques-uns/semaine », « peu actif »…).
+/// Fonction **pure** : le chip horloge du header en dérive un libellé naturel
+/// (« 70 articles par jour en moyenne », « quelques articles par semaine »…).
 ///
 /// - [articles30d] : nombre d'articles publiés sur les 30 derniers jours
 ///   (= `articles_30d` du profil = somme des `theme_distribution`).
@@ -27,10 +27,13 @@ String humanizeFrequency(
 
   final perDay = articles30d / windowDays;
 
-  if (perDay >= 10) return '~${_niceRound(perDay)}/jour';
-  if (perDay >= 1.5) return 'quelques-uns/jour';
-  if (perDay * 7 >= 1.5) return 'quelques-uns/semaine';
-  return 'quelques-uns/mois';
+  if (perDay >= 10) {
+    final rounded = _niceRound(perDay);
+    return '$rounded articles par jour en moyenne';
+  }
+  if (perDay >= 1.5) return 'quelques articles par jour';
+  if (perDay * 7 >= 1.5) return 'quelques articles par semaine';
+  return 'quelques articles par mois';
 }
 
 /// Arrondi « joli » pour les gros volumes (lecture rapide, pas exacte).

--- a/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
@@ -7,6 +7,8 @@ import 'package:timeago/timeago.dart' as timeago;
 import '../../../config/routes.dart';
 import '../../../config/theme.dart';
 import '../../../config/topic_labels.dart';
+import '../../../features/detail/screens/content_detail_screen.dart';
+import '../../../shared/widgets/navigation/swipe_back_page.dart';
 import '../../../widgets/design/facteur_button.dart';
 import '../../feed/models/content_model.dart';
 import '../../flux_continu/utils/theme_color_mapping.dart';
@@ -23,6 +25,9 @@ import 'source_logo_avatar.dart';
 
 /// Espace fine insécable (U+202F) — avant `? ! : ;`, milliers, unités.
 const String _nnbsp = ' ';
+
+typedef SourceArticleOpener = void Function(
+    BuildContext context, Content article);
 
 /// Fiche source v2 — présentation du média d'abord, évaluation repliée.
 ///
@@ -48,6 +53,11 @@ class SourceDetailModal extends ConsumerWidget {
   /// de sélection du questionnaire (et non l'état « confiance » global).
   final bool? isSelectedOverride;
 
+  /// Ouvre un article récent. En mode normal, la fiche conserve le routing
+  /// historique GoRouter. L'onboarding injecte un push root Navigator pour que
+  /// le reader s'affiche au-dessus du flow sans redirection vers `/onboarding`.
+  final SourceArticleOpener? articleOpener;
+
   /// Libellé du bouton principal quand la source n'est pas sélectionnée
   /// (contexte onboarding). Défaut : « Sélectionner cette source ».
   final String? selectLabel;
@@ -60,6 +70,7 @@ class SourceDetailModal extends ConsumerWidget {
     this.onCopyFeedUrl,
     this.recentItems,
     this.isSelectedOverride,
+    this.articleOpener,
     this.selectLabel,
   });
 
@@ -107,6 +118,7 @@ class SourceDetailModal extends ConsumerWidget {
                 child: _FsBody(
                   source: liveSource,
                   recentItems: recentItems,
+                  articleOpener: articleOpener,
                 ),
               ),
             ),
@@ -136,8 +148,9 @@ class SourceDetailModal extends ConsumerWidget {
 class _FsBody extends ConsumerWidget {
   final Source source;
   final List<SmartSearchRecentItem>? recentItems;
+  final SourceArticleOpener? articleOpener;
 
-  const _FsBody({required this.source, this.recentItems});
+  const _FsBody({required this.source, this.recentItems, this.articleOpener});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -160,7 +173,10 @@ class _FsBody extends ConsumerWidget {
       loading: () => (
         null,
         const [
-          _FsSection(title: 'Couverture par thèmes', child: _CoverageSkeleton()),
+          _FsSection(
+            title: 'Couverture par thèmes',
+            child: _CoverageSkeleton(),
+          ),
           _FsSection(title: 'Derniers articles', child: _ArticlesSkeleton()),
         ],
       ),
@@ -182,7 +198,10 @@ class _FsBody extends ConsumerWidget {
                 caption: _coverageCaption(profile.articles30d),
               ),
             ),
-          _FsArticlesSection(articles: profile.recentArticles),
+          _FsArticlesSection(
+            articles: profile.recentArticles,
+            articleOpener: articleOpener,
+          ),
         ],
       ),
     );
@@ -230,19 +249,23 @@ class _FsHeader extends StatelessWidget {
 
     final signals = <Widget>[];
     if (followerCount > 0) {
-      signals.add(_signal(
-        context,
-        PhosphorIcons.users(PhosphorIconsStyle.regular),
-        'Suivi par ${_formatThousands(followerCount)} '
-        '${followerCount > 1 ? 'lecteurs' : 'lecteur'}',
-      ));
+      signals.add(
+        _signal(
+          context,
+          PhosphorIcons.users(PhosphorIconsStyle.regular),
+          'Suivi par ${_formatThousands(followerCount)} '
+          '${followerCount > 1 ? 'lecteurs' : 'lecteur'}',
+        ),
+      );
     }
     if (frequencyLabel != null && frequencyLabel!.isNotEmpty) {
-      signals.add(_signal(
-        context,
-        PhosphorIcons.clock(PhosphorIconsStyle.regular),
-        frequencyLabel!,
-      ));
+      signals.add(
+        _signal(
+          context,
+          PhosphorIcons.clock(PhosphorIconsStyle.regular),
+          frequencyLabel!,
+        ),
+      );
     }
     // Format (non-article uniquement) : rend lisible vidéo/podcast/Reddit. Rendu
     // dans l'idiome « signal » du header plutôt qu'en pill, pour rester cohérent
@@ -268,8 +291,9 @@ class _FsHeader extends StatelessWidget {
                   children: [
                     Text(
                       source.name,
-                      style: FacteurTypography.serifTitle(colors.textPrimary)
-                          .copyWith(fontSize: 22, letterSpacing: -0.4),
+                      style: FacteurTypography.serifTitle(
+                        colors.textPrimary,
+                      ).copyWith(fontSize: 22, letterSpacing: -0.4),
                     ),
                     if (domain != null) ...[
                       const SizedBox(height: 2),
@@ -344,7 +368,7 @@ class _FsEval extends StatefulWidget {
 }
 
 class _FsEvalState extends State<_FsEval> {
-  bool _open = false;
+  bool _open = true;
 
   @override
   Widget build(BuildContext context) {
@@ -379,33 +403,35 @@ class _FsEvalState extends State<_FsEval> {
               padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 13),
               child: Row(
                 children: [
-                  Flexible(
-                    child: Text(
-                      'Évaluation Facteur',
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: textTheme.labelMedium?.copyWith(
-                        color: colors.textSecondary,
-                        fontWeight: FontWeight.w700,
-                        fontSize: 13,
-                        letterSpacing: 0,
-                      ),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Évaluation Facteur',
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: textTheme.labelMedium?.copyWith(
+                            color: colors.textSecondary,
+                            fontWeight: FontWeight.w700,
+                            fontSize: 13,
+                            letterSpacing: 0,
+                          ),
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          'à titre indicatif',
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: textTheme.labelSmall?.copyWith(
+                            color: colors.textTertiary,
+                            fontWeight: FontWeight.w500,
+                            letterSpacing: 0,
+                          ),
+                        ),
+                      ],
                     ),
                   ),
-                  const SizedBox(width: 5),
-                  Flexible(
-                    child: Text(
-                      '· à titre indicatif',
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: textTheme.labelSmall?.copyWith(
-                        color: colors.textTertiary,
-                        fontWeight: FontWeight.w500,
-                        letterSpacing: 0,
-                      ),
-                    ),
-                  ),
-                  const Spacer(),
                   if (hasEval)
                     Row(
                       mainAxisSize: MainAxisSize.min,
@@ -441,9 +467,8 @@ class _FsEvalState extends State<_FsEval> {
                   const SizedBox(width: 6),
                   AnimatedRotation(
                     turns: _open ? 0.5 : 0,
-                    duration: reduceMotion
-                        ? Duration.zero
-                        : FacteurDurations.fast,
+                    duration:
+                        reduceMotion ? Duration.zero : FacteurDurations.fast,
                     child: Icon(
                       PhosphorIcons.caretDown(PhosphorIconsStyle.regular),
                       size: 14,
@@ -458,8 +483,13 @@ class _FsEvalState extends State<_FsEval> {
             Padding(
               padding: const EdgeInsets.fromLTRB(14, 2, 14, 14),
               child: hasEval
-                  ? _buildEvalBody(context, colors, textTheme, reliabilityLabel,
-                      reliabilityColor)
+                  ? _buildEvalBody(
+                      context,
+                      colors,
+                      textTheme,
+                      reliabilityLabel,
+                      reliabilityColor,
+                    )
                   : _buildNotEvaluated(context, colors, textTheme),
             ),
         ],
@@ -521,11 +551,7 @@ class _FsEvalState extends State<_FsEval> {
           ),
         ],
         const SizedBox(height: 12),
-        _evalRow(
-          context,
-          'Bord politique',
-          _BiasPill(source: source),
-        ),
+        _evalRow(context, 'Bord politique', _BiasPill(source: source)),
         // Ligne communauté : conditionnelle, masquée par défaut (pas de
         // métrique dédiée pour l'instant — cf. story 7.8 hors périmètre).
         if (hasRecoPerso) ...[
@@ -572,9 +598,7 @@ class _FsEvalState extends State<_FsEval> {
       padding: const EdgeInsets.only(top: 10),
       decoration: BoxDecoration(
         border: Border(
-          top: BorderSide(
-            color: colors.textPrimary.withValues(alpha: 0.08),
-          ),
+          top: BorderSide(color: colors.textPrimary.withValues(alpha: 0.08)),
         ),
       ),
       child: Column(
@@ -717,9 +741,8 @@ class _FsRecoPersoState extends State<_FsRecoPerso> {
     final colors = context.facteurColors;
     final textTheme = Theme.of(context).textTheme;
     final reduceMotion = MediaQuery.of(context).disableAnimations;
-    final initial = widget.name.trim().isEmpty
-        ? '?'
-        : widget.name.trim()[0].toUpperCase();
+    final initial =
+        widget.name.trim().isEmpty ? '?' : widget.name.trim()[0].toUpperCase();
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -783,9 +806,7 @@ class _FsRecoPersoState extends State<_FsRecoPerso> {
                 topRight: Radius.circular(FacteurRadius.medium),
                 bottomRight: Radius.circular(FacteurRadius.medium),
               ),
-              border: Border(
-                left: BorderSide(color: colors.primary, width: 3),
-              ),
+              border: Border(left: BorderSide(color: colors.primary, width: 3)),
             ),
             child: Text(
               widget.comment,
@@ -829,9 +850,7 @@ class _FsCoverageFromProvider extends ConsumerWidget {
           title: 'Couverture par thèmes',
           action: coverage.periodLabel.isNotEmpty ? coverage.periodLabel : null,
           child: _CoverageBars(
-            rows: [
-              for (final r in coverage.rows) (theme: r.theme, pct: r.pct),
-            ],
+            rows: [for (final r in coverage.rows) (theme: r.theme, pct: r.pct)],
             caption: coverage.caption,
           ),
         );
@@ -975,7 +994,9 @@ class _CoverageSkeleton extends StatelessWidget {
 /// `Content` viennent complets du profil unifié.
 class _FsArticlesSection extends StatelessWidget {
   final List<Content> articles;
-  const _FsArticlesSection({required this.articles});
+  final SourceArticleOpener? articleOpener;
+
+  const _FsArticlesSection({required this.articles, this.articleOpener});
 
   @override
   Widget build(BuildContext context) {
@@ -1013,6 +1034,12 @@ class _FsArticlesSection extends StatelessWidget {
   }
 
   void _openArticle(BuildContext context, Content article) {
+    final opener = articleOpener;
+    if (opener != null) {
+      opener(context, article);
+      return;
+    }
+
     // Reader unique (root navigator) : la sheet reste vivante dessous.
     context.pushNamed(
       RouteNames.contentDetail,
@@ -1020,6 +1047,14 @@ class _FsArticlesSection extends StatelessWidget {
       extra: article,
     );
   }
+}
+
+void openSourceArticleOnRootNavigator(BuildContext context, Content article) {
+  Navigator.of(context, rootNavigator: true).push<void>(
+    FullSwipeCupertinoPage<void>(
+      child: ContentDetailScreen(contentId: article.id, content: article),
+    ).createRoute(context),
+  );
 }
 
 /// Carte vide partagée (mode smart-search & mode normal sans article).
@@ -1036,9 +1071,7 @@ class _ArticlesEmptyCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: colors.surface.withValues(alpha: 0.4),
         borderRadius: BorderRadius.circular(FacteurRadius.large),
-        border: Border.all(
-          color: colors.textTertiary.withValues(alpha: 0.25),
-        ),
+        border: Border.all(color: colors.textTertiary.withValues(alpha: 0.25)),
       ),
       child: Row(
         children: [
@@ -1474,9 +1507,7 @@ class _ManageButton extends StatelessWidget {
               ? colors.textPrimary.withValues(alpha: 0.05)
               : Colors.transparent,
           borderRadius: BorderRadius.circular(FacteurRadius.medium),
-          border: Border.all(
-            color: isOn ? Colors.transparent : colors.border,
-          ),
+          border: Border.all(color: isOn ? Colors.transparent : colors.border),
         ),
         child: Row(
           mainAxisSize: MainAxisSize.min,
@@ -1551,8 +1582,8 @@ class _FsActionBar extends ConsumerWidget {
           Expanded(
             child: FacteurButton(
               onPressed: () {
-                onToggleTrust();
                 Navigator.pop(context);
+                onToggleTrust();
               },
               label: followLabel,
               type: isSelected
@@ -1581,8 +1612,7 @@ class _FsActionBar extends ConsumerWidget {
     WidgetRef ref,
     bool isFavorite,
   ) async {
-    final next =
-        isFavorite ? InterestState.followed : InterestState.favorite;
+    final next = isFavorite ? InterestState.followed : InterestState.favorite;
     try {
       await ref
           .read(userSourcesStateProvider.notifier)

--- a/apps/mobile/test/features/onboarding/data/source_recommender_test.dart
+++ b/apps/mobile/test/features/onboarding/data/source_recommender_test.dart
@@ -63,7 +63,8 @@ void main() {
       expect(
         reco.matched.length,
         greaterThanOrEqualTo(5),
-        reason: 'Le fallback fiabilité doit garantir un plancher de suggestions',
+        reason:
+            'Le fallback fiabilité doit garantir un plancher de suggestions',
       );
     });
 
@@ -100,30 +101,38 @@ void main() {
         swipeLiked: const ['off'],
       );
 
-      expect(reco.matched.first.source.id, 'off',
-          reason: 'Le like révélé doit primer sur le match thématique');
-    });
-
-    test('swipeDisliked exclut une source des matched malgré un match thème',
-        () {
-      final sources = [
-        _src('tech-1', theme: 'tech'),
-        _src('tech-2', theme: 'tech'),
-        _src('tech-bad', theme: 'tech'), // 4 - 4 = 0 → exclu des matched
-      ];
-
-      final reco = SourceRecommender.recommend(
-        selectedThemes: const ['tech'],
-        selectedSubtopics: const [],
-        allSources: sources,
-        swipeDisliked: const ['tech-bad'],
+      expect(
+        reco.matched.first.source.id,
+        'off',
+        reason: 'Le like révélé doit primer sur le match thématique',
       );
-
-      final matchedIds = reco.matched.map((r) => r.source.id);
-      expect(matchedIds, containsAll(<String>['tech-1', 'tech-2']));
-      expect(matchedIds, isNot(contains('tech-bad')),
-          reason: 'Le rejet révélé doit retirer la source des suggestions');
     });
+
+    test(
+      'swipeDisliked exclut une source des matched malgré un match thème',
+      () {
+        final sources = [
+          _src('tech-1', theme: 'tech'),
+          _src('tech-2', theme: 'tech'),
+          _src('tech-bad', theme: 'tech'), // 4 - 4 = 0 → exclu des matched
+        ];
+
+        final reco = SourceRecommender.recommend(
+          selectedThemes: const ['tech'],
+          selectedSubtopics: const [],
+          allSources: sources,
+          swipeDisliked: const ['tech-bad'],
+        );
+
+        final matchedIds = reco.matched.map((r) => r.source.id);
+        expect(matchedIds, containsAll(<String>['tech-1', 'tech-2']));
+        expect(
+          matchedIds,
+          isNot(contains('tech-bad')),
+          reason: 'Le rejet révélé doit retirer la source des suggestions',
+        );
+      },
+    );
 
     test('depthPref oriente le tier privilégié', () {
       final sources = [
@@ -150,8 +159,7 @@ void main() {
 
     test('independencePref=independent booste la forte indépendance', () {
       final sources = [
-        _src('indie',
-            theme: 'tech', independence: 0.9, reliability: 'unknown'),
+        _src('indie', theme: 'tech', independence: 0.9, reliability: 'unknown'),
         _src('inst', theme: 'tech', independence: 0.2), // reliability high
       ];
 
@@ -172,24 +180,32 @@ void main() {
   // ─────────────────────────────────────────────────────────────────────────
   group('SourceRecommender — signal pôle généralisé', () {
     Map<String, RecommendedSource> byId(SourceRecommendation r) => {
-          for (final rec in [
-            ...r.matched,
-            ...r.perspective,
-            ...r.gems,
-            ...r.catalog,
-          ])
-            rec.source.id: rec
-        };
+      for (final rec in [
+        ...r.matched,
+        ...r.perspective,
+        ...r.gems,
+        ...r.catalog,
+      ])
+        rec.source.id: rec,
+    };
 
     test('un like booste une source non swipée du même pôle (deep)', () {
       final sources = [
         _src('deep-liked', theme: 'tech', tier: 'deep'),
         // même pôle (deep) mais hors-thème et non swipée → doit être boostée.
-        _src('deep-other',
-            theme: 'sport', tier: 'deep', reliability: 'unknown'),
+        _src(
+          'deep-other',
+          theme: 'sport',
+          tier: 'deep',
+          reliability: 'unknown',
+        ),
         // autre pôle (mainstream) hors-thème → aucun boost.
-        _src('main-other',
-            theme: 'sport', tier: 'mainstream', reliability: 'unknown'),
+        _src(
+          'main-other',
+          theme: 'sport',
+          tier: 'mainstream',
+          reliability: 'unknown',
+        ),
       ];
 
       final reco = SourceRecommender.recommend(
@@ -200,10 +216,16 @@ void main() {
       );
 
       final m = byId(reco);
-      expect(m['deep-other']!.score, greaterThan(0),
-          reason: 'le pôle deep liké booste les autres sources deep');
-      expect(m['deep-other']!.score, greaterThan(m['main-other']!.score),
-          reason: 'le boost vise le pôle, pas les autres pôles');
+      expect(
+        m['deep-other']!.score,
+        greaterThan(0),
+        reason: 'le pôle deep liké booste les autres sources deep',
+      );
+      expect(
+        m['deep-other']!.score,
+        greaterThan(m['main-other']!.score),
+        reason: 'le boost vise le pôle, pas les autres pôles',
+      );
     });
 
     test('un rejet pénalise une autre source du même pôle (deep)', () {
@@ -221,8 +243,11 @@ void main() {
       );
 
       final m = byId(reco);
-      expect(m['deep-other']!.score, lessThan(m['main-other']!.score),
-          reason: 'le rejet du pôle deep pénalise les autres sources deep');
+      expect(
+        m['deep-other']!.score,
+        lessThan(m['main-other']!.score),
+        reason: 'le rejet du pôle deep pénalise les autres sources deep',
+      );
     });
   });
 
@@ -244,39 +269,49 @@ void main() {
 
     test('une reco partageant thème + tier avec une likée reçoit le tag', () {
       final sources = [
-        _src('anchor',
-            name: 'Le Monde', theme: 'tech', tier: 'deep', followers: 999),
+        _src(
+          'anchor',
+          name: 'Le Monde',
+          theme: 'tech',
+          tier: 'deep',
+          followers: 999,
+        ),
         // même thème + même tier (deep) → similaire à l'ancre likée.
         _src('reco', theme: 'tech', tier: 'deep'),
       ];
 
       final reco = SourceRecommender.recommend(
-        selectedThemes: const ['tech'],
+        selectedThemes: const [],
         selectedSubtopics: const [],
         allSources: sources,
         swipeLiked: const ['anchor'],
       );
 
       final tag = similarTagOf(reco, 'reco');
-      expect(tag, isNotNull,
-          reason: 'thème + tier partagés avec une source likée');
+      expect(
+        tag,
+        isNotNull,
+        reason: 'thème + tier partagés avec une source likée',
+      );
       expect(tag!.label, contains('Le Monde'));
     });
 
     test('une reco partageant thème + biais avec une likée reçoit le tag', () {
       final sources = [
-        _src('anchor',
-            name: 'Libération',
-            theme: 'tech',
-            tier: 'mainstream',
-            bias: 'left',
-            followers: 999),
+        _src(
+          'anchor',
+          name: 'Libération',
+          theme: 'tech',
+          tier: 'mainstream',
+          bias: 'left',
+          followers: 999,
+        ),
         // tier différent mais même biais (left) + même thème → similaire.
         _src('reco', theme: 'tech', tier: 'deep', bias: 'left'),
       ];
 
       final reco = SourceRecommender.recommend(
-        selectedThemes: const ['tech'],
+        selectedThemes: const [],
         selectedSubtopics: const [],
         allSources: sources,
         swipeLiked: const ['anchor'],
@@ -305,18 +340,20 @@ void main() {
 
     test('thème commun mais ni tier ni biais partagé : pas de tag', () {
       final sources = [
-        _src('anchor',
-            name: 'Mediapart',
-            theme: 'tech',
-            tier: 'deep',
-            bias: 'left',
-            followers: 999),
+        _src(
+          'anchor',
+          name: 'Mediapart',
+          theme: 'tech',
+          tier: 'deep',
+          bias: 'left',
+          followers: 999,
+        ),
         // même thème mais tier ET biais différents → pas similaire.
         _src('reco', theme: 'tech', tier: 'mainstream', bias: 'right'),
       ];
 
       final reco = SourceRecommender.recommend(
-        selectedThemes: const ['tech'],
+        selectedThemes: const [],
         selectedSubtopics: const [],
         allSources: sources,
         swipeLiked: const ['anchor'],
@@ -324,24 +361,94 @@ void main() {
 
       expect(similarTagOf(reco, 'reco'), isNull);
     });
+
+    test(
+      'limite le tag similaire à 2 occurrences et le masque si tag précis',
+      () {
+        final sources = [
+          _src(
+            'anchor',
+            name: 'Sismique',
+            theme: 'tech',
+            tier: 'deep',
+            followers: 999,
+          ),
+          for (var i = 0; i < 4; i++)
+            _src('similar-$i', theme: 'tech', tier: 'deep'),
+          _src('precise', theme: 'tech', tier: 'deep'),
+        ];
+
+        final recoNoPrecise = SourceRecommender.recommend(
+          selectedThemes: const [],
+          selectedSubtopics: const [],
+          allSources: sources,
+          swipeLiked: const ['anchor'],
+        );
+
+        final allVisible = [
+          ...recoNoPrecise.specialists,
+          ...recoNoPrecise.matched,
+          ...recoNoPrecise.perspective,
+          ...recoNoPrecise.gems,
+        ];
+        final similarToSismique = allVisible
+            .expand((r) => r.tags)
+            .where((t) => t.label == 'Similaire à Sismique')
+            .length;
+
+        expect(similarToSismique, 2);
+
+        final recoPrecise = SourceRecommender.recommend(
+          selectedThemes: const ['tech'],
+          selectedSubtopics: const [],
+          allSources: sources,
+          swipeLiked: const ['anchor'],
+        );
+        expect(
+          similarTagOf(recoPrecise, 'precise'),
+          isNull,
+          reason: 'le tag thème Tech est plus précis que le fallback similaire',
+        );
+      },
+    );
   });
 
   group('SourceRecommender.buildSpanningSet', () {
     test('étale ~8-10 cartes (N par pôle) sur plusieurs pôles', () {
       // 2 candidats « purs » par pôle → set bien rempli (round-robin perPole=2).
       final sources = [
-        _src('deep-1', theme: 'tech', tier: 'deep', reliability: 'unknown',
-            followers: 50),
-        _src('deep-2', theme: 'tech', tier: 'deep', reliability: 'unknown',
-            followers: 40),
+        _src(
+          'deep-1',
+          theme: 'tech',
+          tier: 'deep',
+          reliability: 'unknown',
+          followers: 50,
+        ),
+        _src(
+          'deep-2',
+          theme: 'tech',
+          tier: 'deep',
+          reliability: 'unknown',
+          followers: 40,
+        ),
         _src('indie-1', theme: 'tech', independence: 0.9, bias: 'alternative'),
         _src('indie-2', theme: 'tech', independence: 0.8, bias: 'specialized'),
         _src('est-1', theme: 'tech', independence: 0.2, reliability: 'high'),
         _src('est-2', theme: 'tech', independence: 0.3, reliability: 'high'),
-        _src('main-1', theme: 'tech', tier: 'mainstream',
-            reliability: 'unknown', followers: 100),
-        _src('main-2', theme: 'tech', tier: 'mainstream',
-            reliability: 'unknown', followers: 90),
+        _src(
+          'main-1',
+          theme: 'tech',
+          tier: 'mainstream',
+          reliability: 'unknown',
+          followers: 100,
+        ),
+        _src(
+          'main-2',
+          theme: 'tech',
+          tier: 'mainstream',
+          reliability: 'unknown',
+          followers: 90,
+        ),
         _src('left-1', theme: 'tech', bias: 'left', reliability: 'unknown'),
         _src('right-1', theme: 'tech', bias: 'right', reliability: 'unknown'),
       ];
@@ -357,8 +464,11 @@ void main() {
       final ids = set.map((s) => s.source.id).toList();
       expect(ids.toSet().length, ids.length, reason: 'pas de doublon');
       final poles = set.map((s) => s.pole).toSet();
-      expect(poles.length, greaterThanOrEqualTo(4),
-          reason: 'plusieurs pôles couverts');
+      expect(
+        poles.length,
+        greaterThanOrEqualTo(4),
+        reason: 'plusieurs pôles couverts',
+      );
     });
 
     test('renvoie une liste vide sans source curée', () {
@@ -393,10 +503,22 @@ void main() {
       // Deux sources mainstream identiques sauf le volume — la productive
       // (articles30d élevé) doit être préférée, même avec moins de followers.
       final sources = [
-        _src('quiet', theme: 'tech', tier: 'mainstream', reliability: 'unknown',
-            followers: 1000, articles30d: 0),
-        _src('active', theme: 'tech', tier: 'mainstream', reliability: 'unknown',
-            followers: 10, articles30d: 200),
+        _src(
+          'quiet',
+          theme: 'tech',
+          tier: 'mainstream',
+          reliability: 'unknown',
+          followers: 1000,
+          articles30d: 0,
+        ),
+        _src(
+          'active',
+          theme: 'tech',
+          tier: 'mainstream',
+          reliability: 'unknown',
+          followers: 10,
+          articles30d: 200,
+        ),
       ];
 
       final set = SourceRecommender.buildSpanningSet(
@@ -407,8 +529,11 @@ void main() {
         perPole: 1,
       );
 
-      expect(set.first.source.id, 'active',
-          reason: 'volume prime sur followers à match égal');
+      expect(
+        set.first.source.id,
+        'active',
+        reason: 'volume prime sur followers à match égal',
+      );
     });
   });
 
@@ -426,8 +551,11 @@ void main() {
       );
 
       final ids = reco.matched.map((r) => r.source.id).toList();
-      expect(ids.indexOf('active'), lessThan(ids.indexOf('quiet')),
-          reason: 'le bonus volume départage à match thématique égal');
+      expect(
+        ids.indexOf('active'),
+        lessThan(ids.indexOf('quiet')),
+        reason: 'le bonus volume départage à match thématique égal',
+      );
     });
 
     test('articles30d absent (0) : aucun effet (rétro-compatible)', () {
@@ -458,22 +586,23 @@ void main() {
       required List<String> topics,
       String reliability = 'high',
       String? theme,
-    }) =>
-        Source(
-          id: id,
-          name: 'Source $id',
-          type: SourceType.article,
-          isCurated: true,
-          reliabilityScore: reliability,
-          theme: theme,
-          granularTopics: topics,
-        );
+    }) => Source(
+      id: id,
+      name: 'Source $id',
+      type: SourceType.article,
+      isCurated: true,
+      reliabilityScore: reliability,
+      theme: theme,
+      granularTopics: topics,
+    );
 
     bool hasSpecialistTag(RecommendedSource r) =>
         r.tags.any((t) => t.type == RecommendationTagType.specialist);
 
     test('spécialité dominante ∈ sujets → badge « Spécialisé en X »', () {
-      final sources = [spec('ai', topics: ['ai', 'tech'], theme: 'tech')];
+      final sources = [
+        spec('ai', topics: ['ai', 'tech'], theme: 'tech'),
+      ];
 
       final reco = SourceRecommender.recommend(
         selectedThemes: const ['tech'],
@@ -494,7 +623,9 @@ void main() {
     test('subtopic non dominant → pas de badge spécialiste sur cette source', () {
       // 'ai' n'est PAS la spécialité dominante (tech l'est) → la carte garde un
       // tag thème « IA » mais aucun badge spécialiste.
-      final sources = [spec('s', topics: ['tech', 'ai'], theme: 'tech')];
+      final sources = [
+        spec('s', topics: ['tech', 'ai'], theme: 'tech'),
+      ];
 
       final reco = SourceRecommender.recommend(
         selectedThemes: const ['tech'],
@@ -506,37 +637,45 @@ void main() {
       expect(hasSpecialistTag(card), isFalse);
     });
 
-    test('garantie : un spécialiste hors-matched est remonté dans specialists',
-        () {
-      // 15 sources tech (score 4) saturent matched ; le spécialiste factcheck
-      // (score 2) en serait exclu → la garantie de couverture le rapatrie.
-      final sources = [
-        for (var i = 0; i < 15; i++) spec('tech-$i', topics: const [], theme: 'tech'),
-        spec('fc', topics: const ['factcheck'], reliability: 'unknown'),
-      ];
+    test(
+      'garantie : un spécialiste hors-matched est remonté dans specialists',
+      () {
+        // 15 sources tech (score 4) saturent matched ; le spécialiste factcheck
+        // (score 2) en serait exclu → la garantie de couverture le rapatrie.
+        final sources = [
+          for (var i = 0; i < 15; i++)
+            spec('tech-$i', topics: const [], theme: 'tech'),
+          spec('fc', topics: const ['factcheck'], reliability: 'unknown'),
+        ];
 
-      final reco = SourceRecommender.recommend(
-        selectedThemes: const ['tech'],
-        selectedSubtopics: const ['factcheck'],
-        allSources: sources,
-      );
+        final reco = SourceRecommender.recommend(
+          selectedThemes: const ['tech'],
+          selectedSubtopics: const ['factcheck'],
+          allSources: sources,
+        );
 
-      expect(reco.matched.any((r) => r.source.id == 'fc'), isFalse,
-          reason: 'le spécialiste de faible score ne rentre pas dans matched');
-      final fc = reco.specialists.firstWhere((r) => r.source.id == 'fc');
-      expect(hasSpecialistTag(fc), isTrue);
-      expect(
-        fc.tags
-            .firstWhere((t) => t.type == RecommendationTagType.specialist)
-            .label,
-        'Spécialisé en Fact-checking',
-      );
-      // Pré-coché pour l'effet « wow ».
-      expect(reco.preselectedIds, contains('fc'));
-    });
+        expect(
+          reco.matched.any((r) => r.source.id == 'fc'),
+          isFalse,
+          reason: 'le spécialiste de faible score ne rentre pas dans matched',
+        );
+        final fc = reco.specialists.firstWhere((r) => r.source.id == 'fc');
+        expect(hasSpecialistTag(fc), isTrue);
+        expect(
+          fc.tags
+              .firstWhere((t) => t.type == RecommendationTagType.specialist)
+              .label,
+          'Spécialisé en Fact-checking',
+        );
+        // Pré-coché pour l'effet « wow ».
+        expect(reco.preselectedIds, contains('fc'));
+      },
+    );
 
     test('spécialiste déjà dominant dans matched → pas de doublon', () {
-      final sources = [spec('ai', topics: const ['ai'], theme: 'tech')];
+      final sources = [
+        spec('ai', topics: const ['ai'], theme: 'tech'),
+      ];
 
       final reco = SourceRecommender.recommend(
         selectedThemes: const ['tech'],
@@ -554,7 +693,8 @@ void main() {
       // Deux sujets « pauvres » non couverts par matched ; deux spécialistes
       // distincts disponibles → une carte chacun.
       final sources = [
-        for (var i = 0; i < 15; i++) spec('tech-$i', topics: const [], theme: 'tech'),
+        for (var i = 0; i < 15; i++)
+          spec('tech-$i', topics: const [], theme: 'tech'),
         spec('fc', topics: const ['factcheck'], reliability: 'unknown'),
         spec('rel', topics: const ['relationships'], reliability: 'unknown'),
       ];

--- a/apps/mobile/test/features/onboarding/screens/digest_mode_question_test.dart
+++ b/apps/mobile/test/features/onboarding/screens/digest_mode_question_test.dart
@@ -1,0 +1,61 @@
+import 'dart:io';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/onboarding/onboarding_strings.dart';
+import 'package:facteur/features/onboarding/providers/onboarding_provider.dart';
+import 'package:facteur/features/onboarding/screens/questions/digest_mode_question.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+void main() {
+  setUpAll(() {
+    Hive.init(Directory.systemTemp.createTempSync('digest_mode_test').path);
+  });
+
+  ProviderContainer makeContainer() {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  Widget buildTestWidget(ProviderContainer container) {
+    return UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        theme: FacteurTheme.lightTheme,
+        home: const Scaffold(body: DigestModeQuestion()),
+      ),
+    );
+  }
+
+  testWidgets(
+    'mode serein : plus de CTA personnalisation, note paramètres visible',
+    (tester) async {
+      final container = makeContainer();
+      await tester.pumpWidget(buildTestWidget(container));
+      await tester.pumpAndSettle();
+
+      expect(find.text(OnboardingStrings.personalizeSereinCta), findsNothing);
+      expect(
+          find.text(OnboardingStrings.digestModeAnytimeNote), findsOneWidget);
+
+      await tester.tap(find.text('Oui, rester serein'));
+      await tester.pump();
+      expect(
+        container.read(onboardingProvider).answers.digestMode,
+        'serein',
+      );
+
+      await tester.tap(find.text('Non, tout voir'));
+      await tester.pump();
+      expect(
+        container.read(onboardingProvider).answers.digestMode,
+        'pour_vous',
+      );
+
+      await tester.pump(const Duration(seconds: 2));
+    },
+  );
+}

--- a/apps/mobile/test/features/onboarding/screens/sources_question_test.dart
+++ b/apps/mobile/test/features/onboarding/screens/sources_question_test.dart
@@ -9,12 +9,14 @@ import 'package:facteur/config/theme.dart';
 import 'package:facteur/core/providers/analytics_provider.dart';
 import 'package:facteur/core/services/analytics_service.dart';
 import 'package:facteur/features/onboarding/onboarding_strings.dart';
+import 'package:facteur/features/onboarding/data/source_recommender.dart';
 import 'package:facteur/features/onboarding/providers/onboarding_provider.dart';
 import 'package:facteur/features/onboarding/screens/questions/sources_question.dart';
 import 'package:facteur/features/onboarding/widgets/recommendation_section.dart';
 import 'package:facteur/features/onboarding/widgets/source_recommendation_card.dart';
 import 'package:facteur/features/sources/models/smart_search_result.dart';
 import 'package:facteur/features/sources/models/source_model.dart';
+import 'package:facteur/features/sources/models/source_profile.dart';
 import 'package:facteur/features/sources/providers/sources_providers.dart';
 import 'package:facteur/features/sources/repositories/sources_repository.dart';
 import 'package:facteur/features/sources/widgets/source_add_panel.dart';
@@ -53,17 +55,17 @@ class _FakeSourcesRepository implements SourcesRepository {
 /// La première est un gros publieur mainstream (« Grand Média », fort
 /// followerCount) qu'on doit retrouver dans les suggestions.
 List<Source> _makeTechSources() => List.generate(15, (i) {
-      return Source(
-        id: 'src-$i',
-        name: i == 0 ? 'Grand Média' : 'Source $i',
-        type: SourceType.article,
-        theme: 'tech',
-        isCurated: true,
-        sourceTier: 'mainstream',
-        followerCount: i == 0 ? 100000 : 100 - i,
-        reliabilityScore: 'high',
-      );
-    });
+  return Source(
+    id: 'src-$i',
+    name: i == 0 ? 'Grand Média' : 'Source $i',
+    type: SourceType.article,
+    theme: 'tech',
+    isCurated: true,
+    sourceTier: 'mainstream',
+    followerCount: i == 0 ? 100000 : 100 - i,
+    reliabilityScore: 'high',
+  );
+});
 
 void main() {
   // Hive est initialisé mais la box n'est jamais ouverte hors zone de test :
@@ -75,11 +77,19 @@ void main() {
   });
 
   ProviderContainer makeContainer(List<Source> sources) {
-    final container = ProviderContainer(overrides: [
-      userSourcesProvider.overrideWith(() => _FakeUserSourcesNotifier(sources)),
-      sourcesRepositoryProvider.overrideWithValue(_FakeSourcesRepository()),
-      analyticsServiceProvider.overrideWithValue(AnalyticsService.disabled()),
-    ]);
+    final container = ProviderContainer(
+      overrides: [
+        userSourcesProvider.overrideWith(
+          () => _FakeUserSourcesNotifier(sources),
+        ),
+        for (final source in sources)
+          sourceProfileProvider(
+            source.id,
+          ).overrideWith((_) async => const SourceProfile()),
+        sourcesRepositoryProvider.overrideWithValue(_FakeSourcesRepository()),
+        analyticsServiceProvider.overrideWithValue(AnalyticsService.disabled()),
+      ],
+    );
     addTearDown(container.dispose);
     return container;
   }
@@ -94,9 +104,9 @@ void main() {
     );
   }
 
-  testWidgets(
-      '4 blocs numérotés, ≤18 suggestions, top 9 pré-cochées',
-      (tester) async {
+  testWidgets('4 blocs numérotés, ≤18 suggestions, top 9 pré-cochées', (
+    tester,
+  ) async {
     final container = makeContainer(_makeTechSources());
     // bypassOnboarding pose themes=[tech, international].
     container.read(onboardingProvider.notifier).bypassOnboarding();
@@ -114,10 +124,7 @@ void main() {
     expect(cards, findsNWidgets(15));
 
     // Pré-sélection = top 9 uniquement (le reste affiché décoché).
-    expect(
-      find.text(OnboardingStrings.selectedCount(9)),
-      findsOneWidget,
-    );
+    expect(find.text(OnboardingStrings.selectedCount(9)), findsOneWidget);
 
     // Le gros publieur mainstream remonte dans les suggestions (volume-proxy).
     expect(find.text('Grand Média'), findsOneWidget);
@@ -130,14 +137,12 @@ void main() {
     expect(find.byType(SourceAddPanel), findsNothing);
 
     // Bloc ③ : catalogue replié.
-    expect(
-      find.text(OnboardingStrings.sourcesSeeAllCatalog),
-      findsOneWidget,
-    );
+    expect(find.text(OnboardingStrings.sourcesSeeAllCatalog), findsOneWidget);
   });
 
-  testWidgets('panneau d\'ajout dépliable : SourceAddPanel monté au tap',
-      (tester) async {
+  testWidgets('panneau d\'ajout dépliable : SourceAddPanel monté au tap', (
+    tester,
+  ) async {
     final container = makeContainer(_makeTechSources());
     container.read(onboardingProvider.notifier).bypassOnboarding();
 
@@ -155,4 +160,78 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byType(SourceAddPanel), findsOneWidget);
   });
+
+  testWidgets(
+    'sources likées : sélectionnées, récapitulées et retirées des suggestions',
+    (tester) async {
+      final liked = Source(
+        id: 'sismique',
+        name: 'Sismique',
+        type: SourceType.article,
+        theme: 'tech',
+        isCurated: true,
+        sourceTier: 'mainstream',
+        reliabilityScore: 'high',
+        followerCount: 5000,
+      );
+      final sources = [liked, ..._makeTechSources()];
+      final container = makeContainer(sources);
+      container.read(onboardingProvider.notifier).bypassOnboarding();
+      container.read(onboardingProvider.notifier).completeSwipe(const [
+        'sismique',
+      ], const []);
+
+      await tester.pumpWidget(buildTestWidget(container));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Déjà ajoutées'), findsOneWidget);
+      expect(find.text('Sismique'), findsOneWidget);
+      expect(
+        find.text(OnboardingStrings.selectedCount(10)),
+        findsOneWidget,
+        reason: '9 suggestions précochées + la source likée déjà validée',
+      );
+
+      final suggestionCards = tester
+          .widgetList<SourceRecommendationCard>(
+            find.byType(SourceRecommendationCard),
+          )
+          .toList();
+      expect(
+        suggestionCards.map((c) => c.recommendation.source.id),
+        isNot(contains('sismique')),
+      );
+    },
+  );
+
+  testWidgets(
+    'SourceRecommendationCard affiche le nombre de lecteurs Facteur',
+    (tester) async {
+      final source = Source(
+        id: 'reader-count',
+        name: 'Le Signal',
+        type: SourceType.article,
+        followerCount: 2,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: FacteurTheme.lightTheme,
+          home: Scaffold(
+            body: SourceRecommendationCard(
+              recommendation: RecommendedSource(
+                source: source,
+                category: SourceCategory.matched,
+              ),
+              isSelected: false,
+              onToggle: () {},
+              onInfoTap: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Suivi par 2 lecteurs Facteur'), findsOneWidget);
+    },
+  );
 }

--- a/apps/mobile/test/features/onboarding/screens/swipe_disambiguator_question_test.dart
+++ b/apps/mobile/test/features/onboarding/screens/swipe_disambiguator_question_test.dart
@@ -8,10 +8,13 @@ import 'package:hive/hive.dart';
 import 'package:facteur/config/theme.dart';
 import 'package:facteur/core/providers/analytics_provider.dart';
 import 'package:facteur/core/services/analytics_service.dart';
+import 'package:facteur/widgets/design/facteur_button.dart';
 import 'package:facteur/features/onboarding/onboarding_strings.dart';
+import 'package:facteur/features/onboarding/data/source_recommender.dart';
 import 'package:facteur/features/onboarding/providers/onboarding_provider.dart';
 import 'package:facteur/features/onboarding/screens/questions/swipe_disambiguator_question.dart';
 import 'package:facteur/features/sources/models/source_model.dart';
+import 'package:facteur/features/sources/models/source_profile.dart';
 import 'package:facteur/features/sources/providers/sources_providers.dart';
 
 class _FakeUserSourcesNotifier extends UserSourcesNotifier {
@@ -48,10 +51,18 @@ void main() {
   });
 
   ProviderContainer makeContainer(List<Source> sources) {
-    final container = ProviderContainer(overrides: [
-      userSourcesProvider.overrideWith(() => _FakeUserSourcesNotifier(sources)),
-      analyticsServiceProvider.overrideWithValue(AnalyticsService.disabled()),
-    ]);
+    final container = ProviderContainer(
+      overrides: [
+        userSourcesProvider.overrideWith(
+          () => _FakeUserSourcesNotifier(sources),
+        ),
+        for (final source in sources)
+          sourceProfileProvider(
+            source.id,
+          ).overrideWith((_) async => const SourceProfile()),
+        analyticsServiceProvider.overrideWithValue(AnalyticsService.disabled()),
+      ],
+    );
     addTearDown(container.dispose);
     return container;
   }
@@ -86,54 +97,74 @@ void main() {
     expect(find.text(OnboardingStrings.swipeReliabilityPrefix), findsWidgets);
   });
 
-  testWidgets('like (carte unique) : fling, vote enregistré, avance vers sources',
-      (tester) async {
-    final container = makeContainer([_src('solo', tier: 'mainstream')]);
-    await tester.pumpWidget(buildTestWidget(container));
-    await tester.pumpAndSettle();
+  testWidgets(
+    'like (carte unique) : fling, vote enregistré, avance vers sources',
+    (tester) async {
+      final container = makeContainer([_src('solo', tier: 'mainstream')]);
+      await tester.pumpWidget(buildTestWidget(container));
+      await tester.pumpAndSettle();
 
-    await tester.tap(find.widgetWithIcon(InkWell, Icons.favorite_rounded));
-    await tester.pump(); // démarre le fling
-    await tester.pump(const Duration(milliseconds: 400)); // fling terminé → vote
+      await tester.tap(find.widgetWithIcon(InkWell, Icons.favorite_rounded));
+      await tester.pump(); // démarre le fling
+      await tester.pump(
+        const Duration(milliseconds: 400),
+      ); // fling terminé → vote
 
-    // Dernière carte triée → moment « on affine vos sources » (overlay ~1,4 s).
-    expect(find.text(OnboardingStrings.swipeRefiningTitle), findsOneWidget);
+      // Dernière carte triée → moment « on affine vos sources » (overlay ~1,4 s).
+      expect(find.text(OnboardingStrings.swipeRefiningTitle), findsOneWidget);
 
-    await tester.pump(const Duration(milliseconds: 1500)); // refining → completeSwipe
-    expect(container.read(onboardingProvider).answers.swipeLiked,
-        equals(['solo']));
+      await tester.pump(
+        const Duration(milliseconds: 1500),
+      ); // refining → completeSwipe
+      expect(
+        container.read(onboardingProvider).answers.swipeLiked,
+        equals(['solo']),
+      );
 
-    await tester.pump(const Duration(milliseconds: 350)); // transition completeSwipe
-    expect(
-      container.read(onboardingProvider).currentQuestionIndex,
-      Section3Question.sources.index,
-    );
-  });
+      await tester.pump(
+        const Duration(milliseconds: 350),
+      ); // transition completeSwipe
+      expect(
+        container.read(onboardingProvider).currentQuestionIndex,
+        Section3Question.sources.index,
+      );
+    },
+  );
 
-  testWidgets('skip (carte unique) : fling, rejet enregistré, avance vers sources',
-      (tester) async {
-    final container = makeContainer([_src('solo', tier: 'mainstream')]);
-    await tester.pumpWidget(buildTestWidget(container));
-    await tester.pumpAndSettle();
+  testWidgets(
+    'skip (carte unique) : fling, rejet enregistré, avance vers sources',
+    (tester) async {
+      final container = makeContainer([_src('solo', tier: 'mainstream')]);
+      await tester.pumpWidget(buildTestWidget(container));
+      await tester.pumpAndSettle();
 
-    await tester.tap(find.widgetWithIcon(InkWell, Icons.close_rounded));
-    await tester.pump(); // démarre le fling
-    await tester.pump(const Duration(milliseconds: 400)); // fling terminé → vote
+      await tester.tap(find.widgetWithIcon(InkWell, Icons.close_rounded));
+      await tester.pump(); // démarre le fling
+      await tester.pump(
+        const Duration(milliseconds: 400),
+      ); // fling terminé → vote
 
-    // Dernière carte triée → moment « on affine vos sources » (overlay ~1,4 s).
-    expect(find.text(OnboardingStrings.swipeRefiningTitle), findsOneWidget);
+      // Dernière carte triée → moment « on affine vos sources » (overlay ~1,4 s).
+      expect(find.text(OnboardingStrings.swipeRefiningTitle), findsOneWidget);
 
-    await tester.pump(const Duration(milliseconds: 1500)); // refining → completeSwipe
-    expect(container.read(onboardingProvider).answers.swipeDisliked,
-        equals(['solo']));
-    expect(container.read(onboardingProvider).answers.swipeLiked, isEmpty);
+      await tester.pump(
+        const Duration(milliseconds: 1500),
+      ); // refining → completeSwipe
+      expect(
+        container.read(onboardingProvider).answers.swipeDisliked,
+        equals(['solo']),
+      );
+      expect(container.read(onboardingProvider).answers.swipeLiked, isEmpty);
 
-    await tester.pump(const Duration(milliseconds: 350)); // transition completeSwipe
-    expect(
-      container.read(onboardingProvider).currentQuestionIndex,
-      Section3Question.sources.index,
-    );
-  });
+      await tester.pump(
+        const Duration(milliseconds: 350),
+      ); // transition completeSwipe
+      expect(
+        container.read(onboardingProvider).currentQuestionIndex,
+        Section3Question.sources.index,
+      );
+    },
+  );
 
   // Deck large et étalé (~8-10 cartes) pour exercer le compteur et la phrase
   // inline « ce qu'on retient ».
@@ -150,8 +181,9 @@ void main() {
         _src('right-1', bias: 'right'),
       ];
 
-  testWidgets('compteur humanisé + pas de chips de profil au départ',
-      (tester) async {
+  testWidgets('compteur humanisé + pas de chips de profil au départ', (
+    tester,
+  ) async {
     final container = makeContainer(_richDeck());
     await tester.pumpWidget(buildTestWidget(container));
     await tester.pumpAndSettle();
@@ -162,33 +194,200 @@ void main() {
     expect(find.textContaining('Premières cartes'), findsOneWidget);
     expect(find.textContaining('Carte '), findsNothing);
     // Aucun vote encore → la phrase inline « ce qu'on retient » est absente.
-    expect(find.textContaining(OnboardingStrings.swipeProfileInline),
-        findsNothing);
+    expect(
+      find.textContaining(OnboardingStrings.swipeProfileInline),
+      findsNothing,
+    );
   });
 
-  testWidgets('phrase inline « ce qu\'on retient » apparaît après un vote net-positif',
-      (tester) async {
-    final container = makeContainer(_richDeck());
-    await tester.pumpWidget(buildTestWidget(container));
-    await tester.pumpAndSettle();
+  testWidgets(
+    'précharge uniquement les 3 profils visibles et ignore les erreurs',
+    (tester) async {
+      final sources = _richDeck();
+      final expected = SourceRecommender.buildSpanningSet(
+        selectedThemes: const [],
+        selectedSubtopics: const [],
+        allSources: sources,
+      ).take(3).map((s) => s.source.id).toSet();
+      final preloaded = <String>[];
+      final container = ProviderContainer(
+        overrides: [
+          userSourcesProvider.overrideWith(
+            () => _FakeUserSourcesNotifier(sources),
+          ),
+          for (final source in sources)
+            sourceProfileProvider(source.id).overrideWith((_) async {
+              preloaded.add(source.id);
+              if (source.id == expected.first) {
+                throw Exception('profile down');
+              }
+              return const SourceProfile();
+            }),
+          analyticsServiceProvider.overrideWithValue(
+            AnalyticsService.disabled(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
 
-    // Like la carte du dessus (mainstream par défaut le plus suivi) → un pôle
-    // passe net-positif → la phrase inline s'affiche sous le deck.
-    await tester.tap(find.widgetWithIcon(InkWell, Icons.favorite_rounded));
-    await tester.pump(); // démarre le fling
-    await tester.pump(const Duration(milliseconds: 400)); // fling → vote
-    await tester.pumpAndSettle();
+      await tester.pumpWidget(buildTestWidget(container));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
 
-    expect(find.textContaining(OnboardingStrings.swipeProfileInline),
-        findsOneWidget);
-  });
+      expect(find.text(OnboardingStrings.swipeTitle), findsOneWidget);
+      expect(preloaded.toSet(), expected);
+    },
+  );
 
-  testWidgets('spanning set vide : saute directement vers sources',
-      (tester) async {
+  testWidgets(
+    'phrase inline « ce qu\'on retient » apparaît après un vote net-positif',
+    (tester) async {
+      final container = makeContainer(_richDeck());
+      await tester.pumpWidget(buildTestWidget(container));
+      await tester.pumpAndSettle();
+
+      // Like la carte du dessus (mainstream par défaut le plus suivi) → un pôle
+      // passe net-positif → la phrase inline s'affiche sous le deck.
+      await tester.tap(find.widgetWithIcon(InkWell, Icons.favorite_rounded));
+      await tester.pump(); // démarre le fling
+      await tester.pump(const Duration(milliseconds: 400)); // fling → vote
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining(OnboardingStrings.swipeProfileInline),
+        findsOneWidget,
+      );
+    },
+  );
+
+  testWidgets(
+    'bouton retour : restaure la dernière carte et permet de revoter',
+    (tester) async {
+      final sources = _richDeck();
+      final firstCard = SourceRecommender.buildSpanningSet(
+        selectedThemes: const [],
+        selectedSubtopics: const [],
+        allSources: sources,
+      ).first;
+      final container = makeContainer(sources);
+      await tester.pumpWidget(buildTestWidget(container));
+      await tester.pumpAndSettle();
+
+      expect(find.text(firstCard.source.name), findsOneWidget);
+
+      await tester.tap(find.widgetWithIcon(InkWell, Icons.favorite_rounded));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(find.text(OnboardingStrings.swipeUndoLabel), findsOneWidget);
+      expect(find.text(firstCard.source.name), findsNothing);
+      expect(
+        find.textContaining(OnboardingStrings.swipeProfileInline),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.text(OnboardingStrings.swipeUndoLabel));
+      await tester.pumpAndSettle();
+
+      expect(find.text(firstCard.source.name), findsOneWidget);
+      expect(find.text(OnboardingStrings.swipeUndoLabel), findsNothing);
+      expect(
+        find.textContaining(OnboardingStrings.swipeProfileInline),
+        findsNothing,
+      );
+
+      await tester.tap(find.widgetWithIcon(InkWell, Icons.close_rounded));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(find.text(OnboardingStrings.swipeUndoLabel), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'bouton retour pendant l\'overlay final : annule la fin et restaure la carte',
+    (tester) async {
+      final container = makeContainer([_src('solo', tier: 'mainstream')]);
+      await tester.pumpWidget(buildTestWidget(container));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithIcon(InkWell, Icons.favorite_rounded));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(find.text(OnboardingStrings.swipeRefiningTitle), findsOneWidget);
+      expect(find.text(OnboardingStrings.swipeUndoLabel), findsOneWidget);
+
+      await tester.tap(find.text(OnboardingStrings.swipeUndoLabel));
+      await tester.pumpAndSettle();
+
+      expect(find.text(OnboardingStrings.swipeRefiningTitle), findsNothing);
+      expect(find.text('Source solo'), findsOneWidget);
+
+      await tester.pump(const Duration(milliseconds: 1500));
+      expect(container.read(onboardingProvider).answers.swipeLiked, isNull);
+      expect(
+        container.read(onboardingProvider).currentQuestionIndex,
+        isNot(Section3Question.sources.index),
+      );
+    },
+  );
+
+  testWidgets(
+    'fiche source : CTA like ferme la modal une seule fois et avance la carte',
+    (tester) async {
+      final container = makeContainer([
+        _src('indie', independence: 0.9, bias: 'alternative'),
+        _src('deep', tier: 'deep'),
+      ]);
+      await tester.pumpWidget(buildTestWidget(container));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Source indie'), findsOneWidget);
+      await tester.tap(find.text('Source indie'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Sélectionner cette source'), findsNothing);
+      expect(find.text(OnboardingStrings.swipeLikeHint), findsWidgets);
+
+      tester
+          .widget<FacteurButton>(
+            find.widgetWithText(FacteurButton, OnboardingStrings.swipeLikeHint),
+          )
+          .onPressed!();
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(find.text('Gestion de la source'), findsNothing);
+      expect(find.text('Source deep'), findsOneWidget);
+
+      await tester.tap(find.widgetWithIcon(InkWell, Icons.close_rounded));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pump(const Duration(milliseconds: 1500));
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(
+        container.read(onboardingProvider).answers.swipeLiked,
+        equals(['indie']),
+      );
+      expect(
+        container.read(onboardingProvider).answers.swipeDisliked,
+        equals(['deep']),
+      );
+    },
+  );
+
+  testWidgets('spanning set vide : saute directement vers sources', (
+    tester,
+  ) async {
     final container = makeContainer(const []);
     await tester.pumpWidget(buildTestWidget(container));
-    await tester.pump(); // résout le FutureProvider → _ensureBuilt → post-frame _complete()
-    await tester.pump(const Duration(milliseconds: 350)); // transition completeSwipe
+    await tester
+        .pump(); // résout le FutureProvider → _ensureBuilt → post-frame _complete()
+    await tester.pump(
+      const Duration(milliseconds: 350),
+    ); // transition completeSwipe
 
     expect(
       container.read(onboardingProvider).currentQuestionIndex,

--- a/apps/mobile/test/features/sources/utils/publication_frequency_test.dart
+++ b/apps/mobile/test/features/sources/utils/publication_frequency_test.dart
@@ -9,25 +9,26 @@ void main() {
       expect(humanizeFrequency(-3, null), 'peu actif');
     });
 
-    test('gros volume → ~N/jour arrondi joli', () {
-      expect(humanizeFrequency(3000, null), '~100/jour'); // 100/jour pile
-      expect(humanizeFrequency(2850, null), '~100/jour'); // 95 → 100 (dizaine)
-      expect(humanizeFrequency(870, null), '~30/jour'); // 29 → 30 (dizaine)
-      expect(humanizeFrequency(360, null), '~12/jour'); // 12 exact (<20)
+    test('gros volume → phrase explicite par jour', () {
+      expect(humanizeFrequency(2100, null), '70 articles par jour en moyenne');
+      expect(humanizeFrequency(3000, null), '100 articles par jour en moyenne');
+      expect(humanizeFrequency(2850, null), '100 articles par jour en moyenne');
+      expect(humanizeFrequency(870, null), '30 articles par jour en moyenne');
+      expect(humanizeFrequency(360, null), '12 articles par jour en moyenne');
     });
 
-    test('volume moyen → quelques-uns/jour (perDay ≥ 1.5)', () {
-      expect(humanizeFrequency(60, null), 'quelques-uns/jour'); // 2/jour
-      expect(humanizeFrequency(45, null), 'quelques-uns/jour'); // 1.5 borne
+    test('volume moyen → quelques articles par jour (perDay ≥ 1.5)', () {
+      expect(humanizeFrequency(60, null), 'quelques articles par jour');
+      expect(humanizeFrequency(45, null), 'quelques articles par jour');
     });
 
-    test('volume faible → quelques-uns/semaine', () {
-      expect(humanizeFrequency(10, null), 'quelques-uns/semaine'); // ~0.33/jour
+    test('volume faible → quelques articles par semaine', () {
+      expect(humanizeFrequency(10, null), 'quelques articles par semaine');
     });
 
-    test('très faible → quelques-uns/mois', () {
-      expect(humanizeFrequency(3, null), 'quelques-uns/mois');
-      expect(humanizeFrequency(1, null), 'quelques-uns/mois');
+    test('très faible → quelques articles par mois', () {
+      expect(humanizeFrequency(3, null), 'quelques articles par mois');
+      expect(humanizeFrequency(1, null), 'quelques articles par mois');
     });
   });
 
@@ -36,20 +37,29 @@ void main() {
       final now = DateTime(2026, 6, 15);
       final oldest = DateTime(2026, 6, 13); // 2 jours d'historique
       // 8 articles en 2 j → 4/jour. Sans clamp : 8/30 ≈ 0.27 → /semaine.
-      expect(humanizeFrequency(8, oldest, now: now), 'quelques-uns/jour');
+      expect(
+        humanizeFrequency(8, oldest, now: now),
+        'quelques articles par jour',
+      );
     });
 
     test('âge < 1 jour → fenêtre clampée à 1 (pas de division par 0)', () {
       final now = DateTime(2026, 6, 15, 12);
       final oldest = DateTime(2026, 6, 15, 6); // même jour → inDays 0
-      expect(humanizeFrequency(5, oldest, now: now), 'quelques-uns/jour');
+      expect(
+        humanizeFrequency(5, oldest, now: now),
+        'quelques articles par jour',
+      );
     });
 
     test('âge ≥ 30 jours → fenêtre plafonnée à 30', () {
       final now = DateTime(2026, 6, 15);
       final oldest = DateTime(2026, 1, 1); // bien > 30 j
       // 60 articles sur 30 j → 2/jour.
-      expect(humanizeFrequency(60, oldest, now: now), 'quelques-uns/jour');
+      expect(
+        humanizeFrequency(60, oldest, now: now),
+        'quelques articles par jour',
+      );
     });
   });
 }

--- a/apps/mobile/test/features/sources/widgets/source_detail_modal_test.dart
+++ b/apps/mobile/test/features/sources/widgets/source_detail_modal_test.dart
@@ -62,13 +62,17 @@ Widget _wrap({
   SourceCoverage? coverage,
   List<SmartSearchRecentItem>? recentItems,
   bool? isSelectedOverride,
+  SourceArticleOpener? articleOpener,
   UserSourcesState state = _emptyState,
 }) {
   return ProviderScope(
     overrides: [
-      userSourcesProvider.overrideWith(() => _FakeUserSourcesNotifier([source])),
-      userSourcesStateProvider
-          .overrideWith(() => _FakeUserSourcesStateNotifier(state)),
+      userSourcesProvider.overrideWith(
+        () => _FakeUserSourcesNotifier([source]),
+      ),
+      userSourcesStateProvider.overrideWith(
+        () => _FakeUserSourcesStateNotifier(state),
+      ),
       displayModeSpecProvider.overrideWith((ref) => DisplayModeSpec.normal),
       sourceCoverageProvider(source.id).overrideWith(
         (_) async =>
@@ -88,6 +92,7 @@ Widget _wrap({
           onToggleMute: () {},
           isSelectedOverride: isSelectedOverride,
           recentItems: recentItems,
+          articleOpener: articleOpener,
         ),
       ),
     ),
@@ -100,8 +105,9 @@ void main() {
   });
 
   group('SourceDetailModal — header & layout', () {
-    testWidgets('renders name, domain, follower signal and description',
-        (tester) async {
+    testWidgets('renders name, domain, follower signal and description', (
+      tester,
+    ) async {
       final source = Source(
         id: 's1',
         name: 'Le Monde',
@@ -121,83 +127,87 @@ void main() {
       expect(find.textContaining('lecteurs'), findsOneWidget);
     });
 
-    testWidgets('frequency chip rendered from profile (header signals)',
-        (tester) async {
-      final source =
-          Source(id: 's1', name: 'Le Monde', type: SourceType.article);
-      // 60 articles, fenêtre 30 j → 2/jour → « quelques-uns/jour ».
+    testWidgets('frequency chip rendered from profile (header signals)', (
+      tester,
+    ) async {
+      final source = Source(
+        id: 's1',
+        name: 'Le Monde',
+        type: SourceType.article,
+      );
+      // 60 articles, fenêtre 30 j → 2/jour → wording naturel.
       const profile = SourceProfile(articles30d: 60);
 
       await tester.pumpWidget(_wrap(source: source, profile: profile));
       await tester.pumpAndSettle();
 
-      expect(find.text('quelques-uns/jour'), findsOneWidget);
+      expect(find.text('quelques articles par jour'), findsOneWidget);
     });
   });
 
-  group('SourceDetailModal — évaluation (cas Le Monde : complète + premium)',
-      () {
-    testWidgets('eval is collapsed by default, expands on tap with gauges',
-        (tester) async {
-      final source = Source(
-        id: 'monde',
-        name: 'Le Monde',
-        url: 'https://lemonde.fr',
-        type: SourceType.article,
-        reliabilityScore: 'high',
-        biasStance: 'center',
-        scoreIndependence: 0.55,
-        scoreRigor: 0.85,
-        scoreUx: 0.70,
-      );
+  group(
+    'SourceDetailModal — évaluation (cas Le Monde : complète + premium)',
+    () {
+      testWidgets('eval is open by default with subtitle below title', (
+        tester,
+      ) async {
+        final source = Source(
+          id: 'monde',
+          name: 'Le Monde',
+          url: 'https://lemonde.fr',
+          type: SourceType.article,
+          reliabilityScore: 'high',
+          biasStance: 'center',
+          scoreIndependence: 0.55,
+          scoreRigor: 0.85,
+          scoreUx: 0.70,
+        );
 
-      await tester.pumpWidget(_wrap(source: source));
-      await tester.pumpAndSettle();
+        await tester.pumpWidget(_wrap(source: source));
+        await tester.pumpAndSettle();
 
-      // Collapsed: header title + reliability pill visible, gauges hidden.
-      expect(find.text('Évaluation Facteur'), findsOneWidget);
-      expect(find.text('Solide'), findsOneWidget);
-      expect(find.text('Indépendance'), findsNothing);
+        // Open by default: title, subtitle, reliability and gauges visible.
+        expect(find.text('Évaluation Facteur'), findsOneWidget);
+        expect(find.text('à titre indicatif'), findsOneWidget);
+        expect(find.text('Solide'), findsWidgets);
+        expect(find.text('Indépendance'), findsOneWidget);
+        expect(find.text('Rigueur'), findsOneWidget);
+        expect(find.text('Accessibilité'), findsOneWidget);
+        // Gauge words derived by thresholds.
+        expect(find.text('Correcte'), findsOneWidget); // 0.55
+        expect(find.text('Élevée'), findsOneWidget); // 0.85
+        expect(find.text('Bonne'), findsOneWidget); // 0.70
+        expect(find.text('Voir la méthodologie'), findsOneWidget);
+      });
 
-      // Expand.
-      await tester.tap(find.text('Évaluation Facteur'));
-      await tester.pumpAndSettle();
+      testWidgets(
+          'premium block always visible when premiumConnection != null '
+          'even when not followed', (tester) async {
+        final source = Source(
+          id: 'monde',
+          name: 'Le Monde',
+          type: SourceType.article,
+          isTrusted: false,
+          premiumConnection: const PremiumConnection(
+            loginUrl: 'https://lemonde.fr/login',
+            testUrl: 'https://lemonde.fr/test',
+            isGeneric: true,
+          ),
+        );
 
-      expect(find.text('Indépendance'), findsOneWidget);
-      expect(find.text('Rigueur'), findsOneWidget);
-      expect(find.text('Accessibilité'), findsOneWidget);
-      // Gauge words derived by thresholds.
-      expect(find.text('Correcte'), findsOneWidget); // 0.55
-      expect(find.text('Élevée'), findsOneWidget); // 0.85
-      expect(find.text('Bonne'), findsOneWidget); // 0.70
-      expect(find.text('Voir la méthodologie'), findsOneWidget);
-    });
+        await tester.pumpWidget(_wrap(source: source));
+        await tester.pumpAndSettle();
 
-    testWidgets('premium block always visible when premiumConnection != null '
-        'even when not followed', (tester) async {
-      final source = Source(
-        id: 'monde',
-        name: 'Le Monde',
-        type: SourceType.article,
-        isTrusted: false,
-        premiumConnection: const PremiumConnection(
-          loginUrl: 'https://lemonde.fr/login',
-          testUrl: 'https://lemonde.fr/test',
-          isGeneric: true,
-        ),
-      );
-
-      await tester.pumpWidget(_wrap(source: source));
-      await tester.pumpAndSettle();
-
-      expect(find.text('Gestion de la source'), findsOneWidget);
-      expect(find.text('Associer mon abonnement'), findsOneWidget);
-    });
-  });
+        expect(find.text('Gestion de la source'), findsOneWidget);
+        expect(find.text('Associer mon abonnement'), findsOneWidget);
+      });
+    },
+  );
 
   group('SourceDetailModal — cas Reporterre (jauge null + reco perso)', () {
-    testWidgets('hides null gauge and shows collapsible reco perso',
-        (tester) async {
+    testWidgets('hides null gauge and shows collapsible reco perso', (
+      tester,
+    ) async {
       final source = Source(
         id: 'reporterre',
         name: 'Reporterre',
@@ -212,9 +222,6 @@ void main() {
       );
 
       await tester.pumpWidget(_wrap(source: source));
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.text('Évaluation Facteur'));
       await tester.pumpAndSettle();
 
       expect(find.text('Indépendance'), findsOneWidget);
@@ -240,10 +247,14 @@ void main() {
   });
 
   group('SourceDetailModal — couverture (mode normal, profil unifié)', () {
-    testWidgets('renders coverage bars + caption derived from articles_30d',
-        (tester) async {
-      final source =
-          Source(id: 'monde', name: 'Le Monde', type: SourceType.article);
+    testWidgets('renders coverage bars + caption derived from articles_30d', (
+      tester,
+    ) async {
+      final source = Source(
+        id: 'monde',
+        name: 'Le Monde',
+        type: SourceType.article,
+      );
       const profile = SourceProfile(
         articles30d: 3012,
         themeDistribution: [
@@ -268,8 +279,9 @@ void main() {
       );
     });
 
-    testWidgets('hides coverage section when theme_distribution empty',
-        (tester) async {
+    testWidgets('hides coverage section when theme_distribution empty', (
+      tester,
+    ) async {
       final source = Source(id: 'x', name: 'X', type: SourceType.article);
       await tester.pumpWidget(
         _wrap(source: source, profile: const SourceProfile(articles30d: 0)),
@@ -281,10 +293,14 @@ void main() {
   });
 
   group('SourceDetailModal — articles (mode normal, cartes cliquables)', () {
-    testWidgets('renders up to 3 FluxContinuArticleCard from recent_articles',
-        (tester) async {
-      final source =
-          Source(id: 'monde', name: 'Le Monde', type: SourceType.article);
+    testWidgets('renders up to 3 FluxContinuArticleCard from recent_articles', (
+      tester,
+    ) async {
+      final source = Source(
+        id: 'monde',
+        name: 'Le Monde',
+        type: SourceType.article,
+      );
       final profile = SourceProfile(
         recentArticles: [
           _article('a', 'Article A', theme: 'politics'),
@@ -305,6 +321,32 @@ void main() {
       expect(find.text('Article D'), findsNothing);
     });
 
+    testWidgets('articleOpener injecté ouvre sans GoRouter', (tester) async {
+      final source = Source(
+        id: 'monde',
+        name: 'Le Monde',
+        type: SourceType.article,
+      );
+      final opened = <String>[];
+      final profile = SourceProfile(
+        recentArticles: [_article('a', 'Article A', theme: 'politics')],
+      );
+
+      await tester.pumpWidget(
+        _wrap(
+          source: source,
+          profile: profile,
+          articleOpener: (_, article) => opened.add(article.id),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Article A'));
+      await tester.pumpAndSettle();
+
+      expect(opened, equals(['a']));
+    });
+
     testWidgets('empty recent_articles → neutral empty card', (tester) async {
       final source = Source(id: 'x', name: 'X', type: SourceType.article);
       await tester.pumpWidget(
@@ -317,8 +359,9 @@ void main() {
   });
 
   group('SourceDetailModal — fallback réseau (/profile en erreur)', () {
-    testWidgets('error → header + éval restent, couverture/articles masqués',
-        (tester) async {
+    testWidgets('error → header + éval restent, couverture/articles masqués', (
+      tester,
+    ) async {
       final source = Source(
         id: 'monde',
         name: 'Le Monde',
@@ -341,10 +384,14 @@ void main() {
   });
 
   group('SourceDetailModal — mode smart-search (recentItems préchargés)', () {
-    testWidgets('renders minimal article cards + coverage from provider',
-        (tester) async {
-      final source =
-          Source(id: 'monde', name: 'Le Monde', type: SourceType.article);
+    testWidgets('renders minimal article cards + coverage from provider', (
+      tester,
+    ) async {
+      final source = Source(
+        id: 'monde',
+        name: 'Le Monde',
+        type: SourceType.article,
+      );
       const coverage = SourceCoverage(
         periodLabel: '30 derniers jours',
         totalCount: 100,
@@ -372,18 +419,27 @@ void main() {
   });
 
   group('SourceDetailModal — réglages conditionnels', () {
-    testWidgets('settings (priority pill) hidden when NOT followed',
-        (tester) async {
-      final notFollowed =
-          Source(id: 'a', name: 'A', type: SourceType.article, isTrusted: false);
+    testWidgets('settings (priority pill) hidden when NOT followed', (
+      tester,
+    ) async {
+      final notFollowed = Source(
+        id: 'a',
+        name: 'A',
+        type: SourceType.article,
+        isTrusted: false,
+      );
       await tester.pumpWidget(_wrap(source: notFollowed));
       await tester.pumpAndSettle();
       expect(find.text('Réglages de suivi'), findsNothing);
     });
 
     testWidgets('settings (priority pill) shown when followed', (tester) async {
-      final followed =
-          Source(id: 'b', name: 'B', type: SourceType.article, isTrusted: true);
+      final followed = Source(
+        id: 'b',
+        name: 'B',
+        type: SourceType.article,
+        isTrusted: true,
+      );
       await tester.pumpWidget(_wrap(source: followed));
       await tester.pumpAndSettle();
       expect(find.text('Réglages de suivi'), findsOneWidget);
@@ -392,10 +448,15 @@ void main() {
   });
 
   group('SourceDetailModal — actions & mute toggle', () {
-    testWidgets('primary action shows "Suivre {nom}" when not followed',
-        (tester) async {
+    testWidgets('primary action shows "Suivre {nom}" when not followed', (
+      tester,
+    ) async {
       final notFollowed = Source(
-          id: 'a', name: 'Mediapart', type: SourceType.article, isTrusted: false);
+        id: 'a',
+        name: 'Mediapart',
+        type: SourceType.article,
+        isTrusted: false,
+      );
       await tester.pumpWidget(_wrap(source: notFollowed));
       await tester.pumpAndSettle();
       expect(find.text('Suivre Mediapart'), findsOneWidget);
@@ -403,7 +464,11 @@ void main() {
 
     testWidgets('primary action shows "Suivie" when followed', (tester) async {
       final followed = Source(
-          id: 'b', name: 'Mediapart', type: SourceType.article, isTrusted: true);
+        id: 'b',
+        name: 'Mediapart',
+        type: SourceType.article,
+        isTrusted: true,
+      );
       await tester.pumpWidget(_wrap(source: followed));
       await tester.pumpAndSettle();
       expect(find.text('Suivie'), findsOneWidget);
@@ -411,25 +476,34 @@ void main() {
 
     testWidgets('onboarding override uses selection labels', (tester) async {
       final source = Source(id: 'c', name: 'Le Pli', type: SourceType.article);
-      await tester.pumpWidget(
-        _wrap(source: source, isSelectedOverride: false),
-      );
+      await tester.pumpWidget(_wrap(source: source, isSelectedOverride: false));
       await tester.pumpAndSettle();
       expect(find.text('Sélectionner cette source'), findsOneWidget);
     });
 
-    testWidgets('mute button shows "Masquer cette source" when not muted',
-        (tester) async {
-      final notMuted =
-          Source(id: 'd', name: 'D', type: SourceType.article, isMuted: false);
+    testWidgets('mute button shows "Masquer cette source" when not muted', (
+      tester,
+    ) async {
+      final notMuted = Source(
+        id: 'd',
+        name: 'D',
+        type: SourceType.article,
+        isMuted: false,
+      );
       await tester.pumpWidget(_wrap(source: notMuted));
       await tester.pumpAndSettle();
       expect(find.text('Masquer cette source'), findsOneWidget);
     });
 
-    testWidgets('mute button shows "Source masquée" when muted', (tester) async {
-      final muted =
-          Source(id: 'e', name: 'E', type: SourceType.article, isMuted: true);
+    testWidgets('mute button shows "Source masquée" when muted', (
+      tester,
+    ) async {
+      final muted = Source(
+        id: 'e',
+        name: 'E',
+        type: SourceType.article,
+        isMuted: true,
+      );
       await tester.pumpWidget(_wrap(source: muted));
       await tester.pumpAndSettle();
       expect(find.text('Source masquée'), findsOneWidget);


### PR DESCRIPTION
## Quoi
**Fiche source repensée** (`SourceDetailModal`) — articles récents cliquables, thèmes couverts, fréquence de publication — avec un `articleOpener` **optionnel** (rétro-compatible avec les 9 appelants). L'**onboarding** consomme la nouvelle fiche : tri des sources plus clair, suggestions plus pertinentes, écran de reco et désambiguïsation par swipe alignés.

## Pourquoi
La fiche source était pauvre ; l'onboarding doit ouvrir cette même fiche. Onboarding et fiche sont **couplés** (l'onboarding appelle le nouveau paramètre `articleOpener`), d'où une seule PR cohérente.

## Comment ça a été vérifié
- [x] `flutter analyze lib` — aucune erreur app-wide (rétro-compat des 9 appelants du modal confirmée)
- [x] `flutter test` ciblé : **66 tests** (source_recommender, digest_mode, sources_question, swipe_disambiguator, publication_frequency, source_detail_modal) ✓
- [ ] `/validate-feature` (Playwright) recommandé avant deploy — UI onboarding

## Zones à risque
`SourceDetailModal` est partagé (9 appelants). Nouveau param **optionnel** ⇒ pas de rupture.
