### PR TITLE
feat(essentiel): complétion depuis sources suivies + masquage si trop maigre

### DIFF
--- a/packages/api/app/routers/essentiel.py
+++ b/packages/api/app/routers/essentiel.py
@@ -21,7 +21,8 @@ from app.dependencies import get_current_user_id
 from app.schemas.essentiel import EssentielResponse
 from app.services.digest_service import DigestService, read_digest_or_fallback
 from app.services.essentiel_service import (
-    build_essentiel_response,
+    ESSENTIEL_MIN_ARTICLES,
+    build_essentiel_response_with_supplements,
     fetch_user_essentiel_context,
 )
 from app.utils.time import today_paris
@@ -72,7 +73,19 @@ async def get_essentiel(
     # promouvoir les articles qui matchent les prefs de l'utilisateur.
     # Pas de pipeline LLM, juste 2 SELECTs courts indexés sur `user_id`.
     user_context = await fetch_user_essentiel_context(db, user_uuid)
-    response = build_essentiel_response(digest, user_context=user_context)
+    response = await build_essentiel_response_with_supplements(
+        db,
+        user_uuid,
+        digest,
+        user_context=user_context,
+        is_serene=serein_enabled,
+    )
+
+    # Plancher de qualité : on n'expose jamais une carte Essentiel pauvre
+    # (1-2 articles). Si la complétion depuis les sources suivies n'a pas
+    # atteint 3 articles, on signale au client que l'essentiel se prépare.
+    if len(response.articles) < ESSENTIEL_MIN_ARTICLES:
+        return _preparing_response()
 
     logger.info(
         "essentiel_retrieved",

--- a/packages/api/app/services/essentiel_service.py
+++ b/packages/api/app/services/essentiel_service.py
@@ -34,10 +34,14 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
-from sqlalchemy import text
+from sqlalchemy import exists, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
-from app.models.enums import ContentType, InterestState, SourceType
+from app.models.content import Content, UserContentStatus
+from app.models.enums import ContentStatus, ContentType, InterestState, SourceType
+from app.models.source import Source
+from app.schemas.content import SourceMini
 from app.schemas.digest import DigestResponse, DigestTopic, DigestTopicArticle
 from app.schemas.essentiel import EssentielArticle, EssentielKind, EssentielResponse
 from app.services.language_user_filter import (
@@ -56,6 +60,15 @@ logger = logging.getLogger(__name__)
 
 ESSENTIEL_MAX_ARTICLES = 5
 ESSENTIEL_MAX_PER_SOURCE = 2  # Diversité dure : max 2 articles d'une même source.
+
+# Plancher de qualité : en-dessous de ce nombre d'articles issus du digest, on
+# complète depuis les sources suivies/favorites de l'utilisateur ; si le total
+# reste < ESSENTIEL_MIN_ARTICLES, le router renvoie 202 ``preparing`` plutôt
+# qu'une carte pauvre (1-2 articles).
+ESSENTIEL_MIN_ARTICLES = 3
+# Taille du pool de candidats frais piochés dans les sources suivies pour la
+# complétion — borne le SELECT, on ne garde au plus que les slots manquants.
+ESSENTIEL_SUPPLEMENT_CANDIDATE_CAP = 30
 
 # Fenêtre de fraîcheur commune aux deux tiers de sélection. Les sources
 # suivies sont prioritaires, puis le pool éditorial global frais complète.
@@ -682,3 +695,177 @@ def build_essentiel_response(
         articles=articles,
         is_stale_fallback=digest.is_stale_fallback,
     )
+
+
+def _content_to_essentiel_article(
+    content: Content,
+    rank: int,
+    ctx: EssentielUserContext,
+) -> EssentielArticle:
+    """Projette un `Content` brut (complément sources suivies) en EssentielArticle.
+
+    Utilisé par le fallback de complétion quand le digest produit < 3 articles.
+    L'article vient forcément d'une source suivie/favorite → `is_followed_source`
+    est toujours vrai ; pas de topic transversal d'origine, on retombe sur le nom
+    de la source comme libellé de section et `perspective_count=0`.
+    """
+    source = SourceMini.model_validate(content.source)
+    return EssentielArticle(
+        content_id=content.id,
+        title=content.title,
+        url=content.url,
+        thumbnail_url=content.thumbnail_url,
+        published_at=content.published_at,
+        source=source,
+        source_letter=_source_letter(content.source.name),
+        kind=EssentielKind.THEME,
+        theme=content.theme,
+        section_label=content.source.name,
+        perspective_count=0,
+        rank=rank,
+        is_followed_source=True,
+        is_followed_topic=bool(content.theme and content.theme in ctx.topic_weights),
+        is_actu_du_jour=False,
+        language=content.language,
+    )
+
+
+async def _fetch_followed_source_supplements(
+    db: AsyncSession,
+    user_id: UUID,
+    ctx: EssentielUserContext,
+    *,
+    is_serene: bool,
+    existing: list[EssentielArticle],
+    limit: int,
+    now: datetime | None = None,
+) -> list[EssentielArticle]:
+    """Complète l'Essentiel avec des articles frais des sources suivies/favorites.
+
+    Déclenché quand le digest produit moins de `ESSENTIEL_MIN_ARTICLES`. Pour
+    borner la surface éditoriale, on ne pioche que dans les sources explicitement
+    suivies/favorites (`followed_source_ids`), fenêtre de fraîcheur commune
+    (`ESSENTIEL_TOURNEE_WINDOW`), en excluant :
+    - contenus lus (`status == CONSUMED`) ou masqués (`is_hidden`),
+    - sources mutées et sujets mutés (`muted_topic_slugs`),
+    - doublons de contenu/source (cap 2/source)/sujet déjà présents,
+    - en mode serein, tout `Content.is_serene != True`,
+    - podcasts/vidéos/Reddit/bulletins (mêmes critères que le digest).
+    """
+    if limit <= 0:
+        return []
+    candidate_source_ids = list(ctx.followed_source_ids - ctx.muted_source_ids)
+    if not candidate_source_ids:
+        return []
+
+    cutoff = (now or datetime.now(UTC)) - ESSENTIEL_TOURNEE_WINDOW
+    already_read_or_hidden = exists().where(
+        UserContentStatus.content_id == Content.id,
+        UserContentStatus.user_id == user_id,
+        or_(
+            UserContentStatus.is_hidden,
+            UserContentStatus.status == ContentStatus.CONSUMED,
+        ),
+    )
+
+    query = (
+        select(Content)
+        .join(Content.source)
+        .options(selectinload(Content.source))
+        .where(Content.source_id.in_(candidate_source_ids))
+        .where(Content.published_at >= cutoff)
+        .where(Content.content_type == ContentType.ARTICLE)
+        .where(~already_read_or_hidden)
+        .where(Source.is_active.is_(True))
+        .order_by(Content.published_at.desc())
+        .limit(ESSENTIEL_SUPPLEMENT_CANDIDATE_CAP)
+    )
+    if is_serene:
+        query = query.where(Content.is_serene.is_(True))
+
+    candidates = (await db.execute(query)).scalars().all()
+    if not candidates:
+        return []
+
+    # Dédup contre les articles déjà retenus (digest) : content_id, cap source,
+    # similarité de titre — mêmes garde-fous que `_pick_transversal_articles`.
+    seen_content_ids = {a.content_id for a in existing}
+    source_count: dict[UUID, int] = {}
+    for article in existing:
+        source_count[article.source.id] = source_count.get(article.source.id, 0) + 1
+    picked_title_tokens = [normalize_title(a.title) for a in existing if a.title]
+
+    supplements: list[EssentielArticle] = []
+    rank = len(existing) + 1
+    for content in candidates:
+        if len(supplements) >= limit:
+            break
+        if content.id in seen_content_ids:
+            continue
+        source = content.source
+        if (source.type or "").lower() in _EXCLUDED_SOURCE_TYPES:
+            continue
+        if is_news_bulletin_title(content.title):
+            continue
+        if ctx.muted_topic_slugs and ctx.muted_topic_slugs.intersection(
+            content.topics or ()
+        ):
+            continue
+        if source_count.get(source.id, 0) >= ESSENTIEL_MAX_PER_SOURCE:
+            continue
+        tokens = normalize_title(content.title)
+        if tokens and any(
+            jaccard_similarity(tokens, prev) >= ScoringWeights.TOPIC_CLUSTER_THRESHOLD
+            for prev in picked_title_tokens
+            if prev
+        ):
+            continue
+        supplements.append(_content_to_essentiel_article(content, rank, ctx))
+        seen_content_ids.add(content.id)
+        source_count[source.id] = source_count.get(source.id, 0) + 1
+        picked_title_tokens.append(tokens)
+        rank += 1
+
+    return supplements
+
+
+async def build_essentiel_response_with_supplements(
+    db: AsyncSession,
+    user_id: UUID,
+    digest: DigestResponse,
+    *,
+    user_context: EssentielUserContext,
+    is_serene: bool,
+    now: datetime | None = None,
+) -> EssentielResponse:
+    """Construit l'Essentiel depuis le digest, puis complète si < 3 articles.
+
+    1. Projection digest → jusqu'à 5 articles transversaux (logique historique).
+    2. Si le résultat est < `ESSENTIEL_MIN_ARTICLES`, complète jusqu'à
+       `ESSENTIEL_MAX_ARTICLES` avec des articles frais des sources suivies.
+    3. Le router décide ensuite du 202 ``preparing`` si le total reste < 3.
+    """
+    response = build_essentiel_response(digest, user_context=user_context, now=now)
+    if len(response.articles) >= ESSENTIEL_MIN_ARTICLES:
+        return response
+
+    supplements = await _fetch_followed_source_supplements(
+        db,
+        user_id,
+        user_context,
+        is_serene=is_serene,
+        existing=response.articles,
+        limit=ESSENTIEL_MAX_ARTICLES - len(response.articles),
+        now=now,
+    )
+    if not supplements:
+        return response
+
+    merged = list(response.articles) + supplements
+    logger.info(
+        "essentiel_supplemented digest_count=%d supplements=%d final_count=%d",
+        len(response.articles),
+        len(supplements),
+        len(merged),
+    )
+    return response.model_copy(update={"articles": merged})

--- a/packages/api/tests/test_essentiel_endpoint.py
+++ b/packages/api/tests/test_essentiel_endpoint.py
@@ -343,7 +343,10 @@ async def test_get_essentiel_401_without_token():
 
 @pytest.mark.asyncio
 async def test_get_essentiel_propagates_stale_fallback(auth_override: UUID):
-    topics = [_make_topic(rank=1, label="Tech", n_articles=5)]
+    # ≥3 sujets distincts → ≥3 articles, au-dessus du plancher ESSENTIEL_MIN_ARTICLES.
+    topics = [
+        _make_topic(rank=i + 1, label=f"T{i + 1}", n_articles=2) for i in range(3)
+    ]
     digest = _make_digest(topics, is_stale=True)
 
     with (
@@ -852,6 +855,17 @@ async def test_get_essentiel_uses_user_context_from_router(auth_override: UUID):
             perspective_count=2,
             articles=[_make_article(rank=1, title="C-1", source=followed_source)],
         ),
+        # 3e sujet pour franchir le plancher ESSENTIEL_MIN_ARTICLES (=3) sans
+        # déclencher la complétion 202 ; n'affecte pas le rang du suivi.
+        DigestTopic(
+            topic_id="t3",
+            label="Économie",
+            rank=3,
+            reason="Test",
+            theme="economy",
+            perspective_count=2,
+            articles=[_make_article(rank=1, title="E-1", source=other_source)],
+        ),
     ]
     digest = _make_digest(topics)
 
@@ -889,7 +903,12 @@ async def test_get_essentiel_serein_user_fetches_serein_digest(
     auth_override: UUID,
 ):
     """serein_enabled=True propagates is_serene=True to read_digest_or_fallback."""
-    topics = [_make_topic(rank=1, label="Tech", n_articles=3)]
+    # 3 sujets aux titres distincts → 3 articles (au-dessus du plancher), pas 202.
+    topics = [
+        _make_topic(rank=1, label="Politique", theme="politique", n_articles=1),
+        _make_topic(rank=2, label="Sciences", theme="sciences", n_articles=1),
+        _make_topic(rank=3, label="Cuisine", theme="cuisine", n_articles=1),
+    ]
     digest = _make_digest(topics)
 
     with (

--- a/packages/api/tests/test_essentiel_supplements.py
+++ b/packages/api/tests/test_essentiel_supplements.py
@@ -1,0 +1,302 @@
+"""Tests de complétion de l'Essentiel depuis les sources suivies (plan QA).
+
+Quand le digest produit moins de `ESSENTIEL_MIN_ARTICLES`, on complète avec des
+articles frais des sources suivies/favorites, en excluant lus/masqués, et en
+mode serein on ne garde que `Content.is_serene == True`. Si le total reste < 3,
+le router renverra 202 (ici on vérifie le contrat du service).
+"""
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+from app.models.content import Content, UserContentStatus
+from app.models.enums import ContentStatus, ContentType, SourceType
+from app.models.source import Source
+from app.schemas.digest import DigestResponse
+from app.services.essentiel_service import (
+    ESSENTIEL_MIN_ARTICLES,
+    EssentielUserContext,
+    build_essentiel_response_with_supplements,
+)
+
+
+def _empty_digest() -> DigestResponse:
+    """Digest vide → 0 article issu du digest, force le chemin de complétion."""
+    return DigestResponse(
+        digest_id=uuid4(),
+        user_id=uuid4(),
+        target_date=datetime.now(UTC).date(),
+        generated_at=datetime.now(UTC),
+        format_version="topics_v1",
+        items=[],
+        topics=[],
+        is_stale_fallback=False,
+    )
+
+
+@pytest_asyncio.fixture
+async def make_source(db_session):
+    async def _make(name: str) -> Source:
+        source = Source(
+            id=uuid4(),
+            name=name,
+            url=f"https://{name.lower()}.example.com",
+            feed_url=f"https://{name.lower()}.example.com/feed-{uuid4()}.xml",
+            type=SourceType.ARTICLE,
+            theme="politics",
+            is_active=True,
+            is_curated=False,
+        )
+        db_session.add(source)
+        await db_session.commit()
+        return source
+
+    return _make
+
+
+async def _add_content(
+    db,
+    source: Source,
+    *,
+    title: str,
+    is_serene=None,
+    minutes_ago: int = 30,
+    content_type: ContentType = ContentType.ARTICLE,
+) -> Content:
+    content = Content(
+        id=uuid4(),
+        source_id=source.id,
+        title=title,
+        url=f"https://example.com/{uuid4()}",
+        published_at=datetime.now(UTC) - timedelta(minutes=minutes_ago),
+        content_type=content_type,
+        guid=str(uuid4()),
+        is_serene=is_serene,
+    )
+    db.add(content)
+    await db.commit()
+    return content
+
+
+@pytest.mark.asyncio
+async def test_poor_digest_completed_from_followed_sources(db_session, make_source):
+    """Digest vide + 3 sources suivies avec articles frais → 3 articles complétés."""
+    user_id = uuid4()
+    # Titres mono-mot distincts → pas de dédup par similarité de titre.
+    titles = ["Politique", "Economie", "Climat"]
+    sources = [await make_source(f"Src{i}") for i in range(3)]
+    for src, title in zip(sources, titles, strict=True):
+        await _add_content(db_session, src, title=title)
+
+    ctx = EssentielUserContext(
+        followed_source_ids=frozenset(s.id for s in sources),
+    )
+
+    response = await build_essentiel_response_with_supplements(
+        db_session,
+        user_id,
+        _empty_digest(),
+        user_context=ctx,
+        is_serene=False,
+    )
+
+    assert 3 <= len(response.articles) <= 5
+    # Tous viennent des sources suivies → flag is_followed_source à True, ranks 1..N.
+    assert all(a.is_followed_source for a in response.articles)
+    assert [a.rank for a in response.articles] == list(
+        range(1, len(response.articles) + 1)
+    )
+
+
+@pytest.mark.asyncio
+async def test_serein_mode_excludes_non_serene_content(db_session, make_source):
+    """En mode serein, seuls les contenus `is_serene == True` complètent."""
+    user_id = uuid4()
+    serene_titles = ["Sport", "Culture", "Sciences"]
+    serene_sources = [await make_source(f"Calme{i}") for i in range(3)]
+    for src, title in zip(serene_sources, serene_titles, strict=True):
+        await _add_content(db_session, src, title=title, is_serene=True)
+    anxious = await make_source("Anxiogene")
+    anxious_content = await _add_content(
+        db_session, anxious, title="Catastrophe", is_serene=False
+    )
+
+    ctx = EssentielUserContext(
+        followed_source_ids=frozenset([*(s.id for s in serene_sources), anxious.id]),
+    )
+
+    response = await build_essentiel_response_with_supplements(
+        db_session,
+        user_id,
+        _empty_digest(),
+        user_context=ctx,
+        is_serene=True,
+    )
+
+    assert len(response.articles) >= 3
+    ids = {a.content_id for a in response.articles}
+    assert anxious_content.id not in ids, "un contenu non-serein ne doit pas compléter"
+
+
+@pytest.mark.asyncio
+async def test_read_and_hidden_content_excluded(db_session, make_source):
+    """Les contenus lus (CONSUMED) ou masqués sont écartés de la complétion."""
+    user_id = uuid4()
+    source = await make_source("Mediapart")
+    read = await _add_content(db_session, source, title="Article deja lu")
+    hidden = await _add_content(db_session, source, title="Article masque par moi")
+    fresh = await _add_content(db_session, source, title="Article jamais vu")
+
+    db_session.add(
+        UserContentStatus(
+            id=uuid4(),
+            user_id=user_id,
+            content_id=read.id,
+            status=ContentStatus.CONSUMED,
+        )
+    )
+    db_session.add(
+        UserContentStatus(
+            id=uuid4(),
+            user_id=user_id,
+            content_id=hidden.id,
+            status=ContentStatus.UNSEEN,
+            is_hidden=True,
+        )
+    )
+    await db_session.commit()
+
+    ctx = EssentielUserContext(followed_source_ids=frozenset({source.id}))
+
+    response = await build_essentiel_response_with_supplements(
+        db_session,
+        user_id,
+        _empty_digest(),
+        user_context=ctx,
+        is_serene=False,
+    )
+
+    ids = {a.content_id for a in response.articles}
+    assert read.id not in ids
+    assert hidden.id not in ids
+    assert fresh.id in ids
+
+
+@pytest.mark.asyncio
+async def test_no_admissible_supplement_stays_below_floor(db_session, make_source):
+    """Sans complément admissible, le total reste < 3 (le router renverra 202)."""
+    user_id = uuid4()
+    source = await make_source("Mediapart")
+    # Seul contenu : déjà lu → exclu.
+    read = await _add_content(db_session, source, title="Tout est lu")
+    db_session.add(
+        UserContentStatus(
+            id=uuid4(),
+            user_id=user_id,
+            content_id=read.id,
+            status=ContentStatus.CONSUMED,
+        )
+    )
+    await db_session.commit()
+
+    ctx = EssentielUserContext(followed_source_ids=frozenset({source.id}))
+
+    response = await build_essentiel_response_with_supplements(
+        db_session,
+        user_id,
+        _empty_digest(),
+        user_context=ctx,
+        is_serene=False,
+    )
+
+    assert len(response.articles) < ESSENTIEL_MIN_ARTICLES
+
+
+@pytest.mark.asyncio
+async def test_max_two_articles_per_source(db_session, make_source):
+    """Diversité dure : au plus 2 articles d'une même source dans la complétion."""
+    user_id = uuid4()
+    source = await make_source("Mediapart")
+    for title in ["Politique", "Economie", "Climat", "Sport"]:
+        await _add_content(db_session, source, title=title)
+
+    ctx = EssentielUserContext(followed_source_ids=frozenset({source.id}))
+
+    response = await build_essentiel_response_with_supplements(
+        db_session,
+        user_id,
+        _empty_digest(),
+        user_context=ctx,
+        is_serene=False,
+    )
+
+    # 4 articles distincts d'une seule source → cap dur à 2.
+    assert len(response.articles) == 2, "cap de 2 articles par source"
+
+
+@pytest.mark.asyncio
+async def test_rich_digest_skips_supplement_query(db_session, make_source):
+    """Digest déjà ≥3 articles → pas de complétion (les sources suivies ignorées)."""
+    user_id = uuid4()
+    source = await make_source("Mediapart")
+    supplement = await _add_content(db_session, source, title="Ne doit pas apparaitre")
+
+    # Digest "riche" simulé via 3 articles supplémentaires injectés ? Ici on
+    # vérifie surtout que si le digest fournit >= 3 articles, le contenu DB des
+    # sources suivies n'est pas pioché. On construit un digest à 3 topics.
+    from app.schemas.content import SourceMini
+    from app.schemas.digest import DigestTopic, DigestTopicArticle
+
+    def _topic(label: str) -> DigestTopic:
+        return DigestTopic(
+            topic_id=uuid4().hex,
+            label=label,
+            rank=1,
+            reason="Test",
+            theme=label.lower(),
+            perspective_count=2,
+            articles=[
+                DigestTopicArticle(
+                    content_id=uuid4(),
+                    title=label,
+                    url=f"https://example.com/{label.lower()}",
+                    published_at=datetime.now(UTC),
+                    source=SourceMini(
+                        id=uuid4(),
+                        name="Le Monde",
+                        logo_url=None,
+                        type="rss",
+                        theme=None,
+                    ),
+                    rank=1,
+                    reason="Test",
+                )
+            ],
+        )
+
+    digest = DigestResponse(
+        digest_id=uuid4(),
+        user_id=uuid4(),
+        target_date=datetime.now(UTC).date(),
+        generated_at=datetime.now(UTC),
+        format_version="topics_v1",
+        items=[],
+        topics=[_topic("Politique"), _topic("Sciences"), _topic("Cuisine")],
+        is_stale_fallback=False,
+    )
+
+    ctx = EssentielUserContext(followed_source_ids=frozenset({source.id}))
+
+    response = await build_essentiel_response_with_supplements(
+        db_session,
+        user_id,
+        digest,
+        user_context=ctx,
+        is_serene=False,
+    )
+
+    assert len(response.articles) == 3
+    assert supplement.id not in {a.content_id for a in response.articles}


### PR DESCRIPTION
## Quoi
Complète l'**Essentiel** depuis les **sources suivies** quand le digest est trop maigre (serein-aware, dédup lus/masqués, max 2 articles/source). Sous le **plancher de 3** sans complément admissible, le router renvoie **202** (Essentiel non affiché).

## Pourquoi
Un digest pauvre produisait un Essentiel « carte pauvre ». La complétion garantit un Essentiel digne ou son masquage propre.

## Comment ça a été vérifié
- [x] `pytest` : **54 tests** (test_essentiel_supplements + test_essentiel_endpoint) ✓
- [x] `ruff check` + `ruff format --check` ✓

## Zones à risque
Backend only. Additif, **aucune migration Alembic**.
