### PR TITLE
feat(custom_topics): slug_parent dans follow topic/entity + idempotence

### DIFF
--- a/apps/mobile/lib/features/custom_topics/providers/custom_topics_provider.dart
+++ b/apps/mobile/lib/features/custom_topics/providers/custom_topics_provider.dart
@@ -94,7 +94,8 @@ class CustomTopicsNotifier extends AsyncNotifier<List<UserTopicProfile>> {
     }
 
     try {
-      final created = await repo.followTopic(name, priorityMultiplier: priorityMultiplier);
+      final created = await repo.followTopic(name,
+          slugParent: slugParent, priorityMultiplier: priorityMultiplier);
 
       // Replace placeholder with server-enriched profile
       if (state.hasValue) {
@@ -241,7 +242,8 @@ class CustomTopicsNotifier extends AsyncNotifier<List<UserTopicProfile>> {
     }
 
     try {
-      final created = await repo.followEntity(name, entityType);
+      final created =
+          await repo.followEntity(name, entityType, slugParent: slugParent);
       if (state.hasValue) {
         final updated = state.value!
             .map((t) => t.id == placeholder.id ? created : t)

--- a/apps/mobile/lib/features/custom_topics/repositories/topic_repository.dart
+++ b/apps/mobile/lib/features/custom_topics/repositories/topic_repository.dart
@@ -31,9 +31,14 @@ class TopicRepository {
 
   /// POST personalization/topics/ → UserTopicProfile (LLM-enriched)
   /// Trailing slash required: backend uses redirect_slashes=False.
-  Future<UserTopicProfile> followTopic(String name, {double? priorityMultiplier}) async {
+  /// [slugParent] : thème parent explicite (carrousel onboarding, TopicChip,
+  /// EntityAddSheet…) — le backend le préfère au slug deviné par le LLM, ce qui
+  /// garde le sujet dans la bonne catégorie « Mes Intérêts ».
+  Future<UserTopicProfile> followTopic(String name,
+      {String? slugParent, double? priorityMultiplier}) async {
     try {
       final body = <String, dynamic>{'name': name};
+      if (slugParent != null) body['slug_parent'] = slugParent;
       if (priorityMultiplier != null) body['priority_multiplier'] = priorityMultiplier;
       final data = await _apiClient.post(
         'personalization/topics/',
@@ -106,11 +111,15 @@ class TopicRepository {
   }
 
   /// POST personalization/topics/ with entity_type → UserTopicProfile
-  Future<UserTopicProfile> followEntity(String name, String entityType) async {
+  /// [slugParent] : thème parent explicite préservé côté backend (cf. followTopic).
+  Future<UserTopicProfile> followEntity(String name, String entityType,
+      {String? slugParent}) async {
     try {
+      final body = <String, dynamic>{'name': name, 'entity_type': entityType};
+      if (slugParent != null) body['slug_parent'] = slugParent;
       final data = await _apiClient.post(
         'personalization/topics/',
-        body: {'name': name, 'entity_type': entityType},
+        body: body,
       );
       return UserTopicProfile.fromJson(data as Map<String, dynamic>);
     } on DioException catch (e) {

--- a/apps/mobile/test/features/custom_topics/custom_topics_provider_test.dart
+++ b/apps/mobile/test/features/custom_topics/custom_topics_provider_test.dart
@@ -129,10 +129,33 @@ void main() {
       expect(topics.any((t) => t.id.startsWith('temp_')), isFalse);
     });
 
+    test('forwards explicit slugParent to the repository', () async {
+      when(() => mockRepo.getTopics())
+          .thenAnswer((_) async => [mockTopics[0]]);
+      when(() => mockRepo.followTopic('Tennis',
+              slugParent: 'sport',
+              priorityMultiplier: any(named: 'priorityMultiplier')))
+          .thenAnswer((_) async => const UserTopicProfile(
+              id: 'new-tennis', name: 'Tennis', slugParent: 'sport'));
+
+      await container.read(customTopicsProvider.future);
+      final notifier = container.read(customTopicsProvider.notifier);
+
+      final result = await notifier.followTopic('Tennis', slugParent: 'sport');
+
+      expect(result!.slugParent, 'sport');
+      // Le provider doit transmettre le parent explicite au repository.
+      verify(() => mockRepo.followTopic('Tennis',
+          slugParent: 'sport',
+          priorityMultiplier: any(named: 'priorityMultiplier'))).called(1);
+    });
+
     test('rolls back on API error', () async {
       when(() => mockRepo.getTopics())
           .thenAnswer((_) async => [mockTopics[0]]);
-      when(() => mockRepo.followTopic(any()))
+      when(() => mockRepo.followTopic(any(),
+              slugParent: any(named: 'slugParent'),
+              priorityMultiplier: any(named: 'priorityMultiplier')))
           .thenThrow(Exception('API error'));
 
       await container.read(customTopicsProvider.future);

--- a/apps/mobile/test/features/custom_topics/topic_repository_test.dart
+++ b/apps/mobile/test/features/custom_topics/topic_repository_test.dart
@@ -102,6 +102,56 @@ void main() {
       expect(result.intentDescription, 'Suivi actualites mobilite');
     });
 
+    test('sends slug_parent in body when provided (explicit parent)', () async {
+      when(() => mockApiClient.post(
+            'personalization/topics/',
+            body: {'name': 'Tennis', 'slug_parent': 'sport'},
+            queryParameters: any(named: 'queryParameters'),
+            options: any(named: 'options'),
+          )).thenAnswer((_) async => {
+            'id': 'uuid-tennis',
+            'topic_name': 'Tennis',
+            'slug_parent': 'sport',
+            'priority_multiplier': 1.0,
+          });
+
+      final result =
+          await repository.followTopic('Tennis', slugParent: 'sport');
+
+      expect(result.slugParent, 'sport');
+      // Vérifie explicitement que slug_parent a bien été envoyé au backend.
+      verify(() => mockApiClient.post(
+            'personalization/topics/',
+            body: {'name': 'Tennis', 'slug_parent': 'sport'},
+            queryParameters: any(named: 'queryParameters'),
+            options: any(named: 'options'),
+          )).called(1);
+    });
+
+    test('omits slug_parent from body when not provided', () async {
+      when(() => mockApiClient.post(
+            'personalization/topics/',
+            body: {'name': 'IA'},
+            queryParameters: any(named: 'queryParameters'),
+            options: any(named: 'options'),
+          )).thenAnswer((_) async => {
+            'id': 'uuid-ia',
+            'topic_name': 'IA',
+            'slug_parent': 'ai',
+            'priority_multiplier': 1.0,
+          });
+
+      await repository.followTopic('IA');
+
+      // body ne contient PAS la clé slug_parent (le backend devine via LLM).
+      verify(() => mockApiClient.post(
+            'personalization/topics/',
+            body: {'name': 'IA'},
+            queryParameters: any(named: 'queryParameters'),
+            options: any(named: 'options'),
+          )).called(1);
+    });
+
     test('rethrows DioException on 409 conflict (duplicate)', () async {
       when(() => mockApiClient.post(
             'personalization/topics/',
@@ -119,6 +169,69 @@ void main() {
 
       expect(
           () => repository.followTopic('IA'), throwsA(isA<DioException>()));
+    });
+  });
+
+  group('followEntity', () {
+    test('sends entity_type and slug_parent in body when provided', () async {
+      when(() => mockApiClient.post(
+            'personalization/topics/',
+            body: {
+              'name': 'Kylian Mbappe',
+              'entity_type': 'PERSON',
+              'slug_parent': 'sport',
+            },
+            queryParameters: any(named: 'queryParameters'),
+            options: any(named: 'options'),
+          )).thenAnswer((_) async => {
+            'id': 'uuid-entity',
+            'topic_name': 'Kylian Mbappe',
+            'slug_parent': 'sport',
+            'entity_type': 'PERSON',
+            'canonical_name': 'Kylian Mbappe',
+            'priority_multiplier': 1.0,
+          });
+
+      final result = await repository.followEntity('Kylian Mbappe', 'PERSON',
+          slugParent: 'sport');
+
+      expect(result.slugParent, 'sport');
+      expect(result.entityType, 'PERSON');
+      verify(() => mockApiClient.post(
+            'personalization/topics/',
+            body: {
+              'name': 'Kylian Mbappe',
+              'entity_type': 'PERSON',
+              'slug_parent': 'sport',
+            },
+            queryParameters: any(named: 'queryParameters'),
+            options: any(named: 'options'),
+          )).called(1);
+    });
+
+    test('omits slug_parent when not provided', () async {
+      when(() => mockApiClient.post(
+            'personalization/topics/',
+            body: {'name': 'OpenAI', 'entity_type': 'ORG'},
+            queryParameters: any(named: 'queryParameters'),
+            options: any(named: 'options'),
+          )).thenAnswer((_) async => {
+            'id': 'uuid-org',
+            'topic_name': 'OpenAI',
+            'slug_parent': 'ai',
+            'entity_type': 'ORG',
+            'canonical_name': 'OpenAI',
+            'priority_multiplier': 1.0,
+          });
+
+      await repository.followEntity('OpenAI', 'ORG');
+
+      verify(() => mockApiClient.post(
+            'personalization/topics/',
+            body: {'name': 'OpenAI', 'entity_type': 'ORG'},
+            queryParameters: any(named: 'queryParameters'),
+            options: any(named: 'options'),
+          )).called(1);
     });
   });
 

--- a/packages/api/app/routers/custom_topics.py
+++ b/packages/api/app/routers/custom_topics.py
@@ -47,6 +47,11 @@ class CreateTopicRequest(BaseModel):
     name: str
     entity_type: str | None = None
     priority_multiplier: float | None = None
+    # Thème parent explicite fourni par un contexte UI/onboarding (carrousel
+    # sujet, TopicChip, EntityAddSheet…). Quand présent, il prime sur le
+    # `slug_parent` deviné par l'enrichissement LLM — l'utilisateur a déjà
+    # tranché la catégorie, on ne la laisse pas dériver.
+    slug_parent: str | None = None
 
     @field_validator("priority_multiplier")
     @classmethod
@@ -77,6 +82,18 @@ class CreateTopicRequest(BaseModel):
                 f"entity_type doit être PERSON, ORG, EVENT, LOCATION ou PRODUCT (reçu: {v})"
             )
         return v.upper() if v else None
+
+    @field_validator("slug_parent")
+    @classmethod
+    def validate_slug_parent(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        v = v.strip().lower()
+        if not v:
+            return None
+        if v not in VALID_TOPIC_SLUGS:
+            raise ValueError(f"slug_parent invalide (reçu: {v})")
+        return v
 
 
 class UpdateTopicRequest(BaseModel):
@@ -232,14 +249,21 @@ async def create_topic(
 
     # Determine entity fields (explicit request OR auto-detected by enrichment)
     entity_type = request.entity_type or result.entity_type
-    canonical_name = request.name.strip() if entity_type else None
+    topic_name = request.name.strip()
+    canonical_name = topic_name if entity_type else None
+
+    # Parent explicite (UI/onboarding) prime sur le slug deviné par le LLM :
+    # l'utilisateur a déjà choisi la catégorie, on la préserve telle quelle.
+    effective_slug_parent = request.slug_parent or result.slug_parent
 
     # Duplicate check depends on entity vs topic subscription
     if canonical_name:
+        # Entités : dédoublonnage par (user_id, canonical_name) insensible à la
+        # casse — « Kylian Mbappé » et « kylian mbappé » sont la même entité.
         existing = await db.scalar(
             select(UserTopicProfile).where(
                 UserTopicProfile.user_id == user_uuid,
-                UserTopicProfile.canonical_name == canonical_name,
+                func.lower(UserTopicProfile.canonical_name) == canonical_name.lower(),
             )
         )
         if existing:
@@ -248,17 +272,33 @@ async def create_topic(
                 detail=f"Tu suis déjà l'entité '{canonical_name}'",
             )
     else:
+        # Sujets : un même nom dans le même thème parent ne doit pas créer de
+        # doublon. Renvoie l'existant (idempotent) plutôt que de dupliquer une
+        # ligne — robuste aux ré-envois (onboarding multi-sujets, retries).
+        existing_topic = await db.scalar(
+            select(UserTopicProfile).where(
+                UserTopicProfile.user_id == user_uuid,
+                UserTopicProfile.canonical_name.is_(None),
+                func.lower(UserTopicProfile.topic_name) == topic_name.lower(),
+                UserTopicProfile.slug_parent == effective_slug_parent,
+            )
+        )
+        if existing_topic:
+            return _topic_to_response(existing_topic)
+
         count = await db.scalar(
             select(func.count())
             .select_from(UserTopicProfile)
             .where(
                 UserTopicProfile.user_id == user_uuid,
-                UserTopicProfile.slug_parent == result.slug_parent,
+                UserTopicProfile.slug_parent == effective_slug_parent,
                 UserTopicProfile.canonical_name.is_(None),
             )
         )
         if count >= 3:
-            category_label = SLUG_TO_LABEL.get(result.slug_parent, result.slug_parent)
+            category_label = SLUG_TO_LABEL.get(
+                effective_slug_parent, effective_slug_parent
+            )
             raise HTTPException(
                 status_code=409,
                 detail=f"3 sujets personnalisés maximum par thème ({category_label})",
@@ -266,8 +306,8 @@ async def create_topic(
 
     topic = UserTopicProfile(
         user_id=user_uuid,
-        topic_name=request.name.strip(),
-        slug_parent=result.slug_parent,
+        topic_name=topic_name,
+        slug_parent=effective_slug_parent,
         keywords=result.keywords,
         intent_description=result.intent_description,
         entity_type=entity_type,
@@ -288,7 +328,8 @@ async def create_topic(
         "custom_topic_created",
         user_id=current_user_id,
         topic_name=request.name,
-        slug=result.slug_parent,
+        slug=effective_slug_parent,
+        slug_parent_explicit=request.slug_parent is not None,
         entity_type=entity_type,
     )
 

--- a/packages/api/tests/test_custom_topics_slug_parent.py
+++ b/packages/api/tests/test_custom_topics_slug_parent.py
@@ -1,0 +1,140 @@
+"""Tests endpoint `POST /personalization/topics/` — parent explicite `slug_parent`.
+
+Couvre le plan QA onboarding (partie 2) :
+- un `slug_parent` fourni par l'UI/onboarding prime sur celui deviné par le LLM ;
+- un `slug_parent` invalide est rejeté (422) ;
+- un même sujet (nom + parent) n'est jamais dupliqué (idempotent), et conserve
+  son parent explicite.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import func, select
+
+from app.database import get_db
+from app.dependencies import get_current_user_id
+from app.main import app
+from app.models.user_topic_profile import UserTopicProfile
+from app.services.ml.topic_enrichment_service import TopicEnrichmentResult
+
+
+def _enrichment_service(
+    *, slug_parent: str = "society", entity_type=None, canonical_name=None
+):
+    """Mock du service d'enrichissement LLM avec un `slug_parent` deviné fixe."""
+    svc = MagicMock()
+    svc.enrich = AsyncMock(
+        return_value=TopicEnrichmentResult(
+            slug_parent=slug_parent,
+            keywords=["mot1", "mot2"],
+            intent_description="Description de suivi",
+            entity_type=entity_type,
+            canonical_name=canonical_name,
+        )
+    )
+    return svc
+
+
+@pytest_asyncio.fixture
+async def client_with_user(db_session):
+    """Client HTTP avec auth bypass + `get_db` câblé sur la session de test."""
+    user_id = uuid4()
+
+    async def _fake_user() -> str:
+        return str(user_id)
+
+    async def _fake_db():
+        yield db_session
+
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+    transport = ASGITransport(app=app)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac, user_id, db_session
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.mark.asyncio
+async def test_explicit_slug_parent_overrides_llm(client_with_user):
+    """`name=Tennis, slug_parent=sport` → slug_parent=sport (le LLM devinait autre)."""
+    ac, _user_id, _db = client_with_user
+    with patch(
+        "app.routers.custom_topics.get_topic_enrichment_service",
+        return_value=_enrichment_service(slug_parent="society"),
+    ):
+        resp = await ac.post(
+            "/api/personalization/topics/",
+            json={"name": "Tennis", "slug_parent": "sport"},
+        )
+    assert resp.status_code == 201
+    assert resp.json()["slug_parent"] == "sport"
+
+
+@pytest.mark.asyncio
+async def test_llm_slug_used_when_no_explicit_parent(client_with_user):
+    """Sans `slug_parent`, on retombe sur le slug deviné par le LLM."""
+    ac, _user_id, _db = client_with_user
+    with patch(
+        "app.routers.custom_topics.get_topic_enrichment_service",
+        return_value=_enrichment_service(slug_parent="ai"),
+    ):
+        resp = await ac.post(
+            "/api/personalization/topics/",
+            json={"name": "Modèles de langage"},
+        )
+    assert resp.status_code == 201
+    assert resp.json()["slug_parent"] == "ai"
+
+
+@pytest.mark.asyncio
+async def test_invalid_slug_parent_rejected(client_with_user):
+    """Un `slug_parent` hors `VALID_TOPIC_SLUGS` est refusé (422)."""
+    ac, _user_id, _db = client_with_user
+    with patch(
+        "app.routers.custom_topics.get_topic_enrichment_service",
+        return_value=_enrichment_service(),
+    ):
+        resp = await ac.post(
+            "/api/personalization/topics/",
+            json={"name": "Tennis", "slug_parent": "pas-un-slug"},
+        )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_duplicate_topic_is_idempotent_and_keeps_parent(client_with_user):
+    """`name=Biologie, slug_parent=science` deux fois → 1 seule ligne, slug=science."""
+    ac, user_id, db = client_with_user
+    with patch(
+        "app.routers.custom_topics.get_topic_enrichment_service",
+        # Le LLM devinerait "society" — l'explicite "science" doit être conservé
+        # et la 2e tentative ne doit pas créer de doublon incohérent.
+        return_value=_enrichment_service(slug_parent="society"),
+    ):
+        r1 = await ac.post(
+            "/api/personalization/topics/",
+            json={"name": "Biologie", "slug_parent": "science"},
+        )
+        r2 = await ac.post(
+            "/api/personalization/topics/",
+            json={"name": "biologie", "slug_parent": "science"},
+        )
+
+    assert r1.status_code == 201
+    assert r1.json()["slug_parent"] == "science"
+    # Idempotent : même sujet (nom insensible à la casse + parent) → renvoie l'existant.
+    assert r2.json()["slug_parent"] == "science"
+
+    count = await db.scalar(
+        select(func.count())
+        .select_from(UserTopicProfile)
+        .where(UserTopicProfile.user_id == user_id)
+    )
+    assert count == 1, "aucun doublon ne doit être créé pour le même sujet/parent"


### PR DESCRIPTION
## Quoi
Envoie `slug_parent` dans le body de `followTopic`/`followEntity` quand fourni (omis sinon) ; le backend gère le **doublon de façon idempotente** en conservant le parent.

## Pourquoi
Le rattachement parent d'un sujet/entité suivi n'était pas transmis ni conservé en cas de re-follow.

## Comment ça a été vérifié
- [x] `pytest` : **4 tests** (test_custom_topics_slug_parent) ✓ · `ruff` ✓
- [x] `flutter test` : **29 tests** (custom_topics_provider, topic_repository) ✓
- [x] `flutter analyze` — aucune erreur dans les fichiers modifiés

## Zones à risque
Backend additif (pas de migration) + mobile. Endpoint custom_topics.
