### PR TITLE
feat(ranking): jauge CTR par pilier + hygiène boucle sujets (decay + position) — PR1

### DIFF
--- a/docs/maintenance/maintenance-ranking-jauge-pr1.md
+++ b/docs/maintenance/maintenance-ranking-jauge-pr1.md
@@ -1,0 +1,96 @@
+# Maintenance — Ranking PR1 : la jauge + hygiène boucle sujets
+
+> **Objectif global (2 PRs)** : améliorer le ranking utilisé partout (L'Essentiel,
+> Flâner, Veille) **sans vectorisation** — préférer des signaux granulaires
+> *explicables/contrôlables*. PR1 = poser la **mesure** (jauge) + corriger 2 défauts
+> structurels de la boucle sujets. PR2 (séparée) = **affinité entités**.
+
+Classification : **Maintenance** (instrumentation + hygiène structurelle, zéro migration).
+
+---
+
+## Constat (validé sur le code)
+
+- `user_subtopics.weight` (0.1→3.0) est appris sur like/save/read/dismiss
+  (`content_service.py::_adjust_subtopic_weights`) et multiplie `TOPIC_MATCH` (45 pts)
+  dans `pertinence.py::_score_subtopics`. **Trous** : (a) aucun decay → dérive
+  permanente ; (b) tous les sujets matchés pondérés à égalité alors que
+  `content.topics` est ordonné par confiance LLM (`topics[0]` = principal).
+- Le ranking **pilote à l'aveugle** : `PillarScoreResult.pillar_scores` est calculé
+  (`scoring_engine.py:147`) puis **jeté** — dans `digest_selector.py:1442` il n'est
+  plus que loggé. Aucun CTR par sujet/entité/position.
+
+## PR1.1 — Persister le breakdown par pilier (zéro migration)
+
+`daily_digest.items` est un JSONB schemaless ⇒ ajout de clés sans DDL. Mobile parse
+par clés nommées (`digest_models.g.dart`, json_serializable permissif) ⇒ **clés
+inconnues ignorées, aucun risque de casse**. Vérifié.
+
+`pillar_scores` n'est pas porté jusqu'à la sérialisation ⇒ il faut le **threader** :
+
+1. `digest_selector.py::_score_candidates` (≈L1380-1465) : le tuple `scored`
+   passe de `(content, final_score, breakdown)` à
+   `(content, final_score, breakdown, pillar_scores)` (dict déjà dispo L1442).
+2. `digest_selector.py::_select_with_diversity` (≈L1467) : propager `pillar_scores`
+   (tuple sortant `(content, score, reason, breakdown)` → ajouter `pillar_scores`).
+3. `DigestItem` dataclass (`digest_selector.py:137`) : nouveau champ
+   `pillar_scores: dict[str, float] | None = None` + construction L589-598.
+4. **Sérialisation** `digest_service.py::_create_digest_record` (L1722-1758) :
+   ajouter au `item_data` →
+   `"pillar_scores": item.pillar_scores or {}` et `"final_score": float(item.score)`.
+   (Note : `score` == `final_score` déjà ; on émet la clé nommée demandée.)
+
+Path secondaire « on-demand » (`digest_generation_job.py:1104`) : ajout optionnel des
+mêmes clés pour cohérence — non bloquant (path de fallback).
+
+## PR1.2 — Script offline de mesure
+
+Nouveau `packages/api/scripts/evaluate_feed_ranking.py`, calqué sur la **structure**
+de `evaluate_veille_curation.py` (argparse + rapport markdown lisible).
+⚠️ contrairement à `evaluate_veille_curation.py` (fixture JSON, pas de DB), ce script
+**a besoin de la DB** : connexion via `DATABASE_URL` (réutiliser l'engine async de
+`app/database.py` ou un `asyncpg`/SQLAlchemy direct).
+
+CTR = consommés / montrés, en joignant :
+`daily_digest.items` (`rank`, `content_id`, `pillar_scores`) ↔ `user_content_status`
+(`status == CONSUMED` = clic, `last_impressed_at` = montré) ↔ `contents`
+(`topics`, `entities`).
+
+Sorties : CTR **par slug de sujet**, **par entité**, **par rang/position**, **par
+bande de score pilier**. C'est la jauge qui calibrera PR2 et validera 1.3.
+
+## PR1.3 — Hygiène boucle sujets (structurel, sûr)
+
+**a. Decay des poids** — job batch quotidien accroché au scheduler APScheduler
+(`app/workers/scheduler.py`, près de `daily_digest` 07:30 Paris). Un seul UPDATE bulk :
+```sql
+UPDATE user_subtopics SET weight = 1.0 + (weight - 1.0) * :decay
+```
+→ normalise tout vers 1.0, O(1) requête/jour, aucun schéma.
+(Alt. notée et écartée : colonne `updated_at` additive + decay paresseux = migration.)
+
+**b. Pondération par position** dans `pertinence.py::_score_subtopics` (L297-301) :
+aujourd'hui `score += TOPIC_MATCH * w` à égalité. Pondérer par l'index du sujet dans
+`content.topics` : facteur `1.0` pour index 0, puis `SUBTOPIC_POSITION_FACTOR` par cran
+(≈0.6 → index1=0.6, index2=0.36). `TOPIC_MAX_MATCHES=2` inchangé.
+⚠️ `_score_subtopics` calcule `matches = content_topics & user_subtopics` puis
+`sorted(matches)` — il **perd l'ordre** de `content.topics`. Il faut récupérer
+l'index de chaque match dans `content.topics` (et non l'ordre alpha) pour appliquer
+le bon facteur.
+
+Nouvelles constantes dans `scoring_config.py` :
+`SUBTOPIC_DECAY = 0.98`, `SUBTOPIC_POSITION_FACTOR = 0.6`.
+
+## Tests
+
+- `packages/api/tests` : étendre les tests de pertinence — vérifier que
+  `topics[0]` contribue plus que `topics[1]` (pondération position) ; test du job decay
+  (poids > 1 décroît vers 1.0, poids < 1 croît vers 1.0).
+- DB locale `facteur_test` (port 54322, `DATABASE_URL` depuis `.env`) ;
+  `cd packages/api && pytest -v`.
+- Lancer `python scripts/evaluate_feed_ranking.py` et lire le rapport.
+
+## Hors-scope PR1
+
+Affinité entités (bonus positif sur `contents.entities`) = **PR2**, calibrée par la
+jauge de PR1.

--- a/packages/api/app/services/digest_selector.py
+++ b/packages/api/app/services/digest_selector.py
@@ -151,6 +151,7 @@ class DigestItem:
     rank: int
     reason: str
     breakdown: list[DigestScoreBreakdown] | None = None
+    pillar_scores: dict[str, float] | None = None
 
 
 @dataclass
@@ -543,10 +544,10 @@ class DigestSelector:
                 scoring_time = time.time() - step_start
 
                 non_zero_scores = [
-                    s for _, s, _ in scored_candidates_with_breakdown if s > 0
+                    s for _, s, _, _ in scored_candidates_with_breakdown if s > 0
                 ]
                 zero_scores = [
-                    s for _, s, _ in scored_candidates_with_breakdown if s == 0
+                    s for _, s, _, _ in scored_candidates_with_breakdown if s == 0
                 ]
 
                 logger.info(
@@ -557,7 +558,7 @@ class DigestSelector:
                     zero_count=len(zero_scores),
                     max_score=round(
                         max(
-                            (s for _, s, _ in scored_candidates_with_breakdown),
+                            (s for _, s, _, _ in scored_candidates_with_breakdown),
                             default=0,
                         ),
                         2,
@@ -586,7 +587,9 @@ class DigestSelector:
             user_source_items = []
             curated_items = []
 
-            for i, (content, score, reason, breakdown) in enumerate(selected, 1):
+            for i, (content, score, reason, breakdown, pillar_scores) in enumerate(
+                selected, 1
+            ):
                 digest_items.append(
                     DigestItem(
                         content=content,
@@ -594,6 +597,7 @@ class DigestSelector:
                         rank=i,
                         reason=reason,
                         breakdown=breakdown,
+                        pillar_scores=pillar_scores,
                     )
                 )
                 # Track source type
@@ -1222,7 +1226,7 @@ class DigestSelector:
         if score_inputs:
             try:
                 scored = await self._score_candidates(score_inputs, context, mode=mode)
-                score_map = {c.id: sc for c, sc, _bd in scored}
+                score_map = {c.id: sc for c, sc, _bd, _pillar_scores in scored}
             except Exception:
                 # Dégradation sûre : sans scoring on garde l'ordre run_for_user.
                 logger.exception(
@@ -1334,7 +1338,7 @@ class DigestSelector:
         candidates: list[Content],
         context: DigestContext,
         mode: str = "pour_vous",
-    ) -> list[tuple[Content, float, list[DigestScoreBreakdown]]]:
+    ) -> list[tuple[Content, float, list[DigestScoreBreakdown], dict[str, float]]]:
         """Score les candidats via le moteur de piliers unifié (PillarScoringEngine).
 
         Le scoring (pertinence/source/fraîcheur/qualité + pénalités) est entièrement
@@ -1444,7 +1448,14 @@ class DigestSelector:
                     breakdown_count=len(breakdown),
                 )
 
-                scored.append((content, final_score, breakdown))
+                scored.append(
+                    (
+                        content,
+                        final_score,
+                        breakdown,
+                        dict(pillar_result.pillar_scores),
+                    )
+                )
             except Exception as e:
                 logger.error(
                     "digest_scoring_failed",
@@ -1457,7 +1468,7 @@ class DigestSelector:
                     exc_info=True,
                 )
                 # Attribuer un score minimal pour ne pas bloquer
-                scored.append((content, 0.0, breakdown))
+                scored.append((content, 0.0, breakdown, {}))
 
         # Trier par score décroissant
         scored.sort(key=lambda x: x[1], reverse=True)
@@ -1466,12 +1477,15 @@ class DigestSelector:
 
     def _select_with_diversity(
         self,
-        scored_candidates: list[tuple[Content, float, list[DigestScoreBreakdown]]],
+        scored_candidates: list[
+            tuple[Content, float, list[DigestScoreBreakdown]]
+            | tuple[Content, float, list[DigestScoreBreakdown], dict[str, float]]
+        ],
         target_count: int,
         mode: str = "pour_vous",
         initial_source_counts: dict[UUID, int] | None = None,
         initial_theme_counts: dict[str, int] | None = None,
-    ) -> list[tuple[Content, float, str, list[DigestScoreBreakdown]]]:
+    ) -> list[tuple[Content, float, str, list[DigestScoreBreakdown], dict[str, float]]]:
         """Sélectionne les articles avec contraintes de diversité.
 
         Contraintes:
@@ -1485,14 +1499,14 @@ class DigestSelector:
             initial_theme_counts: Compteurs thème pré-existants (pour continuité entre passes)
 
         Returns:
-            Liste de tuples (Content, score, reason, breakdown)
+            Liste de tuples (Content, score, reason, breakdown, pillar_scores)
         """
         DIVERSITY_DIVISOR = ScoringWeights.DIGEST_DIVERSITY_DIVISOR
 
         effective_max_per_theme = self.constraints.MAX_PER_THEME
 
         # Count distinct sources in candidate pool for fallback decision
-        distinct_sources = {c.source_id for c, _, _ in scored_candidates}
+        distinct_sources = {candidate[0].source_id for candidate in scored_candidates}
         effective_max_per_source = self.constraints.MAX_PER_SOURCE
 
         if len(distinct_sources) < self.constraints.TARGET_DIGEST_SIZE:
@@ -1508,7 +1522,13 @@ class DigestSelector:
         source_counts: dict[UUID, int] = defaultdict(int, initial_source_counts or {})
         theme_counts: dict[str, int] = defaultdict(int, initial_theme_counts or {})
 
-        for content, score, breakdown in scored_candidates:
+        for candidate in scored_candidates:
+            if len(candidate) == 3:
+                content, score, breakdown = candidate
+                pillar_scores = {}
+            else:
+                content, score, breakdown, pillar_scores = candidate
+
             if len(selected) >= target_count:
                 break
 
@@ -1549,7 +1569,7 @@ class DigestSelector:
             reason = self._generate_reason(
                 content, source_counts, theme_counts, breakdown
             )
-            selected.append((content, final_score, reason, breakdown))
+            selected.append((content, final_score, reason, breakdown, pillar_scores))
             source_counts[source_id] += 1
             if theme:
                 theme_counts[theme] += 1
@@ -1643,7 +1663,7 @@ class DigestSelector:
         context: DigestContext,
         trending_context: GlobalTrendingContext,
         target_count: int,
-    ) -> list[tuple[Content, float, str, list[DigestScoreBreakdown]]]:
+    ) -> list[tuple[Content, float, str, list[DigestScoreBreakdown], dict[str, float]]]:
         """Sélection hybride en 2 passes : trending + personnalisé.
 
         Pass 1 : Sélectionner les articles trending/une pertinents pour l'utilisateur
@@ -1696,8 +1716,10 @@ class DigestSelector:
         )
 
         # === PASSE 1 : Score et sélection trending ===
-        _4t = list[tuple[Content, float, str, list[DigestScoreBreakdown]]]
-        pass1_selected: _4t = []
+        _5t = list[
+            tuple[Content, float, str, list[DigestScoreBreakdown], dict[str, float]]
+        ]
+        pass1_selected: _5t = []
         if trending_candidates:
             scored_trending = await self._score_candidates(
                 trending_candidates,
@@ -1706,9 +1728,11 @@ class DigestSelector:
             )
 
             # Ajouter les bonus trending/une
-            _3t = list[tuple[Content, float, list[DigestScoreBreakdown]]]
-            boosted_trending: _3t = []
-            for content, score, breakdown in scored_trending:
+            _4t = list[
+                tuple[Content, float, list[DigestScoreBreakdown], dict[str, float]]
+            ]
+            boosted_trending: _4t = []
+            for content, score, breakdown, pillar_scores in scored_trending:
                 bonus = 0.0
                 bd_copy = list(breakdown)
 
@@ -1732,7 +1756,9 @@ class DigestSelector:
                         )
                     )
 
-                boosted_trending.append((content, score + bonus, bd_copy))
+                boosted_trending.append(
+                    (content, score + bonus, bd_copy, pillar_scores)
+                )
 
             # Trier par score boosté décroissant
             boosted_trending.sort(key=lambda x: x[1], reverse=True)
@@ -1748,7 +1774,7 @@ class DigestSelector:
 
         # === PASSE 2 : Compléter avec personnalisé ===
         remaining_count = target_count - len(pass1_selected)
-        pass2_selected: _4t = []
+        pass2_selected: _5t = []
 
         if remaining_count > 0 and personalized_candidates:
             scored_personalized = await self._score_candidates(
@@ -1760,7 +1786,7 @@ class DigestSelector:
             # Construire les compteurs existants depuis pass 1 pour continuité diversité
             pass1_source_counts: dict[UUID, int] = defaultdict(int)
             pass1_theme_counts: dict[str, int] = defaultdict(int)
-            for content, _, _, _ in pass1_selected:
+            for content, _, _, _, _ in pass1_selected:
                 pass1_source_counts[content.source_id] += 1
                 theme = getattr(content, "theme", None)
                 if not theme and content.source:

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -296,6 +296,19 @@ def _count_digest_items(digest_items) -> int:
     return len(digest_items) if digest_items else 0
 
 
+def _serialize_breakdown(breakdown) -> list[dict]:
+    """Serialize score breakdown contributions for the daily_digest JSONB."""
+    return [
+        {
+            "label": b.label,
+            "points": b.points,
+            "is_positive": b.is_positive,
+            "pillar": b.pillar,
+        }
+        for b in (breakdown or [])
+    ]
+
+
 # --- Serein quotes -----------------------------------------------------------
 
 from pathlib import Path as _Path
@@ -1728,6 +1741,8 @@ class DigestService:
                 if item.content.source
                 else None,
                 "score": float(item.score),
+                "final_score": float(item.score),
+                "pillar_scores": getattr(item, "pillar_scores", None) or {},
                 "entities": item.content.entities or [],
             }
 
@@ -1743,10 +1758,7 @@ class DigestService:
                     breakdown_count=len(breakdown),
                     breakdown_labels=[b.label for b in breakdown[:3]],
                 )
-                item_data["breakdown"] = [
-                    {"label": b.label, "points": b.points, "is_positive": b.is_positive}
-                    for b in breakdown
-                ]
+                item_data["breakdown"] = _serialize_breakdown(breakdown)
             else:
                 logger.warning(
                     "no_breakdown_available_for_digest_item",
@@ -1819,15 +1831,10 @@ class DigestService:
                             if a.content.source
                             else None,
                             "score": float(a.score),
+                            "final_score": float(a.score),
+                            "pillar_scores": a.pillar_scores or {},
                             "is_followed_source": a.is_followed_source,
-                            "breakdown": [
-                                {
-                                    "label": b.label,
-                                    "points": b.points,
-                                    "is_positive": b.is_positive,
-                                }
-                                for b in (a.breakdown or [])
-                            ],
+                            "breakdown": _serialize_breakdown(a.breakdown),
                         }
                         for j, a in enumerate(tg.articles)
                     ],
@@ -2123,6 +2130,7 @@ class DigestService:
                         label=b.get("label", ""),
                         points=b.get("points", 0.0),
                         is_positive=b.get("is_positive", True),
+                        pillar=b.get("pillar"),
                     )
                     for b in breakdown_data
                     if isinstance(b, dict) and b.get("label")
@@ -2533,6 +2541,7 @@ class DigestService:
                         label=b.get("label", ""),
                         points=b.get("points", 0.0),
                         is_positive=b.get("is_positive", True),
+                        pillar=b.get("pillar"),
                     )
                     for b in breakdown_raw
                     if isinstance(b, dict) and b.get("label")

--- a/packages/api/app/services/recommendation/pillars/pertinence.py
+++ b/packages/api/app/services/recommendation/pillars/pertinence.py
@@ -281,22 +281,34 @@ class PertinencePillar(BasePillar):
         if not context.user_subtopics or not content.topics:
             return 0.0, []
 
-        content_topics = {t.lower().strip() for t in content.topics if t}
         user_subtopics = {s.lower().strip() for s in context.user_subtopics}
-        matches = content_topics & user_subtopics
-        match_count = min(len(matches), ScoringWeights.TOPIC_MAX_MATCHES)
 
-        if match_count == 0:
+        matched_topics: list[tuple[str, float]] = []
+        seen_topics: set[str] = set()
+        for index, raw_topic in enumerate(content.topics):
+            topic = raw_topic.lower().strip() if isinstance(raw_topic, str) else ""
+            if not topic or topic in seen_topics:
+                continue
+            seen_topics.add(topic)
+            if topic not in user_subtopics:
+                continue
+
+            position_factor = ScoringWeights.SUBTOPIC_POSITION_FACTOR**index
+            matched_topics.append((topic, position_factor))
+            if len(matched_topics) >= ScoringWeights.TOPIC_MAX_MATCHES:
+                break
+
+        if not matched_topics:
             return 0.0, []
 
         weights = context.user_subtopic_weights
-        matched_list = sorted(matches)[:match_count]
+        matched_list = [topic for topic, _ in matched_topics]
         score = 0.0
         boosted_topics = []
 
-        for topic in matched_list:
+        for topic, position_factor in matched_topics:
             w = weights.get(topic, 1.0)
-            score += ScoringWeights.TOPIC_MATCH * w
+            score += ScoringWeights.TOPIC_MATCH * w * position_factor
             if w > 1.0:
                 boosted_topics.append(topic)
 

--- a/packages/api/app/services/recommendation/scoring_config.py
+++ b/packages/api/app/services/recommendation/scoring_config.py
@@ -126,6 +126,8 @@ class ScoringWeights:
     # Réduit de 60→45 car content.theme capture déjà le signal broad.
     TOPIC_MATCH = 45.0
     TOPIC_MAX_MATCHES = 2  # Max 90pts (2 x 45)
+    SUBTOPIC_POSITION_FACTOR = 0.6
+    SUBTOPIC_DECAY = 0.98
 
     # Bonus de précision : si article a match thème ET sous-thème
     # Réduit de 20→18.

--- a/packages/api/app/services/topic_selector.py
+++ b/packages/api/app/services/topic_selector.py
@@ -44,6 +44,7 @@ class ScoredArticle:
     score: float
     reason: str
     breakdown: list[DigestScoreBreakdown] = field(default_factory=list)
+    pillar_scores: dict[str, float] = field(default_factory=dict)
     is_followed_source: bool = False
 
 
@@ -410,7 +411,7 @@ class TopicSelector:
         UNE_BONUS = 12.0  # ~35/300 from old scale
 
         article_scores: list[
-            tuple[Content, float, str, list[DigestScoreBreakdown]]
+            tuple[Content, float, str, list[DigestScoreBreakdown], dict[str, float]]
         ] = []
 
         for content in cluster.contents:
@@ -455,7 +456,9 @@ class TopicSelector:
 
             # Build reason
             reason = self._article_reason(content, context, breakdown)
-            article_scores.append((content, score, reason, breakdown))
+            article_scores.append(
+                (content, score, reason, breakdown, dict(pillar_result.pillar_scores))
+            )
 
         # Sort by score desc
         article_scores.sort(key=lambda x: x[1], reverse=True)
@@ -468,20 +471,21 @@ class TopicSelector:
             )
 
             seed = compute_seed(str(context.user_id), granularity="daily")
-            # Wrap full tuples for randomized_sort: T = (content, reason, breakdown)
+            # Wrap full tuples for randomized_sort:
+            # T = (content, reason, breakdown, pillar_scores)
             wrapped = [
-                ((content, reason, breakdown), score)
-                for content, score, reason, breakdown in article_scores
+                ((content, reason, breakdown, pillar_scores), score)
+                for content, score, reason, breakdown, pillar_scores in article_scores
             ]
             randomized = randomized_sort(
                 wrapped,
                 temperature=ScoringWeights.DIGEST_RANDOMIZATION_TEMPERATURE,
                 seed=seed,
             )
-            article_scores = [(t[0], s, t[1], t[2]) for t, s in randomized]
+            article_scores = [(t[0], s, t[1], t[2], t[3]) for t, s in randomized]
 
             # Add randomization transparency
-            for _content, _score, _reason, bd in article_scores:
+            for _content, _score, _reason, bd, _pillar_scores in article_scores:
                 bd.append(
                     DigestScoreBreakdown(
                         label="Hasard pour diversifier",
@@ -495,7 +499,7 @@ class TopicSelector:
         selected: list[ScoredArticle] = []
         used_sources: set[UUID] = set()
 
-        for content, score, reason, breakdown in article_scores:
+        for content, score, reason, breakdown, pillar_scores in article_scores:
             if len(selected) >= max_articles:
                 break
             if content.source_id in used_sources:
@@ -507,6 +511,7 @@ class TopicSelector:
                     score=score,
                     reason=reason,
                     breakdown=breakdown,
+                    pillar_scores=pillar_scores,
                     is_followed_source=content.source_id in context.followed_source_ids,
                 )
             )

--- a/packages/api/app/workers/scheduler.py
+++ b/packages/api/app/workers/scheduler.py
@@ -5,6 +5,7 @@ import structlog
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
+from sqlalchemy import text
 
 from app.config import get_settings
 from app.jobs.digest_generation_job import (
@@ -15,6 +16,7 @@ from app.jobs.purge_deleted_users import purge_deleted_users
 from app.jobs.recompute_source_language import recompute_source_language
 from app.services.observability.cost_budget import log_budget_projection
 from app.services.push_dispatcher import dispatch_daily_essentiel_pushes
+from app.services.recommendation.scoring_config import ScoringWeights
 from app.workers.rss_sync import sync_all_sources
 from app.workers.storage_cleanup import cleanup_old_articles
 
@@ -39,8 +41,48 @@ _PARIS_TZ = pytz.timezone("Europe/Paris")
 # sont déjà dans le pool candidat.
 DIGEST_CRON_HOUR_PARIS = 7
 DIGEST_CRON_MINUTE_PARIS = 30
+SUBTOPIC_DECAY_HOUR_PARIS = 7
+SUBTOPIC_DECAY_MINUTE_PARIS = 20
 
 scheduler: AsyncIOScheduler | None = None
+
+
+def decayed_subtopic_weight(
+    weight: float, decay: float = ScoringWeights.SUBTOPIC_DECAY
+) -> float:
+    """Return a subtopic weight moved one daily step toward neutral 1.0."""
+    return 1.0 + (weight - 1.0) * decay
+
+
+async def decay_user_subtopic_weights() -> None:
+    """Apply the daily O(1) decay to all learned subtopic weights."""
+    from app.database import safe_async_session
+
+    try:
+        async with safe_async_session() as session:
+            result = await session.execute(
+                text(
+                    """
+                    UPDATE user_subtopics
+                    SET weight = 1.0 + (weight - 1.0) * :decay
+                    WHERE weight != 1.0
+                    """
+                ),
+                {"decay": ScoringWeights.SUBTOPIC_DECAY},
+            )
+            await session.commit()
+            logger.info(
+                "subtopic_weight_decay_completed",
+                decay=ScoringWeights.SUBTOPIC_DECAY,
+                rowcount=getattr(result, "rowcount", None),
+            )
+    except Exception as exc:
+        logger.error(
+            "subtopic_weight_decay_failed",
+            error=str(exc),
+            error_type=type(exc).__name__,
+            exc_info=True,
+        )
 
 
 async def _digest_watchdog() -> None:
@@ -216,6 +258,22 @@ def start_scheduler() -> None:
         ),
         id="daily_digest",
         name="Daily Digest Generation",
+        replace_existing=True,
+        misfire_grace_time=14400,
+        coalesce=True,
+    )
+
+    # Daily learned-subtopic decay (07h20 Paris) so digest scoring at 07h30
+    # uses weights nudged toward neutral without requiring a schema migration.
+    scheduler.add_job(
+        decay_user_subtopic_weights,
+        trigger=CronTrigger(
+            hour=SUBTOPIC_DECAY_HOUR_PARIS,
+            minute=SUBTOPIC_DECAY_MINUTE_PARIS,
+            timezone=_PARIS_TZ,
+        ),
+        id="subtopic_weight_decay",
+        name="Subtopic Weight Decay",
         replace_existing=True,
         misfire_grace_time=14400,
         coalesce=True,

--- a/packages/api/scripts/evaluate_feed_ranking.py
+++ b/packages/api/scripts/evaluate_feed_ranking.py
@@ -1,0 +1,474 @@
+"""Offline CTR gauge for digest/feed ranking.
+
+The script reads persisted ``daily_digest.items`` and joins them with
+``user_content_status`` plus ``contents``. It reports CTR by topic, entity,
+rank, and pillar score band.
+
+Usage:
+    cd packages/api
+    PYTHONPATH=. python scripts/evaluate_feed_ranking.py --days 14
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime as dt
+import json
+import os
+import sys
+from collections import defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONTEXT_DIR = REPO_ROOT / ".context"
+
+PILLARS = ("pertinence", "source", "fraicheur", "qualite")
+
+
+@dataclass
+class CtrBucket:
+    shown: int = 0
+    consumed: int = 0
+
+    def add(self, *, consumed: bool) -> None:
+        self.shown += 1
+        if consumed:
+            self.consumed += 1
+
+    @property
+    def ctr(self) -> float:
+        if self.shown == 0:
+            return 0.0
+        return self.consumed / self.shown
+
+
+def _load_env_file(path: Path) -> None:
+    if not path.exists():
+        return
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if key and key not in os.environ:
+            os.environ[key] = value.strip().strip('"').strip("'")
+
+
+def _database_url() -> str:
+    _load_env_file(REPO_ROOT / "packages" / "api" / ".env")
+    _load_env_file(REPO_ROOT / ".env")
+
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        raise SystemExit("DATABASE_URL is required")
+    if url.startswith("postgres://"):
+        return "postgresql+psycopg://" + url.removeprefix("postgres://")
+    if url.startswith("postgresql://"):
+        return "postgresql+psycopg://" + url.removeprefix("postgresql://")
+    return url
+
+
+def _parse_date(value: str | None) -> dt.datetime | None:
+    if not value:
+        return None
+    parsed = dt.datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed.astimezone(dt.UTC)
+
+
+def _coerce_json_object(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _entity_name(raw: Any) -> str | None:
+    value = raw
+    if isinstance(raw, str):
+        stripped = raw.strip()
+        if not stripped:
+            return None
+        if stripped.startswith("{"):
+            try:
+                value = json.loads(stripped)
+            except json.JSONDecodeError:
+                value = stripped
+        else:
+            value = stripped
+
+    if isinstance(value, dict):
+        name = (
+            value.get("canonical")
+            or value.get("canonical_name")
+            or value.get("name")
+            or value.get("text")
+        )
+    else:
+        name = value
+
+    if not isinstance(name, str):
+        return None
+    normalized = " ".join(name.strip().split())
+    return normalized or None
+
+
+def _entity_names(raw_entities: Iterable[Any] | None) -> list[str]:
+    seen: set[str] = set()
+    names: list[str] = []
+    for raw in raw_entities or []:
+        name = _entity_name(raw)
+        if not name:
+            continue
+        key = name.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        names.append(name)
+    return names
+
+
+def _topic_slugs(raw_topics: Iterable[Any] | None) -> list[str]:
+    seen: set[str] = set()
+    topics: list[str] = []
+    for raw in raw_topics or []:
+        if not isinstance(raw, str):
+            continue
+        topic = raw.strip().lower()
+        if not topic or topic in seen:
+            continue
+        seen.add(topic)
+        topics.append(topic)
+    return topics
+
+
+def _score_band(score: Any, step: int = 20) -> str:
+    if not isinstance(score, int | float):
+        return "missing"
+    if score < 0:
+        return "<0"
+    if score >= 100:
+        return "100+"
+    low = int(score // step) * step
+    return f"{low:02d}-{low + step:02d}"
+
+
+def _pct(value: float) -> str:
+    return f"{value * 100:.1f}%"
+
+
+def _format_rows(
+    rows: list[tuple[str, CtrBucket]],
+    *,
+    key_label: str,
+    min_shown: int,
+    top: int | None = None,
+) -> list[str]:
+    filtered = [(label, bucket) for label, bucket in rows if bucket.shown >= min_shown]
+    if top is not None:
+        filtered = filtered[:top]
+    if not filtered:
+        return ["_No rows above threshold._"]
+
+    lines = [
+        f"| {key_label} | shown | consumed | CTR |",
+        f"| {'-' * len(key_label)} | ---: | ---: | ---: |",
+    ]
+    for label, bucket in filtered:
+        lines.append(
+            f"| {label} | {bucket.shown} | {bucket.consumed} | {_pct(bucket.ctr)} |"
+        )
+    return lines
+
+
+def _build_report(
+    *,
+    rows: list[dict[str, Any]],
+    since: dt.datetime,
+    until: dt.datetime,
+    mode: str | None,
+    include_serene: bool,
+    min_shown: int,
+    top: int,
+) -> str:
+    global_bucket = CtrBucket()
+    by_rank: defaultdict[int, CtrBucket] = defaultdict(CtrBucket)
+    by_topic: defaultdict[str, CtrBucket] = defaultdict(CtrBucket)
+    by_entity: defaultdict[str, CtrBucket] = defaultdict(CtrBucket)
+    by_pillar_band: dict[str, defaultdict[str, CtrBucket]] = {
+        pillar: defaultdict(CtrBucket) for pillar in PILLARS
+    }
+
+    skipped_unshown = 0
+    shown_digest_ids: set[str] = set()
+    shown_user_ids: set[str] = set()
+
+    for row in rows:
+        status = str(row.get("status") or "").lower()
+        consumed = status == "consumed"
+        shown = row.get("last_impressed_at") is not None or consumed
+        if not shown:
+            skipped_unshown += 1
+            continue
+
+        global_bucket.add(consumed=consumed)
+        shown_digest_ids.add(str(row.get("digest_id")))
+        shown_user_ids.add(str(row.get("user_id")))
+
+        rank = row.get("rank")
+        if isinstance(rank, int):
+            by_rank[rank].add(consumed=consumed)
+
+        for topic in _topic_slugs(row.get("topics")):
+            by_topic[topic].add(consumed=consumed)
+
+        for entity in _entity_names(row.get("entities")):
+            by_entity[entity].add(consumed=consumed)
+
+        pillar_scores = _coerce_json_object(row.get("pillar_scores"))
+        for pillar in PILLARS:
+            band = _score_band(pillar_scores.get(pillar))
+            by_pillar_band[pillar][band].add(consumed=consumed)
+
+    generated_at = dt.datetime.now(dt.UTC).strftime("%Y-%m-%d %H:%M:%SZ")
+    lines = [
+        f"# Feed Ranking CTR Gauge - {generated_at}",
+        "",
+        f"- Window: {since.isoformat()} -> {until.isoformat()}",
+        f"- Mode: {mode or 'all'}",
+        f"- Includes serene digests: {'yes' if include_serene else 'no'}",
+        f"- Rows fetched: {len(rows)}",
+        f"- Rows skipped because not shown: {skipped_unshown}",
+        f"- Shown digests: {len(shown_digest_ids)}",
+        f"- Users with shown items: {len(shown_user_ids)}",
+        f"- Global CTR: {global_bucket.consumed}/{global_bucket.shown} = {_pct(global_bucket.ctr)}",
+        "",
+        "## CTR by Rank",
+        "",
+    ]
+
+    rank_rows = [
+        (str(rank), bucket)
+        for rank, bucket in sorted(by_rank.items(), key=lambda x: x[0])
+    ]
+    lines.extend(
+        _format_rows(rank_rows, key_label="rank", min_shown=min_shown, top=None)
+    )
+
+    lines.extend(["", "## CTR by Topic", ""])
+    topic_rows = sorted(by_topic.items(), key=lambda x: (-x[1].shown, -x[1].ctr, x[0]))
+    lines.extend(
+        _format_rows(topic_rows, key_label="topic", min_shown=min_shown, top=top)
+    )
+
+    lines.extend(["", "## CTR by Entity", ""])
+    entity_rows = sorted(
+        by_entity.items(), key=lambda x: (-x[1].shown, -x[1].ctr, x[0].casefold())
+    )
+    lines.extend(
+        _format_rows(entity_rows, key_label="entity", min_shown=min_shown, top=top)
+    )
+
+    lines.extend(["", "## CTR by Pillar Score Band", ""])
+    for pillar in PILLARS:
+        lines.extend([f"### {pillar.capitalize()}", ""])
+        band_rows = sorted(
+            by_pillar_band[pillar].items(),
+            key=lambda x: (x[0] == "missing", x[0]),
+        )
+        lines.extend(
+            _format_rows(band_rows, key_label="score band", min_shown=1, top=None)
+        )
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+SQL = """
+WITH flat_items AS (
+    SELECT
+        dd.id AS digest_id,
+        dd.user_id,
+        dd.target_date,
+        dd.generated_at,
+        dd.mode,
+        dd.is_serene,
+        item AS item_json,
+        NULL::integer AS topic_rank
+    FROM daily_digest dd
+    CROSS JOIN LATERAL jsonb_array_elements(
+        CASE
+            WHEN jsonb_typeof(dd.items) = 'array' THEN dd.items
+            ELSE '[]'::jsonb
+        END
+    ) AS item
+    WHERE dd.generated_at >= :since
+      AND dd.generated_at < :until
+      AND (:mode IS NULL OR dd.mode = :mode)
+      AND (:include_serene OR dd.is_serene = false)
+),
+topic_items AS (
+    SELECT
+        dd.id AS digest_id,
+        dd.user_id,
+        dd.target_date,
+        dd.generated_at,
+        dd.mode,
+        dd.is_serene,
+        article_item AS item_json,
+        NULLIF(topic_item->>'rank', '')::integer AS topic_rank
+    FROM daily_digest dd
+    CROSS JOIN LATERAL jsonb_array_elements(
+        CASE
+            WHEN jsonb_typeof(dd.items) = 'object'
+                THEN COALESCE(dd.items->'topics', '[]'::jsonb)
+            ELSE '[]'::jsonb
+        END
+    ) AS topic_item
+    CROSS JOIN LATERAL jsonb_array_elements(
+        COALESCE(topic_item->'articles', '[]'::jsonb)
+    ) AS article_item
+    WHERE dd.generated_at >= :since
+      AND dd.generated_at < :until
+      AND (:mode IS NULL OR dd.mode = :mode)
+      AND (:include_serene OR dd.is_serene = false)
+),
+digest_items AS (
+    SELECT * FROM flat_items
+    UNION ALL
+    SELECT * FROM topic_items
+),
+parsed_items AS (
+    SELECT
+        digest_id,
+        user_id,
+        target_date,
+        generated_at,
+        mode,
+        is_serene,
+        NULLIF(item_json->>'content_id', '') AS content_id_text,
+        COALESCE(NULLIF(item_json->>'rank', '')::integer, topic_rank) AS rank,
+        COALESCE(
+            NULLIF(item_json->>'final_score', '')::double precision,
+            NULLIF(item_json->>'score', '')::double precision
+        ) AS final_score,
+        COALESCE(item_json->'pillar_scores', '{}'::jsonb) AS pillar_scores
+    FROM digest_items
+    WHERE item_json ? 'content_id'
+)
+SELECT
+    pi.digest_id,
+    pi.user_id,
+    pi.target_date,
+    pi.generated_at,
+    pi.mode,
+    pi.is_serene,
+    pi.content_id_text::uuid AS content_id,
+    pi.rank,
+    pi.final_score,
+    pi.pillar_scores,
+    ucs.status::text AS status,
+    ucs.last_impressed_at,
+    c.topics,
+    c.entities
+FROM parsed_items pi
+JOIN contents c ON c.id = pi.content_id_text::uuid
+LEFT JOIN user_content_status ucs
+    ON ucs.user_id = pi.user_id
+   AND ucs.content_id = pi.content_id_text::uuid
+ORDER BY pi.generated_at DESC, pi.rank NULLS LAST
+LIMIT :row_limit
+"""
+
+
+async def _fetch_rows(args: argparse.Namespace) -> list[dict[str, Any]]:
+    url = _database_url()
+    connect_args: dict[str, Any] = {}
+    if "+psycopg" in url:
+        connect_args["prepare_threshold"] = None
+
+    engine = create_async_engine(url, pool_pre_ping=False, connect_args=connect_args)
+    try:
+        async with engine.connect() as conn:
+            result = await conn.execute(
+                text(SQL),
+                {
+                    "since": args.since,
+                    "until": args.until,
+                    "mode": args.mode,
+                    "include_serene": args.include_serene,
+                    "row_limit": args.row_limit,
+                },
+            )
+            return [dict(row._mapping) for row in result.fetchall()]
+    finally:
+        await engine.dispose()
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--days", type=int, default=14, help="Lookback window in days")
+    parser.add_argument("--since", help="UTC ISO datetime/date lower bound")
+    parser.add_argument("--until", help="UTC ISO datetime/date upper bound")
+    parser.add_argument("--mode", help="Filter daily_digest.mode")
+    parser.add_argument(
+        "--include-serene",
+        action="store_true",
+        help="Include serene digest variants",
+    )
+    parser.add_argument("--min-shown", type=int, default=5)
+    parser.add_argument("--top", type=int, default=25)
+    parser.add_argument("--row-limit", type=int, default=20000)
+    parser.add_argument("--tag", default="latest")
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--no-write", action="store_true")
+    args = parser.parse_args(argv)
+
+    now = dt.datetime.now(dt.UTC)
+    args.until = _parse_date(args.until) or now
+    args.since = _parse_date(args.since) or (args.until - dt.timedelta(days=args.days))
+    if args.since >= args.until:
+        raise SystemExit("--since must be earlier than --until")
+    return args
+
+
+async def _main(argv: list[str]) -> int:
+    args = _parse_args(argv)
+    rows = await _fetch_rows(args)
+    report = _build_report(
+        rows=rows,
+        since=args.since,
+        until=args.until,
+        mode=args.mode,
+        include_serene=args.include_serene,
+        min_shown=args.min_shown,
+        top=args.top,
+    )
+    print(report)
+
+    if not args.no_write:
+        CONTEXT_DIR.mkdir(parents=True, exist_ok=True)
+        timestamp = dt.datetime.now(dt.UTC).strftime("%Y%m%d-%H%M%S")
+        output = args.output or CONTEXT_DIR / f"feed-ranking-{args.tag}-{timestamp}.md"
+        output.write_text(report)
+        print(f"Wrote {output}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main(sys.argv[1:])))

--- a/packages/api/tests/recommendation/test_pertinence_pillar.py
+++ b/packages/api/tests/recommendation/test_pertinence_pillar.py
@@ -1,7 +1,10 @@
 """Tests unitaires pour PertinencePillar — Theme Mismatch Malus."""
+
 from datetime import datetime
 from unittest.mock import MagicMock
 from uuid import uuid4
+
+import pytest
 
 from app.services.recommendation.pillars.pertinence import PertinencePillar
 from app.services.recommendation.scoring_config import ScoringWeights
@@ -29,9 +32,7 @@ class MockContent:
         self.duration_seconds = None
 
 
-def _context(
-    user_interests=None, user_subtopics=None, user_custom_topics=None
-):
+def _context(user_interests=None, user_subtopics=None, user_custom_topics=None):
     return ScoringContext(
         user_profile=MagicMock(id=uuid4()),
         user_interests=set(user_interests or []),
@@ -74,9 +75,7 @@ class TestThemeMismatchMalus:
     def test_no_malus_when_subtopic_matches(self):
         """Sous-thème matche → pas de malus, même si thème ne matche pas."""
         content = MockContent(theme="sports", source_theme="sports", topics=["ai"])
-        context = _context(
-            user_interests={"tech"}, user_subtopics={"ai"}
-        )
+        context = _context(user_interests={"tech"}, user_subtopics={"ai"})
 
         pillar = PertinencePillar()
         raw, contribs = pillar.compute_raw(content, context)
@@ -122,3 +121,36 @@ class TestThemeMismatchMalus:
 
         assert result.raw_score == ScoringWeights.THEME_MISMATCH_MALUS
         assert result.normalized_score == 0.0
+
+
+class TestSubtopicPositionWeighting:
+    def test_primary_topic_scores_higher_than_secondary_topic(self):
+        """A match at topics[0] should outrank the same match at topics[1]."""
+        pillar = PertinencePillar()
+        context = _context(user_subtopics={"ai"})
+
+        primary = MockContent(topics=["ai", "climate"])
+        secondary = MockContent(topics=["climate", "ai"])
+
+        primary_score, _ = pillar._score_subtopics(primary, context)
+        secondary_score, _ = pillar._score_subtopics(secondary, context)
+
+        assert primary_score == pytest.approx(ScoringWeights.TOPIC_MATCH)
+        assert secondary_score == pytest.approx(
+            ScoringWeights.TOPIC_MATCH * ScoringWeights.SUBTOPIC_POSITION_FACTOR
+        )
+        assert primary_score > secondary_score
+
+    def test_max_matches_keep_article_order_and_position_factor(self):
+        """Only the first two matching topics count, with position decay."""
+        pillar = PertinencePillar()
+        content = MockContent(topics=["ai", "tech", "cybersecurity"])
+        context = _context(user_subtopics={"ai", "tech", "cybersecurity"})
+
+        score, contributions = pillar._score_subtopics(content, context)
+
+        expected = ScoringWeights.TOPIC_MATCH * (
+            1.0 + ScoringWeights.SUBTOPIC_POSITION_FACTOR
+        )
+        assert score == pytest.approx(expected)
+        assert contributions[0].label == "Sujet : IA, Tech"

--- a/packages/api/tests/test_digest_selector.py
+++ b/packages/api/tests/test_digest_selector.py
@@ -5,26 +5,33 @@ Couvre:
 - Decay factor 0.70 appliqué aux sources répétées
 - Maximum 1 article par source (fallback à 2 si < 7 sources distinctes)
 - Minimum 4 sources différentes
-- Retourne des 4-tuples (content, score, reason, breakdown)
+- Retourne des 5-tuples (content, score, reason, breakdown, pillar_scores)
 - Gestion des cas limites (peu de candidats, source unique)
 - Sélection hybride deux passes (trending + personnalisé)
 - Continuité diversité entre passes
 """
 
-import pytest
-from unittest.mock import Mock, AsyncMock, patch, MagicMock
-from uuid import uuid4
-from datetime import datetime, timezone, timedelta
 from collections import defaultdict
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import uuid4
 
-from app.services.digest_selector import DigestSelector, DigestContext, DiversityConstraints, GlobalTrendingContext
+import pytest
+
 from app.schemas.digest import DigestScoreBreakdown
-
+from app.services.digest_selector import (
+    DigestContext,
+    DigestSelector,
+    DiversityConstraints,
+    GlobalTrendingContext,
+)
 
 # ─── Factories ────────────────────────────────────────────────────────────────
 
 
-def make_source(name="Test Source", theme="tech", is_curated=False, secondary_themes=None):
+def make_source(
+    name="Test Source", theme="tech", is_curated=False, secondary_themes=None
+):
     """Factory pour créer un objet Source mocké."""
     source = Mock()
     source.id = uuid4()
@@ -36,13 +43,15 @@ def make_source(name="Test Source", theme="tech", is_curated=False, secondary_th
     return source
 
 
-def make_content(source=None, topics=None, published_at=None, content_type=None, theme=None):
+def make_content(
+    source=None, topics=None, published_at=None, content_type=None, theme=None
+):
     """Factory pour créer un objet Content mocké."""
     content = Mock()
     content.id = uuid4()
     content.source = source or make_source()
     content.source_id = content.source.id
-    content.published_at = published_at or datetime.now(timezone.utc)
+    content.published_at = published_at or datetime.now(UTC)
     content.topics = topics
     content.content_type = content_type
     content.theme = theme
@@ -61,15 +70,17 @@ def make_scored_candidates(contents_with_scores):
         contents_with_scores: list of (content, score) or (content, score, breakdown)
 
     Returns:
-        list of (content, score, breakdown) — format d'entrée de _select_with_diversity
+        list of (content, score, breakdown, pillar_scores) — format d'entrée
+        de _select_with_diversity
     """
     result = []
     for item in contents_with_scores:
         if len(item) == 3:
-            result.append(item)
+            content, score, breakdown = item
+            result.append((content, score, breakdown, {}))
         else:
             content, score = item
-            result.append((content, score, []))
+            result.append((content, score, [], {}))
     return result
 
 
@@ -89,7 +100,7 @@ def selector(mock_session):
     Note: on patche rec_service pour éviter l'initialisation
     de RecommendationService qui nécessite une vraie session DB.
     """
-    with patch('app.services.digest_selector.RecommendationService'):
+    with patch("app.services.digest_selector.RecommendationService"):
         sel = DigestSelector(mock_session)
     return sel
 
@@ -102,7 +113,7 @@ class TestSelectWithDiversity:
 
     Cette méthode est synchrone (pas de DB), donc testable directement.
     Elle prend des scored_candidates triés par score et retourne
-    des 4-tuples (content, decayed_score, reason, breakdown).
+    des 5-tuples (content, decayed_score, reason, breakdown, pillar_scores).
     """
 
     def test_selects_exactly_target_count(self, selector):
@@ -119,8 +130,8 @@ class TestSelectWithDiversity:
 
         assert len(selected) == 7
 
-    def test_returns_four_tuple(self, selector):
-        """Each result element is a 4-tuple (content, score, reason, breakdown)."""
+    def test_returns_five_tuple(self, selector):
+        """Each result carries content, score, reason, breakdown, pillar_scores."""
         source = make_source()
         content = make_content(source=source)
         scored = [(content, 100.0, [])]
@@ -128,12 +139,13 @@ class TestSelectWithDiversity:
         selected = selector._select_with_diversity(scored, target_count=1)
 
         assert len(selected) == 1
-        # Unpack 4 values — must not raise ValueError
-        content_out, score_out, reason_out, breakdown_out = selected[0]
+        # Unpack 5 values — must not raise ValueError
+        content_out, score_out, reason_out, breakdown_out, pillar_scores = selected[0]
         assert content_out is content
         assert isinstance(score_out, float)
         assert isinstance(reason_out, str)
         assert isinstance(breakdown_out, list)
+        assert isinstance(pillar_scores, dict)
 
     def test_diversity_max_one_per_source_with_enough_sources(self, selector):
         """With >= 7 distinct sources, max 1 article per source."""
@@ -148,11 +160,13 @@ class TestSelectWithDiversity:
 
         # Count articles per source — should be max 1 each
         source_counts = defaultdict(int)
-        for content, _, _, _ in selected:
+        for content, _, _, _, _ in selected:
             source_counts[content.source_id] += 1
 
         for source_id, count in source_counts.items():
-            assert count <= 1, f"Source {source_id} has {count} articles (max 1 with >= 7 sources)"
+            assert count <= 1, (
+                f"Source {source_id} has {count} articles (max 1 with >= 7 sources)"
+            )
 
     def test_diversity_fallback_max_two_per_source_with_few_sources(self, selector):
         """With < 7 distinct sources, fallback to max 2 per source."""
@@ -175,11 +189,13 @@ class TestSelectWithDiversity:
 
         # Count articles per source — should allow up to 2
         source_counts = defaultdict(int)
-        for content, _, _, _ in selected:
+        for content, _, _, _, _ in selected:
             source_counts[content.source_id] += 1
 
         for source_id, count in source_counts.items():
-            assert count <= 2, f"Source {source_id} has {count} articles (max 2 with < 7 sources)"
+            assert count <= 2, (
+                f"Source {source_id} has {count} articles (max 2 with < 7 sources)"
+            )
 
     def test_decay_factor_applied(self, selector):
         """Score should decrease with repeated source selection (÷2 divisor).
@@ -199,8 +215,8 @@ class TestSelectWithDiversity:
         selected = selector._select_with_diversity(candidates, target_count=2)
 
         assert len(selected) == 2
-        _, score1, _, _ = selected[0]
-        _, score2, _, _ = selected[1]
+        _, score1, _, _, _ = selected[0]
+        _, score2, _, _, _ = selected[1]
 
         # First article: no penalty → score = 100.0
         assert score1 == pytest.approx(100.0)
@@ -219,7 +235,7 @@ class TestSelectWithDiversity:
         selected = selector._select_with_diversity(candidates, target_count=7)
 
         # Scores should be in descending order (all from different sources, no decay)
-        scores = [score for _, score, _, _ in selected]
+        scores = [score for _, score, _, _, _ in selected]
         assert scores == sorted(scores, reverse=True)
 
     def test_fewer_candidates_than_target(self, selector):
@@ -273,7 +289,7 @@ class TestSelectWithDiversity:
 
         # Count articles per theme
         theme_counts = defaultdict(int)
-        for content, _, _, _ in selected:
+        for content, _, _, _, _ in selected:
             theme = content.source.theme
             theme_counts[theme] += 1
 
@@ -296,8 +312,8 @@ class TestSelectWithDiversity:
 
         selected = selector._select_with_diversity(candidates, target_count=2)
 
-        _, score1, _, _ = selected[0]
-        _, score2, _, _ = selected[1]
+        _, score1, _, _, _ = selected[0]
+        _, score2, _, _, _ = selected[1]
 
         # First: 220 (no penalty)
         assert score1 == pytest.approx(220.0)
@@ -312,7 +328,7 @@ class TestSelectWithDiversity:
 
         selected = selector._select_with_diversity(candidates, target_count=1)
 
-        _, _, reason, _ = selected[0]
+        _, _, reason, _, _ = selected[0]
         assert reason  # Non-empty
         assert isinstance(reason, str)
         assert len(reason) > 0
@@ -322,21 +338,29 @@ class TestSelectWithDiversity:
         source = make_source(name="Breakdown Source", theme="tech")
         content = make_content(source=source)
         breakdown_input = [
-            DigestScoreBreakdown(label="Thème matché : tech", points=70.0, is_positive=True),
-            DigestScoreBreakdown(label="Source de confiance", points=50.0, is_positive=True),
+            DigestScoreBreakdown(
+                label="Thème matché : tech", points=70.0, is_positive=True
+            ),
+            DigestScoreBreakdown(
+                label="Source de confiance", points=50.0, is_positive=True
+            ),
         ]
         candidates = [(content, 120.0, breakdown_input)]
 
         selected = selector._select_with_diversity(candidates, target_count=1)
 
-        _, _, _, breakdown_out = selected[0]
+        _, _, _, breakdown_out, pillar_scores = selected[0]
         assert len(breakdown_out) == 2
         assert breakdown_out[0].label == "Thème matché : tech"
         assert breakdown_out[1].points == 50.0
+        assert pillar_scores == {}
 
     def test_mixed_sources_diversity(self, selector):
         """With 7 different sources and varied scores, all 7 sources represented."""
-        sources = [make_source(name=f"Source {chr(65+i)}", theme=f"theme{i}") for i in range(7)]
+        sources = [
+            make_source(name=f"Source {chr(65 + i)}", theme=f"theme{i}")
+            for i in range(7)
+        ]
         candidates = []
         for i, source in enumerate(sources):
             content = make_content(source=source)
@@ -345,7 +369,7 @@ class TestSelectWithDiversity:
         selected = selector._select_with_diversity(candidates, target_count=7)
 
         assert len(selected) == 7
-        unique_sources = set(c.source_id for c, _, _, _ in selected)
+        unique_sources = {c.source_id for c, _, _, _, _ in selected}
         assert len(unique_sources) == 7
 
     def test_empty_candidates_returns_empty(self, selector):
@@ -381,8 +405,10 @@ class TestDiversityConstraints:
     def test_diversity_divisor_value(self):
         """Verify diversity divisor is 2 (score ÷ 2) as per algorithm spec."""
         from app.services.recommendation.scoring_config import ScoringWeights
-        assert ScoringWeights.DIGEST_DIVERSITY_DIVISOR == 2, \
+
+        assert ScoringWeights.DIGEST_DIVERSITY_DIVISOR == 2, (
             "Diversity divisor should be 2 (score ÷ 2)"
+        )
 
 
 # ─── Tests: Diversity Revue de Presse (÷2 Penalty) ────────────────────────────
@@ -406,13 +432,18 @@ class TestDiversityRevueDePresse:
 
         # The 2nd article should have "Diversité revue de presse" in its breakdown
         assert len(selected) == 2
-        second_article_breakdown = selected[1][3]  # (content, score, reason, breakdown)
+        second_article_breakdown = selected[1][3]
         diversity_labels = [b.label for b in second_article_breakdown]
-        assert "Diversité revue de presse" in diversity_labels, \
+        assert "Diversité revue de presse" in diversity_labels, (
             f"Expected 'Diversité revue de presse' in breakdown, got: {diversity_labels}"
+        )
 
         # The penalty should be -100 (200 / 2)
-        diversity_entry = next(b for b in second_article_breakdown if b.label == "Diversité revue de presse")
+        diversity_entry = next(
+            b
+            for b in second_article_breakdown
+            if b.label == "Diversité revue de presse"
+        )
         assert diversity_entry.points == -100.0
         assert diversity_entry.is_positive is False
 
@@ -481,8 +512,6 @@ class TestDiversityInitialCounts:
 
         # source_a article should be skipped (max 1 per source with >= 7 distinct)
         # With < 7 sources, fallback to max 2 → source_a gets penalty ÷2
-        # But the key test: source_a count starts at 1
-        source_ids = [c.source_id for c, _, _, _ in selected]
         # source_b and source_c should be selected first (no prior count)
         assert len(selected) == 2
 
@@ -494,8 +523,8 @@ class TestDiversityInitialCounts:
 
         candidates = [
             (make_content(source=sources[0]), 200.0, []),  # tech (already at 2 → skip)
-            (make_content(source=sources[3]), 150.0, []),   # other0
-            (make_content(source=sources[4]), 120.0, []),   # other1
+            (make_content(source=sources[3]), 150.0, []),  # other0
+            (make_content(source=sources[4]), 120.0, []),  # other1
         ]
 
         # theme "tech" already has 2 articles from pass 1
@@ -507,7 +536,7 @@ class TestDiversityInitialCounts:
 
         # tech article should be skipped (max 2 per theme)
         themes = []
-        for content, _, _, _ in selected:
+        for content, _, _, _, _ in selected:
             themes.append(content.source.theme)
         assert "tech" not in themes
         assert len(selected) == 2
@@ -515,16 +544,23 @@ class TestDiversityInitialCounts:
     def test_no_initial_counts_matches_original_behavior(self, selector):
         """Sans compteurs initiaux, le comportement est identique à l'original."""
         sources = [make_source(name=f"S{i}", theme=f"t{i}") for i in range(7)]
-        candidates = [(make_content(source=s), 100.0 - i * 10, []) for i, s in enumerate(sources)]
+        candidates = [
+            (make_content(source=s), 100.0 - i * 10, []) for i, s in enumerate(sources)
+        ]
 
         selected_default = selector._select_with_diversity(candidates, target_count=7)
         selected_explicit = selector._select_with_diversity(
-            candidates, target_count=7, initial_source_counts=None, initial_theme_counts=None,
+            candidates,
+            target_count=7,
+            initial_source_counts=None,
+            initial_theme_counts=None,
         )
 
         # Both should select same articles in same order
         assert len(selected_default) == len(selected_explicit)
-        for (c1, s1, _, _), (c2, s2, _, _) in zip(selected_default, selected_explicit):
+        for (c1, s1, _, _, _), (c2, s2, _, _, _) in zip(
+            selected_default, selected_explicit, strict=True
+        ):
             assert c1.id == c2.id
             assert s1 == s2
 
@@ -560,13 +596,21 @@ class TestTwoPassSelection:
         return GlobalTrendingContext(
             trending_content_ids=set(),
             une_content_ids=set(),
-            computed_at=datetime.now(timezone.utc),
+            computed_at=datetime.now(UTC),
         )
 
     @pytest.mark.asyncio
     async def test_two_pass_with_trending(self, selector, context, trending_context):
         """Les articles trending sont sélectionnés en passe 1, le reste en passe 2."""
-        themes = ["tech", "science", "culture", "economy", "politics", "environment", "international"]
+        themes = [
+            "tech",
+            "science",
+            "culture",
+            "economy",
+            "politics",
+            "environment",
+            "international",
+        ]
         sources = [make_source(name=f"Source {i}", theme=themes[i]) for i in range(7)]
         context.user_interests = set(themes)
 
@@ -577,7 +621,7 @@ class TestTwoPassSelection:
         all_candidates = [trending_content] + perso_contents
 
         async def mock_score(candidates, ctx, mode="pour_vous"):
-            return [(c, 100.0, []) for c in candidates]
+            return [(c, 100.0, [], {}) for c in candidates]
 
         selector._score_candidates = mock_score
 
@@ -600,7 +644,9 @@ class TestTwoPassSelection:
         assert "Sujet du jour" in labels
 
     @pytest.mark.asyncio
-    async def test_two_pass_trending_relevance_filter(self, selector, context, trending_context):
+    async def test_two_pass_trending_relevance_filter(
+        self, selector, context, trending_context
+    ):
         """Articles trending hors thèmes/sources utilisateur → pool personnalisé."""
         # Source avec thème "sports" (PAS dans user_interests)
         source_sports = make_source(name="L'Équipe", theme="sports")
@@ -613,7 +659,7 @@ class TestTwoPassSelection:
         trending_context.trending_content_ids = {trending_but_irrelevant.id}
 
         async def mock_score(candidates, ctx, mode="pour_vous"):
-            return [(c, 100.0, []) for c in candidates]
+            return [(c, 100.0, [], {}) for c in candidates]
 
         selector._score_candidates = mock_score
 
@@ -628,14 +674,24 @@ class TestTwoPassSelection:
         # Les deux articles devraient être sélectionnés mais sans bonus trending
         assert len(selected) == 2
         # Pas de "Sujet du jour" dans le breakdown car l'article n'est pas pertinent
-        for _, _, _, breakdown in selected:
+        for _, _, _, breakdown, _ in selected:
             labels = [b.label for b in breakdown]
             assert "Sujet du jour" not in labels
 
     @pytest.mark.asyncio
-    async def test_two_pass_full_personalized_fallback(self, selector, context, trending_context):
+    async def test_two_pass_full_personalized_fallback(
+        self, selector, context, trending_context
+    ):
         """Sans contenu trending, le digest est 100% personnalisé."""
-        themes = ["tech", "science", "culture", "economy", "politics", "environment", "international"]
+        themes = [
+            "tech",
+            "science",
+            "culture",
+            "economy",
+            "politics",
+            "environment",
+            "international",
+        ]
         sources = [make_source(name=f"S{i}", theme=themes[i]) for i in range(7)]
         contents = [make_content(source=s) for s in sources]
         context.user_interests = set(themes)
@@ -644,7 +700,7 @@ class TestTwoPassSelection:
         assert len(trending_context.trending_content_ids) == 0
 
         async def mock_score(candidates, ctx, mode="pour_vous"):
-            return [(c, 100.0 - i * 10, []) for i, c in enumerate(candidates)]
+            return [(c, 100.0 - i * 10, [], {}) for i, c in enumerate(candidates)]
 
         selector._score_candidates = mock_score
 
@@ -657,13 +713,15 @@ class TestTwoPassSelection:
 
         assert len(selected) == 7
         # Aucun breakdown ne contient "Sujet du jour" ou "À la une"
-        for _, _, _, breakdown in selected:
+        for _, _, _, breakdown, _ in selected:
             labels = [b.label for b in breakdown]
             assert "Sujet du jour" not in labels
             assert "À la une" not in labels
 
     @pytest.mark.asyncio
-    async def test_two_pass_diversity_continuity(self, selector, context, trending_context):
+    async def test_two_pass_diversity_continuity(
+        self, selector, context, trending_context
+    ):
         """Pass 2 respecte les source/theme counts de pass 1."""
         # Source A trending, Source A aussi dans perso → max 1 per source
         source_a = make_source(name="Source A", theme="tech")
@@ -671,8 +729,9 @@ class TestTwoPassSelection:
         source_c = make_source(name="Source C", theme="culture")
 
         # Construire assez de sources pour que max_per_source = 1
-        extra_sources = [make_source(name=f"Extra{i}", theme=f"extra{i}") for i in range(5)]
-        all_sources = [source_a, source_b, source_c] + extra_sources
+        extra_sources = [
+            make_source(name=f"Extra{i}", theme=f"extra{i}") for i in range(5)
+        ]
 
         trending_article = make_content(source=source_a)
         perso_article_same_source = make_content(source=source_a)
@@ -681,12 +740,26 @@ class TestTwoPassSelection:
         perso_extras = [make_content(source=s) for s in extra_sources]
 
         trending_context.trending_content_ids = {trending_article.id}
-        context.user_interests = {"tech", "science", "culture", "extra0", "extra1", "extra2", "extra3", "extra4"}
+        context.user_interests = {
+            "tech",
+            "science",
+            "culture",
+            "extra0",
+            "extra1",
+            "extra2",
+            "extra3",
+            "extra4",
+        }
 
-        all_candidates = [trending_article, perso_article_same_source, perso_article_b, perso_article_c] + perso_extras
+        all_candidates = [
+            trending_article,
+            perso_article_same_source,
+            perso_article_b,
+            perso_article_c,
+        ] + perso_extras
 
         async def mock_score(candidates, ctx, mode="pour_vous"):
-            return [(c, 200.0 - i * 10, []) for i, c in enumerate(candidates)]
+            return [(c, 200.0 - i * 10, [], {}) for i, c in enumerate(candidates)]
 
         selector._score_candidates = mock_score
 
@@ -699,7 +772,7 @@ class TestTwoPassSelection:
 
         # Compter les articles par source
         source_counts = defaultdict(int)
-        for content, _, _, _ in selected:
+        for content, _, _, _, _ in selected:
             source_counts[content.source_id] += 1
 
         # source_a ne devrait pas avoir plus de 1 article (pass1 trending + continuité)
@@ -708,19 +781,23 @@ class TestTwoPassSelection:
     @pytest.mark.asyncio
     async def test_two_pass_trending_capped(self, selector, context, trending_context):
         """Pass 1 ne sélectionne pas plus que ceil(target * ratio) articles."""
-        from app.services.recommendation.scoring_config import ScoringWeights
         from math import ceil
+
+        from app.services.recommendation.scoring_config import ScoringWeights
 
         sources = [make_source(name=f"S{i}", theme="tech") for i in range(10)]
         # 8 articles trending (plus que le cap)
         trending_contents = [make_content(source=sources[i]) for i in range(8)]
-        perso_contents = [make_content(source=sources[8]), make_content(source=sources[9])]
+        perso_contents = [
+            make_content(source=sources[8]),
+            make_content(source=sources[9]),
+        ]
 
         trending_context.trending_content_ids = {c.id for c in trending_contents}
         context.user_interests = {"tech"}
 
         async def mock_score(candidates, ctx, mode="pour_vous"):
-            return [(c, 100.0, []) for c in candidates]
+            return [(c, 100.0, [], {}) for c in candidates]
 
         selector._score_candidates = mock_score
 
@@ -734,7 +811,8 @@ class TestTwoPassSelection:
 
         # Compter les articles trending dans la sélection
         trending_in_selection = sum(
-            1 for c, _, _, bd in selected
+            1
+            for c, _, _, bd, _ in selected
             if any(b.label == "Sujet du jour" for b in bd)
         )
 
@@ -742,7 +820,9 @@ class TestTwoPassSelection:
         assert trending_in_selection <= max_trending
 
     @pytest.mark.asyncio
-    async def test_trending_bonus_in_breakdown(self, selector, context, trending_context):
+    async def test_trending_bonus_in_breakdown(
+        self, selector, context, trending_context
+    ):
         """Les labels 'Sujet du jour' et 'À la une' apparaissent dans le breakdown."""
         source = make_source(name="Le Monde", theme="tech")
         content_both = make_content(source=source)
@@ -753,7 +833,7 @@ class TestTwoPassSelection:
         context.user_interests = {"tech"}
 
         async def mock_score(candidates, ctx, mode="pour_vous"):
-            return [(c, 100.0, []) for c in candidates]
+            return [(c, 100.0, [], {}) for c in candidates]
 
         selector._score_candidates = mock_score
 
@@ -774,6 +854,7 @@ class TestTwoPassSelection:
         trending_entry = next(b for b in breakdown if b.label == "Sujet du jour")
         une_entry = next(b for b in breakdown if b.label == "À la une")
         from app.services.recommendation.scoring_config import ScoringWeights
+
         assert trending_entry.points == ScoringWeights.DIGEST_TRENDING_BONUS
         assert une_entry.points == ScoringWeights.DIGEST_UNE_BONUS
 
@@ -791,11 +872,17 @@ class TestGenerateReasonTrending:
 
         breakdown = [
             DigestScoreBreakdown(label="Sujet du jour", points=45.0, is_positive=True),
-            DigestScoreBreakdown(label="Sous-thème : AI", points=45.0, is_positive=True),
-            DigestScoreBreakdown(label="Source de confiance", points=35.0, is_positive=True),
+            DigestScoreBreakdown(
+                label="Sous-thème : AI", points=45.0, is_positive=True
+            ),
+            DigestScoreBreakdown(
+                label="Source de confiance", points=35.0, is_positive=True
+            ),
         ]
 
-        reason = selector._generate_reason(content, defaultdict(int), defaultdict(int), breakdown)
+        reason = selector._generate_reason(
+            content, defaultdict(int), defaultdict(int), breakdown
+        )
         assert reason == "Sujet du jour"
 
     def test_une_reason_takes_priority(self, selector):
@@ -805,10 +892,14 @@ class TestGenerateReasonTrending:
 
         breakdown = [
             DigestScoreBreakdown(label="À la une", points=35.0, is_positive=True),
-            DigestScoreBreakdown(label="Thème matché : tech", points=50.0, is_positive=True),
+            DigestScoreBreakdown(
+                label="Thème matché : tech", points=50.0, is_positive=True
+            ),
         ]
 
-        reason = selector._generate_reason(content, defaultdict(int), defaultdict(int), breakdown)
+        reason = selector._generate_reason(
+            content, defaultdict(int), defaultdict(int), breakdown
+        )
         assert reason == "À la une"
 
     def test_no_trending_falls_through_to_subtopic(self, selector):
@@ -817,23 +908,27 @@ class TestGenerateReasonTrending:
         content = make_content(source=source)
 
         breakdown = [
-            DigestScoreBreakdown(label="Sous-thème : AI", points=45.0, is_positive=True),
+            DigestScoreBreakdown(
+                label="Sous-thème : AI", points=45.0, is_positive=True
+            ),
         ]
 
-        reason = selector._generate_reason(content, defaultdict(int), defaultdict(int), breakdown)
+        reason = selector._generate_reason(
+            content, defaultdict(int), defaultdict(int), breakdown
+        )
         assert reason == "Thème : AI"
 
 
 # ─── Helpers: pillar engine ──────────────────────────────────────────────────
 
 
-def make_pillar_result(final_score=100.0, contributions=None):
+def make_pillar_result(final_score=100.0, contributions=None, pillar_scores=None):
     """Construit un PillarScoreResult minimal pour mocker pillar_engine."""
     from app.services.recommendation.scoring_engine import PillarScoreResult
 
     return PillarScoreResult(
         final_score=final_score,
-        pillar_scores={},
+        pillar_scores=pillar_scores or {},
         contributions=contributions or [],
     )
 
@@ -869,7 +964,7 @@ class TestScoreCandidatesSportPenalty:
 
         sport_src = make_source(name="Sport Source", theme="sport")
         tech_src = make_source(name="Tech Source", theme="tech")
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         sport_content = make_content(source=sport_src, theme="sport", published_at=now)
         tech_content = make_content(source=tech_src, theme="tech", published_at=now)
 
@@ -885,7 +980,7 @@ class TestScoreCandidatesSportPenalty:
             [sport_content, tech_content], context, mode="pour_vous"
         )
 
-        by_id = {c.id: (s, bd) for c, s, bd in scored}
+        by_id = {c.id: (s, bd) for c, s, bd, _ in scored}
         sport_score, sport_breakdown = by_id[sport_content.id]
         tech_score, _ = by_id[tech_content.id]
 
@@ -905,7 +1000,7 @@ class TestScoreCandidatesSportPenalty:
         from app.services.recommendation.scoring_config import ScoringWeights
 
         sport_src = make_source(name="Sport Source", theme="sport")
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         sport_content = make_content(source=sport_src, theme="sport", published_at=now)
 
         selector.rec_service = Mock()
@@ -919,7 +1014,7 @@ class TestScoreCandidatesSportPenalty:
             [sport_content], context, mode="serein"
         )
 
-        _, _, breakdown = scored[0]
+        _, _, breakdown, _ = scored[0]
         sport_entry = next(
             (b for b in breakdown if b.label == "Sport (priorité réduite)"), None
         )
@@ -930,7 +1025,7 @@ class TestScoreCandidatesSportPenalty:
     async def test_sport_detected_via_topics(self, selector, context):
         """Article non-sport en theme mais avec 'sport' dans topics est pénalisé."""
         src = make_source(name="Mixed Source", theme="tech")
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         content = make_content(
             source=src, theme="tech", topics=["sport", "football"], published_at=now
         )
@@ -943,9 +1038,37 @@ class TestScoreCandidatesSportPenalty:
         )
 
         scored = await selector._score_candidates([content], context, mode="pour_vous")
-        _, _, breakdown = scored[0]
+        _, _, breakdown, _ = scored[0]
         labels = [b.label for b in breakdown]
         assert "Sport (priorité réduite)" in labels
+
+    @pytest.mark.asyncio
+    async def test_score_candidates_returns_pillar_scores(self, selector, context):
+        """Pillar scores are returned for persistence in daily_digest.items."""
+        src = make_source(name="Tech Source", theme="tech")
+        content = make_content(source=src, theme="tech")
+        pillar_scores = {
+            "pertinence": 70.0,
+            "source": 55.0,
+            "fraicheur": 90.0,
+            "qualite": 25.0,
+        }
+
+        selector.rec_service = Mock()
+        selector.rec_service.fetch_impression_data = AsyncMock(return_value={})
+        selector.rec_service.pillar_engine = Mock()
+        selector.rec_service.pillar_engine.compute_score = Mock(
+            return_value=make_pillar_result(
+                final_score=80.0,
+                pillar_scores=pillar_scores,
+            )
+        )
+
+        scored = await selector._score_candidates([content], context, mode="pour_vous")
+
+        _, score, _, returned_pillar_scores = scored[0]
+        assert score == 80.0
+        assert returned_pillar_scores == pillar_scores
 
 
 # ─── Tests: unified pillar scoring (P0) ───────────────────────────────────────
@@ -999,7 +1122,7 @@ class TestScoreCandidatesUnifiedPillars:
     ):
         """Une source suivie reçoit une contribution mappée avec pillar='source'."""
         self._wire_real_engine(selector)
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         followed_content = make_content(
             source=followed_src, theme="tech", published_at=now
         )
@@ -1009,7 +1132,7 @@ class TestScoreCandidatesUnifiedPillars:
             [followed_content, other_content], context, mode="pour_vous"
         )
 
-        by_id = {c.id: bd for c, _, bd in scored}
+        by_id = {c.id: bd for c, _, bd, _ in scored}
         followed_bd = by_id[followed_content.id]
         other_bd = by_id[other_content.id]
 
@@ -1024,7 +1147,7 @@ class TestScoreCandidatesUnifiedPillars:
     ):
         """Tout égal par ailleurs, l'article d'une source suivie score plus haut."""
         self._wire_real_engine(selector)
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         followed_content = make_content(
             source=followed_src, theme="tech", published_at=now
         )
@@ -1034,7 +1157,7 @@ class TestScoreCandidatesUnifiedPillars:
             [followed_content, other_content], context, mode="pour_vous"
         )
 
-        by_id = {c.id: s for c, s, _ in scored}
+        by_id = {c.id: s for c, s, _, _ in scored}
         assert by_id[followed_content.id] > by_id[other_content.id]
 
     @pytest.mark.asyncio
@@ -1043,13 +1166,11 @@ class TestScoreCandidatesUnifiedPillars:
     ):
         """La récence vient uniquement du FraicheurPillar, comptée une seule fois."""
         self._wire_real_engine(selector)
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         content = make_content(source=followed_src, theme="tech", published_at=now)
 
-        scored = await selector._score_candidates(
-            [content], context, mode="pour_vous"
-        )
-        _, _, breakdown = scored[0]
+        scored = await selector._score_candidates([content], context, mode="pour_vous")
+        _, _, breakdown, _ = scored[0]
 
         fraicheur_contribs = [b for b in breakdown if b.pillar == "fraicheur"]
         # Exactement une contribution de récence (pas de préférence de récence
@@ -1072,10 +1193,10 @@ class TestScoreCandidatesUnifiedPillars:
     ):
         """Aucune contribution 'Source suivie' si l'article n'est d'aucune source suivie."""
         self._wire_real_engine(selector)
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         content = make_content(source=other_src, theme="tech", published_at=now)
 
         scored = await selector._score_candidates([content], context, mode="pour_vous")
-        _, _, breakdown = scored[0]
+        _, _, breakdown, _ = scored[0]
         labels = [b.label for b in breakdown]
         assert "Source suivie" not in labels

--- a/packages/api/tests/test_digest_service.py
+++ b/packages/api/tests/test_digest_service.py
@@ -204,6 +204,58 @@ class TestApplyAction:
         assert isinstance(result["applied_at"], datetime)
 
 
+class TestCreateDigestRecord:
+    """Tests for the persisted daily_digest.items payload."""
+
+    @pytest.mark.asyncio
+    async def test_persists_pillar_scores_and_final_score(self, service, mock_session):
+        from app.schemas.digest import DigestScoreBreakdown
+        from app.services.digest_selector import DigestItem
+
+        source = Mock()
+        source.name = "Test Source"
+        content = Mock()
+        content.id = uuid4()
+        content.title = "Test article"
+        content.source = source
+        content.entities = []
+
+        item = DigestItem(
+            content=content,
+            score=87.5,
+            rank=1,
+            reason="Thème : Tech",
+            breakdown=[
+                DigestScoreBreakdown(
+                    label="Source suivie",
+                    points=35.0,
+                    is_positive=True,
+                    pillar="source",
+                )
+            ],
+            pillar_scores={
+                "pertinence": 70.0,
+                "source": 55.0,
+                "fraicheur": 90.0,
+                "qualite": 25.0,
+            },
+        )
+
+        digest = await service._create_digest_record(
+            user_id=uuid4(),
+            target_date=date.today(),
+            digest_items=[item],
+        )
+
+        stored = digest.items[0]
+        assert stored["score"] == 87.5
+        assert stored["final_score"] == 87.5
+        assert stored["pillar_scores"] == item.pillar_scores
+        assert stored["breakdown"][0]["pillar"] == "source"
+        mock_session.add.assert_called_once_with(digest)
+        mock_session.flush.assert_awaited_once()
+
+
 # ─── Tests: complete_digest ───────────────────────────────────────────────────
 
 
@@ -322,9 +374,7 @@ class TestCompleteDigest:
         ]
         assert len(upserts) == 1
 
-        compiled = str(
-            upserts[0].compile(dialect=postgresql.dialect())
-        ).lower()
+        compiled = str(upserts[0].compile(dialect=postgresql.dialect())).lower()
         assert "on conflict" in compiled
         assert "do update" in compiled
 
@@ -1188,9 +1238,7 @@ async def test_editorial_label_falls_back_to_actu_title(
         patch.object(
             service, "_get_batch_action_states", new=AsyncMock(return_value={})
         ),
-        patch.object(
-            service, "_compute_target_size", new=AsyncMock(return_value=5)
-        ),
+        patch.object(service, "_compute_target_size", new=AsyncMock(return_value=5)),
     ):
         response = await service._build_editorial_response(digest, digest.user_id)
 

--- a/packages/api/tests/test_topic_selector.py
+++ b/packages/api/tests/test_topic_selector.py
@@ -8,16 +8,15 @@ Couvre:
 - _score_and_select_articles: scoring et sélection intra-topic
 """
 
-import pytest
 import uuid
-from datetime import datetime, timezone, timedelta
-from unittest.mock import Mock, MagicMock
+from datetime import UTC, datetime, timedelta
+from unittest.mock import Mock
 
-from app.services.topic_selector import TopicSelector, TopicGroup, ScoredArticle
+import pytest
+
 from app.services.briefing.importance_detector import TopicCluster
 from app.services.digest_selector import DigestContext, GlobalTrendingContext
-from app.schemas.digest import DigestScoreBreakdown
-
+from app.services.topic_selector import ScoredArticle, TopicGroup, TopicSelector
 
 # ─── Factories ────────────────────────────────────────────────────────────────
 
@@ -38,7 +37,7 @@ def make_content(source=None, title=None, published_at=None, theme=None):
     content.id = uuid.uuid4()
     content.source = source or make_source()
     content.source_id = content.source.id
-    content.published_at = published_at or datetime.now(timezone.utc)
+    content.published_at = published_at or datetime.now(UTC)
     content.title = title or f"Article {content.id}"
     content.url = f"https://example.com/{content.id}"
     content.thumbnail_url = None
@@ -54,7 +53,7 @@ def make_content(source=None, title=None, published_at=None, theme=None):
 
 def make_cluster(contents, theme=None, cluster_id=None):
     """Create a TopicCluster from a list of mock contents."""
-    source_ids = set(c.source_id for c in contents)
+    source_ids = {c.source_id for c in contents}
     source_domains = {f"source-{sid}.example.com" for sid in source_ids}
     return TopicCluster(
         cluster_id=cluster_id or str(uuid.uuid4()),
@@ -384,8 +383,11 @@ class TestTopicMatchScoring:
         from app.services.recommendation.scoring_config import ScoringWeights
 
         assert len(topic_breakdowns) == 1
-        # Points should reflect exactly TOPIC_MAX_MATCHES × TOPIC_MATCH
-        assert topic_breakdowns[0].points == ScoringWeights.TOPIC_MATCH * ScoringWeights.TOPIC_MAX_MATCHES
+        # Points reflect article-topic order: topics[0] full, topics[1] decayed.
+        expected = ScoringWeights.TOPIC_MATCH * (
+            1.0 + ScoringWeights.SUBTOPIC_POSITION_FACTOR
+        )
+        assert topic_breakdowns[0].points == expected
 
     def test_article_precision_bonus(self):
         """Topic match + theme match adds SUBTOPIC_PRECISION_BONUS to score."""
@@ -407,7 +409,10 @@ class TestTopicMatchScoring:
 
         assert len(topic_bd) == 1
         # Points = TOPIC_MATCH + SUBTOPIC_PRECISION_BONUS
-        assert topic_bd[0].points == ScoringWeights.TOPIC_MATCH + ScoringWeights.SUBTOPIC_PRECISION_BONUS
+        assert (
+            topic_bd[0].points
+            == ScoringWeights.TOPIC_MATCH + ScoringWeights.SUBTOPIC_PRECISION_BONUS
+        )
 
     def test_article_no_precision_bonus_without_theme(self):
         """Topic match without theme match does NOT trigger precision bonus."""
@@ -478,7 +483,7 @@ class TestScoreAndSelectArticles:
         """Each result should be a ScoredArticle with breakdown."""
         selector = TopicSelector()
         src = make_source()
-        content = make_content(source=src, published_at=datetime.now(timezone.utc))
+        content = make_content(source=src, published_at=datetime.now(UTC))
         cluster = make_cluster([content])
 
         context = make_context()
@@ -513,8 +518,7 @@ class TestSelectTopicsForUser:
                     make_content(
                         source=src,
                         title=f"Article about {src.theme} topic {i}",
-                        published_at=datetime.now(timezone.utc)
-                        - timedelta(hours=i * 6),
+                        published_at=datetime.now(UTC) - timedelta(hours=i * 6),
                     )
                 )
 

--- a/packages/api/tests/workers/test_scheduler.py
+++ b/packages/api/tests/workers/test_scheduler.py
@@ -14,7 +14,16 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from apscheduler.triggers.cron import CronTrigger
 
-from app.workers.scheduler import _digest_watchdog, start_scheduler, stop_scheduler
+from app.services.recommendation.scoring_config import ScoringWeights
+from app.workers.scheduler import (
+    SUBTOPIC_DECAY_HOUR_PARIS,
+    SUBTOPIC_DECAY_MINUTE_PARIS,
+    _digest_watchdog,
+    decay_user_subtopic_weights,
+    decayed_subtopic_weight,
+    start_scheduler,
+    stop_scheduler,
+)
 
 
 class TestScheduler:
@@ -251,6 +260,36 @@ class TestDigestJobConfiguration:
                 f"Expected minute=15, got {trigger.fields[6]}"
             )
 
+    def test_scheduler_includes_subtopic_weight_decay_job(self):
+        """Verify learned subtopic weights decay before the daily digest."""
+        with patch("app.workers.scheduler.AsyncIOScheduler") as mock_scheduler_class:
+            mock_scheduler = Mock()
+            mock_scheduler_class.return_value = mock_scheduler
+
+            captured_jobs = {}
+
+            def capture_add_job(*args, **kwargs):
+                job_id = kwargs.get("id")
+                if job_id:
+                    captured_jobs[job_id] = {
+                        "func": args[0] if args else kwargs.get("func"),
+                        "trigger": kwargs.get("trigger"),
+                        "name": kwargs.get("name"),
+                    }
+
+            mock_scheduler.add_job = capture_add_job
+
+            start_scheduler()
+
+            assert "subtopic_weight_decay" in captured_jobs
+            job = captured_jobs["subtopic_weight_decay"]
+            assert job["func"].__name__ == "decay_user_subtopic_weights"
+            assert job["name"] == "Subtopic Weight Decay"
+            trigger = job["trigger"]
+            assert isinstance(trigger, CronTrigger)
+            assert str(trigger.fields[5]) == str(SUBTOPIC_DECAY_HOUR_PARIS)
+            assert str(trigger.fields[6]) == str(SUBTOPIC_DECAY_MINUTE_PARIS)
+
     def test_scheduled_restart_job_is_not_registered(self):
         """Regression guard: `scheduled_restart` was a temporary SIGTERM-based
         mitigation for a SQLAlchemy pool leak. Railway's `restartPolicyType:
@@ -297,6 +336,47 @@ class TestDigestJobConfiguration:
             assert "veille_stuck_cleanup" not in job_ids, (
                 f"veille_stuck_cleanup job should not be registered. Jobs: {job_ids}"
             )
+
+
+class TestSubtopicWeightDecay:
+    """Daily subtopic decay should move learned weights toward neutral 1.0."""
+
+    def test_decayed_subtopic_weight_moves_toward_neutral(self):
+        assert decayed_subtopic_weight(3.0) == pytest.approx(
+            1.0 + (3.0 - 1.0) * ScoringWeights.SUBTOPIC_DECAY
+        )
+        assert decayed_subtopic_weight(3.0) < 3.0
+        assert decayed_subtopic_weight(0.1) == pytest.approx(
+            1.0 + (0.1 - 1.0) * ScoringWeights.SUBTOPIC_DECAY
+        )
+        assert decayed_subtopic_weight(0.1) > 0.1
+        assert decayed_subtopic_weight(1.0) == pytest.approx(1.0)
+
+    @pytest.mark.asyncio
+    async def test_decay_job_runs_one_bulk_update(self):
+        from contextlib import asynccontextmanager
+
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=Mock(rowcount=42))
+        mock_session.commit = AsyncMock()
+
+        @asynccontextmanager
+        async def fake_session_manager():
+            yield mock_session
+
+        with patch(
+            "app.database.safe_async_session",
+            side_effect=lambda: fake_session_manager(),
+        ):
+            await decay_user_subtopic_weights()
+
+        mock_session.execute.assert_awaited_once()
+        statement, params = mock_session.execute.await_args.args
+        sql = str(statement)
+        assert "UPDATE user_subtopics" in sql
+        assert "SET weight = 1.0 + (weight - 1.0) * :decay" in sql
+        assert params == {"decay": ScoringWeights.SUBTOPIC_DECAY}
+        mock_session.commit.assert_awaited_once()
 
 
 class TestDigestWatchdogCoverage:


### PR DESCRIPTION
feat(ranking): jauge CTR par pilier + hygiène boucle sujets (decay + position) — PR1

Améliore le ranking utilisé partout (L'Essentiel, Flâner, Veille) **sans
vectorisation** : on pose d'abord la **mesure** (une jauge CTR explicable) puis on
corrige 2 défauts structurels de la boucle d'apprentissage des sujets. **Backend-only,
aucune migration Alembic** — les clés ajoutées au JSONB `daily_digest.items` sont
additives (le mobile ignore les clés inconnues). PR2 (séparée) ajoutera l'affinité
entités, calibrée par cette jauge.

## Problème

- `user_subtopics.weight` (0.1→3.0) est appris sur like/save/read/dismiss et multiplie
  `TOPIC_MATCH` (45 pts) dans le pilier pertinence. Deux trous : (a) **aucun decay** →
  les poids dérivent en permanence et ne reviennent jamais au neutre ; (b) tous les
  sujets matchés sont pondérés **à égalité** alors que `content.topics` est ordonné par
  confiance LLM (`topics[0]` = sujet principal).
- Le ranking **pilote à l'aveugle** : `pillar_scores` est calculé par le moteur de
  piliers puis **jeté** avant la sérialisation. Aucune visibilité CTR par
  sujet/entité/position/pilier pour calibrer la suite.

## Ce que ça change

**PR1.1 — Persistance du breakdown par pilier (zéro migration)**
- `pillar_scores` + `final_score` (et le champ `pillar` de chaque contribution du
  breakdown) sont threadés jusqu'au JSONB `daily_digest.items`, via les chemins digest
  (`digest_selector.py`, `digest_service.py`) **et** topic (`topic_selector.py`).
- `DigestItem` et `ScoredArticle` portent désormais `pillar_scores`.

**PR1.2 — Script offline de mesure (la jauge)**
- Nouveau `packages/api/scripts/evaluate_feed_ranking.py` : calcule le CTR
  (consommés / montrés) **par slug de sujet, par entité, par rang/position, et par bande
  de score de pilier**, en joignant `daily_digest.items` ↔ `user_content_status` ↔
  `contents`. Rapport markdown lisible. Calqué sur la structure de
  `evaluate_veille_curation.py` (mais lit la DB via `DATABASE_URL`).

**PR1.3 — Hygiène boucle sujets (structurel, sûr)**
- **Decay quotidien** : job APScheduler à 07h20 Paris (avant le digest 07h30) — un seul
  `UPDATE` bulk `weight = 1.0 + (weight - 1.0) * SUBTOPIC_DECAY`, O(1)/jour, ramène les
  poids vers le neutre 1.0. Aucun schéma (alternative colonne `updated_at` + decay
  paresseux écartée car = migration).
- **Pondération par position** dans `pertinence.py::_score_subtopics` : le match sur
  `topics[0]` contribue à plein, puis facteur `SUBTOPIC_POSITION_FACTOR` par cran
  (index1 = 0.6, index2 = 0.36). On récupère le vrai index dans `content.topics` (l'ancien
  `sorted(matches)` perdait l'ordre LLM). `TOPIC_MAX_MATCHES = 2` inchangé.
- Constantes ajoutées dans `scoring_config.py` : `SUBTOPIC_DECAY = 0.98`,
  `SUBTOPIC_POSITION_FACTOR = 0.6`.

## Tests

- Suite backend complète verte (`pytest` : 1805 passed, 18 skipped, 2 xfailed).
- Pertinence : `topics[0]` contribue plus que `topics[1]` (pondération position).
- Decay : poids > 1 décroît vers 1.0, poids < 1 croît vers 1.0 ; helper
  `decayed_subtopic_weight` + job `decay_user_subtopic_weights`.
- Sérialisation `pillar_scores`/`final_score`/`pillar` round-trip dans les tests digest.
- Script : `python scripts/evaluate_feed_ranking.py --help` OK (exécution réelle =
  dépend d'une DB peuplée).

## Notes

- **Backend-only** (workers/services/script) → pas de `/validate-feature` (zéro écran).
- **Pas d'entrée changelog** : changement non user-visible (instrumentation + algo),
  règle des 400 lignes by-passée.
- ⚠️ `main` porte déjà un **fork Alembic à 2 heads** pré-existant
  (`pn01_server_push` + `sc01_drop_ucs_excl_idx`) — **indépendant de cette PR** (zéro
  migration ajoutée ici, alembic-smoke path-gated ne se déclenche pas). À traiter
  séparément par une revision de merge (DB prod partagée, gate PO).
