### PR TITLE
Harden backend auth controls

### DIFF
--- a/docs/maintenance/maintenance-auth-backend-hardening.md
+++ b/docs/maintenance/maintenance-auth-backend-hardening.md
@@ -1,0 +1,46 @@
+# Auth Backend Hardening
+
+Date: 2026-06-17
+
+## Scope
+
+- Protected all `/api/internal/*` routes with the existing `X-Admin-Token` admin
+  dependency at router level.
+- Kept `ADMIN_API_TOKEN` as the sole admin secret for internal/admin maintenance
+  endpoints.
+- Switched admin token comparison to `hmac.compare_digest` while preserving
+  fail-closed behavior: missing or invalid token returns `401`, absent
+  `ADMIN_API_TOKEN` returns `503`.
+- Hardened API JWT auth to accept only Supabase ES256 tokens verified through
+  JWKS with `algorithms=["ES256"]` and `audience="authenticated"`.
+- Removed the `SUPABASE_JWT_SECRET` / HS256 fallback from API auth.
+- Updated `python-jose[cryptography]` in `requirements.txt` to `3.5.0`.
+
+## Validation
+
+- Added focused tests for `/api/internal/admin/ner-health`, `/api/internal/sync`,
+  admin token failure modes, and ES256-only JWT decoding.
+- `packages/api/uv.lock` already resolved `python-jose` to `3.5.0`, so no lock
+  regeneration was needed for this maintenance change.
+
+Recommended commands:
+
+```bash
+cd packages/api
+python -m pytest -q tests/test_auth_jwt_algorithms.py tests/routers/test_internal_ner_health.py tests/routers/test_admin_cohorts.py
+python -m pytest -v
+curl -i -X POST http://localhost:8080/api/internal/sync
+```
+
+Expected local curl result without `X-Admin-Token`: `401` when
+`ADMIN_API_TOKEN` is configured, or `503` when it is absent. It must not return
+`200`.
+
+## Exclusions
+
+- RLS migrations and schema files are intentionally excluded and handled
+  separately.
+- SSRF/url-safety work from the original workspace branch is intentionally
+  excluded from this PR.
+- Existing email-confirmation fallback behavior in `dependencies.py` is
+  unchanged.

--- a/packages/api/app/dependencies.py
+++ b/packages/api/app/dependencies.py
@@ -186,27 +186,24 @@ async def get_current_user_id(
     token = credentials.credentials
 
     try:
-        # 1. Obtenir le header pour connaître l'algorithme
+        # 1. Obtenir le header uniquement pour vérifier l'algorithme annoncé.
         header = jwt.get_unverified_header(token)
-        alg = header.get("alg", "HS256")
+        alg = header.get("alg")
 
-        if alg == "ES256":
-            # 2. Utiliser JWKS pour l'algorithme asymétrique ES256
-            jwks = await fetch_jwks()
-            payload = jwt.decode(
-                token,
-                jwks,
-                algorithms=["ES256"],
-                audience="authenticated",
+        if alg != "ES256":
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid token: unsupported algorithm",
             )
-        else:
-            # 3. Utiliser le secret symétrique pour HS256
-            payload = jwt.decode(
-                token,
-                settings.supabase_jwt_secret,
-                algorithms=["HS256"],
-                audience="authenticated",
-            )
+
+        # 2. Utiliser exclusivement les JWKS Supabase pour l'algorithme ES256.
+        jwks = await fetch_jwks()
+        payload = jwt.decode(
+            token,
+            jwks,
+            algorithms=["ES256"],
+            audience="authenticated",
+        )
 
         user_id = payload.get("sub")
 

--- a/packages/api/app/routers/admin_cohorts.py
+++ b/packages/api/app/routers/admin_cohorts.py
@@ -8,6 +8,7 @@ propage immédiatement vers PostHog via `identify()`.
 
 from __future__ import annotations
 
+import hmac
 from typing import Literal
 from uuid import UUID
 
@@ -63,7 +64,7 @@ def require_admin_token(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Admin API disabled: ADMIN_API_TOKEN not configured",
         )
-    if not x_admin_token or x_admin_token != expected:
+    if not x_admin_token or not hmac.compare_digest(x_admin_token, expected):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or missing X-Admin-Token header",

--- a/packages/api/app/routers/internal.py
+++ b/packages/api/app/routers/internal.py
@@ -2,17 +2,16 @@ from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
+from app.routers.admin_cohorts import require_admin_token
 from app.services.classification_queue_service import ClassificationQueueService
 from app.services.title_annotation_service import get_title_annotation_service
 from app.workers.rss_sync import sync_all_sources
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_admin_token)])
 
 
 @router.post("/sync", status_code=status.HTTP_200_OK)
-async def trigger_sync(
-    # Ajouter ici une protection admin si nécessaire (Depends(get_current_admin_user))
-):
+async def trigger_sync():
     """Déclenche manuellement la synchronisation RSS de toutes les sources."""
     results = await sync_all_sources()
     return {"message": "Sync completed", "results": results}

--- a/packages/api/requirements.txt
+++ b/packages/api/requirements.txt
@@ -14,7 +14,7 @@ psycopg[binary,pool]>=3.2.0
 alembic==1.13.1
 
 # Auth
-python-jose[cryptography]==3.3.0
+python-jose[cryptography]==3.5.0
 passlib[bcrypt]==1.7.4
 
 # HTTP Client

--- a/packages/api/tests/routers/test_internal_ner_health.py
+++ b/packages/api/tests/routers/test_internal_ner_health.py
@@ -1,4 +1,4 @@
-"""Tests pour `/api/internal/admin/ner-health`.
+"""Tests pour les endpoints `/api/internal/*`.
 
 Endpoint diagnostique ajouté après l'incident du 19 mai 2026 où spaCy n'était
 plus installé dans l'image Railway. La chaîne `TitleAnnotationService`
@@ -6,7 +6,7 @@ dégradait silencieusement sans erreur visible côté client — d'où ce health
 check explicite.
 """
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
@@ -22,6 +22,36 @@ async def client():
         yield ac
 
 
+async def test_ner_health_without_admin_token_returns_401(client):
+    with patch("app.routers.admin_cohorts.get_settings") as mock_settings:
+        mock_settings.return_value.admin_api_token = "s3cr3t"
+        response = await client.get("/api/internal/admin/ner-health")
+
+    assert response.status_code == 401
+
+
+async def test_ner_health_invalid_admin_token_returns_401(client):
+    with patch("app.routers.admin_cohorts.get_settings") as mock_settings:
+        mock_settings.return_value.admin_api_token = "s3cr3t"
+        response = await client.get(
+            "/api/internal/admin/ner-health",
+            headers={"X-Admin-Token": "nope"},
+        )
+
+    assert response.status_code == 401
+
+
+async def test_ner_health_without_configured_admin_token_returns_503(client):
+    with patch("app.routers.admin_cohorts.get_settings") as mock_settings:
+        mock_settings.return_value.admin_api_token = ""
+        response = await client.get(
+            "/api/internal/admin/ner-health",
+            headers={"X-Admin-Token": "anything"},
+        )
+
+    assert response.status_code == 503
+
+
 async def test_ner_health_reports_available_when_nlp_loaded(client):
     docs = {
         "Tsahal frappe Gaza": FakeDoc(
@@ -34,13 +64,18 @@ async def test_ner_health_reports_available_when_nlp_loaded(client):
     }
     fake_svc = service_with_nlp(FakeNlp(docs))
 
-    with patch(
-        "app.routers.internal.get_title_annotation_service",
-        return_value=fake_svc,
+    with (
+        patch("app.routers.admin_cohorts.get_settings") as mock_settings,
+        patch(
+            "app.routers.internal.get_title_annotation_service",
+            return_value=fake_svc,
+        ),
     ):
+        mock_settings.return_value.admin_api_token = "s3cr3t"
         response = await client.get(
             "/api/internal/admin/ner-health",
             params={"sample_title": "Tsahal frappe Gaza"},
+            headers={"X-Admin-Token": "s3cr3t"},
         )
 
     assert response.status_code == 200
@@ -55,13 +90,39 @@ async def test_ner_health_reports_available_when_nlp_loaded(client):
 async def test_ner_health_reports_unavailable_when_nlp_missing(client):
     fake_svc = service_with_nlp(None)
 
-    with patch(
-        "app.routers.internal.get_title_annotation_service",
-        return_value=fake_svc,
+    with (
+        patch("app.routers.admin_cohorts.get_settings") as mock_settings,
+        patch(
+            "app.routers.internal.get_title_annotation_service",
+            return_value=fake_svc,
+        ),
     ):
-        response = await client.get("/api/internal/admin/ner-health")
+        mock_settings.return_value.admin_api_token = "s3cr3t"
+        response = await client.get(
+            "/api/internal/admin/ner-health",
+            headers={"X-Admin-Token": "s3cr3t"},
+        )
 
     assert response.status_code == 200
     body = response.json()
     assert body["nlp_available"] is False
     assert body["sample_tokens"] == []
+
+
+async def test_internal_sync_with_valid_admin_token_reaches_handler(client):
+    with (
+        patch("app.routers.admin_cohorts.get_settings") as mock_settings,
+        patch(
+            "app.routers.internal.sync_all_sources",
+            new=AsyncMock(return_value={"sources_synced": 2}),
+        ) as mock_sync,
+    ):
+        mock_settings.return_value.admin_api_token = "s3cr3t"
+        response = await client.post(
+            "/api/internal/sync",
+            headers={"X-Admin-Token": "s3cr3t"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["results"] == {"sources_synced": 2}
+    mock_sync.assert_awaited_once()

--- a/packages/api/tests/test_auth_jwt_algorithms.py
+++ b/packages/api/tests/test_auth_jwt_algorithms.py
@@ -1,0 +1,61 @@
+"""JWT algorithm hardening tests."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.dependencies import get_current_user_id
+
+
+@pytest.mark.asyncio
+async def test_hs256_token_rejected_before_decode():
+    credentials = SimpleNamespace(credentials="hs256-token")
+
+    with (
+        patch(
+            "app.dependencies.jwt.get_unverified_header",
+            return_value={"alg": "HS256"},
+        ),
+        patch("app.dependencies.jwt.decode") as mock_decode,
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await get_current_user_id(credentials)
+
+    assert exc_info.value.status_code == 401
+    mock_decode.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_es256_token_decodes_with_supabase_jwks_and_returns_sub():
+    credentials = SimpleNamespace(credentials="es256-token")
+    jwks = {"keys": [{"kid": "test-key"}]}
+
+    with (
+        patch(
+            "app.dependencies.jwt.get_unverified_header",
+            return_value={"alg": "ES256"},
+        ),
+        patch(
+            "app.dependencies.fetch_jwks",
+            new=AsyncMock(return_value=jwks),
+        ) as mock_fetch,
+        patch(
+            "app.dependencies.jwt.decode",
+            return_value={
+                "sub": "user-123",
+                "email_confirmed_at": "2026-06-17T09:00:00Z",
+            },
+        ) as mock_decode,
+    ):
+        user_id = await get_current_user_id(credentials)
+
+    assert user_id == "user-123"
+    mock_fetch.assert_awaited_once()
+    mock_decode.assert_called_once_with(
+        "es256-token",
+        jwks,
+        algorithms=["ES256"],
+        audience="authenticated",
+    )


### PR DESCRIPTION
## Summary
- Protect all /api/internal/* routes with the existing X-Admin-Token admin dependency at router level
- Harden admin token comparison with hmac.compare_digest while preserving 401/503 fail-closed behavior
- Restrict API JWT auth to Supabase ES256/JWKS verification and remove HS256/SUPABASE_JWT_SECRET fallback
- Update python-jose[cryptography] to 3.5.0 in requirements.txt; uv.lock already resolved 3.5.0
- Add focused tests and a maintenance note

## Validation
- cd packages/api && python -m pytest -q tests/test_auth_jwt_algorithms.py tests/routers/test_internal_ner_health.py tests/routers/test_admin_cohorts.py
- cd packages/api && python -m ruff check app/routers/internal.py app/routers/admin_cohorts.py app/dependencies.py tests/test_auth_jwt_algorithms.py tests/routers/test_internal_ner_health.py
- cd packages/api && python -m pytest -v: fails in local DB-backed tests because localhost:54322 rejects postgres/postgres; focused auth/internal tests pass inside the full run
- Local curl after starting API: POST http://localhost:8080/api/internal/sync without X-Admin-Token returned 503 because ADMIN_API_TOKEN is absent, never 200

## Exclusions
- RLS migrations and schema files are intentionally excluded and handled separately
- SSRF/url-safety work from the original workspace branch is intentionally excluded