### PR TITLE
fix(android): retire REQUEST_INSTALL_PACKAGES du flavor playstore

### DIFF
--- a/apps/mobile/android/app/src/playstore/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/playstore/AndroidManifest.xml
@@ -1,4 +1,7 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <!-- Présent pour matérialiser le flavor Gradle. Aucune permission
-         supplémentaire au-delà de src/main/AndroidManifest.xml. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <!-- Flavor Play Store : retire REQUEST_INSTALL_PACKAGES, injectee par open_filex (auto-update APK side-load). Bannie du Play Store, inutile ici car les MAJ passent par le Store. -->
+    <uses-permission
+        android:name="android.permission.REQUEST_INSTALL_PACKAGES"
+        tools:node="remove" />
 </manifest>


### PR DESCRIPTION
## Problème

L'AAB du flavor `playstore` contient la permission `REQUEST_INSTALL_PACKAGES`, refusée par Google Play (permission sensible sans cas d'usage valide pour une app d'actualité).

## Cause

La permission n'est pas déclarée par nos manifests (`src/main`, `src/playstore`) mais injectée par la dépendance `open_filex` (utilisée pour l'auto-update APK side-load). Les permissions des librairies fusionnent dans tous les flavors, y compris `playstore`.

## Correctif

Ajout de `tools:node="remove"` sur `REQUEST_INSTALL_PACKAGES` dans `src/playstore/AndroidManifest.xml` → le manifest merger retire la permission du flavor playstore. Le flavor `beta` la conserve (auto-update side-load préservé).

## À vérifier après merge

- Rebuild AAB (workflow GitHub « Build Android AAB (Play Store) »)
- - Confirmer l'absence de la permission dans le manifest fusionné avant re-upload Play Console
## Suivi (non bloquant)

Le code d'auto-update (open_filex/flutter_downloader) reste compilé dans le build playstore mais inopérant sans la permission. À désactiver côté Dart sur ce flavor plus tard.