### PR TITLE
feat(onboarding): remap vocab hérité avant purge (retag sources, anti perte spécialités)

### DIFF
--- a/packages/api/scripts/retag_and_promote_sources.py
+++ b/packages/api/scripts/retag_and_promote_sources.py
@@ -69,6 +69,49 @@ PROMO_WINDOW_DAYS = 30  # fenêtre du volume pour la promotion
 PROMO_MIN_VOLUME = 20  # articles_30d mini pour promouvoir
 PROMO_RELIABILITY = {"medium", "high"}
 
+# Vocab hérité (sources.granular_topics) -> 51-slugs valides. Appliqué AVANT le
+# purge dans `resolve_new_topics` : sans cette map, une source à faible activité
+# (dérivation vide) perdrait ses slugs hérités au lieu de les convertir.
+# Surensemble de `SLUG_MIGRATION_MAP` (e12a0001, slugs préférence user) étendu à
+# tout le vocab observé dans `sources.granular_topics` en prod (2026-06-17).
+# Idempotente : un slug déjà valide n'apparaît pas en clé -> passe inchangé.
+EXTENDED_MIGRATION_MAP: dict[str, str] = {
+    # --- hérité de e12a0001 (slugs préférence user) ---
+    "crypto": "finance",
+    "social-justice": "justice",
+    "housing": "realestate",
+    "energy-transition": "energy",
+    "macro": "economy",
+    "media-critics": "media",
+    "elections": "politics",
+    "institutions": "politics",
+    "fundamental-research": "science",
+    "applied-science": "science",
+    "middle-east": "middleeast",
+    "physics": "science",
+    "biology": "science",
+    "arts": "art",
+    "french-politics": "politics",
+    "labor": "work",
+    "macroeconomics": "economy",
+    # --- extensions vocab curation (présents dans sources.granular_topics) ---
+    "democracy": "politics",
+    "labor-market": "work",
+    "data-privacy": "privacy",
+    "justice-system": "justice",
+    "work-reform": "work",
+    "venture-capital": "finance",
+    "taxation": "economy",
+    "trade": "economy",
+    "quantum": "science",
+    "pollution": "environment",
+    "robotics": "tech",
+    "activism": "inequality",  # décision PO (cluster social-justice)
+    "cleantech": "environment",  # décision PO
+    "circular-economy": "environment",
+    "regulation": "politics",
+}
+
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 DEFAULT_CSV = PROJECT_ROOT / "sources" / "sources_master.csv"
 
@@ -179,17 +222,22 @@ def resolve_new_topics(
     existing: list[str] | None,
     *,
     valid_slugs: set[str] = VALID_TOPIC_SLUGS,
+    migration: dict[str, str] = EXTENDED_MIGRATION_MAP,
 ) -> list[str] | None:
     """Décide la valeur `granular_topics` finale, conservatrice.
 
     - Dérivation non vide -> elle gagne (data-driven, ordonnée par share).
-    - Dérivation vide -> on **garde** les slugs déjà valides et on **purge**
-      l'ancien vocab (slug hors 51). Jamais de wipe d'un vrai spécialiste mince.
-      Renvoie None quand il ne reste rien.
+    - Dérivation vide -> on **remappe** le vocab hérité connu vers les 51-slugs
+      (via `migration`), puis on ne garde que les slugs valides en dédupliquant
+      dans l'ordre. Jamais de wipe d'un vrai spécialiste mince, et plus de purge
+      sèche d'un slug mappable. Renvoie None quand il ne reste rien.
+      Idempotent : un slug déjà valide passe inchangé.
     """
     if derived:
         return derived
-    cleaned = [t for t in (existing or []) if t in valid_slugs]
+    remapped = (migration.get(t, t) for t in (existing or []))
+    # dict.fromkeys = dédup en conservant l'ordre de 1re occurrence (idiome maison).
+    cleaned = list(dict.fromkeys(t for t in remapped if t in valid_slugs))
     return cleaned or None
 
 

--- a/packages/api/tests/scripts/test_retag_and_promote_sources.py
+++ b/packages/api/tests/scripts/test_retag_and_promote_sources.py
@@ -8,7 +8,9 @@ régénération CSV (update colonnes + append promues + préservation commentair
 
 from __future__ import annotations
 
+from app.services.ml.classification_service import VALID_TOPIC_SLUGS
 from scripts.retag_and_promote_sources import (
+    EXTENDED_MIGRATION_MAP,
     Promotion,
     SourceMeta,
     compute_plan,
@@ -90,18 +92,58 @@ def test_resolve_derived_wins():
     assert resolve_new_topics(["politics"], ["social-justice"]) == ["politics"]
 
 
-def test_resolve_empty_derived_purges_old_vocab_keeps_valid():
-    # "social-justice" (ancien vocab) purgé, "health" (valide) conservé.
-    assert resolve_new_topics([], ["social-justice", "health"]) == ["health"]
+def test_resolve_empty_derived_remaps_old_vocab_keeps_valid():
+    # "social-justice" remappé -> "justice" (au lieu d'être purgé), "health"
+    # (déjà valide) conservé. Ordre préservé.
+    assert resolve_new_topics([], ["social-justice", "health"]) == [
+        "justice",
+        "health",
+    ]
 
 
-def test_resolve_empty_derived_all_old_vocab_becomes_none():
-    assert resolve_new_topics([], ["social-justice", "energy-transition"]) is None
+def test_resolve_empty_derived_remaps_in_order():
+    # Remap sans collision, ordre conservé : social-justice->justice,
+    # democracy->politics, health (valide).
+    assert resolve_new_topics([], ["social-justice", "democracy", "health"]) == [
+        "justice",
+        "politics",
+        "health",
+    ]
+
+
+def test_resolve_empty_derived_dedupes_collisions_from_remap():
+    # Deux slugs hérités convergent vers le même 51-slug -> un seul, ordre 1re occ.
+    assert resolve_new_topics([], ["elections", "democracy", "institutions"]) == [
+        "politics",
+    ]
+
+
+def test_resolve_empty_derived_unmapped_invalid_becomes_none():
+    # Slugs hors-51 ET hors-map : aucune conversion possible -> None.
+    assert resolve_new_topics([], ["foo-old", "bar-baz"]) is None
+
+
+def test_resolve_empty_derived_idempotent_on_valid_slugs():
+    # Déjà 51-slugs : inchangé (la map ne les touche pas).
+    assert resolve_new_topics([], ["justice", "politics", "health"]) == [
+        "justice",
+        "politics",
+        "health",
+    ]
 
 
 def test_resolve_empty_derived_preserves_thin_valid_specialist():
     # Spécialiste mince déjà en 51-slugs : on ne wipe pas faute d'articles.
     assert resolve_new_topics([], ["factcheck"]) == ["factcheck"]
+
+
+def test_extended_migration_map_targets_are_all_valid_slugs():
+    # Garde-fou : toute cible de remap DOIT être un 51-slug valide, sinon le
+    # remap réinjecterait du vocab périmé. Les clés ne doivent jamais être valides
+    # (sinon entrée inutile / risque d'idempotence cassée).
+    for old, new in EXTENDED_MIGRATION_MAP.items():
+        assert new in VALID_TOPIC_SLUGS, f"cible invalide: {old} -> {new}"
+        assert old not in VALID_TOPIC_SLUGS, f"clé déjà valide: {old}"
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Quoi

`resolve_new_topics()` (script `retag_and_promote_sources.py`) **purgeait** tout
slug hors-51 dès que la dérivation 51-slug était vide (source à faible activité).
Résultat : **23 sources curées** perdaient leurs spécialités héritées, dont **12 à
0 article/90j** (podcasts/newsletters/niches mensuelles — exactement les pépites à
garder).

Ce PR ajoute `EXTENDED_MIGRATION_MAP` (17 entrées de `e12a0001` + 15 extensions
vocab curation validées PO) et **remappe** le vocab hérité connu vers les 51-slugs
**avant** le purge, avec dédup en conservant l'ordre.

- Dérivation non vide → elle gagne (inchangé).
- Dérivation vide → remap puis garde uniquement les 51-slugs (dédup ordonnée).
- Idempotent : un slug déjà valide passe inchangé.
- Slug hors-51 **et** hors-map → toujours purgé (→ `None` si plus rien).

## Pourquoi

Le re-tag de PR #850 n'a jamais été appliqué en prod : `sources.granular_topics`
est resté en vocab périmé (`social-justice`, `democracy`, `macro`…), donc le badge
« Spécialisé en X » et la garantie de couverture ne se déclenchent quasi jamais.
La map e12a0001 (conçue pour les prefs user) ne couvre que 7 des 14 slugs non-51
présents côté curation → 7 trous purgés. Cette map étendue ferme ces trous.

## Comment ça a été vérifié

- [x] `pytest tests/scripts/test_retag_and_promote_sources.py` → **23/23 OK**
  (remap+keep, dédup collisions, unmapped→None, idempotence, garde-fou « toute
  cible ∈ 51-slugs »)
- [x] Suite backend complète : **1448 passed**. Les 379 erreurs sont toutes dans
  `tests/test_veille_*` (faux négatifs DB locale connus, cf. memory), étrangères
  au diff.
- [x] `ruff check` + `ruff format --check` clean
- [x] `/simplify` passé (boucle dédup → idiome maison `dict.fromkeys`)

## Zones à risque

- Script **PO-gated** : aucune mutation DB dans ce PR. L'exécution
  `--apply --allow-prod` contre la DB Supabase de prod partagée reste une étape PO
  séparée (dry-run → apply → `--write-csv`).
- Aucune modif app/mobile. Pas de DDL → pas de migration Alembic.

## Follow-ups (hors PR)

- **A.** Sourcing des 33 sous-thèmes sans spécialiste dominant (ajout manuel CSV).
- **B.** Ticket ingestion séparé : feeds mainstream cassés (Le Point, Libération,
  Les Échos, Brut…) — à réparer, **pas** à supprimer.
- Idée altitude (notée en review) : surfacer dans le dry-run les slugs hérités
  *droppés* (ni valides ni mappés) pour rendre visible la péremption du snapshot.