### PR TITLE
Guard source detection fetches against SSRF

### DIFF
--- a/packages/api/app/services/rss_parser.py
+++ b/packages/api/app/services/rss_parser.py
@@ -9,6 +9,7 @@ from bs4 import BeautifulSoup
 from pydantic import BaseModel
 
 from app.config import get_settings
+from app.utils.url_safety import validate_url_for_fetch
 
 logger = structlog.get_logger()
 
@@ -99,7 +100,7 @@ class RSSParser:
     def __init__(self):
         self.client = httpx.AsyncClient(
             timeout=7.0,
-            follow_redirects=True,
+            follow_redirects=False,
             headers={
                 "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
                 "Accept-Language": "en-US,en;q=0.9",
@@ -111,6 +112,31 @@ class RSSParser:
         await self.client.aclose()
 
     # ─── Helpers ──────────────────────────────────────────────────
+
+    async def _safe_get(
+        self,
+        url: str,
+        *,
+        max_redirects: int = 5,
+        **kwargs,
+    ) -> httpx.Response:
+        """GET a URL after SSRF validation, validating every redirect target."""
+        current_url = validate_url_for_fetch(url)
+        for _ in range(max_redirects + 1):
+            response = await self.client.get(
+                current_url,
+                follow_redirects=False,
+                **kwargs,
+            )
+            if response.status_code not in {301, 302, 303, 307, 308}:
+                return response
+
+            location = response.headers.get("location")
+            if not location:
+                return response
+            current_url = validate_url_for_fetch(urljoin(current_url, location))
+
+        raise ValueError("Too many redirects while fetching URL")
 
     @staticmethod
     def _is_feed_content_type(response: httpx.Response) -> bool:
@@ -143,21 +169,35 @@ class RSSParser:
 
         try:
             async with AsyncSession(impersonate="chrome", timeout=10) as s:
-                resp = await s.get(
-                    url,
-                    headers={
-                        "Accept-Language": "fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7",
-                        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-                    },
-                )
-                if resp.status_code == 200:
-                    logger.info("curl-cffi fallback succeeded", url=url)
-                    return resp.text
-                logger.warning(
-                    "curl-cffi fallback returned non-200",
-                    url=url,
-                    status=resp.status_code,
-                )
+                current_url = validate_url_for_fetch(url)
+                for _ in range(6):
+                    resp = await s.get(
+                        current_url,
+                        allow_redirects=False,
+                        headers={
+                            "Accept-Language": "fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7",
+                            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                        },
+                    )
+                    if resp.status_code in {301, 302, 303, 307, 308}:
+                        location = resp.headers.get("location")
+                        if not location:
+                            break
+                        current_url = validate_url_for_fetch(
+                            urljoin(current_url, location)
+                        )
+                        continue
+                    if resp.status_code == 200:
+                        logger.info("curl-cffi fallback succeeded", url=current_url)
+                        return resp.text
+                    logger.warning(
+                        "curl-cffi fallback returned non-200",
+                        url=current_url,
+                        status=resp.status_code,
+                    )
+                    break
+        except ValueError:
+            raise
         except Exception as e:
             logger.warning("curl-cffi fetch failed", url=url, error=str(e))
         return None
@@ -208,7 +248,7 @@ class RSSParser:
         loop = asyncio.get_event_loop()
 
         try:
-            response = await self.client.get(url)
+            response = await self._safe_get(url)
             response.raise_for_status()
             content = response.text
         except Exception as e:
@@ -266,7 +306,7 @@ class RSSParser:
         try:
             if handle:
                 # forHandle works for @handle URLs
-                resp = await self.client.get(
+                resp = await self._safe_get(
                     "https://www.googleapis.com/youtube/v3/channels",
                     params={"forHandle": handle, "part": "id", "key": api_key},
                 )
@@ -284,7 +324,7 @@ class RSSParser:
 
             if custom_name:
                 # Search for custom URL name
-                resp = await self.client.get(
+                resp = await self._safe_get(
                     "https://www.googleapis.com/youtube/v3/search",
                     params={
                         "q": custom_name,
@@ -314,7 +354,7 @@ class RSSParser:
     async def _channel_id_from_video_page(self, url: str) -> str | None:
         """Extract channel_id from a YouTube video watch page HTML."""
         try:
-            resp = await self.client.get(url)
+            resp = await self._safe_get(url)
             if resp.status_code == 200:
                 match = re.search(r'"channelId":"(UC[\w-]+)"', resp.text)
                 if match:
@@ -330,7 +370,7 @@ class RSSParser:
     async def _channel_id_from_html(self, url: str) -> str | None:
         """Fallback: try to extract channelId from page HTML via regex."""
         try:
-            resp = await self.client.get(url)
+            resp = await self._safe_get(url)
             if resp.status_code == 200:
                 match = re.search(r'"channelId":"(UC[\w-]+)"', resp.text)
                 if match:
@@ -398,7 +438,7 @@ class RSSParser:
         for index_url in to_try:
             html: str | None = None
             try:
-                resp = await self.client.get(index_url)
+                resp = await self._safe_get(index_url)
             except Exception as e:
                 logger.debug(
                     "Feed index page fetch failed",
@@ -484,7 +524,7 @@ class RSSParser:
         for candidate in candidates[:10]:
             feed_text: str | None = None
             try:
-                resp = await self.client.get(candidate)
+                resp = await self._safe_get(candidate)
             except Exception:
                 resp = None
 
@@ -530,6 +570,7 @@ class RSSParser:
         5. Expanded suffix fallback with Content-Type validation.
         """
         logger.info("Detecting feed", url=url)
+        validate_url_for_fetch(url)
         loop = asyncio.get_event_loop()
         detection_log: list[str] = []
 
@@ -539,7 +580,7 @@ class RSSParser:
             logger.info("Domain override matched", url=url, feed_url=override_feed)
             detection_log.append(f"override={override_feed}")
             try:
-                resp = await self.client.get(override_feed)
+                resp = await self._safe_get(override_feed)
                 if resp.status_code == 200:
                     feed_data = await loop.run_in_executor(
                         None, feedparser.parse, resp.text
@@ -566,7 +607,7 @@ class RSSParser:
             )
             detection_log.append(f"platform_transform={transformed_url}")
             try:
-                resp = await self.client.get(transformed_url)
+                resp = await self._safe_get(transformed_url)
                 if resp.status_code == 200:
                     feed_data = await loop.run_in_executor(
                         None, feedparser.parse, resp.text
@@ -591,7 +632,7 @@ class RSSParser:
             rss_url = f"https://www.reddit.com/r/{subreddit}/.rss"
             logger.info("Reddit URL detected", subreddit=subreddit, rss_url=rss_url)
             try:
-                feed_resp = await self.client.get(rss_url)
+                feed_resp = await self._safe_get(rss_url)
                 feed_resp.raise_for_status()
                 reddit_feed = await loop.run_in_executor(
                     None, feedparser.parse, feed_resp.text
@@ -618,7 +659,7 @@ class RSSParser:
         if "youtube.com/feeds/videos.xml" in url:
             logger.info("YouTube feed URL detected, parsing directly", url=url)
             try:
-                feed_resp = await self.client.get(url)
+                feed_resp = await self._safe_get(url)
                 feed_resp.raise_for_status()
                 yt_feed = await loop.run_in_executor(
                     None, feedparser.parse, feed_resp.text
@@ -648,7 +689,7 @@ class RSSParser:
                     rss_url=rss_url,
                 )
                 try:
-                    feed_resp = await self.client.get(rss_url)
+                    feed_resp = await self._safe_get(rss_url)
                     feed_resp.raise_for_status()
                     yt_feed = await loop.run_in_executor(
                         None, feedparser.parse, feed_resp.text
@@ -668,7 +709,7 @@ class RSSParser:
         # ── Stage 1: Fetch URL (httpx → curl-cffi fallback) ────────
         content = None
         try:
-            response = await self.client.get(url)
+            response = await self._safe_get(url)
             logger.info("Fetched URL", url=url, status_code=response.status_code)
 
             if self._is_antibot_response(response.status_code, response.text):
@@ -744,7 +785,7 @@ class RSSParser:
             detection_log.append(f"link_alternate={found_url}")
             if found_url != url:
                 try:
-                    feed_resp = await self.client.get(found_url)
+                    feed_resp = await self._safe_get(found_url)
                     feed_resp.raise_for_status()
                     found_feed_data = await loop.run_in_executor(
                         None, feedparser.parse, feed_resp.text
@@ -787,7 +828,7 @@ class RSSParser:
             detection_log.append(f"a_tag_scan={len(candidate_urls)}_candidates")
             for candidate in candidate_urls[:5]:
                 try:
-                    cand_resp = await self.client.get(candidate)
+                    cand_resp = await self._safe_get(candidate)
                     if cand_resp.status_code != 200:
                         continue
                     if self._is_feed_content_type(cand_resp):
@@ -844,7 +885,7 @@ class RSSParser:
             try_url = url.rstrip("/") + suffix
             async with suffix_sem:
                 try:
-                    resp = await self.client.get(try_url)
+                    resp = await self._safe_get(try_url)
                 except Exception:
                     return None
                 suffix_tried["n"] += 1

--- a/packages/api/app/utils/url_safety.py
+++ b/packages/api/app/utils/url_safety.py
@@ -1,0 +1,103 @@
+"""Outbound URL safety checks for user-supplied fetch targets."""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+_ALLOWED_SCHEMES = {"http", "https"}
+_METADATA_IP = ipaddress.ip_address("169.254.169.254")
+
+
+def _normalize_hostname(hostname: str | None) -> str:
+    if not hostname:
+        raise ValueError("URL must include a hostname")
+
+    host = hostname.strip().strip(".").lower()
+    if not host:
+        raise ValueError("URL must include a hostname")
+
+    try:
+        return host.encode("idna").decode("ascii")
+    except UnicodeError as exc:
+        raise ValueError("URL hostname is invalid") from exc
+
+
+def _is_localhost_name(host: str) -> bool:
+    return (
+        host == "localhost"
+        or host.endswith(".localhost")
+        or host == "localhost.localdomain"
+        or host.endswith(".localhost.localdomain")
+    )
+
+
+def _blocked_ip_reason(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> str | None:
+    if ip == _METADATA_IP:
+        return "metadata address"
+    if ip.is_private:
+        return "private address"
+    if ip.is_loopback:
+        return "loopback address"
+    if ip.is_link_local:
+        return "link-local address"
+    if ip.is_multicast:
+        return "multicast address"
+    if ip.is_unspecified:
+        return "unspecified address"
+    if ip.is_reserved:
+        return "reserved address"
+    return None
+
+
+def _validate_ip(ip_text: str) -> None:
+    try:
+        ip = ipaddress.ip_address(ip_text)
+    except ValueError as exc:
+        raise ValueError(f"Resolved IP address is invalid: {ip_text}") from exc
+
+    reason = _blocked_ip_reason(ip)
+    if reason:
+        raise ValueError(f"URL host resolves to blocked {reason}: {ip}")
+
+
+def validate_url_for_fetch(url: str) -> str:
+    """Validate that a URL is safe to fetch from the API server.
+
+    The check intentionally fails closed: a hostname must resolve, and every
+    returned address must be publicly routable.
+    """
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        raise ValueError("URL scheme must be http or https")
+
+    host = _normalize_hostname(parsed.hostname)
+    if _is_localhost_name(host):
+        raise ValueError("URL hostname is not allowed")
+
+    try:
+        literal_ip = ipaddress.ip_address(host)
+    except ValueError:
+        literal_ip = None
+
+    if literal_ip is not None:
+        reason = _blocked_ip_reason(literal_ip)
+        if reason:
+            raise ValueError(f"URL host is blocked {reason}: {literal_ip}")
+        return url
+
+    try:
+        resolved = socket.getaddrinfo(host, parsed.port, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise ValueError(f"URL hostname could not be resolved: {host}") from exc
+
+    addresses = {info[4][0] for info in resolved}
+    if not addresses:
+        raise ValueError(f"URL hostname could not be resolved: {host}")
+
+    for address in addresses:
+        _validate_ip(address)
+
+    return url

--- a/packages/api/tests/test_rss_parser.py
+++ b/packages/api/tests/test_rss_parser.py
@@ -1,6 +1,9 @@
-import pytest
+import socket
 from unittest.mock import AsyncMock, MagicMock, patch
-from app.services.rss_parser import RSSParser, DetectedFeed
+
+import pytest
+
+from app.services.rss_parser import RSSParser
 
 
 class AttrDict(dict):
@@ -35,6 +38,15 @@ class BadFeed:
         self.entries = []
         self.feed = {}
         self.version = ""
+
+
+@pytest.fixture(autouse=True)
+def mock_public_dns(monkeypatch):
+    def _getaddrinfo(host, port, *args, **kwargs):
+        address = "10.0.0.5" if host == "private.example.test" else "93.184.216.34"
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (address, port or 443))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _getaddrinfo)
 
 
 # ─── Existing Tests ───────────────────────────────────────────────
@@ -621,3 +633,66 @@ async def test_error_diagnostics_include_detection_log():
     assert "No RSS feed found" in error_msg
     assert "Tried:" in error_msg
     assert "direct_parse=fail" in error_msg
+
+
+# ─── SSRF Guard Tests ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_detect_private_ip_rejected_before_fetch():
+    parser = RSSParser()
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+        with pytest.raises(ValueError):
+            await parser.detect("http://127.0.0.1/feed")
+
+    mock_get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_redirect_to_private_ip_rejected_before_final_fetch():
+    parser = RSSParser()
+
+    redirect = MagicMock()
+    redirect.status_code = 302
+    redirect.headers = {"location": "http://127.0.0.1/feed"}
+    redirect.text = ""
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = redirect
+        with pytest.raises(ValueError):
+            await parser.detect("https://example.com")
+
+    assert mock_get.await_count == 1
+    assert mock_get.await_args.args[0] == "https://example.com"
+
+
+@pytest.mark.asyncio
+async def test_discovered_private_candidate_is_not_fetched():
+    parser = RSSParser()
+
+    main_response = MagicMock()
+    main_response.text = """
+    <html><body>
+        <a href="https://private.example.test/feed.xml">RSS</a>
+    </body></html>
+    """
+    main_response.status_code = 200
+    main_response.headers = {"content-type": "text/html"}
+    main_response.raise_for_status = MagicMock()
+
+    not_found = MagicMock()
+    not_found.status_code = 404
+    not_found.text = "Not Found"
+    not_found.headers = {"content-type": "text/html"}
+
+    async def mock_get(url, **kwargs):
+        assert "private.example.test" not in url
+        if url == "https://example.com":
+            return main_response
+        return not_found
+
+    with patch("httpx.AsyncClient.get", side_effect=mock_get):
+        with patch("feedparser.parse", return_value=BadFeed()):
+            with pytest.raises(ValueError, match="No RSS feed found"):
+                await parser.detect("https://example.com")

--- a/packages/api/tests/test_source_addition_fix.py
+++ b/packages/api/tests/test_source_addition_fix.py
@@ -24,14 +24,18 @@ def test_source_service_has_logger():
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
+from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.database import get_db
+from app.dependencies import get_current_user_id
+from app.main import app
 from app.models.enums import InterestState, SourceType
 from app.models.source import Source, UserSource
 from app.models.user import UserProfile
 from app.models.user_favorites import UserFavoriteSource
-from app.schemas.source import SourceDetectResponse
+from app.schemas.source import SourceDetectResponse, SourceResponse
 from app.services.source_service import SourceService
 
 
@@ -105,6 +109,127 @@ async def test_add_custom_source_idempotent(db_session: AsyncSession, fake_detec
     )
     rows = result.scalars().all()
     assert len(rows) == 1
+
+
+async def _fake_user():
+    return str(uuid4())
+
+
+class _DummyDB:
+    async def commit(self):
+        return None
+
+
+async def _fake_db():
+    yield _DummyDB()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"url": "http://127.0.0.1/feed"},
+        {"url": "localhost.localdomain"},
+    ],
+)
+async def test_detect_route_rejects_private_internal_url(payload):
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            with patch(
+                "app.routers.sources._log_failed_source_attempt",
+                new_callable=AsyncMock,
+            ):
+                resp = await ac.post("/api/sources/detect", json=payload)
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_custom_route_rejects_private_internal_url():
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            with patch(
+                "app.routers.sources._log_failed_source_attempt",
+                new_callable=AsyncMock,
+            ):
+                resp = await ac.post(
+                    "/api/sources/custom", json={"url": "http://127.0.0.1/feed"}
+                )
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("url", ["https://www.example.com/feed", "vert.eco"])
+async def test_detect_route_public_url_success_mocked(url, fake_detection):
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            with patch.object(
+                SourceService,
+                "detect_source",
+                new_callable=AsyncMock,
+                return_value=fake_detection,
+            ):
+                resp = await ac.post("/api/sources/detect", json={"url": url})
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    assert resp.json()["feed_url"] == fake_detection.feed_url
+
+
+@pytest.mark.asyncio
+async def test_custom_route_public_url_success_mocked():
+    response = SourceResponse(
+        id=uuid4(),
+        name="Vert",
+        url="https://vert.eco",
+        type=SourceType.ARTICLE,
+        theme="environment",
+        description=None,
+        logo_url=None,
+        is_curated=False,
+        is_custom=True,
+        is_trusted=True,
+        content_count=0,
+    )
+
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            with patch.object(
+                SourceService,
+                "add_custom_source",
+                new_callable=AsyncMock,
+                return_value=response,
+            ):
+                resp = await ac.post(
+                    "/api/sources/custom", json={"url": "https://vert.eco"}
+                )
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    assert resp.json()["url"] == "https://vert.eco"
 
 
 @pytest.mark.asyncio

--- a/packages/api/tests/test_url_safety.py
+++ b/packages/api/tests/test_url_safety.py
@@ -1,0 +1,64 @@
+import socket
+
+import pytest
+
+from app.utils.url_safety import validate_url_for_fetch
+
+
+def _addrinfo(address: str):
+    return [
+        (
+            socket.AF_INET6 if ":" in address else socket.AF_INET,
+            socket.SOCK_STREAM,
+            6,
+            "",
+            (address, 443),
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost/feed",
+        "http://localhost.localdomain/feed",
+        "http://127.0.0.1/feed",
+        "http://[::1]/feed",
+        "http://10.0.0.1/feed",
+        "http://172.16.0.1/feed",
+        "http://192.168.0.1/feed",
+        "http://169.254.169.254/latest/meta-data",
+        "http://0.0.0.0/feed",
+        "ftp://example.com/feed",
+        "file:///etc/passwd",
+    ],
+)
+def test_validate_url_for_fetch_rejects_internal_and_non_http(url):
+    with pytest.raises(ValueError):
+        validate_url_for_fetch(url)
+
+
+def test_validate_url_for_fetch_rejects_hostname_resolving_private(monkeypatch):
+    def private_addrinfo(host, port, family=0, type=0, proto=0, flags=0):
+        return _addrinfo("10.1.2.3")
+
+    monkeypatch.setattr(socket, "getaddrinfo", private_addrinfo)
+
+    with pytest.raises(ValueError, match="blocked"):
+        validate_url_for_fetch("https://feeds.example.com/rss.xml")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://www.example.com/feed",
+        "https://vert.eco",
+    ],
+)
+def test_validate_url_for_fetch_allows_public_hosts(monkeypatch, url):
+    def public_addrinfo(host, port, family=0, type=0, proto=0, flags=0):
+        return _addrinfo("93.184.216.34")
+
+    monkeypatch.setattr(socket, "getaddrinfo", public_addrinfo)
+
+    assert validate_url_for_fetch(url) == url


### PR DESCRIPTION
## Summary
- Add centralized outbound URL safety validation for source detection fetches
- Reject non-http schemes, localhost/internal hostnames, private/special IP literals, and hostnames resolving to blocked IPs
- Route RSS discovery fetches through safe manual redirect handling, including overrides, platform transforms, Reddit/YouTube feeds, HTML discovery, index pages, and suffix probes
- Add SSRF regression coverage for URL validation, RSSParser fetch boundaries, redirects, discovered candidates, and source routes

## Verification
- PASS: `python -m ruff check app/utils/url_safety.py tests/test_url_safety.py`
- PASS: `python -m ruff check --select I,F app/services/rss_parser.py tests/test_rss_parser.py tests/test_source_addition_fix.py`
- PASS: `PYTHONPATH=. pytest -v tests/test_url_safety.py tests/test_rss_parser.py tests/test_source_addition_fix.py -k 'url_safety or rss_parser or source_service_has_logger or route'` (49 passed, 3 deselected)
- ENV BLOCKED: `PYTHONPATH=. pytest -v tests/test_url_safety.py tests/test_rss_parser.py tests/test_source_addition_fix.py` reaches 49 passed, then 3 existing DB-backed tests error during setup because local Postgres at `localhost:54322` rejects auth for user `postgres`
