### PR TITLE
feat(onboarding): polish du cœur sélection des sources (swipe + page sur-mesure)

### DIFF
--- a/.context/qa-handoff.md
+++ b/.context/qa-handoff.md
@@ -1,73 +1,67 @@
-# QA Handoff — Onboarding sources : re-mapping taxonomie + badge « Spécialisé en X »
+# QA Handoff — Onboarding : polish du « cœur » sélection des sources
 
-> Rempli par l'agent dev après VERIFY. Input de `/validate-feature` (agent QA Chrome).
-
-## Feature développée
-
-Pendant l'onboarding, l'écran de reco sources devient « wow » : chaque sujet (subtopic)
-sélectionné obtient **au moins une source spécialisée visible**, badgée « Spécialisé en X ».
-Côté backend, un script aligne le vocabulaire des `granular_topics` des sources sur la
-taxonomie 51-slugs des users/articles (re-dérivée du contenu réellement publié) et élargit
-le catalogue curé. Côté mobile, le recommender ajoute un badge spécialiste sur la spécialité
-dominante d'une source, **et** une garantie de couverture qui rapatrie le meilleur spécialiste
-curé pour tout sujet choisi non couvert (carte distincte par sujet, pré-cochée).
-
-> ⚠️ La partie data (re-tag + promotion en base) est **gatée PO** et tourne séparément
-> (`scripts/retag_and_promote_sources.py --apply --allow-prod`) après merge. La validation QA
-> ci-dessous porte sur l'**UI mobile** (badge + visibilité). Sur l'env staging, l'effet plein
-> n'apparaît qu'une fois la base re-taggée ; le badge et la garantie restent testables avec
-> les `granular_topics` déjà présents.
-
-## PR associée
-<!-- gh pr view --web après /go -->
+Branche : `boujonlaurin-dotcom/onboarding-source-selection-polish` (base `main`).
+Backend non touché. Feature UI only.
 
 ## Écrans impactés
-| Écran | Route | Modifié / Nouveau |
-|-------|-------|-------------------|
-| Onboarding — Sources (« sur mesure ») | flow onboarding, étape sources | Modifié |
 
-## Scénarios de test
+1. **Swipe de calibration** (`SwipeDisambiguatorQuestion`, Q9c)
+2. **Page « Tes médias, sur mesure »** (`SourcesQuestion`, Q10)
 
-### Scénario 1 : Happy path — sujet avec spécialiste
-**Parcours** :
-1. Lancer l'onboarding, choisir des thèmes (ex. Tech, Société) puis des sous-sujets variés
-   (ex. `IA`, `Climat`).
-2. Passer le swipe de calibration, arriver sur l'écran « ① Suggestions sur mesure ».
-**Résultat attendu** : pour chaque sous-sujet choisi qui dispose d'un spécialiste curé, une
-carte porte un chip teinté primary **« 🎯 Spécialisé en {sujet} »** (ex. « Spécialisé en
-Intelligence artificielle »). Ces cartes apparaissent **en tête** des suggestions et sont
-**pré-cochées**.
+## Setup
 
-### Scénario 2 : Edge case — sujets « pauvres »
-**Parcours** :
-1. Refaire l'onboarding en choisissant des sous-sujets réputés minces
-   (ex. `Fact-checking`, `Relations et amour`, `Jeux vidéo`).
-**Résultat attendu** : au moins une carte « Spécialisé en X » remonte pour chacun **quand la
-data le permet** (cartes distinctes par sujet). Si aucun spécialiste curé n'existe pour un
-sujet sur l'env testé, pas de carte fantôme et pas d'erreur — dégradation propre.
+- Build web Flutter, viewport mobile **390x844**, sémantique activée au boot
+  (cf. skill `facteur-qa-web`).
+- Parcourir l'onboarding jusqu'au swipe (répondre thèmes/sujets pour avoir des
+  groupes thématisés), puis continuer jusqu'à la page sur-mesure.
 
-### Scénario 3 : Pas de doublon / cohérence des chips
-**Parcours** :
-1. Choisir un sujet dont la source dominante matche (ex. une source dont la spécialité
-   dominante est exactement le sujet choisi).
-**Résultat attendu** : la carte montre **un seul** chip « Spécialisé en X » (pas de double
-chip « X » thème + « Spécialisé en X »). La source n'apparaît pas deux fois.
+## Scénarios — Swipe (B)
+
+- **En-tête dynamique (B.2)** : plus de titre statique « Quels médias suivre ? ».
+  Un en-tête par **groupe** s'affiche (ex. « L'actu au quotidien »,
+  « Des médias indépendants », « Pour aller au fond… », « Un autre point de
+  vue », ou thématisé « Pour creuser Tech & Innovation… »). Il **change** quand
+  on passe d'un bloc de cartes au suivant (transition douce).
+  - Edge : l'ordre des blocs suit les prefs — répondre « médias spécialisés »
+    (independent) doit mener avec indépendants/fond ; « grands médias »
+    (established) avec références/grands médias.
+- **Hint (B.1)** : sous la carte, texte renommé **« Touche pour ouvrir le
+  média »** (visible sur la 1ʳᵉ carte, disparaît au 1ᵉʳ geste), rapproché du bas
+  du deck.
+- **Centrage (B.3)** : le deck est centré verticalement (plus d'espace mort en
+  haut depuis la suppression du gros titre).
+- **Undo (B.4)** : 3 boutons ronds sur une ligne — **undo discret (plus petit,
+  gris) à gauche** de (X) et (♥). Invisible tant qu'aucun vote ; (X)/(♥) restent
+  centrés (placeholder symétrique). L'undo de l'overlay final reste inchangé.
+
+## Scénarios — Page sur-mesure (A)
+
+- **Déjà ajoutés (A.1)** : en tête de la section 1, puces **discrètes** (libellé
+  léger « Déjà ajoutés », logos ~18px), alimentées par les sources likées au
+  swipe. Ces sources sont hors carrousel et déjà cochées.
+- **Carrousels (A.2)** : sections 1 (suggestions) **et** 3 (catalogue) en
+  **carrousel horizontal** (swipe latéral, ~1,2 carte visible, peek sur la
+  suivante). Le filtre par thème (section 3) repart de la 1ʳᵉ carte.
+- **Cartes (A.3/A.4)** : cartes portrait — logo + nom + pastille de biais en
+  tête ; **aspects matchés** (tags : thème, « Spécialisé en X », « ≈ Similaire à
+  … », fiable/anti-bruit/serein) mis en valeur au cœur ; cercle de sélection
+  ≥44px ; tap carte → modale détail.
 
 ## Critères d'acceptation
-- [ ] ≥1 carte « Spécialisé en {sujet} » visible par sous-sujet sélectionné (quand un
-      spécialiste curé existe).
-- [ ] Le badge utilise le bon libellé FR (`getTopicLabel`) pour les 51 slugs.
-- [ ] Les cartes spécialistes sont en tête des suggestions et pré-cochées.
-- [ ] Pas de doublon de carte ni de double chip thème+spécialiste.
-- [ ] Console sans erreur, pas de requête 4xx/5xx inattendue.
 
-## Zones de risque
-- Spécialité dominante = `granularTopics.first` : dépend de l'ordre (par share desc) écrit par
-  le re-tag backend. Sur un env non encore re-taggé, l'ordre vient du seed CSV.
-- Cap des suggestions (`_suggestionsLimit = 18`) : les spécialistes sont placés en tête pour
-  survivre au cap — vérifier qu'ils ne sont jamais tronqués.
+- En-tête de swipe change visiblement entre groupes ; aucun em-dash.
+- Carrousels fluides, peek visible ; sélection/desélection OK ; modale détail OK.
+- Console sans erreurs ; pas de 4xx/5xx réseau inattendus.
 
-## Dépendances
-- Aucune nouvelle API. Sérialisation existante `granular_topics` / `articles_30d`
-  (`schemas/source.py`, `routers/sources.py`). Pas de migration Alembic.
-- Effet data complet conditionné à l'apply prod gaté PO du script de re-tag/promotion.
+## Vérifs déjà passées (dev)
+
+- `flutter test test/features/onboarding` → **84 passed** (dont nouveaux tests
+  `buildSpanningGroups` : ordre par prefs, libellé thème vs pôle, dégradation).
+- `flutter analyze` sur les fichiers touchés → propre (seuls infos `withOpacity`
+  pré-existantes, conformes au reste du code).
+
+## Note hors-scope (à signaler)
+
+`apps/mobile/assets/changelog.json` était **JSON invalide sur `main`** (deux
+entrées `unreleased` fusionnées par un mauvais merge → parsing cassé). Réparé
+dans cette PR + ajout de l'entrée « Onboarding » de la feature.

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -3,8 +3,14 @@
     {
       "tag": "Pas de recul",
       "summary": "L'analyse de fond « Pas de recul » s'affiche désormais instantanément à l'ouverture d'un article, sans attente."
+    },
+    {
       "tag": "Onboarding",
       "summary": "Choix de tes médias repensé : sections claires qui s'ouvrent une à une, et un ton plus direct dans tout le questionnaire."
+    },
+    {
+      "tag": "Onboarding",
+      "summary": "Choisir tes médias devient plus simple et lisible : un swipe guidé par petits groupes, et des suggestions présentées en cartes faciles à parcourir."
     },
     {
       "tag": "Tournée",

--- a/apps/mobile/lib/features/onboarding/data/source_recommender.dart
+++ b/apps/mobile/lib/features/onboarding/data/source_recommender.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 
 import '../../../config/topic_labels.dart';
 import '../../sources/models/source_model.dart';
+import '../onboarding_strings.dart';
 
 /// Category of a recommended source.
 enum SourceCategory { matched, perspective, gem, catalog }
@@ -91,6 +92,21 @@ class SpanningSource {
   final Source source;
   final SwipeAxisPole pole;
   const SpanningSource({required this.source, required this.pole});
+}
+
+/// Un bloc contigu de cartes du swipe partageant un même pôle d'axe, avec un
+/// en-tête humain (« mix type + thème »). L'ordre des groupes est piloté par
+/// les préférences déclarées (indépendance / profondeur) ; cf.
+/// [SourceRecommender.buildSpanningGroups].
+class SwipeGroup {
+  final SwipeAxisPole pole;
+  final String label;
+  final List<SpanningSource> cards;
+  const SwipeGroup({
+    required this.pole,
+    required this.label,
+    required this.cards,
+  });
 }
 
 /// Computes personalized source recommendations based on user's onboarding choices.
@@ -814,6 +830,160 @@ class SourceRecommender {
     }
 
     return result;
+  }
+
+  /// Organise le spanning set en **groupes contigus** par pôle d'axe, avec un
+  /// en-tête humain par groupe, l'ordre des groupes étant piloté par les
+  /// préférences déclarées.
+  ///
+  /// Fonction *pure* (testable) : s'appuie sur [buildSpanningSet] pour le choix
+  /// des cartes (mêmes cartes ⇒ même calibration, le signal par pôle étant
+  /// agrégé au reveal indépendamment de l'ordre), puis :
+  /// - regroupe les cartes par pôle en préservant l'ordre d'apparition ;
+  /// - ordonne les groupes selon [independencePref] (`independent` ⇒ mener avec
+  ///   indépendants/fond ; `established` ⇒ mener avec références/grands médias)
+  ///   et [depthPref] (`detailed` ⇒ remonter le fond). Le pôle `perspective`
+  ///   ferme toujours la marche ;
+  /// - libelle chaque groupe en « mix type + thème » : si le groupe est cohérent
+  ///   sur un thème des prefs (thème dominant), spécialise (« Pour creuser … »),
+  ///   sinon libellé par pôle.
+  static List<SwipeGroup> buildSpanningGroups({
+    required List<String> selectedThemes,
+    required List<String> selectedSubtopics,
+    required List<Source> allSources,
+    String? independencePref,
+    String? depthPref,
+    int maxCards = 10,
+    int perPole = 2,
+  }) {
+    final set = buildSpanningSet(
+      selectedThemes: selectedThemes,
+      selectedSubtopics: selectedSubtopics,
+      allSources: allSources,
+      maxCards: maxCards,
+      perPole: perPole,
+    );
+    if (set.isEmpty) return const [];
+
+    // Regroupe par pôle en préservant l'ordre d'apparition des pôles ET des
+    // cartes (LinkedHashMap garde l'ordre d'insertion).
+    final byPole = <SwipeAxisPole, List<SpanningSource>>{};
+    for (final s in set) {
+      (byPole[s.pole] ??= <SpanningSource>[]).add(s);
+    }
+
+    final orderedPoles = byPole.keys.toList()
+      ..sort(
+        (a, b) => _poleOrderWeight(
+          a,
+          independencePref,
+          depthPref,
+        ).compareTo(_poleOrderWeight(b, independencePref, depthPref)),
+      );
+
+    return [
+      for (final pole in orderedPoles)
+        SwipeGroup(
+          pole: pole,
+          label: _groupLabel(pole, byPole[pole]!, selectedThemes),
+          cards: byPole[pole]!,
+        ),
+    ];
+  }
+
+  /// Poids d'ordonnancement d'un groupe (plus petit = plus tôt). `perspective`
+  /// reste toujours en fin (poids élevé non touché par les prefs).
+  static double _poleOrderWeight(
+    SwipeAxisPole pole,
+    String? independencePref,
+    String? depthPref,
+  ) {
+    var w = switch (pole) {
+      SwipeAxisPole.mainstream => 2.0,
+      SwipeAxisPole.established => 2.5,
+      SwipeAxisPole.deep => 3.0,
+      SwipeAxisPole.independent => 4.0,
+      SwipeAxisPole.perspective => 9.0,
+    };
+    if (independencePref == 'independent') {
+      w = switch (pole) {
+        SwipeAxisPole.independent => 0.0,
+        SwipeAxisPole.deep => 1.0,
+        SwipeAxisPole.mainstream => 5.0,
+        SwipeAxisPole.established => 6.0,
+        SwipeAxisPole.perspective => 9.0,
+      };
+    } else if (independencePref == 'established') {
+      w = switch (pole) {
+        SwipeAxisPole.established => 0.0,
+        SwipeAxisPole.mainstream => 1.0,
+        SwipeAxisPole.deep => 4.0,
+        SwipeAxisPole.independent => 6.0,
+        SwipeAxisPole.perspective => 9.0,
+      };
+    }
+    // Préférence « analyse de fond » : remonte le fond (jamais devant
+    // perspective, qui garde son poids élevé).
+    if (depthPref == 'detailed' && pole == SwipeAxisPole.deep) {
+      w -= 2.5;
+    }
+    return w;
+  }
+
+  /// Libellé d'un groupe : « mix type + thème ». Spécialise si le groupe est
+  /// cohérent sur un thème des prefs (majorité stricte des cartes), sinon
+  /// libellé par pôle. Le pôle `perspective` (relatif) n'est jamais thématisé.
+  static String _groupLabel(
+    SwipeAxisPole pole,
+    List<SpanningSource> cards,
+    List<String> selectedThemes,
+  ) {
+    if (pole != SwipeAxisPole.perspective && selectedThemes.isNotEmpty) {
+      final themed = _dominantPrefTheme(cards, selectedThemes);
+      if (themed != null) {
+        final label = cards
+            .firstWhere((c) => c.source.theme == themed)
+            .source
+            .getThemeLabel();
+        final template = pole == SwipeAxisPole.deep
+            ? OnboardingStrings.swipeGroupThemedDeep
+            : OnboardingStrings.swipeGroupThemedDefault;
+        return template.replaceFirst('%s', label);
+      }
+    }
+    return switch (pole) {
+      SwipeAxisPole.deep => OnboardingStrings.swipeGroupDeep,
+      SwipeAxisPole.independent => OnboardingStrings.swipeGroupIndependent,
+      SwipeAxisPole.established => OnboardingStrings.swipeGroupEstablished,
+      SwipeAxisPole.mainstream => OnboardingStrings.swipeGroupMainstream,
+      SwipeAxisPole.perspective => OnboardingStrings.swipeGroupPerspective,
+    };
+  }
+
+  /// Thème dominant (parmi les prefs) d'un groupe de cartes : thème principal
+  /// le plus fréquent qui appartient aux thèmes choisis, retenu seulement s'il
+  /// couvre une **majorité stricte** des cartes du groupe (groupe « cohérent »).
+  static String? _dominantPrefTheme(
+    List<SpanningSource> cards,
+    List<String> selectedThemes,
+  ) {
+    final counts = <String, int>{};
+    for (final c in cards) {
+      final t = c.source.theme;
+      if (t != null && selectedThemes.contains(t)) {
+        counts[t] = (counts[t] ?? 0) + 1;
+      }
+    }
+    if (counts.isEmpty) return null;
+    String? best;
+    var bestCount = 0;
+    counts.forEach((theme, count) {
+      if (count > bestCount) {
+        bestCount = count;
+        best = theme;
+      }
+    });
+    return bestCount * 2 > cards.length ? best : null;
   }
 
   /// Pôle(s) d'axe *intrinsèque(s)* d'une source — utilisé pour généraliser le

--- a/apps/mobile/lib/features/onboarding/onboarding_strings.dart
+++ b/apps/mobile/lib/features/onboarding/onboarding_strings.dart
@@ -101,8 +101,8 @@ class OnboardingStrings {
 
   // Swipe désambiguateur (Q9c bis, v6) : quelques sources étalées sur les axes
   // (profondeur, indépendance, perspective) que l'utilisateur trie d'un geste.
-  // Glisser à droite = ça m'intéresse ; gauche = pas pour moi.
-  static const String swipeTitle = 'Quels médias suivre ?';
+  // Glisser à droite = ça m'intéresse ; gauche = pas pour moi. (Le titre statique
+  // a été remplacé par des en-têtes dynamiques par groupe, cf. swipeGroup*.)
   static const String swipeSubtitle =
       'Glisse à droite ceux qui te parlent, à gauche les autres. '
       'On ajuste tes suggestions en direct.';
@@ -116,7 +116,18 @@ class OnboardingStrings {
   static const String swipeProgressMiddle = 'On affine (%d/%d)';
   static const String swipeProgressEnd = 'Encore quelques-unes (%d/%d)';
   // Nudge discret sur la 1ère carte (disparaît au 1er geste).
-  static const String swipeTapHint = 'Touche pour explorer';
+  static const String swipeTapHint = 'Touche pour ouvrir le média';
+
+  // En-têtes dynamiques par groupe de cartes (mix type + thème). Le libellé
+  // affiché suit le groupe de la carte du dessus et change d'un bloc à l'autre.
+  // Tournure douce/humaine, sans em-dash (règle PO). « %s » = libellé de thème.
+  static const String swipeGroupThemedDeep = 'Pour creuser %s…';
+  static const String swipeGroupThemedDefault = 'Un peu de %s…';
+  static const String swipeGroupDeep = 'Pour aller au fond…';
+  static const String swipeGroupIndependent = 'Des médias indépendants';
+  static const String swipeGroupEstablished = 'Quelques médias traditionnels';
+  static const String swipeGroupMainstream = 'L\'actu au quotidien';
+  static const String swipeGroupPerspective = 'Un autre point de vue';
   // Profil révélé en direct, en phrase inline sous le deck (remplace les chips
   // du haut). Suivi des libellés de pôles nets-positifs joints par virgules.
   static const String swipeProfileInline = 'On retient pour ta sélection : ';

--- a/apps/mobile/lib/features/onboarding/screens/questions/sources_question.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/sources_question.dart
@@ -18,8 +18,8 @@ import '../../providers/onboarding_provider.dart';
 import '../../widgets/add_subscription_card.dart';
 import '../../widgets/onboarding_toggle_section.dart';
 import '../../widgets/premium_sources_sheet.dart';
+import '../../widgets/source_carousel.dart';
 import '../../widgets/source_catalog_section.dart';
-import '../../widgets/source_recommendation_card.dart';
 
 /// Q10 : page sources « sur mesure », 4 blocs numérotés (①②③④).
 ///
@@ -40,6 +40,11 @@ class _SourcesQuestionState extends ConsumerState<SourcesQuestion> {
   bool _hasAppliedPreselection = false;
   SourceRecommendation? _recommendation;
   List<RecommendedSource>? _suggestions;
+
+  /// Sources likées au swipe, résolues en [Source] : récapitulées en tête de la
+  /// section 1 (puces discrètes « Déjà ajoutés »), exclues des suggestions et
+  /// pré-cochées.
+  List<Source> _alreadyAdded = const [];
 
   /// Accordéon piloté : index de la section ouverte (1→4). Une seule à la fois ;
   /// le bouton « Suivant » ouvre la suivante, et sur la dernière il valide.
@@ -96,6 +101,12 @@ class _SourcesQuestionState extends ConsumerState<SourcesQuestion> {
       hasThemes: themes.isNotEmpty,
       excludedIds: swipeLiked.toSet(),
     );
+    // Récap « Déjà ajoutés » : sources likées au swipe, dans l'ordre du like.
+    final byId = {for (final s in allSources) s.id: s};
+    _alreadyAdded = [
+      for (final id in swipeLiked)
+        if (byId[id] != null) byId[id]!,
+    ];
     _preloadSuggestionProfiles(_suggestions!);
 
     // Pré-sélection : top `_preselectLimit` des suggestions (déjà triées) +
@@ -369,18 +380,28 @@ class _SourcesQuestionState extends ConsumerState<SourcesQuestion> {
         description: OnboardingStrings.sourcesBlockSuggestionsDesc,
         expanded: _openSection == 1,
         onToggle: () => setState(() => _openSection = 1),
-        child: suggestions.isEmpty
-            ? Text(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (_alreadyAdded.isNotEmpty)
+              _AlreadyAddedSources(sources: _alreadyAdded),
+            if (suggestions.isEmpty)
+              Text(
                 OnboardingStrings.q9EmptyList,
                 style: Theme.of(context)
                     .textTheme
                     .bodyMedium
                     ?.copyWith(color: colors.textSecondary),
               )
-            : Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: suggestions.map(_buildSuggestionCard).toList(),
+            else
+              SourceCarousel(
+                sources: suggestions,
+                selectedIds: _selectedSourceIds,
+                onToggle: _toggleSource,
+                onInfoTap: _showSourceDetail,
               ),
+          ],
+        ),
       ),
       const SizedBox(height: FacteurSpacing.space4),
 
@@ -429,18 +450,6 @@ class _SourcesQuestionState extends ConsumerState<SourcesQuestion> {
 
   // ── Briques partagées ────────────────────────────────────────────────────
 
-  Widget _buildSuggestionCard(RecommendedSource r) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: FacteurSpacing.space2),
-      child: SourceRecommendationCard(
-        recommendation: r,
-        isSelected: _selectedSourceIds.contains(r.source.id),
-        onToggle: () => _toggleSource(r.source.id),
-        onInfoTap: () => _showSourceDetail(r.source),
-      ),
-    );
-  }
-
   Widget _buildEmbeddedAddPanel() {
     return SourceAddPanel(
       padding: EdgeInsets.zero,
@@ -456,6 +465,9 @@ class _SourcesQuestionState extends ConsumerState<SourcesQuestion> {
   }
 }
 
+/// Récap discret des sources déjà ajoutées (likées au swipe), en tête de la
+/// section « Tes suggestions » : libellé léger + puces fines (logo ~18px + nom,
+/// fond très subtil). Ces sources sont déjà cochées et hors des suggestions.
 class _AlreadyAddedSources extends StatelessWidget {
   final List<Source> sources;
 
@@ -465,44 +477,40 @@ class _AlreadyAddedSources extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
     return Padding(
-      padding: const EdgeInsets.only(bottom: FacteurSpacing.space4),
+      padding: const EdgeInsets.only(bottom: FacteurSpacing.space3),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            'Déjà ajoutées',
-            style: Theme.of(context).textTheme.titleSmall?.copyWith(
-              color: colors.textPrimary,
-              fontWeight: FontWeight.w700,
-            ),
+            'Déjà ajoutés',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: colors.textTertiary,
+                ),
           ),
-          const SizedBox(height: FacteurSpacing.space2),
+          const SizedBox(height: 6),
           Wrap(
-            spacing: FacteurSpacing.space2,
-            runSpacing: FacteurSpacing.space2,
+            spacing: 6,
+            runSpacing: 6,
             children: [
               for (final source in sources)
                 Container(
                   padding: const EdgeInsets.symmetric(
-                    horizontal: 10,
-                    vertical: 8,
+                    horizontal: 8,
+                    vertical: 5,
                   ),
                   decoration: BoxDecoration(
-                    color: colors.primary.withOpacity(0.08),
-                    borderRadius: BorderRadius.circular(FacteurRadius.medium),
-                    border: Border.all(color: colors.primary.withOpacity(0.18)),
+                    color: colors.textPrimary.withOpacity(0.04),
+                    borderRadius: BorderRadius.circular(FacteurRadius.pill),
                   ),
                   child: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      SourceLogoAvatar(source: source, size: 22, radius: 6),
-                      const SizedBox(width: 7),
+                      SourceLogoAvatar(source: source, size: 18, radius: 5),
+                      const SizedBox(width: 6),
                       Text(
                         source.name,
-                        style: Theme.of(context).textTheme.labelMedium
-                            ?.copyWith(
-                              color: colors.textPrimary,
-                              fontWeight: FontWeight.w600,
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: colors.textSecondary,
                             ),
                       ),
                     ],

--- a/apps/mobile/lib/features/onboarding/screens/questions/swipe_disambiguator_question.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/swipe_disambiguator_question.dart
@@ -54,6 +54,10 @@ class _SwipeDisambiguatorQuestionState
     with SingleTickerProviderStateMixin {
   /// File des cartes restantes : le **dernier** élément est la carte du dessus.
   List<SpanningSource>? _queue;
+
+  /// Libellé d'en-tête (groupe) par id de source : l'en-tête affiche celui de la
+  /// carte du dessus et change quand on passe d'un bloc à l'autre.
+  final Map<String, String> _groupLabelById = {};
   int _total = 0;
   final List<String> _liked = [];
   final List<String> _disliked = [];
@@ -124,18 +128,30 @@ class _SwipeDisambiguatorQuestionState
   void _ensureBuilt(List<Source> sources) {
     if (_queue != null) return;
     final answers = ref.read(onboardingProvider).answers;
-    final set = SourceRecommender.buildSpanningSet(
+    // Groupes contigus par pôle, ordonnés par les prefs déclarées (le set de
+    // cartes est inchangé ⇒ même calibration), chaque carte portant le libellé
+    // d'en-tête de son groupe.
+    final groups = SourceRecommender.buildSpanningGroups(
       selectedThemes: answers.themes ?? const [],
       selectedSubtopics: answers.subtopics ?? const [],
       allSources: sources,
+      independencePref: answers.independencePref,
+      depthPref: answers.approach,
     );
-    _queue = set.reversed.toList(); // dernier = première carte montrée
-    _total = set.length;
+    final flat = <SpanningSource>[];
+    for (final group in groups) {
+      for (final card in group.cards) {
+        flat.add(card);
+        _groupLabelById[card.source.id] = group.label;
+      }
+    }
+    _queue = flat.reversed.toList(); // dernier = première carte montrée
+    _total = flat.length;
     _preloadTopProfiles();
 
     // Rien à montrer (catalogue indisponible / thèmes trop pauvres) → on saute
     // l'étape sans bloquer le parcours.
-    if (set.isEmpty) {
+    if (flat.isEmpty) {
       WidgetsBinding.instance.addPostFrameCallback((_) => _complete());
     }
   }
@@ -330,6 +346,8 @@ class _SwipeDisambiguatorQuestionState
         final queue = _queue ?? const <SpanningSource>[];
         final remaining = queue.length;
         final current = _total - remaining + 1;
+        final groupLabel =
+            queue.isNotEmpty ? (_groupLabelById[queue.last.source.id] ?? '') : '';
 
         final content = Padding(
           padding: const EdgeInsets.symmetric(
@@ -339,32 +357,50 @@ class _SwipeDisambiguatorQuestionState
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               const SizedBox(height: FacteurSpacing.space4),
-              Text(
-                OnboardingStrings.swipeTitle,
-                style: Theme.of(context).textTheme.displayLarge,
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: FacteurSpacing.space3),
+              // En-tête dynamique : libellé du groupe de la carte du dessus
+              // (remplace l'ancien titre statique), animé au changement de bloc.
+              if (groupLabel.isNotEmpty)
+                AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 250),
+                  child: Text(
+                    groupLabel,
+                    key: ValueKey(groupLabel),
+                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                          fontWeight: FontWeight.w700,
+                        ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              const SizedBox(height: FacteurSpacing.space2),
               Text(
                 OnboardingStrings.swipeSubtitle,
                 style: Theme.of(
                   context,
-                ).textTheme.bodyMedium?.copyWith(color: colors.textSecondary),
+                ).textTheme.bodySmall?.copyWith(color: colors.textSecondary),
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: FacteurSpacing.space2),
               if (remaining > 0)
                 Text(
                   _humanizedProgress(current, _total),
-                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        color: colors.textSecondary,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: colors.textTertiary,
                         fontWeight: FontWeight.w600,
                       ),
                   textAlign: TextAlign.center,
                 ),
               _buildCalibratingHint(context),
-              Expanded(child: _buildCardArea(context, queue)),
-              _buildTapHint(context, isFirstCard: remaining == _total),
+              // Deck centré verticalement dans l'espace restant, avec l'indice
+              // « toucher » directement sous la carte (B.1 + B.3).
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Flexible(child: _buildCardArea(context, queue)),
+                    _buildTapHint(context, isFirstCard: remaining == _total),
+                  ],
+                ),
+              ),
               if (remaining > 0) ...[
                 _buildProfileInline(context),
                 _buildActions(context, queue.last),
@@ -789,7 +825,7 @@ class _SwipeDisambiguatorQuestionState
       child: !show
           ? const SizedBox(width: double.infinity)
           : Padding(
-              padding: const EdgeInsets.only(top: FacteurSpacing.space3),
+              padding: const EdgeInsets.only(top: FacteurSpacing.space2),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
@@ -811,40 +847,68 @@ class _SwipeDisambiguatorQuestionState
     );
   }
 
+  /// Diamètre extérieur du bouton « revenir » secondaire (et de son placeholder
+  /// symétrique) : garde (X)/(V) centrés que l'undo soit visible ou non.
+  static const double _undoButtonSize = 44;
+
   Widget _buildActions(BuildContext context, SpanningSource top) {
     final colors = context.facteurColors;
-    return Column(
-      mainAxisSize: MainAxisSize.min,
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        if (_canUndoSwipe) ...[
-          TextButton.icon(
-            onPressed: _undoLastSwipe,
-            icon: const Icon(Icons.undo_rounded, size: 18),
-            label: const Text(OnboardingStrings.swipeUndoLabel),
-          ),
-          const SizedBox(height: FacteurSpacing.space2),
-        ],
-        Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            _actionButton(
-              context,
-              icon: Icons.close_rounded,
-              color: colors.textSecondary,
-              tooltip: OnboardingStrings.swipeSkipHint,
-              onTap: () => _flingOut(top, liked: false),
-            ),
-            const SizedBox(width: FacteurSpacing.space8),
-            _actionButton(
-              context,
-              icon: Icons.favorite_rounded,
-              color: colors.success,
-              tooltip: OnboardingStrings.swipeLikeHint,
-              onTap: () => _flingOut(top, liked: true),
-            ),
-          ],
+        // « Revenir au média précédent » discret, à gauche de (X)/(V). Réserve
+        // toujours sa place (placeholder) pour ne pas décaler le centre.
+        SizedBox(
+          width: _undoButtonSize,
+          height: _undoButtonSize,
+          child: _canUndoSwipe ? _undoButton(context) : null,
         ),
+        const SizedBox(width: FacteurSpacing.space6),
+        _actionButton(
+          context,
+          icon: Icons.close_rounded,
+          color: colors.textSecondary,
+          tooltip: OnboardingStrings.swipeSkipHint,
+          onTap: () => _flingOut(top, liked: false),
+        ),
+        const SizedBox(width: FacteurSpacing.space8),
+        _actionButton(
+          context,
+          icon: Icons.favorite_rounded,
+          color: colors.success,
+          tooltip: OnboardingStrings.swipeLikeHint,
+          onTap: () => _flingOut(top, liked: true),
+        ),
+        const SizedBox(width: FacteurSpacing.space6),
+        // Placeholder symétrique (équilibre l'undo de gauche).
+        const SizedBox(width: _undoButtonSize, height: _undoButtonSize),
       ],
+    );
+  }
+
+  /// Bouton circulaire secondaire « revenir au média précédent » : plus petit et
+  /// plus discret que (X)/(V), icône `undo_rounded` en teinte tertiaire.
+  Widget _undoButton(BuildContext context) {
+    final colors = context.facteurColors;
+    return Semantics(
+      button: true,
+      label: OnboardingStrings.swipeUndoLabel,
+      child: Material(
+        color: colors.surface,
+        shape: CircleBorder(side: BorderSide(color: colors.border)),
+        child: InkWell(
+          customBorder: const CircleBorder(),
+          onTap: _undoLastSwipe,
+          child: Padding(
+            padding: const EdgeInsets.all(FacteurSpacing.space3),
+            child: Icon(
+              Icons.undo_rounded,
+              color: colors.textTertiary,
+              size: 20,
+            ),
+          ),
+        ),
+      ),
     );
   }
 

--- a/apps/mobile/lib/features/onboarding/widgets/source_carousel.dart
+++ b/apps/mobile/lib/features/onboarding/widgets/source_carousel.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+import '../../../config/theme.dart';
+import '../../sources/models/source_model.dart';
+import '../data/source_recommender.dart';
+import 'source_carousel_card.dart';
+
+/// Carrousel horizontal de sources recommandées : un `PageView` de
+/// [SourceCarouselCard] à hauteur fixe, `viewportFraction` < 1 pour laisser
+/// entrevoir la carte suivante (peek) et inviter au swipe latéral.
+///
+/// Remplace les longues listes verticales des suggestions / du catalogue dans
+/// la page « Tes médias, sur mesure » : plus lisible, hiérarchie claire.
+class SourceCarousel extends StatefulWidget {
+  final List<RecommendedSource> sources;
+  final Set<String> selectedIds;
+  final ValueChanged<String> onToggle;
+  final ValueChanged<Source> onInfoTap;
+
+  /// Affiche les tags/raison de match sur chaque carte (faux pour le catalogue).
+  final bool showReason;
+
+  /// Hauteur fixe du carrousel (cartes bornées et lisibles).
+  final double height;
+
+  const SourceCarousel({
+    super.key,
+    required this.sources,
+    required this.selectedIds,
+    required this.onToggle,
+    required this.onInfoTap,
+    this.showReason = true,
+    this.height = 188,
+  });
+
+  @override
+  State<SourceCarousel> createState() => _SourceCarouselState();
+}
+
+class _SourceCarouselState extends State<SourceCarousel> {
+  late final PageController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    // ~1,2 carte visible : la suivante dépasse (peek) pour signaler le swipe.
+    _controller = PageController(viewportFraction: 0.82);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.sources.isEmpty) return const SizedBox.shrink();
+
+    return SizedBox(
+      height: widget.height,
+      child: PageView.builder(
+        controller: _controller,
+        padEnds: false,
+        itemCount: widget.sources.length,
+        itemBuilder: (context, index) {
+          final r = widget.sources[index];
+          return Padding(
+            padding: const EdgeInsets.only(right: FacteurSpacing.space3),
+            child: SourceCarouselCard(
+              recommendation: r,
+              isSelected: widget.selectedIds.contains(r.source.id),
+              onToggle: () => widget.onToggle(r.source.id),
+              onInfoTap: () => widget.onInfoTap(r.source),
+              showReason: widget.showReason,
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/onboarding/widgets/source_carousel_card.dart
+++ b/apps/mobile/lib/features/onboarding/widgets/source_carousel_card.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../../config/theme.dart';
+import '../../sources/widgets/source_logo_avatar.dart';
+import '../data/source_recommender.dart';
+import 'source_reco_tag.dart';
+
+/// Carte portrait d'une source recommandée, pensée pour le carrousel horizontal
+/// de l'onboarding (`SourceCarousel`). Plus aérée que la `Row` dense de
+/// [SourceRecommendationCard] : logo + nom + pastille de biais en tête, les
+/// **aspects matchés** (tags du recommender) mis en valeur au cœur, et une zone
+/// de sélection claire (≥44px).
+///
+/// Tap sur la carte → [onInfoTap] (modale détail). Tap sur le cercle → [onToggle].
+class SourceCarouselCard extends StatelessWidget {
+  final RecommendedSource recommendation;
+  final bool isSelected;
+  final VoidCallback onToggle;
+  final VoidCallback onInfoTap;
+
+  /// Affiche les tags/raison de match. Faux pour le catalogue brut (section 3),
+  /// dont les sources n'ont pas de raison de reco spécifique.
+  final bool showReason;
+
+  const SourceCarouselCard({
+    super.key,
+    required this.recommendation,
+    required this.isSelected,
+    required this.onToggle,
+    required this.onInfoTap,
+    this.showReason = true,
+  });
+
+  /// Nombre max de tags affichés (garde une hauteur lisible et bornée).
+  static const int _maxTags = 3;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final source = recommendation.source;
+    final tags = showReason
+        ? recommendation.tags.take(_maxTags).toList()
+        : const <RecommendationTag>[];
+
+    return GestureDetector(
+      onTap: () {
+        HapticFeedback.lightImpact();
+        onInfoTap();
+      },
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 150),
+        curve: Curves.easeOut,
+        padding: const EdgeInsets.all(FacteurSpacing.space4),
+        decoration: BoxDecoration(
+          color: colors.surface,
+          borderRadius: BorderRadius.circular(FacteurRadius.large),
+          border: Border.all(
+            color: isSelected
+                ? colors.primary.withOpacity(0.4)
+                : colors.border.withOpacity(0.3),
+            width: isSelected ? 1.5 : 1,
+          ),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // ── En-tête : logo + nom + sélection ──────────────────────────
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SourceLogoAvatar(source: source, size: 40, radius: 10),
+                const SizedBox(width: FacteurSpacing.space3),
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.only(top: 2),
+                    child: Text(
+                      source.name,
+                      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                            color: colors.textPrimary,
+                            fontWeight: FontWeight.w700,
+                          ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ),
+                _selectionCircle(context),
+              ],
+            ),
+
+            // ── Pastille de biais (display-only) ──────────────────────────
+            if (source.biasStance != 'unknown') ...[
+              const SizedBox(height: FacteurSpacing.space2),
+              Row(
+                children: [
+                  Container(
+                    width: 7,
+                    height: 7,
+                    decoration: BoxDecoration(
+                      color: source.getBiasColor(),
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                  const SizedBox(width: 6),
+                  Text(
+                    source.getBiasLabel(),
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: colors.textTertiary,
+                        ),
+                  ),
+                ],
+              ),
+            ],
+
+            const SizedBox(height: FacteurSpacing.space3),
+
+            // ── Cœur : aspects matchés (tags) ou raison ───────────────────
+            Expanded(
+              child: Align(
+                alignment: Alignment.topLeft,
+                child: SingleChildScrollView(
+                  physics: const NeverScrollableScrollPhysics(),
+                  child: _matchBody(context, tags),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _matchBody(BuildContext context, List<RecommendationTag> tags) {
+    final colors = context.facteurColors;
+    if (tags.isNotEmpty) {
+      return Wrap(
+        spacing: 6,
+        runSpacing: 6,
+        children: [for (final tag in tags) SourceRecoTag(tag: tag)],
+      );
+    }
+    if (showReason && recommendation.reason.isNotEmpty) {
+      return Text(
+        recommendation.reason,
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: colors.textSecondary,
+              fontStyle: recommendation.category == SourceCategory.gem
+                  ? FontStyle.italic
+                  : FontStyle.normal,
+            ),
+        maxLines: 3,
+        overflow: TextOverflow.ellipsis,
+      );
+    }
+    return const SizedBox.shrink();
+  }
+
+  Widget _selectionCircle(BuildContext context) {
+    final colors = context.facteurColors;
+    return GestureDetector(
+      onTap: () {
+        HapticFeedback.lightImpact();
+        onToggle();
+      },
+      behavior: HitTestBehavior.opaque,
+      child: Padding(
+        padding: const EdgeInsets.all(10),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 150),
+          width: 24,
+          height: 24,
+          decoration: BoxDecoration(
+            color: isSelected ? colors.primary : Colors.transparent,
+            border: Border.all(
+              color: isSelected ? colors.primary : colors.textTertiary,
+              width: isSelected ? 0 : 1.5,
+            ),
+            shape: BoxShape.circle,
+          ),
+          child: isSelected
+              ? const Icon(Icons.check, size: 16, color: Colors.white)
+              : null,
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/onboarding/widgets/source_catalog_section.dart
+++ b/apps/mobile/lib/features/onboarding/widgets/source_catalog_section.dart
@@ -4,7 +4,7 @@ import '../../../config/theme.dart';
 import '../../sources/models/source_model.dart';
 import '../../sources/widgets/theme_filter_chips.dart';
 import '../data/source_recommender.dart';
-import '../widgets/source_recommendation_card.dart';
+import '../widgets/source_carousel.dart';
 
 /// Catalogue des médias à parcourir, filtrable par thème via des chips
 /// horizontales — reprend le pattern de la feature « Catalogue de sources » de
@@ -65,17 +65,15 @@ class _SourceCatalogSectionState extends State<SourceCatalogSection> {
             ),
           )
         else
-          ...filtered.map(
-            (r) => Padding(
-              padding: const EdgeInsets.only(bottom: FacteurSpacing.space2),
-              child: SourceRecommendationCard(
-                recommendation: r,
-                isSelected: widget.selectedIds.contains(r.source.id),
-                onToggle: () => widget.onToggle(r.source.id),
-                onInfoTap: () => widget.onInfoTap(r.source),
-                showReason: false,
-              ),
-            ),
+          SourceCarousel(
+            // Recrée le carrousel (et son PageController) au changement de
+            // filtre pour repartir de la 1ère carte du thème.
+            key: ValueKey(_selectedTheme),
+            sources: filtered,
+            selectedIds: widget.selectedIds,
+            onToggle: widget.onToggle,
+            onInfoTap: widget.onInfoTap,
+            showReason: false,
           ),
       ],
     );

--- a/apps/mobile/lib/features/onboarding/widgets/source_reco_tag.dart
+++ b/apps/mobile/lib/features/onboarding/widgets/source_reco_tag.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+import '../../../config/theme.dart';
+import '../data/source_recommender.dart';
+
+/// Petite puce affichant un [RecommendationTag] (thème, « Spécialisé en X »,
+/// « Similaire à … », fiable, anti-bruit, serein). Partagée entre la carte
+/// liste ([SourceRecommendationCard]) et la carte carrousel
+/// ([SourceCarouselCard]) pour éviter toute duplication du style.
+///
+/// Les puces « pourquoi » (spécialiste / similaire / fiable / anti-bruit)
+/// ressortent en teinte primary ; les tags purement thématiques restent
+/// neutres.
+class SourceRecoTag extends StatelessWidget {
+  final RecommendationTag tag;
+
+  const SourceRecoTag({super.key, required this.tag});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+
+    final prefix = switch (tag.type) {
+      RecommendationTagType.topic => '',
+      RecommendationTagType.specialist => '\u{1F3AF} ',
+      RecommendationTagType.antiBruit => '\u{1F507} ',
+      RecommendationTagType.fiable => '✓ ',
+      RecommendationTagType.serein => '☀ ',
+      RecommendationTagType.similar => '≈ ',
+    };
+
+    final highlighted = switch (tag.type) {
+      RecommendationTagType.specialist ||
+      RecommendationTagType.similar ||
+      RecommendationTagType.fiable ||
+      RecommendationTagType.antiBruit => true,
+      _ => false,
+    };
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: highlighted
+            ? colors.primary.withOpacity(0.08)
+            : colors.textPrimary.withOpacity(0.05),
+        borderRadius: BorderRadius.circular(FacteurRadius.pill),
+      ),
+      child: Text(
+        '$prefix${tag.label}',
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: highlighted ? colors.primary : colors.textSecondary,
+              fontSize: 11,
+              fontWeight: highlighted ? FontWeight.w600 : null,
+            ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/onboarding/widgets/source_recommendation_card.dart
+++ b/apps/mobile/lib/features/onboarding/widgets/source_recommendation_card.dart
@@ -5,6 +5,7 @@ import '../../../config/theme.dart';
 import '../../../widgets/design/facteur_image.dart';
 import '../../sources/models/source_model.dart';
 import '../data/source_recommender.dart';
+import 'source_reco_tag.dart';
 
 /// Card widget for a recommended source in the onboarding sources screen.
 ///
@@ -139,7 +140,7 @@ class SourceRecommendationCard extends StatelessWidget {
                           _buildTypeChip(context, source),
                         if (showReason)
                           ...recommendation.tags
-                              .map((tag) => _buildTag(context, tag)),
+                              .map((tag) => SourceRecoTag(tag: tag)),
                       ],
                     ),
                   ],
@@ -273,45 +274,4 @@ class SourceRecommendationCard extends StatelessWidget {
     );
   }
 
-  /// Builds a small chip for a recommendation tag.
-  Widget _buildTag(BuildContext context, RecommendationTag tag) {
-    final colors = context.facteurColors;
-
-    final prefix = switch (tag.type) {
-      RecommendationTagType.topic => '',
-      RecommendationTagType.specialist => '\u{1F3AF} ', // \ud83c\udfaf
-      RecommendationTagType.antiBruit => '\u{1F507} ',
-      RecommendationTagType.fiable => '\u2713 ',
-      RecommendationTagType.serein => '\u2600 ',
-      RecommendationTagType.similar => '\u2248 ', // \u2248
-    };
-
-    // Les chips \u00ab pourquoi \u00bb (sp\u00e9cialiste / similaire / fiable / anti-bruit)
-    // ressortent en teinte primary ; les tags purement th\u00e9matiques restent neutres.
-    final highlighted = switch (tag.type) {
-      RecommendationTagType.specialist ||
-      RecommendationTagType.similar ||
-      RecommendationTagType.fiable ||
-      RecommendationTagType.antiBruit => true,
-      _ => false,
-    };
-
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
-      decoration: BoxDecoration(
-        color: highlighted
-            ? colors.primary.withOpacity(0.08)
-            : colors.textPrimary.withOpacity(0.05),
-        borderRadius: BorderRadius.circular(FacteurRadius.pill),
-      ),
-      child: Text(
-        '$prefix${tag.label}',
-        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-          color: highlighted ? colors.primary : colors.textSecondary,
-          fontSize: 11,
-          fontWeight: highlighted ? FontWeight.w600 : null,
-        ),
-      ),
-    );
-  }
 }

--- a/apps/mobile/test/features/onboarding/data/source_recommender_test.dart
+++ b/apps/mobile/test/features/onboarding/data/source_recommender_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:facteur/features/onboarding/data/source_recommender.dart';
+import 'package:facteur/features/onboarding/onboarding_strings.dart';
 import 'package:facteur/features/sources/models/source_model.dart';
 
 Source _curated(String id, {String reliability = 'high', String? theme}) {
@@ -707,6 +708,124 @@ void main() {
 
       final specialistIds = reco.specialists.map((r) => r.source.id).toSet();
       expect(specialistIds, containsAll(<String>['fc', 'rel']));
+    });
+  });
+
+  group('SourceRecommender.buildSpanningGroups — groupes contigus', () {
+    // Un représentant net par pôle (mainstream / deep / indépendant / établi).
+    List<Source> spanningDeck() => [
+          _src('main', tier: 'mainstream', articles30d: 50),
+          _src('deep', tier: 'deep', articles30d: 50),
+          _src('indie', independence: 0.9, bias: 'alternative'),
+          _src('estab', reliability: 'high', independence: 0.2),
+        ];
+
+    int poleIndex(List<SwipeGroup> groups, SwipeAxisPole pole) =>
+        groups.indexWhere((g) => g.pole == pole);
+
+    test('regroupe les cartes en blocs contigus par pôle (pas de doublon)', () {
+      final groups = SourceRecommender.buildSpanningGroups(
+        selectedThemes: const [],
+        selectedSubtopics: const [],
+        allSources: spanningDeck(),
+      );
+      // Un groupe par pôle présent, chaque pôle apparaît une seule fois.
+      final poles = groups.map((g) => g.pole).toList();
+      expect(poles.toSet().length, poles.length);
+      // Mêmes cartes que le spanning set sous-jacent (calibration inchangée).
+      final flat = groups.expand((g) => g.cards).map((c) => c.source.id).toSet();
+      expect(flat, {'main', 'deep', 'indie', 'estab'});
+    });
+
+    test('independencePref « independent » mène avec indépendant/fond', () {
+      final groups = SourceRecommender.buildSpanningGroups(
+        selectedThemes: const [],
+        selectedSubtopics: const [],
+        allSources: spanningDeck(),
+        independencePref: 'independent',
+      );
+      expect(
+        poleIndex(groups, SwipeAxisPole.independent),
+        lessThan(poleIndex(groups, SwipeAxisPole.mainstream)),
+      );
+      expect(
+        poleIndex(groups, SwipeAxisPole.deep),
+        lessThan(poleIndex(groups, SwipeAxisPole.established)),
+      );
+    });
+
+    test('independencePref « established » mène avec établis/grands médias', () {
+      final groups = SourceRecommender.buildSpanningGroups(
+        selectedThemes: const [],
+        selectedSubtopics: const [],
+        allSources: spanningDeck(),
+        independencePref: 'established',
+      );
+      expect(
+        poleIndex(groups, SwipeAxisPole.established),
+        lessThan(poleIndex(groups, SwipeAxisPole.independent)),
+      );
+      expect(
+        poleIndex(groups, SwipeAxisPole.mainstream),
+        lessThan(poleIndex(groups, SwipeAxisPole.independent)),
+      );
+    });
+
+    test('depthPref « detailed » remonte le groupe « fond » en tête', () {
+      final groups = SourceRecommender.buildSpanningGroups(
+        selectedThemes: const [],
+        selectedSubtopics: const [],
+        allSources: spanningDeck(),
+        depthPref: 'detailed',
+      );
+      expect(groups.first.pole, SwipeAxisPole.deep);
+    });
+
+    test('libellé thématique quand le groupe est cohérent sur un thème pref',
+        () {
+      final sources = [
+        _src('d1', tier: 'deep', theme: 'tech'),
+        _src('d2', tier: 'deep', theme: 'tech'),
+        _src('m1', tier: 'mainstream', theme: 'society'),
+      ];
+      final groups = SourceRecommender.buildSpanningGroups(
+        selectedThemes: const ['tech'],
+        selectedSubtopics: const [],
+        allSources: sources,
+      );
+
+      final deepGroup =
+          groups.firstWhere((g) => g.pole == SwipeAxisPole.deep);
+      expect(
+        deepGroup.label,
+        OnboardingStrings.swipeGroupThemedDeep
+            .replaceFirst('%s', 'Tech & Innovation'),
+      );
+
+      // Le groupe mainstream (thème society hors prefs) garde un libellé de pôle.
+      final mainGroup =
+          groups.firstWhere((g) => g.pole == SwipeAxisPole.mainstream);
+      expect(mainGroup.label, OnboardingStrings.swipeGroupMainstream);
+    });
+
+    test('catalogue minimal : dégrade en un groupe à libellé de pôle', () {
+      final groups = SourceRecommender.buildSpanningGroups(
+        selectedThemes: const ['tech'],
+        selectedSubtopics: const [],
+        allSources: [_src('only', tier: 'mainstream')],
+      );
+      expect(groups, isNotEmpty);
+      expect(groups.expand((g) => g.cards).length, 1);
+      expect(groups.first.label, OnboardingStrings.swipeGroupMainstream);
+    });
+
+    test('aucune source → aucun groupe', () {
+      final groups = SourceRecommender.buildSpanningGroups(
+        selectedThemes: const ['tech'],
+        selectedSubtopics: const [],
+        allSources: const [],
+      );
+      expect(groups, isEmpty);
     });
   });
 }

--- a/apps/mobile/test/features/onboarding/screens/sources_question_test.dart
+++ b/apps/mobile/test/features/onboarding/screens/sources_question_test.dart
@@ -13,6 +13,7 @@ import 'package:facteur/features/onboarding/data/source_recommender.dart';
 import 'package:facteur/features/onboarding/providers/onboarding_provider.dart';
 import 'package:facteur/features/onboarding/screens/questions/sources_question.dart';
 import 'package:facteur/features/onboarding/widgets/onboarding_toggle_section.dart';
+import 'package:facteur/features/onboarding/widgets/source_carousel.dart';
 import 'package:facteur/features/onboarding/widgets/source_recommendation_card.dart';
 import 'package:facteur/features/sources/models/smart_search_result.dart';
 import 'package:facteur/features/sources/models/source_model.dart';
@@ -117,14 +118,20 @@ void main() {
     // Les 4 sections numérotées ①②③④ de l'accordéon sont présentes.
     expect(find.byType(OnboardingToggleSection), findsNWidgets(4));
 
-    // Section 1 ouverte par défaut : 15 sources matched → 15 cartes (≤ 18).
-    // Les sections 2/3/4 sont repliées (corps non construit) donc sans carte.
-    final cards = find.byType(SourceRecommendationCard);
-    expect(tester.widgetList(cards).length, lessThanOrEqualTo(18));
-    expect(cards, findsNWidgets(15));
+    // Section 1 ouverte par défaut : suggestions rendues dans un carrousel
+    // horizontal (15 sources matched, ≤ 18). Les sections 2/3/4 repliées n'ont
+    // pas de carrousel monté → un seul SourceCarousel sur l'écran.
+    final carousel = tester.widget<SourceCarousel>(
+      find.byType(SourceCarousel),
+    );
+    expect(carousel.sources.length, lessThanOrEqualTo(18));
+    expect(carousel.sources.length, 15);
 
     // Le gros publieur mainstream remonte dans les suggestions (volume-proxy).
-    expect(find.text('Grand Média'), findsOneWidget);
+    expect(
+      carousel.sources.any((r) => r.source.name == 'Grand Média'),
+      isTrue,
+    );
 
     // Sur la 1ère section, le bouton bas est « Suivant » (pas la validation).
     expect(find.text(OnboardingStrings.nextButton), findsOneWidget);
@@ -193,23 +200,27 @@ void main() {
       await tester.pumpWidget(buildTestWidget(container));
       await tester.pumpAndSettle();
 
-      expect(find.text('Déjà ajoutées'), findsOneWidget);
+      // Récap discret « Déjà ajoutés » alimenté par la source likée au swipe.
+      expect(find.text('Déjà ajoutés'), findsOneWidget);
       expect(find.text('Sismique'), findsOneWidget);
-      expect(
-        find.text(OnboardingStrings.selectedCount(10)),
-        findsOneWidget,
-        reason: '9 suggestions précochées + la source likée déjà validée',
-      );
 
-      final suggestionCards = tester
-          .widgetList<SourceRecommendationCard>(
-            find.byType(SourceRecommendationCard),
-          )
-          .toList();
+      // La source likée est exclue du carrousel de suggestions.
+      final carousel = tester.widget<SourceCarousel>(
+        find.byType(SourceCarousel),
+      );
       expect(
-        suggestionCards.map((c) => c.recommendation.source.id),
+        carousel.sources.map((r) => r.source.id),
         isNot(contains('sismique')),
       );
+
+      // Sur la dernière section, le bouton porte le compte sélectionné :
+      // 9 suggestions précochées + la source likée déjà validée = 10.
+      for (var i = 0; i < 3; i++) {
+        await tester.ensureVisible(find.text(OnboardingStrings.nextButton));
+        await tester.tap(find.text(OnboardingStrings.nextButton));
+        await tester.pumpAndSettle();
+      }
+      expect(find.text(OnboardingStrings.selectedCount(10)), findsOneWidget);
     },
   );
 

--- a/apps/mobile/test/features/onboarding/screens/swipe_disambiguator_question_test.dart
+++ b/apps/mobile/test/features/onboarding/screens/swipe_disambiguator_question_test.dart
@@ -45,6 +45,22 @@ Source _src(
   );
 }
 
+/// Ordre des cartes tel que l'écran l'aplatit : groupes contigus (sans prefs),
+/// concaténés. Sert à prédire la carte du dessus et l'en-tête dynamique.
+List<SpanningSource> _flatGroups(List<Source> sources) =>
+    SourceRecommender.buildSpanningGroups(
+      selectedThemes: const [],
+      selectedSubtopics: const [],
+      allSources: sources,
+    ).expand((g) => g.cards).toList();
+
+String _topGroupLabel(List<Source> sources) =>
+    SourceRecommender.buildSpanningGroups(
+      selectedThemes: const [],
+      selectedSubtopics: const [],
+      allSources: sources,
+    ).first.label;
+
 void main() {
   setUpAll(() {
     Hive.init(Directory.systemTemp.createTempSync('onb_swipe_test').path);
@@ -77,16 +93,19 @@ void main() {
     );
   }
 
-  testWidgets('rend le titre et les boutons d\'action', (tester) async {
-    final container = makeContainer([
+  testWidgets('rend l\'en-tête dynamique et les boutons d\'action',
+      (tester) async {
+    final sources = [
       _src('main', tier: 'mainstream'),
       _src('deep', tier: 'deep'),
       _src('indie', independence: 0.9, bias: 'alternative'),
-    ]);
+    ];
+    final container = makeContainer(sources);
     await tester.pumpWidget(buildTestWidget(container));
     await tester.pumpAndSettle();
 
-    expect(find.text(OnboardingStrings.swipeTitle), findsOneWidget);
+    // En-tête dynamique = libellé du groupe de la carte du dessus.
+    expect(find.text(_topGroupLabel(sources)), findsOneWidget);
     // La carte du dessus + ses boutons d'action (like / pas pour moi).
     expect(find.byIcon(Icons.favorite_rounded), findsOneWidget);
     expect(find.byIcon(Icons.close_rounded), findsOneWidget);
@@ -184,12 +203,13 @@ void main() {
   testWidgets('compteur humanisé + pas de chips de profil au départ', (
     tester,
   ) async {
-    final container = makeContainer(_richDeck());
+    final deck = _richDeck();
+    final container = makeContainer(deck);
     await tester.pumpWidget(buildTestWidget(container));
     await tester.pumpAndSettle();
 
-    // Nouveau titre.
-    expect(find.text('Quels médias suivre ?'), findsOneWidget);
+    // En-tête dynamique par groupe (remplace l'ancien titre statique).
+    expect(find.text(_topGroupLabel(deck)), findsOneWidget);
     // Compteur humanisé (palier « début »), plus jamais l'ancien « Carte X sur Y ».
     expect(find.textContaining('Premières cartes'), findsOneWidget);
     expect(find.textContaining('Carte '), findsNothing);
@@ -204,11 +224,8 @@ void main() {
     'précharge uniquement les 3 profils visibles et ignore les erreurs',
     (tester) async {
       final sources = _richDeck();
-      final expected = SourceRecommender.buildSpanningSet(
-        selectedThemes: const [],
-        selectedSubtopics: const [],
-        allSources: sources,
-      ).take(3).map((s) => s.source.id).toSet();
+      final expected =
+          _flatGroups(sources).take(3).map((s) => s.source.id).toSet();
       final preloaded = <String>[];
       final container = ProviderContainer(
         overrides: [
@@ -234,7 +251,7 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 50));
 
-      expect(find.text(OnboardingStrings.swipeTitle), findsOneWidget);
+      expect(find.text(OnboardingStrings.swipeSubtitle), findsOneWidget);
       expect(preloaded.toSet(), expected);
     },
   );
@@ -264,33 +281,32 @@ void main() {
     'bouton retour : restaure la dernière carte et permet de revoter',
     (tester) async {
       final sources = _richDeck();
-      final firstCard = SourceRecommender.buildSpanningSet(
-        selectedThemes: const [],
-        selectedSubtopics: const [],
-        allSources: sources,
-      ).first;
+      final firstCard = _flatGroups(sources).first;
       final container = makeContainer(sources);
       await tester.pumpWidget(buildTestWidget(container));
       await tester.pumpAndSettle();
 
       expect(find.text(firstCard.source.name), findsOneWidget);
+      // Pas d'undo tant qu'aucun vote.
+      expect(find.byIcon(Icons.undo_rounded), findsNothing);
 
       await tester.tap(find.widgetWithIcon(InkWell, Icons.favorite_rounded));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 400));
 
-      expect(find.text(OnboardingStrings.swipeUndoLabel), findsOneWidget);
+      // Le bouton « revenir » discret (icône seule) apparaît à gauche de X/V.
+      expect(find.byIcon(Icons.undo_rounded), findsOneWidget);
       expect(find.text(firstCard.source.name), findsNothing);
       expect(
         find.textContaining(OnboardingStrings.swipeProfileInline),
         findsOneWidget,
       );
 
-      await tester.tap(find.text(OnboardingStrings.swipeUndoLabel));
+      await tester.tap(find.widgetWithIcon(InkWell, Icons.undo_rounded));
       await tester.pumpAndSettle();
 
       expect(find.text(firstCard.source.name), findsOneWidget);
-      expect(find.text(OnboardingStrings.swipeUndoLabel), findsNothing);
+      expect(find.byIcon(Icons.undo_rounded), findsNothing);
       expect(
         find.textContaining(OnboardingStrings.swipeProfileInline),
         findsNothing,
@@ -300,7 +316,7 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 400));
 
-      expect(find.text(OnboardingStrings.swipeUndoLabel), findsOneWidget);
+      expect(find.byIcon(Icons.undo_rounded), findsOneWidget);
     },
   );
 
@@ -336,15 +352,21 @@ void main() {
   testWidgets(
     'fiche source : CTA like ferme la modal une seule fois et avance la carte',
     (tester) async {
-      final container = makeContainer([
+      final sources = [
         _src('indie', independence: 0.9, bias: 'alternative'),
         _src('deep', tier: 'deep'),
-      ]);
+      ];
+      // L'ordre du deck suit les groupes contigus : on lit la carte du dessus
+      // et la suivante depuis l'aplatissement, sans présumer l'ordre.
+      final flat = _flatGroups(sources);
+      final top = flat.first.source;
+      final next = flat[1].source;
+      final container = makeContainer(sources);
       await tester.pumpWidget(buildTestWidget(container));
       await tester.pumpAndSettle();
 
-      expect(find.text('Source indie'), findsOneWidget);
-      await tester.tap(find.text('Source indie'));
+      expect(find.text(top.name), findsOneWidget);
+      await tester.tap(find.text(top.name));
       await tester.pumpAndSettle();
 
       expect(find.text('Sélectionner cette source'), findsNothing);
@@ -359,7 +381,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 400));
 
       expect(find.text('Gestion de la source'), findsNothing);
-      expect(find.text('Source deep'), findsOneWidget);
+      expect(find.text(next.name), findsOneWidget);
 
       await tester.tap(find.widgetWithIcon(InkWell, Icons.close_rounded));
       await tester.pump();
@@ -369,11 +391,11 @@ void main() {
 
       expect(
         container.read(onboardingProvider).answers.swipeLiked,
-        equals(['indie']),
+        equals([top.id]),
       );
       expect(
         container.read(onboardingProvider).answers.swipeDisliked,
-        equals(['deep']),
+        equals([next.id]),
       );
     },
   );


### PR DESCRIPTION
## Quoi

Polish du « cœur » de la sélection des sources en onboarding (UI only, backend non touché) :

**Swipe de calibration (Q9c)**
- En-têtes **dynamiques par groupe** (mix type + thème, ex. « L'actu au quotidien », « Pour creuser Tech & Innovation… »), ordonnés selon les prefs déclarées (indépendance / profondeur) ; transition douce entre blocs.
- Hint renommé « Touche pour ouvrir le média », rapproché du deck.
- Deck centré verticalement (titre statique supprimé).
- Undo **discret** (rond, gris, plus petit) à gauche de (X)/(♥), avec placeholder symétrique pour garder les boutons centrés.

**Page « Tes médias, sur mesure » (Q10)**
- Récap discret **« Déjà ajoutés »** en tête de la section 1 (sources likées au swipe, pré-cochées, hors carrousel).
- Sections suggestions **et** catalogue en **carrousels horizontaux** (peek ~1,2 carte).
- Cartes **portrait** : logo + nom + pastille de biais, aspects matchés mis en valeur, cercle de sélection ≥44px, tap → modale détail.

`SourceRecoTag` extrait pour dédupliquer le style de tags entre carte liste et carte carrousel.

## Pourquoi

Rendre le moment-clé du choix des médias plus lisible et plus engageant (groupes guidés au swipe, cartes parcourables) — capitalise sur le `SourceRecommender` existant (nouvelle fonction pure `buildSpanningGroups`).

Répare aussi `apps/mobile/assets/changelog.json`, qui était **JSON invalide sur `main`** (deux entrées `unreleased` fusionnées par un mauvais merge) + ajoute l'entrée « Onboarding ».

## Comment ça a été vérifié

- [x] `flutter test test/features/onboarding` → **84 passed** (dont nouveaux tests `buildSpanningGroups` : ordre par prefs, libellé thème vs pôle, dégradation)
- [x] `flutter analyze` sur les fichiers touchés → propre (seuls infos `withOpacity` pré-existantes)
- [x] `changelog.json` re-validé (JSON parseable)
- [x] Aucun em-dash dans la copy ajoutée (règle PO)
- [x] `/simplify` passé (diff jugé déjà propre, aucune modif)
- [ ] Playwright `/validate-feature` — handoff prêt dans `.context/qa-handoff.md` (à lancer côté QA)

## Zones à risque

UI onboarding uniquement (swipe + page sources). `buildSpanningGroups` est une fonction pure qui réutilise `buildSpanningSet` → même calibration (mêmes cartes), seul l'ordre/regroupement change.
