### PR TITLE
Add generated store build numbers to mobile release builds

### DIFF
--- a/.github/workflows/build-aab.yml
+++ b/.github/workflows/build-aab.yml
@@ -52,10 +52,15 @@ jobs:
           cd apps/mobile
           flutter pub run flutter_launcher_icons || true
 
+      - name: Generate store build number
+        id: store_build
+        run: echo "build_number=$(date +%s)" >> "$GITHUB_OUTPUT"
+
       - name: Build AAB (playstore flavor)
         run: |
           cd apps/mobile
           flutter build appbundle --release --flavor playstore \
+            --build-number=${{ steps.store_build.outputs.build_number }} \
             --dart-define="API_BASE_URL=${{ github.event.inputs.api_base_url || 'https://facteur-production.up.railway.app/api' }}" \
             --dart-define="SUPABASE_URL=${{ secrets.SUPABASE_URL }}" \
             --dart-define="SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}" \

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -100,11 +100,17 @@ workflows:
           # fetched into Codemagic). This step applies it to the Xcode project.
           xcode-project use-profiles
 
+      - name: Generate store build number
+        script: |
+          set -euo pipefail
+          echo "STORE_BUILD_NUMBER=$(date +%s)" >> "$CM_ENV"
+
       - name: Build signed iOS IPA
         script: |
           set -euo pipefail
           cd "$APP_DIR"
           flutter build ipa --release \
+            --build-number="$STORE_BUILD_NUMBER" \
             --export-options-plist="$HOME/export_options.plist" \
             --dart-define="API_BASE_URL=${API_BASE_URL:-https://facteur-production.up.railway.app/api}" \
             --dart-define="SUPABASE_URL=${SUPABASE_URL:-}" \
@@ -192,11 +198,17 @@ workflows:
           storeFile=$CM_KEYSTORE_PATH
           EOF
 
+      - name: Generate store build number
+        script: |
+          set -euo pipefail
+          echo "STORE_BUILD_NUMBER=$(date +%s)" >> "$CM_ENV"
+
       - name: Build signed AAB (flavor playstore = production)
         script: |
           set -euo pipefail
           cd "$APP_DIR"
           flutter build appbundle --release --flavor playstore \
+            --build-number="$STORE_BUILD_NUMBER" \
             --dart-define="API_BASE_URL=${API_BASE_URL:-https://facteur-production.up.railway.app/api}" \
             --dart-define="SUPABASE_URL=${SUPABASE_URL:-}" \
             --dart-define="SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY:-}" \


### PR DESCRIPTION
## What

Add generated timestamp-based build numbers to release store builds in GitHub Actions and Codemagic.

## Why

This ensures store builds get unique build numbers for Android and iOS release pipelines without relying on a manually managed value.

## Type

- [ ] Feature
- [ ] Bug fix
- [x] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [ ] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (docs/config only change)