### PR TITLE
fix(digest): backfill deep recommendations

### DIFF
--- a/packages/api/app/jobs/digest_generation_job.py
+++ b/packages/api/app/jobs/digest_generation_job.py
@@ -51,6 +51,46 @@ from app.utils.time import today_paris
 logger = structlog.get_logger()
 
 
+def _extract_editorial_actu_ids_from_items(items: Any) -> set[UUID]:
+    """Extract persisted editorial ``actu_article`` ids from DailyDigest.items."""
+    if not isinstance(items, dict):
+        return set()
+
+    subjects = items.get("subjects")
+    if not isinstance(subjects, list):
+        return set()
+
+    content_ids: set[UUID] = set()
+    for subject in subjects:
+        if not isinstance(subject, dict):
+            continue
+        actu = subject.get("actu_article")
+        if not isinstance(actu, dict):
+            continue
+        raw_content_id = actu.get("content_id")
+        if not raw_content_id:
+            continue
+        try:
+            content_ids.add(UUID(str(raw_content_id)))
+        except (TypeError, ValueError):
+            logger.warning(
+                "digest_generation_deep_precompute_bad_content_id",
+                content_id=str(raw_content_id),
+            )
+    return content_ids
+
+
+def _extract_editorial_actu_ids_from_result(
+    result: EditorialPipelineResult,
+) -> set[UUID]:
+    """Extract the article ids the reader will use for Pas de recul lookup."""
+    return {
+        subject.actu_article.content_id
+        for subject in result.subjects
+        if subject.actu_article is not None
+    }
+
+
 async def compute_digest_coverage(
     session: AsyncSession, target_date: datetime.date
 ) -> tuple[int, int, float]:
@@ -630,12 +670,13 @@ class DigestGenerationJob:
         the missing serein variant.
         """
         semaphore = asyncio.Semaphore(self.concurrency_limit)
+        deep_precompute_ids: set[UUID] = set()
 
-        async def process_with_limit(user_id: UUID) -> None:
+        async def process_with_limit(user_id: UUID) -> set[UUID]:
             # Open a fresh session per user so errors don't poison peers
             async with semaphore, safe_async_session() as user_session:
                 try:
-                    await self._generate_digest_for_user(
+                    content_ids = await self._generate_digest_for_user(
                         user_session,
                         user_id,
                         target_date,
@@ -644,6 +685,7 @@ class DigestGenerationJob:
                         editorial_ctx_serein,
                     )
                     await user_session.commit()
+                    return content_ids
                 except Exception as e:
                     # Per-user failure is contained here; log and move on
                     await user_session.rollback()
@@ -673,10 +715,14 @@ class DigestGenerationJob:
                             "digest_generation_state_record_failed",
                             user_id=str(user_id),
                         )
+                    return set()
 
         # Premier passage
         tasks = [process_with_limit(uid) for uid in user_ids]
-        await asyncio.gather(*tasks, return_exceptions=True)
+        first_pass_results = await asyncio.gather(*tasks, return_exceptions=True)
+        for result in first_pass_results:
+            if isinstance(result, set):
+                deep_precompute_ids.update(result)
 
         async def _missing_pairs() -> list[tuple[UUID, bool]]:
             """Return (user_id, is_serene) pairs missing from daily_digest."""
@@ -710,7 +756,10 @@ class DigestGenerationJob:
             await asyncio.sleep(backoff_seconds)
 
             retry_tasks = [process_with_limit(uid) for uid in missing_user_ids]
-            await asyncio.gather(*retry_tasks, return_exceptions=True)
+            retry_results = await asyncio.gather(*retry_tasks, return_exceptions=True)
+            for result in retry_results:
+                if isinstance(result, set):
+                    deep_precompute_ids.update(result)
 
         # Final audit log
         final_missing = await _missing_pairs()
@@ -724,6 +773,42 @@ class DigestGenerationJob:
                 ],
             )
 
+        await self._precompute_deep_recommendations_for_digest_ids(deep_precompute_ids)
+
+    async def _precompute_deep_recommendations_for_digest_ids(
+        self,
+        content_ids: set[UUID],
+    ) -> None:
+        """Backfill Pas de recul rows for articles actually served in digests."""
+        if not content_ids:
+            return
+
+        try:
+            from app.services.editorial.pipeline import EditorialPipelineService
+
+            async with safe_async_session() as session:
+                pipeline = EditorialPipelineService(
+                    session,
+                    session_maker=safe_async_session,
+                )
+                try:
+                    await pipeline.precompute_deep_recommendations_for_content_ids(
+                        content_ids,
+                        refresh_existing=False,
+                    )
+                finally:
+                    await pipeline.close()
+            logger.info(
+                "digest_generation_deep_precompute_batch_done",
+                total=len(content_ids),
+            )
+        except Exception as exc:
+            logger.exception(
+                "digest_generation_deep_precompute_batch_failed",
+                total=len(content_ids),
+                error=str(exc),
+            )
+
     async def _generate_digest_for_user(
         self,
         session: AsyncSession,
@@ -732,7 +817,7 @@ class DigestGenerationJob:
         global_trending_context: GlobalTrendingContext | None = None,
         editorial_ctx_pour_vous=None,
         editorial_ctx_serein=None,
-    ) -> None:
+    ) -> set[UUID]:
         """Génère les deux digests (normal + serein) pour un utilisateur.
 
         Args:
@@ -744,6 +829,7 @@ class DigestGenerationJob:
             editorial_ctx_serein: Contexte éditorial pré-calculé (mode serein)
         """
         self.stats["processed"] += 1
+        deep_precompute_ids: set[UUID] = set()
 
         try:
             # Load user profile to get per-user daily article count
@@ -811,6 +897,9 @@ class DigestGenerationJob:
                             is_serene=is_serene,
                         )
                         self.stats["skipped"] += 1
+                        deep_precompute_ids.update(
+                            _extract_editorial_actu_ids_from_items(existing.items)
+                        )
                         await state_mark_success(
                             session, user_id, target_date, is_serene
                         )
@@ -862,6 +951,9 @@ class DigestGenerationJob:
                             is_serene=is_serene,
                         )
                         if digest:
+                            deep_precompute_ids.update(
+                                _extract_editorial_actu_ids_from_result(digest_items)
+                            )
                             # Delete stale (non-editorial) digest now that
                             # the new editorial_v1 is safely created.
                             if stale_digest:
@@ -963,6 +1055,8 @@ class DigestGenerationJob:
             # Re-raise so the caller in _process_batch can record the
             # failure in a fresh session after rolling this one back.
             raise
+
+        return deep_precompute_ids
 
 
 # Fonction principale pour l'export

--- a/packages/api/app/services/editorial/pipeline.py
+++ b/packages/api/app/services/editorial/pipeline.py
@@ -912,13 +912,48 @@ class EditorialPipelineService:
         y compris une **sentinelle** (matched_content_id NULL) quand aucun match
         n'est trouvé, afin que le reader n'ait jamais à recalculer à la volée.
         """
-        from app.services.editorial.deep_matcher import DeepMatcher
-
         actu_ids = [
             s.actu_article.content_id for s in subjects if s.actu_article is not None
         ]
+        await self.precompute_deep_recommendations_for_content_ids(
+            actu_ids,
+            refresh_existing=True,
+        )
+
+    async def precompute_deep_recommendations_for_content_ids(
+        self,
+        content_ids: list[UUID] | set[UUID] | tuple[UUID, ...],
+        *,
+        refresh_existing: bool = True,
+    ) -> None:
+        """Pré-calcule le « Pas de recul » pour une liste d'articles.
+
+        ``compute_global_context`` utilise ``refresh_existing=True`` pour
+        rafraîchir les sujets globaux du batch. Le job de digest utilise
+        ``False`` sur les IDs réellement persistés par-user afin de backfiller
+        les articles personnalisés sans refaire les matches déjà écrits.
+        """
+        from app.models.content_deep_recommendation import ContentDeepRecommendation
+        from app.services.editorial.deep_matcher import DeepMatcher
+
+        actu_ids = list(dict.fromkeys(content_ids))
         if not actu_ids:
             return
+
+        if not refresh_existing:
+            async with self._short_session() as db:
+                existing_result = await db.execute(
+                    select(ContentDeepRecommendation.content_id).where(
+                        ContentDeepRecommendation.content_id.in_(actu_ids)
+                    )
+                )
+                existing_ids = set(existing_result.scalars().all())
+            actu_ids = [
+                content_id for content_id in actu_ids if content_id not in existing_ids
+            ]
+            if not actu_ids:
+                logger.info("editorial_pipeline.deep_precompute_all_cached")
+                return
 
         matcher = DeepMatcher(
             session=self.session,

--- a/packages/api/tests/test_digest_generation_job.py
+++ b/packages/api/tests/test_digest_generation_job.py
@@ -6,6 +6,9 @@ from uuid import uuid4
 
 import pytest
 
+from app.jobs.digest_generation_job import (
+    _extract_editorial_actu_ids_from_items,
+)
 from app.services.editorial.schemas import (
     EditorialPipelineResult,
     EditorialSubject,
@@ -119,6 +122,45 @@ class TestEditorialBatchHandling:
         assert job.stats["failed"] == 0
 
     @pytest.mark.asyncio
+    async def test_generate_digest_returns_persisted_editorial_actu_ids(
+        self, job, mock_session
+    ):
+        """Pas de recul precompute uses the actu ids actually served to readers."""
+        user_id = uuid4()
+        target_date = datetime.date.today()
+        editorial_result = _make_editorial_result()
+
+        mock_digest = Mock()
+        mock_digest.id = uuid4()
+        mock_session.scalar = AsyncMock(return_value=None)
+
+        with (
+            patch("app.jobs.digest_generation_job.DigestSelector") as mock_selector_cls,
+            patch("app.services.digest_service.DigestService") as mock_svc_cls,
+            patch("app.jobs.digest_generation_job.select"),
+        ):
+            mock_selector = AsyncMock()
+            mock_selector.select_for_user = AsyncMock(return_value=editorial_result)
+            mock_selector_cls.return_value = mock_selector
+
+            mock_svc = AsyncMock()
+            mock_svc._create_digest_record_editorial = AsyncMock(
+                return_value=mock_digest
+            )
+            mock_svc_cls.return_value = mock_svc
+
+            result = await job._generate_digest_for_user(
+                mock_session, user_id, target_date, None
+            )
+
+        expected = {
+            subject.actu_article.content_id
+            for subject in editorial_result.subjects
+            if subject.actu_article is not None
+        }
+        assert result == expected
+
+    @pytest.mark.asyncio
     async def test_editorial_pipeline_result_empty_subjects_fails(
         self, job, mock_session
     ):
@@ -200,6 +242,42 @@ class TestVariantIsolation:
         assert job.stats["failed"] == 1
 
 
+class TestDeepPrecomputeIdExtraction:
+    """Extract real reader lookup ids from persisted editorial digest JSON."""
+
+    def test_extracts_only_subject_actu_ids(self):
+        actu_id = uuid4()
+        extra_id = uuid4()
+
+        result = _extract_editorial_actu_ids_from_items(
+            {
+                "format_version": "editorial_v2",
+                "subjects": [
+                    {
+                        "actu_article": {"content_id": str(actu_id)},
+                        "extra_actu_articles": [{"content_id": str(extra_id)}],
+                    },
+                    {"actu_article": None},
+                ],
+            }
+        )
+
+        assert result == {actu_id}
+
+    def test_ignores_non_editorial_or_bad_payloads(self):
+        assert (
+            _extract_editorial_actu_ids_from_items([{"content_id": str(uuid4())}])
+            == set()
+        )
+        assert _extract_editorial_actu_ids_from_items({"subjects": "bad"}) == set()
+        assert (
+            _extract_editorial_actu_ids_from_items(
+                {"subjects": [{"actu_article": {"content_id": "not-a-uuid"}}]}
+            )
+            == set()
+        )
+
+
 class TestGlobalCandidatePool:
     """The batch job should fetch a user-agnostic candidate pool for editorial ctx."""
 
@@ -274,7 +352,6 @@ class TestFollowedSourceSlice:
     @pytest.mark.asyncio
     async def test_followed_slice_unioned_and_deduped(self, job):
         """A followed-source article past the top-200 cut is added, deduped."""
-        from app.models.source import Source
 
         followed_src = uuid4()
         # recency slice: c1 (other source), c2 (followed, already present)


### PR DESCRIPTION
## What

Backfill Pas de recul recommendations for the actu article IDs that are actually persisted in generated or skipped editorial digests.

## Why

This prevents readers from recalculating deep recommendations at read time when per-user digest selection serves personalized articles outside the global editorial precompute set.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [x] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)
