### PR TITLE
fix(onboarding): fiche source résiliente, plancher Actus du jour, cartes alignées, connexion premium + polish

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,14 @@
 {
   "unreleased": [
     {
+      "tag": "Onboarding",
+      "summary": "Sélection des médias plus fluide : davantage de suggestions, petites animations de validation à chaque étape, et un écran de fin qui va jusqu'au bout avant de t'emmener dans l'app."
+    },
+    {
+      "tag": "Onboarding",
+      "summary": "Fiches sources plus complètes pendant l'inscription (couverture, fréquence, derniers articles), cartes de sélection mieux alignées, et plus de carte « Actus du jour » réduite à un seul article."
+    },
+    {
       "tag": "Pas de recul",
       "summary": "L'analyse de fond « Pas de recul » s'affiche désormais instantanément à l'ouverture d'un article, sans attente."
     },

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -65,6 +65,14 @@ const String _kEssentielBlurb =
 const String _kActusDuJourBlurb = 'Les sujets les + couverts en France.';
 const String _kBonnesBlurb = 'Un peu de douceur...';
 
+/// Plancher de topics pour « Actus du jour » (DigestTopicSection kind=essentiel).
+/// Sans plancher, un digest pauvre (compte neuf / onboarding) n'expose qu'un
+/// seul topic → une carte isolée perçue comme un « Essentiel à 1 article ». On
+/// masque la section sous ce seuil, à l'image du garde 202 de la carte hi-fi.
+/// Bonnes Nouvelles (kind=bonnes) conserve un plancher de 1 (peut légitimement
+/// être courte hors mode serein).
+const int _kActusMinTopics = 2;
+
 /// Hard cap on the number of favorite theme sections rendered in the tournée.
 /// Mirrors `kFavoriteCap = 7` in the my_interests provider — the value is
 /// duplicated here only because the maps key by sectionKey and we slice the
@@ -437,6 +445,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       accent: _kEssentielAccent,
       illustration: _kEssentielIllustration,
       coreVisibleCount: 3,
+      minTopics: _kActusMinTopics,
     );
     _bonnes = _buildDigestSection(
       digest: dual?.serein,
@@ -915,9 +924,12 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
           final kept = topics
               .where((t) => seen.add(pickTopicLead(t).contentId))
               .toList(growable: false);
-          // Post-filtre : une section Actus du jour vidée par le dedup ne doit
-          // pas laisser un bandeau orphelin → on la retire.
-          if (kept.isEmpty) continue;
+          // Post-filtre : le dedup peut faire retomber « Actus du jour » sous
+          // son plancher (kind=essentiel) → on réapplique le seuil pour éviter
+          // un bandeau réduit à une carte isolée. Les autres DigestTopicSection
+          // (Bonnes Nouvelles) ne sont retirées que si totalement vidées.
+          final minKept = s.kind == SectionKind.essentiel ? _kActusMinTopics : 1;
+          if (kept.length < minKept) continue;
           result.add(
             DigestTopicSection(
               kind: s.kind,
@@ -1181,12 +1193,13 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     required Color accent,
     required String illustration,
     required int coreVisibleCount,
+    int minTopics = 1,
   }) {
     final topics = digest?.topics
             .where((t) => t.articles.isNotEmpty)
             .toList(growable: false) ??
         const <DigestTopic>[];
-    if (topics.isEmpty) return null;
+    if (topics.length < minTopics) return null;
     return DigestTopicSection(
       kind: kind,
       label: label,

--- a/apps/mobile/lib/features/onboarding/data/source_recommender.dart
+++ b/apps/mobile/lib/features/onboarding/data/source_recommender.dart
@@ -114,7 +114,7 @@ class SwipeGroup {
 /// Replaces the static ThemeToSourcesMapping with dynamic scoring using
 /// source.theme, source.granularTopics, source.secondaryThemes, and source.sourceTier.
 class SourceRecommender {
-  static const int _maxMatched = 15;
+  static const int _maxMatched = 20;
   static const int _minMatched = 10;
   static const int _maxPerspective = 5;
   static const int _maxGems = 5;

--- a/apps/mobile/lib/features/onboarding/screens/conclusion_animation_screen.dart
+++ b/apps/mobile/lib/features/onboarding/screens/conclusion_animation_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -28,6 +30,10 @@ class ConclusionAnimationScreen extends ConsumerStatefulWidget {
 
 class _ConclusionAnimationScreenState
     extends ConsumerState<ConclusionAnimationScreen> {
+  /// Phase de completion : `ConclusionSuccess` reçu, on laisse l'animation du
+  /// compteur « flusher » rapidement jusqu'au total avant de naviguer.
+  bool _isCompleting = false;
+
   @override
   void initState() {
     super.initState();
@@ -45,8 +51,17 @@ class _ConclusionAnimationScreenState
 
     // Écouter les changements d'état pour naviguer
     ref.listen<ConclusionState>(conclusionNotifierProvider, (previous, next) {
-      if (next is ConclusionSuccess) {
-        _completeOnboarding();
+      if (next is ConclusionSuccess && !_isCompleting) {
+        // On ne navigue pas immédiatement : on passe en phase de completion
+        // pour laisser le compteur finir de monter jusqu'au total, puis on
+        // navigue après un court délai.
+        setState(() => _isCompleting = true);
+        unawaited(
+          Future.delayed(
+            const Duration(milliseconds: 1200),
+            _completeOnboarding,
+          ),
+        );
       }
     });
 
@@ -54,9 +69,10 @@ class _ConclusionAnimationScreenState
       backgroundColor: colors.backgroundPrimary,
       body: SafeArea(
         child: switch (conclusionState) {
-          ConclusionLoading() => const _LoadingView(),
-          ConclusionSuccess() =>
-            const _LoadingView(), // Garde l'animation pendant la transition
+          ConclusionLoading() => _LoadingView(isCompleting: _isCompleting),
+          ConclusionSuccess() => _LoadingView(
+            isCompleting: _isCompleting,
+          ), // Garde l'animation pendant la transition
           ConclusionError() => LaurinFallbackView(
             title: OnboardingFallbackStrings.title,
             subtitle: OnboardingFallbackStrings.subtitle,
@@ -103,7 +119,9 @@ class _ConclusionAnimationScreenState
 /// Vue de chargement : feed vivant (vrais titres des sources choisies) quand
 /// des données sont disponibles, sinon loader minimaliste classique.
 class _LoadingView extends ConsumerWidget {
-  const _LoadingView();
+  final bool isCompleting;
+
+  const _LoadingView({this.isCompleting = false});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -137,7 +155,10 @@ class _LoadingView extends ConsumerWidget {
     return Center(
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: FacteurSpacing.space6),
-        child: ConclusionLiveFeed(entries: entries),
+        child: ConclusionLiveFeed(
+          entries: entries,
+          isCompleting: isCompleting,
+        ),
       ),
     );
   }

--- a/apps/mobile/lib/features/onboarding/screens/questions/sources_question.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/sources_question.dart
@@ -54,11 +54,11 @@ class _SourcesQuestionState extends ConsumerState<SourcesQuestion> {
   static const int _sectionCount = 4;
 
   /// Cap des suggestions mises en avant (affichées, cochées ou non).
-  static const int _suggestionsLimit = 18;
+  static const int _suggestionsLimit = 20;
 
   /// Parmi les suggestions affichées, seules les `_preselectLimit` premières
   /// (top score) sont pré-cochées ; le reste s'affiche décoché.
-  static const int _preselectLimit = 9;
+  static const int _preselectLimit = 12;
 
   @override
   void initState() {
@@ -379,6 +379,7 @@ class _SourcesQuestionState extends ConsumerState<SourcesQuestion> {
         subtitleWhenCollapsed: selectedSummary,
         description: OnboardingStrings.sourcesBlockSuggestionsDesc,
         expanded: _openSection == 1,
+        validated: _openSection > 1,
         onToggle: () => setState(() => _openSection = 1),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -412,6 +413,7 @@ class _SourcesQuestionState extends ConsumerState<SourcesQuestion> {
         subtitleWhenCollapsed: OnboardingStrings.sourcesBlockHabitualSubtitle,
         description: OnboardingStrings.sourcesBlockHabitualDesc,
         expanded: _openSection == 2,
+        validated: _openSection > 2,
         onToggle: () => setState(() => _openSection = 2),
         child: _buildEmbeddedAddPanel(),
       ),
@@ -424,6 +426,7 @@ class _SourcesQuestionState extends ConsumerState<SourcesQuestion> {
         subtitleWhenCollapsed: OnboardingStrings.sourcesBlockCatalogSubtitle,
         description: OnboardingStrings.sourcesBlockCatalogDesc,
         expanded: _openSection == 3,
+        validated: _openSection > 3,
         onToggle: () => setState(() => _openSection = 3),
         child: SourceCatalogSection(
           catalog: _fullCatalog(reco),

--- a/apps/mobile/lib/features/onboarding/screens/questions/subtopics_question.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/subtopics_question.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../../config/theme.dart';
 import '../../../../core/providers/analytics_provider.dart';
@@ -36,6 +37,10 @@ class _SubtopicsQuestionState extends ConsumerState<SubtopicsQuestion> {
   late final PageController _pageController;
   int _currentTheme = 0;
   final Set<int> _visitedPages = {0};
+
+  /// Brève phase « validé » sur la carte courante avant le scroll horizontal
+  /// vers le thème suivant.
+  bool _isValidatingCurrentPage = false;
 
   List<String> get _selectedThemes =>
       ref.read(onboardingProvider).answers.themes ?? [];
@@ -292,17 +297,57 @@ class _SubtopicsQuestionState extends ConsumerState<SubtopicsQuestion> {
                     itemCount: selectedThemes.length,
                     itemBuilder: (context, index) {
                       final theme = _resolveTheme(selectedThemes[index]);
+                      final isValidating = index == _currentTheme &&
+                          _isValidatingCurrentPage;
                       return Padding(
                         padding: const EdgeInsets.symmetric(horizontal: 4),
-                        child: SingleChildScrollView(
-                          physics: const BouncingScrollPhysics(),
-                          // Extent supplémentaire quand le clavier monte, sinon
-                          // le champ « sujet custom » reste caché derrière lui.
-                          padding: EdgeInsets.only(
-                            bottom: MediaQuery.viewInsetsOf(context).bottom +
-                                FacteurSpacing.space6,
+                        child: AnimatedScale(
+                          scale: isValidating ? 0.96 : 1.0,
+                          duration: const Duration(milliseconds: 200),
+                          curve: Curves.easeInOut,
+                          child: AnimatedOpacity(
+                            opacity: isValidating ? 0.7 : 1.0,
+                            duration: const Duration(milliseconds: 200),
+                            curve: Curves.easeInOut,
+                            child: Stack(
+                              children: [
+                                SingleChildScrollView(
+                                  physics: const BouncingScrollPhysics(),
+                                  // Extent supplémentaire quand le clavier monte,
+                                  // sinon le champ « sujet custom » reste caché
+                                  // derrière lui.
+                                  padding: EdgeInsets.only(
+                                    bottom:
+                                        MediaQuery.viewInsetsOf(context).bottom +
+                                            FacteurSpacing.space6,
+                                  ),
+                                  child: _buildThemeCard(
+                                    theme,
+                                    includeHeader: false,
+                                  ),
+                                ),
+                                if (isValidating)
+                                  Positioned.fill(
+                                    child: Center(
+                                      child: Container(
+                                        padding: const EdgeInsets.all(
+                                          FacteurSpacing.space3,
+                                        ),
+                                        decoration: BoxDecoration(
+                                          color: Colors.green.shade500,
+                                          shape: BoxShape.circle,
+                                        ),
+                                        child: Icon(
+                                          PhosphorIcons.check(),
+                                          color: Colors.white,
+                                          size: 28,
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                              ],
+                            ),
                           ),
-                          child: _buildThemeCard(theme, includeHeader: false),
                         ),
                       );
                     },
@@ -324,7 +369,9 @@ class _SubtopicsQuestionState extends ConsumerState<SubtopicsQuestion> {
           ElevatedButton(
             onPressed: _saving
                 ? null
-                : (isLastPage ? _onContinuePressed : _goToNextPage),
+                : (isLastPage
+                    ? _onContinuePressed
+                    : _validateAndGoToNextPage),
             style: ElevatedButton.styleFrom(
               padding: const EdgeInsets.symmetric(vertical: 24),
             ),
@@ -424,6 +471,17 @@ class _SubtopicsQuestionState extends ConsumerState<SubtopicsQuestion> {
       duration: const Duration(milliseconds: 300),
       curve: Curves.easeOutCubic,
     );
+  }
+
+  /// Joue un bref état « validé » sur la carte courante (scale/opacité +
+  /// check vert) puis enchaîne le scroll vers le thème suivant.
+  Future<void> _validateAndGoToNextPage() async {
+    setState(() => _isValidatingCurrentPage = true);
+    HapticFeedback.selectionClick();
+    await Future.delayed(const Duration(milliseconds: 250));
+    if (!mounted) return;
+    setState(() => _isValidatingCurrentPage = false);
+    _goToNextPage();
   }
 
   Future<void> _onContinuePressed() async {

--- a/apps/mobile/lib/features/onboarding/screens/questions/swipe_disambiguator_question.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/swipe_disambiguator_question.dart
@@ -513,14 +513,6 @@ class _SwipeDisambiguatorQuestionState
                 textAlign: TextAlign.center,
               ),
             ),
-            if (_canUndoSwipe) ...[
-              const SizedBox(height: FacteurSpacing.space6),
-              TextButton.icon(
-                onPressed: _undoLastSwipe,
-                icon: const Icon(Icons.undo_rounded, size: 18),
-                label: const Text(OnboardingStrings.swipeUndoLabel),
-              ),
-            ],
           ],
         ),
       ),

--- a/apps/mobile/lib/features/onboarding/widgets/conclusion_live_feed.dart
+++ b/apps/mobile/lib/features/onboarding/widgets/conclusion_live_feed.dart
@@ -20,10 +20,15 @@ class ConclusionLiveFeed extends StatefulWidget {
   /// Cadence de révélation des titres (exposée pour les tests).
   final Duration revealInterval;
 
+  /// Phase de completion : l'API a répondu, on finit calmement de monter le
+  /// compteur jusqu'à son total avant la navigation.
+  final bool isCompleting;
+
   const ConclusionLiveFeed({
     super.key,
     required this.entries,
-    this.revealInterval = const Duration(milliseconds: 800),
+    this.revealInterval = const Duration(milliseconds: 1000),
+    this.isCompleting = false,
   });
 
   @override
@@ -48,6 +53,11 @@ class _ConclusionLiveFeedState extends State<ConclusionLiveFeed> {
   /// Fenêtre de titres visibles simultanément.
   static const int _windowSize = 5;
 
+  /// Nombre maximum d'articles révélés : on ne montre que les tops articles
+  /// de « Ton Essentiel » (3 à 5), pas tout le flux des sources — un compteur
+  /// calme et lisible plutôt qu'un défilement épileptique.
+  static const int _maxReveal = 5;
+
   /// Logos affichés dans la strip avant le badge « +N ».
   static const int _maxLogos = 8;
 
@@ -55,6 +65,7 @@ class _ConclusionLiveFeedState extends State<ConclusionLiveFeed> {
   final Set<String> _seenKeys = {};
   int _revealed = 0;
   Timer? _timer;
+  Timer? _completionTimer;
   bool _reduceMotion = false;
 
   @override
@@ -82,12 +93,37 @@ class _ConclusionLiveFeedState extends State<ConclusionLiveFeed> {
     _ingest(widget.entries);
     if (_reduceMotion) {
       _revealed = _queue.length;
+    } else if (widget.isCompleting && !oldWidget.isCompleting) {
+      // Entrée en phase de completion : on accélère le timer pour flusher
+      // rapidement le compteur jusqu'au total avant la navigation.
+      _speedUpTimer();
     }
+  }
+
+  /// Termine calmement la révélation des derniers titres restants (≤ quelques
+  /// articles vu le cap [_maxReveal]) avant que l'écran ne soit quitté. Cadence
+  /// posée (280 ms) pour éviter tout défilement épileptique.
+  void _speedUpTimer() {
+    if (_reduceMotion) return;
+    _timer?.cancel();
+    _timer = null;
+    _completionTimer?.cancel();
+    _completionTimer = Timer.periodic(
+      const Duration(milliseconds: 280),
+      (timer) {
+        if (_revealed >= _queue.length) {
+          timer.cancel();
+          return;
+        }
+        setState(() => _revealed++);
+      },
+    );
   }
 
   @override
   void dispose() {
     _timer?.cancel();
+    _completionTimer?.cancel();
     super.dispose();
   }
 
@@ -101,6 +137,8 @@ class _ConclusionLiveFeedState extends State<ConclusionLiveFeed> {
     );
     for (var i = 0; i < maxItems; i++) {
       for (final entry in entries) {
+        // Cap : on ne révèle que les tops articles (≤ _maxReveal).
+        if (_queue.length >= _maxReveal) return;
         if (i >= entry.items.length) continue;
         final title = entry.items[i].title;
         if (title.isEmpty) continue;

--- a/apps/mobile/lib/features/onboarding/widgets/onboarding_toggle_section.dart
+++ b/apps/mobile/lib/features/onboarding/widgets/onboarding_toggle_section.dart
@@ -10,7 +10,7 @@ import '../../../config/theme.dart';
 ///
 /// Une seule section est ouverte à la fois (accordéon piloté) : le parent garde
 /// l'index ouvert et passe `expanded: openIndex == index`.
-class OnboardingToggleSection extends StatelessWidget {
+class OnboardingToggleSection extends StatefulWidget {
   final int index;
   final String title;
 
@@ -24,6 +24,10 @@ class OnboardingToggleSection extends StatelessWidget {
   final String? description;
   final bool expanded;
   final bool enabled;
+
+  /// Section déjà parcourue / validée (l'utilisateur est passé à la suivante) :
+  /// le badge numéroté reste affiché avec un check vert persistant.
+  final bool validated;
   final VoidCallback onToggle;
   final Widget child;
 
@@ -37,12 +41,75 @@ class OnboardingToggleSection extends StatelessWidget {
     this.subtitleWhenCollapsed,
     this.description,
     this.enabled = true,
+    this.validated = false,
   });
+
+  @override
+  State<OnboardingToggleSection> createState() =>
+      _OnboardingToggleSectionState();
+}
+
+class _OnboardingToggleSectionState extends State<OnboardingToggleSection>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _validateController;
+  late final Animation<double> _scaleAnim;
+
+  @override
+  void initState() {
+    super.initState();
+    _validateController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 400),
+      // Déjà validée au premier build (rebuild / restauration) : afficher
+      // directement l'état final sans rejouer la pulse.
+      value: widget.validated ? 1.0 : 0.0,
+    );
+    _scaleAnim = TweenSequence<double>([
+      TweenSequenceItem(
+        tween: Tween(begin: 1.0, end: 1.25)
+            .chain(CurveTween(curve: Curves.easeOut)),
+        weight: 50,
+      ),
+      TweenSequenceItem(
+        tween: Tween(begin: 1.25, end: 1.0)
+            .chain(CurveTween(curve: Curves.easeIn)),
+        weight: 50,
+      ),
+    ]).animate(_validateController);
+  }
+
+  @override
+  void didUpdateWidget(OnboardingToggleSection oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Section nouvellement validée (l'utilisateur passe à la suivante) :
+    // brève pulsation, puis le badge reste sur son check vert persistant.
+    if (!oldWidget.validated && widget.validated) {
+      _validateController.forward(from: 0);
+    } else if (oldWidget.validated && !widget.validated) {
+      // Retour en arrière : on réinitialise l'état du badge.
+      _validateController.value = 0;
+    }
+  }
+
+  @override
+  void dispose() {
+    _validateController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
-    final headerColor = enabled ? colors.textPrimary : colors.textTertiary;
+    final headerColor =
+        widget.enabled ? colors.textPrimary : colors.textTertiary;
+    final index = widget.index;
+    final title = widget.title;
+    final expanded = widget.expanded;
+    final enabled = widget.enabled;
+    final onToggle = widget.onToggle;
+    final subtitleWhenCollapsed = widget.subtitleWhenCollapsed;
+    final description = widget.description;
+    final child = widget.child;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -55,7 +122,13 @@ class OnboardingToggleSection extends StatelessWidget {
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                _SectionIndexBadge(index: index, enabled: enabled),
+                _SectionIndexBadge(
+                  index: index,
+                  enabled: enabled,
+                  validated: widget.validated,
+                  scaleAnim: _scaleAnim,
+                  validateController: _validateController,
+                ),
                 const SizedBox(width: FacteurSpacing.space3),
                 Expanded(
                   child: Column(
@@ -71,10 +144,10 @@ class OnboardingToggleSection extends StatelessWidget {
                       ),
                       if (!expanded &&
                           subtitleWhenCollapsed != null &&
-                          subtitleWhenCollapsed!.isNotEmpty) ...[
+                          subtitleWhenCollapsed.isNotEmpty) ...[
                         const SizedBox(height: FacteurSpacing.space1),
                         Text(
-                          subtitleWhenCollapsed!,
+                          subtitleWhenCollapsed,
                           style: Theme.of(context)
                               .textTheme
                               .bodySmall
@@ -112,9 +185,9 @@ class OnboardingToggleSection extends StatelessWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
-                      if (description != null && description!.isNotEmpty) ...[
+                      if (description != null && description.isNotEmpty) ...[
                         Text(
-                          description!,
+                          description,
                           style: Theme.of(context)
                               .textTheme
                               .bodySmall
@@ -139,33 +212,66 @@ class OnboardingToggleSection extends StatelessWidget {
 class _SectionIndexBadge extends StatelessWidget {
   final int index;
   final bool enabled;
+  final bool validated;
+  final Animation<double> scaleAnim;
+  final AnimationController validateController;
 
-  const _SectionIndexBadge({required this.index, required this.enabled});
+  const _SectionIndexBadge({
+    required this.index,
+    required this.enabled,
+    required this.validated,
+    required this.scaleAnim,
+    required this.validateController,
+  });
 
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
-    final accent = enabled ? colors.primary : colors.textTertiary;
+    final baseAccent = enabled ? colors.primary : colors.textTertiary;
+    final validatedColor = Colors.green.shade500;
 
-    return Container(
-      width: 26,
-      height: 26,
-      margin: const EdgeInsets.only(top: 2),
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        color: enabled
-            ? colors.primary.withValues(alpha: 0.10)
-            : colors.backgroundSecondary,
-        border: Border.all(color: accent.withValues(alpha: 0.4), width: 1.2),
-      ),
-      alignment: Alignment.center,
-      child: Text(
-        '$index',
-        style: Theme.of(context).textTheme.labelMedium?.copyWith(
-              fontWeight: FontWeight.w700,
-              color: accent,
+    return AnimatedBuilder(
+      animation: validateController,
+      builder: (context, _) {
+        final t = validateController.value;
+        // Une fois validée, la section conserve son check vert ; pendant la
+        // pulse (t montant) on bascule tôt sur le check pour l'effet visuel.
+        final showCheck = validated || t > 0.2;
+        // Couleur : vire au vert dès la pulse et y reste tant que validée.
+        final accent = Color.lerp(
+              baseAccent,
+              validatedColor,
+              validated ? 1.0 : (t * 2).clamp(0.0, 1.0),
+            ) ??
+            baseAccent;
+
+        return Transform.scale(
+          scale: scaleAnim.value,
+          child: Container(
+            width: 26,
+            height: 26,
+            margin: const EdgeInsets.only(top: 2),
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: enabled
+                  ? accent.withValues(alpha: 0.10)
+                  : colors.backgroundSecondary,
+              border:
+                  Border.all(color: accent.withValues(alpha: 0.4), width: 1.2),
             ),
-      ),
+            alignment: Alignment.center,
+            child: showCheck
+                ? Icon(PhosphorIcons.check(), size: 14, color: accent)
+                : Text(
+                    '$index',
+                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                          fontWeight: FontWeight.w700,
+                          color: accent,
+                        ),
+                  ),
+          ),
+        );
+      },
     );
   }
 }

--- a/apps/mobile/lib/features/onboarding/widgets/source_carousel.dart
+++ b/apps/mobile/lib/features/onboarding/widgets/source_carousel.dart
@@ -43,8 +43,9 @@ class _SourceCarouselState extends State<SourceCarousel> {
   @override
   void initState() {
     super.initState();
-    // ~1,2 carte visible : la suivante dépasse (peek) pour signaler le swipe.
-    _controller = PageController(viewportFraction: 0.82);
+    // Cartes un peu plus étroites : la suivante dépasse davantage (peek) pour
+    // mieux signaler le swipe et faciliter le parcours du carrousel.
+    _controller = PageController(viewportFraction: 0.74);
   }
 
   @override

--- a/apps/mobile/lib/features/onboarding/widgets/source_carousel_card.dart
+++ b/apps/mobile/lib/features/onboarding/widgets/source_carousel_card.dart
@@ -90,28 +90,35 @@ class SourceCarouselCard extends StatelessWidget {
             ),
 
             // ── Pastille de biais (display-only) ──────────────────────────
-            if (source.biasStance != 'unknown') ...[
-              const SizedBox(height: FacteurSpacing.space2),
-              Row(
-                children: [
-                  Container(
-                    width: 7,
-                    height: 7,
-                    decoration: BoxDecoration(
-                      color: source.getBiasColor(),
-                      shape: BoxShape.circle,
-                    ),
-                  ),
-                  const SizedBox(width: 6),
-                  Text(
-                    source.getBiasLabel(),
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: colors.textTertiary,
+            // Slot réservé à hauteur fixe : même quand le biais est inconnu,
+            // l'espace est conservé pour que le cœur (tags/raison) démarre à la
+            // même hauteur sur toutes les cartes → carrousel visuellement
+            // aligné au swipe (sinon les cartes sans biais « remontent »).
+            const SizedBox(height: FacteurSpacing.space2),
+            SizedBox(
+              height: 18,
+              child: source.biasStance == 'unknown'
+                  ? null
+                  : Row(
+                      children: [
+                        Container(
+                          width: 7,
+                          height: 7,
+                          decoration: BoxDecoration(
+                            color: source.getBiasColor(),
+                            shape: BoxShape.circle,
+                          ),
                         ),
-                  ),
-                ],
-              ),
-            ],
+                        const SizedBox(width: 6),
+                        Text(
+                          source.getBiasLabel(),
+                          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                color: colors.textTertiary,
+                              ),
+                        ),
+                      ],
+                    ),
+            ),
 
             const SizedBox(height: FacteurSpacing.space3),
 

--- a/apps/mobile/lib/features/sources/repositories/sources_repository.dart
+++ b/apps/mobile/lib/features/sources/repositories/sources_repository.dart
@@ -1,3 +1,5 @@
+import 'package:dio/dio.dart';
+
 import '../../../core/api/api_client.dart';
 import '../models/smart_search_result.dart';
 import '../models/source_coverage.dart';
@@ -286,22 +288,46 @@ class SourcesRepository {
   /// (`GET /sources/{id}/profile`).
   ///
   /// Contrairement à [fetchCoverage] (best-effort → vide), on **propage**
-  /// l'erreur : la fiche s'appuie dessus pour basculer en fallback statique
-  /// (header + éval + réglages) plutôt que d'afficher un état vide trompeur.
+  /// l'erreur : la fiche s'appuie dessus pour basculer en fallback gracieux
+  /// (couverture via `/coverage` + bouton « Réessayer ») plutôt que d'afficher
+  /// un état vide trompeur.
+  ///
+  /// Un échec **transitoire** (timeout, coupure réseau, 5xx) est retenté
+  /// jusqu'à 2 fois avec un court backoff : pendant l'onboarding la fiche est
+  /// pré-chargée dès l'ouverture de l'écran, et un premier appel peut échouer
+  /// le temps que la session/réseau se stabilise. On ne retente jamais une
+  /// erreur définitive (4xx : 404 source absente, 422 id invalide).
   Future<SourceProfile> getSourceProfile(String sourceId) async {
-    try {
-      final response = await _apiClient.dio.get<Map<String, dynamic>>(
-        'sources/$sourceId/profile',
-      );
-      if (response.statusCode == 200 && response.data != null) {
-        return SourceProfile.fromJson(response.data!);
+    const maxAttempts = 3;
+    for (var attempt = 1; ; attempt++) {
+      try {
+        final response = await _apiClient.dio.get<Map<String, dynamic>>(
+          'sources/$sourceId/profile',
+        );
+        if (response.statusCode == 200 && response.data != null) {
+          return SourceProfile.fromJson(response.data!);
+        }
+        throw Exception('Failed to load source profile');
+      } catch (e) {
+        if (attempt < maxAttempts && _isTransient(e)) {
+          await Future<void>.delayed(Duration(milliseconds: 250 * attempt));
+          continue;
+        }
+        // ignore: avoid_print
+        print('SourcesRepository: [ERROR] getSourceProfile: $e');
+        rethrow;
       }
-      throw Exception('Failed to load source profile');
-    } catch (e) {
-      // ignore: avoid_print
-      print('SourcesRepository: [ERROR] getSourceProfile: $e');
-      rethrow;
     }
+  }
+
+  /// Vrai si l'erreur est probablement transitoire (réseau/timeout/5xx) et
+  /// donc justifie un retry. Les réponses 4xx sont définitives.
+  bool _isTransient(Object error) {
+    if (error is! DioException) return false;
+    final status = error.response?.statusCode;
+    if (status != null) return status >= 500;
+    // Pas de réponse : timeout, connexion coupée, annulation réseau.
+    return error.type != DioExceptionType.cancel;
   }
 
   Future<void> dismissPepiteCarousel() async {

--- a/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
@@ -180,9 +180,20 @@ class _FsBody extends ConsumerWidget {
           _FsSection(title: 'Derniers articles', child: _ArticlesSkeleton()),
         ],
       ),
-      // Fallback statique : couverture / articles / fréquence masqués, le reste
-      // reste exploitable depuis l'objet Source déjà en main.
-      error: (_, __) => (null, const <Widget>[]),
+      // Fallback gracieux : `/profile` a échoué (réseau/5xx). Plutôt que de
+      // tout masquer (fiche « presque vide »), on retombe sur la couverture via
+      // l'endpoint indépendant `/coverage` (best-effort, se masque seul si lui
+      // aussi échoue) et on propose un retry sur la zone articles. La fréquence
+      // reste masquée (elle dépend du profil).
+      error: (_, __) => (
+        null,
+        [
+          _FsCoverageFromProvider(source: source),
+          _FsArticlesUnavailable(
+            onRetry: () => ref.invalidate(sourceProfileProvider(source.id)),
+          ),
+        ],
+      ),
       data: (profile) => (
         humanizeFrequency(profile.articles30d, profile.oldestContentAt),
         [
@@ -1093,6 +1104,104 @@ class _ArticlesEmptyCard extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// Zone articles en erreur réseau (mode normal) : message sobre + retry, au
+/// lieu de masquer la section. Le tap relance [sourceProfileProvider] ; si le
+/// retry réussit, la fiche bascule sur la branche `data` complète.
+class _FsArticlesUnavailable extends StatelessWidget {
+  final VoidCallback onRetry;
+  const _FsArticlesUnavailable({required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 26, 16, 0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const _FsSectionHeader(title: 'Derniers articles'),
+          const SizedBox(height: 14),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 16),
+            decoration: BoxDecoration(
+              color: colors.surface.withValues(alpha: 0.4),
+              borderRadius: BorderRadius.circular(FacteurRadius.large),
+              border: Border.all(
+                color: colors.textTertiary.withValues(alpha: 0.25),
+              ),
+            ),
+            child: Row(
+              children: [
+                Icon(
+                  PhosphorIcons.warningCircle(PhosphorIconsStyle.regular),
+                  size: 22,
+                  color: colors.textTertiary,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    'Contenu momentanément indisponible.',
+                    style: textTheme.labelMedium?.copyWith(
+                      color: colors.textSecondary,
+                      fontWeight: FontWeight.w600,
+                      fontSize: 13.5,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                _RetryChip(onTap: onRetry),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Pilule « Réessayer » (relance un provider). Réutilisable dans la fiche.
+class _RetryChip extends StatelessWidget {
+  final VoidCallback onTap;
+  const _RetryChip({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return InkWell(
+      borderRadius: BorderRadius.circular(FacteurRadius.pill),
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+        decoration: BoxDecoration(
+          color: colors.primary.withValues(alpha: 0.12),
+          borderRadius: BorderRadius.circular(FacteurRadius.pill),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              PhosphorIcons.arrowClockwise(PhosphorIconsStyle.regular),
+              size: 14,
+              color: colors.primary,
+            ),
+            const SizedBox(width: 5),
+            Text(
+              'Réessayer',
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                    color: colors.primary,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 0,
+                  ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
@@ -934,7 +934,8 @@ void main() {
       SharedPreferences.setMockInitialValues(<String, Object>{});
 
       // Topic A's lead shares the hi-fi card's contentId → it must be dropped.
-      // Topic B is untouched → "Actus du jour" survives with one topic.
+      // Topics B & C survive → 2 topics restants, au-dessus du plancher
+      // `_kActusMinTopics` → « Actus du jour » reste affichée sans le doublon.
       final container = makeDedupContainer(
         hiFiContentId: 'shared-1',
         topics: const [
@@ -947,6 +948,11 @@ void main() {
             topicId: 't2',
             label: 'Topic B',
             articles: [DigestItem(contentId: 'b1', title: 'B')],
+          ),
+          DigestTopic(
+            topicId: 't3',
+            label: 'Topic C',
+            articles: [DigestItem(contentId: 'c1', title: 'C')],
           ),
         ],
       );
@@ -966,7 +972,43 @@ void main() {
       final actusLeadIds =
           actus.topics.map((t) => pickTopicLead(t).contentId).toList();
       expect(actusLeadIds, isNot(contains('shared-1')));
-      expect(actusLeadIds, contains('b1'));
+      expect(actusLeadIds, containsAll(<String>['b1', 'c1']));
+    });
+
+    test(
+        'Actus du jour tombée sous le plancher après dedup est masquée '
+        '(pas de carte isolée)', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+
+      // 2 topics au build (≥ plancher), mais le dedup retire le doublon → 1
+      // topic restant < `_kActusMinTopics` → section masquée plutôt qu'1 carte.
+      final container = makeDedupContainer(
+        hiFiContentId: 'shared-1',
+        topics: const [
+          DigestTopic(
+            topicId: 't1',
+            label: 'Topic A',
+            articles: [DigestItem(contentId: 'shared-1', title: 'A')],
+          ),
+          DigestTopic(
+            topicId: 't2',
+            label: 'Topic B',
+            articles: [DigestItem(contentId: 'b1', title: 'B')],
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final state = await settle(container);
+
+      expect(state.sections.whereType<EssentielSection>(), hasLength(1));
+      expect(
+        state.sections
+            .whereType<DigestTopicSection>()
+            .where((s) => s.kind == SectionKind.essentiel),
+        isEmpty,
+        reason: 'Une Actus du jour réduite à 1 topic par le dedup est masquée',
+      );
     });
 
     test('Actus du jour disappears entirely when fully deduped', () async {
@@ -1232,6 +1274,8 @@ void main() {
           rank: 1,
         );
 
+    // 2 topics : « Actus du jour » doit franchir le plancher `_kActusMinTopics`
+    // (sinon la section est masquée et le base-only n'aurait aucun contenu réel).
     DigestResponse digestWithTopics() => DigestResponse(
           digestId: 'd1',
           userId: 'u1',
@@ -1242,6 +1286,11 @@ void main() {
               topicId: 't1',
               label: 'Topic A',
               articles: [DigestItem(contentId: 'topic-a-1', title: 'A')],
+            ),
+            DigestTopic(
+              topicId: 't2',
+              label: 'Topic B',
+              articles: [DigestItem(contentId: 'topic-b-1', title: 'B')],
             ),
           ],
         );

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_tournee_order_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_tournee_order_test.dart
@@ -194,12 +194,15 @@ DigestTopic _digestTopic(String id) => DigestTopic(
       articles: [_digestItem('digest-$id')],
     );
 
+// 2 topics : « Actus du jour » (kind=essentiel) doit franchir le plancher
+// `_kActusMinTopics` du provider, sinon la section est masquée et l'ordre
+// favoris → Actus → Bonnes ne peut pas être vérifié.
 DigestResponse _digest(String id) => DigestResponse(
       digestId: id,
       userId: 'u',
       targetDate: DateTime(2026, 1, 1),
       generatedAt: DateTime(2026, 1, 1),
-      topics: [_digestTopic(id)],
+      topics: [_digestTopic('$id-a'), _digestTopic('$id-b')],
     );
 
 void main() {

--- a/apps/mobile/test/features/onboarding/data/source_recommender_test.dart
+++ b/apps/mobile/test/features/onboarding/data/source_recommender_test.dart
@@ -641,10 +641,10 @@ void main() {
     test(
       'garantie : un spécialiste hors-matched est remonté dans specialists',
       () {
-        // 15 sources tech (score 4) saturent matched ; le spécialiste factcheck
+        // 20 sources tech (score 4) saturent matched ; le spécialiste factcheck
         // (score 2) en serait exclu → la garantie de couverture le rapatrie.
         final sources = [
-          for (var i = 0; i < 15; i++)
+          for (var i = 0; i < 20; i++)
             spec('tech-$i', topics: const [], theme: 'tech'),
           spec('fc', topics: const ['factcheck'], reliability: 'unknown'),
         ];
@@ -694,7 +694,7 @@ void main() {
       // Deux sujets « pauvres » non couverts par matched ; deux spécialistes
       // distincts disponibles → une carte chacun.
       final sources = [
-        for (var i = 0; i < 15; i++)
+        for (var i = 0; i < 20; i++)
           spec('tech-$i', topics: const [], theme: 'tech'),
         spec('fc', topics: const ['factcheck'], reliability: 'unknown'),
         spec('rel', topics: const ['relationships'], reliability: 'unknown'),

--- a/apps/mobile/test/features/onboarding/screens/sources_question_test.dart
+++ b/apps/mobile/test/features/onboarding/screens/sources_question_test.dart
@@ -106,7 +106,7 @@ void main() {
   }
 
   testWidgets(
-      '4 sections en accordéon, ≤18 suggestions, top 9 pré-cochées',
+      '4 sections en accordéon, ≤20 suggestions, top 12 pré-cochées',
       (tester) async {
     final container = makeContainer(_makeTechSources());
     // bypassOnboarding pose themes=[tech, international].
@@ -119,12 +119,12 @@ void main() {
     expect(find.byType(OnboardingToggleSection), findsNWidgets(4));
 
     // Section 1 ouverte par défaut : suggestions rendues dans un carrousel
-    // horizontal (15 sources matched, ≤ 18). Les sections 2/3/4 repliées n'ont
+    // horizontal (15 sources matched, ≤ 20). Les sections 2/3/4 repliées n'ont
     // pas de carrousel monté → un seul SourceCarousel sur l'écran.
     final carousel = tester.widget<SourceCarousel>(
       find.byType(SourceCarousel),
     );
-    expect(carousel.sources.length, lessThanOrEqualTo(18));
+    expect(carousel.sources.length, lessThanOrEqualTo(20));
     expect(carousel.sources.length, 15);
 
     // Le gros publieur mainstream remonte dans les suggestions (volume-proxy).
@@ -148,13 +148,13 @@ void main() {
     expect(find.byType(SourceAddPanel), findsNothing);
 
     // « Suivant » 3× → dernière section : le bouton valide avec le compte de
-    // pré-sélection (top 9 uniquement, le reste décoché).
+    // pré-sélection (top 12 uniquement, le reste décoché).
     for (var i = 0; i < 3; i++) {
       await tester.ensureVisible(find.text(OnboardingStrings.nextButton));
       await tester.tap(find.text(OnboardingStrings.nextButton));
       await tester.pumpAndSettle();
     }
-    expect(find.text(OnboardingStrings.selectedCount(9)), findsOneWidget);
+    expect(find.text(OnboardingStrings.selectedCount(12)), findsOneWidget);
   });
 
   testWidgets('section « médias habituels » : SourceAddPanel monté au tap',
@@ -214,13 +214,13 @@ void main() {
       );
 
       // Sur la dernière section, le bouton porte le compte sélectionné :
-      // 9 suggestions précochées + la source likée déjà validée = 10.
+      // 12 suggestions précochées + la source likée déjà validée = 13.
       for (var i = 0; i < 3; i++) {
         await tester.ensureVisible(find.text(OnboardingStrings.nextButton));
         await tester.tap(find.text(OnboardingStrings.nextButton));
         await tester.pumpAndSettle();
       }
-      expect(find.text(OnboardingStrings.selectedCount(10)), findsOneWidget);
+      expect(find.text(OnboardingStrings.selectedCount(13)), findsOneWidget);
     },
   );
 

--- a/apps/mobile/test/features/onboarding/screens/swipe_disambiguator_question_test.dart
+++ b/apps/mobile/test/features/onboarding/screens/swipe_disambiguator_question_test.dart
@@ -321,35 +321,6 @@ void main() {
   );
 
   testWidgets(
-    'bouton retour pendant l\'overlay final : annule la fin et restaure la carte',
-    (tester) async {
-      final container = makeContainer([_src('solo', tier: 'mainstream')]);
-      await tester.pumpWidget(buildTestWidget(container));
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.widgetWithIcon(InkWell, Icons.favorite_rounded));
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 400));
-
-      expect(find.text(OnboardingStrings.swipeRefiningTitle), findsOneWidget);
-      expect(find.text(OnboardingStrings.swipeUndoLabel), findsOneWidget);
-
-      await tester.tap(find.text(OnboardingStrings.swipeUndoLabel));
-      await tester.pumpAndSettle();
-
-      expect(find.text(OnboardingStrings.swipeRefiningTitle), findsNothing);
-      expect(find.text('Source solo'), findsOneWidget);
-
-      await tester.pump(const Duration(milliseconds: 1500));
-      expect(container.read(onboardingProvider).answers.swipeLiked, isNull);
-      expect(
-        container.read(onboardingProvider).currentQuestionIndex,
-        isNot(Section3Question.sources.index),
-      );
-    },
-  );
-
-  testWidgets(
     'fiche source : CTA like ferme la modal une seule fois et avance la carte',
     (tester) async {
       final sources = [

--- a/apps/mobile/test/features/onboarding/widgets/conclusion_live_feed_test.dart
+++ b/apps/mobile/test/features/onboarding/widgets/conclusion_live_feed_test.dart
@@ -37,14 +37,14 @@ void main() {
         findsOneWidget);
     expect(find.text('LM un'), findsNothing);
 
-    // 1er tick (800ms) : premier titre (round-robin : LM un).
-    await tester.pump(const Duration(milliseconds: 800));
+    // 1er tick (1000ms) : premier titre (round-robin : LM un).
+    await tester.pump(const Duration(milliseconds: 1000));
     expect(find.text('LM un'), findsOneWidget);
 
     // 2e tick : LB un (entrelacé), 3e tick : LM deux.
-    await tester.pump(const Duration(milliseconds: 800));
+    await tester.pump(const Duration(milliseconds: 1000));
     expect(find.text('LB un'), findsOneWidget);
-    await tester.pump(const Duration(milliseconds: 800));
+    await tester.pump(const Duration(milliseconds: 1000));
     expect(find.text('LM deux'), findsOneWidget);
     await tester.pumpAndSettle();
     expect(find.text(OnboardingStrings.conclusionLiveCounter(3, 2)),
@@ -56,7 +56,7 @@ void main() {
     await tester.pumpWidget(buildTestWidget([
       _entry('s1', 'Le Monde', ['LM un']),
     ]));
-    await tester.pump(const Duration(milliseconds: 800));
+    await tester.pump(const Duration(milliseconds: 1000));
     expect(find.text('LM un'), findsOneWidget);
 
     // L'endpoint répond : s1 enrichi (dédup du titre déjà vu) + s2 ajouté.
@@ -69,8 +69,8 @@ void main() {
     expect(find.text('LM un'), findsOneWidget);
 
     // Les nouveaux arrivent à la suite.
-    await tester.pump(const Duration(milliseconds: 800));
-    await tester.pump(const Duration(milliseconds: 800));
+    await tester.pump(const Duration(milliseconds: 1000));
+    await tester.pump(const Duration(milliseconds: 1000));
     await tester.pumpAndSettle();
     expect(find.text('LM deux'), findsOneWidget);
     expect(find.text('LB un'), findsOneWidget);

--- a/apps/mobile/test/features/sources/widgets/source_detail_modal_test.dart
+++ b/apps/mobile/test/features/sources/widgets/source_detail_modal_test.dart
@@ -359,28 +359,63 @@ void main() {
   });
 
   group('SourceDetailModal — fallback réseau (/profile en erreur)', () {
-    testWidgets('error → header + éval restent, couverture/articles masqués', (
-      tester,
-    ) async {
-      final source = Source(
-        id: 'monde',
-        name: 'Le Monde',
-        type: SourceType.article,
-        reliabilityScore: 'high',
-      );
+    testWidgets(
+      'error → identité/éval restent + zone articles propose un retry',
+      (tester) async {
+        final source = Source(
+          id: 'monde',
+          name: 'Le Monde',
+          type: SourceType.article,
+          reliabilityScore: 'high',
+        );
 
-      await tester.pumpWidget(
-        _wrap(source: source, profileError: Exception('network down')),
-      );
-      await tester.pumpAndSettle();
+        // /profile en erreur ET /coverage vide (pire cas réseau).
+        await tester.pumpWidget(
+          _wrap(source: source, profileError: Exception('network down')),
+        );
+        await tester.pumpAndSettle();
 
-      // La fiche ne bloque jamais : identité + éval toujours là.
-      expect(find.text('Le Monde'), findsOneWidget);
-      expect(find.text('Évaluation Facteur'), findsOneWidget);
-      // Sections data-dépendantes masquées.
-      expect(find.text('Couverture par thèmes'), findsNothing);
-      expect(find.text('Derniers articles'), findsNothing);
-    });
+        // La fiche ne bloque jamais : identité + éval toujours là.
+        expect(find.text('Le Monde'), findsOneWidget);
+        expect(find.text('Évaluation Facteur'), findsOneWidget);
+        // Couverture masquée (/coverage vide), mais la zone articles n'est plus
+        // muette : message d'indisponibilité + bouton « Réessayer ».
+        expect(find.text('Couverture par thèmes'), findsNothing);
+        expect(find.text('Derniers articles'), findsOneWidget);
+        expect(find.text('Contenu momentanément indisponible.'), findsOneWidget);
+        expect(find.text('Réessayer'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'error → couverture retombe sur /coverage (endpoint indépendant)',
+      (tester) async {
+        final source = Source(
+          id: 'monde',
+          name: 'Le Monde',
+          type: SourceType.article,
+        );
+        const coverage = SourceCoverage(
+          periodLabel: '30 derniers jours',
+          totalCount: 100,
+          caption: '100 articles publiés sur la période',
+          rows: [CoverageRow(theme: 'politics', count: 100, pct: 100)],
+        );
+
+        // /profile KO mais /coverage OK → la couverture reste visible.
+        await tester.pumpWidget(
+          _wrap(
+            source: source,
+            profileError: Exception('network down'),
+            coverage: coverage,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Couverture par thèmes'), findsOneWidget);
+        expect(find.text('Réessayer'), findsOneWidget);
+      },
+    );
   });
 
   group('SourceDetailModal — mode smart-search (recentItems préchargés)', () {

--- a/packages/api/app/schemas/source.py
+++ b/packages/api/app/schemas/source.py
@@ -63,6 +63,11 @@ class PremiumConnectionResponse(BaseModel):
     # du CTA ("Associer" vs "Connecter").
     is_generic: bool = False
 
+    @staticmethod
+    def is_explicitly_disabled(config: object) -> bool:
+        """True when a source opts out of the WebView subscription flow."""
+        return isinstance(config, dict) and config.get("enabled") is False
+
     @classmethod
     def from_config(cls, config: object) -> "PremiumConnectionResponse | None":
         if not isinstance(config, dict) or config.get("enabled") is not True:
@@ -98,6 +103,10 @@ class PremiumConnectionResponse(BaseModel):
            URL http(s) valide → fallback générique (login=test=home de la source,
            ``is_generic=True``) ;
         4. sinon ``None``.
+
+        ``premium_connection_config.enabled = false`` est un opt-out explicite :
+        il sert de blocklist pour les sources dont la connexion WebView est
+        connue comme incompatible, et bloque donc aussi la map curée/le fallback.
         """
         # Import local : évite un cycle schemas → services au chargement.
         from app.services.premium_curated_sources import (
@@ -105,7 +114,11 @@ class PremiumConnectionResponse(BaseModel):
             is_paywalled_source,
         )
 
-        explicit = cls.from_config(getattr(source, "premium_connection_config", None))
+        config = getattr(source, "premium_connection_config", None)
+        if cls.is_explicitly_disabled(config):
+            return None
+
+        explicit = cls.from_config(config)
         if explicit is not None:
             return explicit
 

--- a/packages/api/app/services/source_service.py
+++ b/packages/api/app/services/source_service.py
@@ -526,9 +526,11 @@ class SourceService:
     ) -> SourceResponse | None:
         """Met à jour le has_subscription d'une source.
 
-        La connexion positive exige une config premium explicite côté source,
-        puis crée le lien UserSource si nécessaire. La dissociation reste
-        autorisée même si la config source a été retirée.
+        La connexion positive exige une connexion premium résolue : config
+        explicite, domaine curé, ou fallback générique pour source paywalled.
+        La config curée améliore donc l'expérience sans servir de whitelist
+        bloquante. La dissociation reste autorisée même si la config source a
+        été retirée.
         """
         user_uuid = UUID(user_id)
         source_uuid = UUID(source_id)

--- a/packages/api/tests/test_premium_discoverability.py
+++ b/packages/api/tests/test_premium_discoverability.py
@@ -89,6 +89,21 @@ def test_from_source_paywall_config_only_is_generic_using_source_url():
     assert resp.test_url == resp.login_url
 
 
+def test_from_source_disabled_config_blocks_curated_and_generic_fallback():
+    curated = _stub(
+        url="https://www.lemonde.fr/section/x",
+        premium_connection_config={"enabled": False},
+    )
+    assert PremiumConnectionResponse.from_source(curated, curated_map=MAP) is None
+
+    generic = _stub(
+        url="https://unknown-paper.example/news/x",
+        premium_connection_config={"enabled": False},
+        paywall_config={"keywords": ["réservé aux abonnés"]},
+    )
+    assert PremiumConnectionResponse.from_source(generic, curated_map=MAP) is None
+
+
 def test_from_source_free_source_returns_none():
     src = _stub(url="https://free-paper.example/")
     assert PremiumConnectionResponse.from_source(src, curated_map=MAP) is None

--- a/packages/api/tests/test_premium_source_connection.py
+++ b/packages/api/tests/test_premium_source_connection.py
@@ -160,7 +160,7 @@ async def test_subscription_false_clears_timestamps(db_session: AsyncSession):
 
 
 @pytest.mark.asyncio
-async def test_subscription_true_rejects_non_allowlisted_source(
+async def test_subscription_true_rejects_free_non_paywalled_source(
     db_session: AsyncSession,
 ):
     source = Source(
@@ -172,6 +172,31 @@ async def test_subscription_true_rejects_non_allowlisted_source(
         theme="society",
         is_curated=True,
         is_active=True,
+    )
+    db_session.add(source)
+    await db_session.flush()
+
+    with pytest.raises(PremiumConnectionNotEnabled):
+        await SourceService(db_session).update_source_subscription(
+            str(uuid4()), str(source.id), True
+        )
+
+
+@pytest.mark.asyncio
+async def test_subscription_true_rejects_explicitly_disabled_premium_flow(
+    db_session: AsyncSession,
+):
+    source = Source(
+        id=uuid4(),
+        name="Blocked Paywalled Source",
+        url="https://blocked.example.com",
+        feed_url=f"https://blocked.example.com/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_curated=True,
+        is_active=True,
+        paywall_config={"keywords": ["réservé aux abonnés"]},
+        premium_connection_config={"enabled": False},
     )
     db_session.add(source)
     await db_session.flush()


### PR DESCRIPTION
# Fix bugs onboarding : fiche source, Actus du jour, cartes carrousel, connexion premium + polish

Corrige les bugs relevés en session d'onboarding réelle, plus un volet connexion
premium et un polish de validation visuelle des étapes. PR de code unique vers `main`.
Le volet catalogue (#3b) reste un livrable d'audit pour décision PO, pas un changement de code.

## #1 — Fiche source : couverture / articles / fréquence ne disparaissent plus

**Cause** : sur erreur réseau de `GET /sources/{id}/profile`, la branche `error` du
`sourceProfileProvider` retournait `(null, [])` → couverture + derniers articles + chip
fréquence masqués d'un coup (fiche « presque vide »). Le parse était déjà défensif
(`Content.fromJson` / `SourceProfile.fromJson`), donc le coupable est la couche HTTP.

**Fix** :
- `sources_repository.dart` : retry des échecs **transitoires** (timeout / coupure / 5xx),
  jusqu'à 2 fois avec backoff ; les 4xx (404/422) restent définitives. Couvre le cas
  onboarding où la fiche est pré-chargée à l'ouverture de l'écran.
- `source_detail_modal.dart` : la branche `error` retombe désormais sur la couverture via
  l'endpoint indépendant `/coverage` (best-effort) **et** propose un bouton « Réessayer »
  dans la zone articles (relance `sourceProfileProvider`). La fiche n'est plus jamais muette.

## #2 — Plus de carte « Actus du jour » réduite à 1 article

**Cause** (investigation logs/code) : le garde 202 de la carte hi-fi Essentiel est étanche
(`essentiel.py:87`). Ce que le PO a vu = la section legacy **« Actus du jour »**
(`DigestTopicSection kind=essentiel`), qui n'avait **aucun plancher** → 1 topic = 1 carte
isolée (fréquent sur compte neuf / digest pauvre). Le dedup inter-sections pouvait encore
la réduire à 1.

**Fix** (frontend, cadré sources/éditorial, pas d'élargissement du pool global) :
- `flux_continu_provider.dart` : plancher `_kActusMinTopics = 2` ajouté à `_buildDigestSection`
  (param `minTopics`, défaut 1 → **Bonnes Nouvelles inchangée**), appliqué à l'appel
  « Actus du jour » **et** réappliqué après le dedup (sinon une section réduite à 1 topic
  réapparaissait). Sous le plancher, la section est masquée (esprit du garde 202).

> ⚠️ Décision produit : « Actus du jour » est désormais masquée quand elle n'a qu'1 topic
> (tous users, pas seulement onboarding). En pratique seuls les digests pauvres sont
> concernés (comptes neufs) ; un digest riche n'est pas affecté.

## #3a — Cartes du carrousel de sélection alignées

**Cause** : la pastille de biais était conditionnelle (`if biasStance != 'unknown'`) → le
cœur (tags/raison) des cartes démarrait à des hauteurs différentes → cartes « raguées » au
swipe (le `PageView` égalise déjà la hauteur externe).

**Fix** : `source_carousel_card.dart` réserve le slot biais à hauteur fixe (rendu vide si
inconnu) → le cœur démarre à la même hauteur sur toutes les cartes.

## #4 — Connexion premium : opt-out explicite + map curée non bloquante

**Cause** : `premium_connection_config.enabled = false` n'était pas traité comme un opt-out ;
et la connexion positive exigeait une config premium **explicite** côté source, ce qui faisait
de la config curée une whitelist bloquante.

**Fix** (backend) :
- `schemas/source.py` : `PremiumConnectionResponse.is_explicitly_disabled()` + gate dans
  `from_source()` — `enabled = false` bloque désormais aussi la map curée et le fallback
  générique (blocklist pour les sources dont la connexion WebView est connue incompatible).
- `source_service.py` : la connexion positive accepte une connexion premium **résolue**
  (config explicite, domaine curé, ou fallback générique paywalled) ; la config curée
  améliore l'expérience sans servir de whitelist bloquante. Dissociation toujours autorisée.

## #5 — Polish validation des étapes onboarding

- `onboarding_toggle_section.dart` + `sources_question.dart` : badge « validé » sur les
  sections déjà franchies (`validated: _openSection > N`).
- `subtopics_question.dart` : brève phase « validé » (scale/opacity + check) sur la carte
  courante avant le scroll vers le thème suivant.
- `conclusion_animation_screen.dart` / `conclusion_live_feed.dart` : séquencement de la phase
  de complétion (accélération du flux en fin d'animation).
- `source_recommender.dart` + `sources_question.dart` : caps de suggestions élargis
  (matched 15→20, suggestions 18→20, pré-cochées 9→12) pour des suggestions plus riches.

## Tests
- Backend : `pytest -v` → **1869 passed**, 18 skipped, 2 xfailed (dont
  `test_premium_discoverability.py` + `test_premium_source_connection.py`, 17 OK).
- Mobile : `flutter analyze` clean ; suites `flux_continu/`, `onboarding/`, `sources/` vertes
  (`source_detail_modal_test.dart`, `flux_continu_provider_test.dart`,
  `flux_continu_tournee_order_test.dart`, `sources_question_test.dart`,
  `swipe_disambiguator_question_test.dart`, `conclusion_live_feed_test.dart`,
  `source_recommender_test.dart`).
- Aucun changement Alembic.

## Changelog
Entrée `unreleased` ajoutée (tag « Onboarding »).

## Hors PR de code — #3b catalogue (livrable PO, étape gatée séparée)
Audit read-only livré au PO (gaps politics/science/tech, candidats promouvables, flux morts,
retag 51-slug non appliqué). Aucun `--apply` ni ajout `sources_master.csv` sans liste PO.
