### PR TITLE
fix(alembic): empêche le kill idle-in-transaction des migrations (DB gelée à mg01)

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -22,7 +22,10 @@ jobs:
           python-version: '3.12'
 
       - name: Install linter
-        run: pip install ruff
+        # Pinned: an unpinned ruff silently auto-upgrades and enables new lint
+        # rules, turning untouched files red and blocking every PR of the day
+        # (recurring drift). Bump deliberately when adopting a new ruff version.
+        run: pip install ruff==0.15.14
 
       - name: Ruff check
         run: cd packages/api && ruff check app/

--- a/packages/api/alembic/env.py
+++ b/packages/api/alembic/env.py
@@ -54,9 +54,18 @@ MIGRATION_CONNECT_ARGS = {
     "prepare_threshold": None,  # Disable prepared statements (required for PgBouncer transaction mode)
     # 30s TCP connect timeout — prevents infinite hang if session-mode port is unreachable
     "connect_timeout": 30,
-    # Pass timeout options directly to PostgreSQL server via connection options
-    # 10 min statement timeout, 2 min lock timeout
-    "options": "-c statement_timeout=600000 -c lock_timeout=120000",
+    # Pass timeout options directly to PostgreSQL server via connection options.
+    # 10 min statement timeout, 2 min lock timeout, and CRUCIALLY disable the
+    # idle-in-transaction timeout: the whole upgrade runs in ONE transaction
+    # (see do_run_migrations) and the `postgres` role carries a 60s
+    # ``idle_in_transaction_session_timeout`` (ALTER ROLE), which otherwise
+    # kills a multi-migration catch-up mid-flight (FATAL: terminating
+    # connection due to idle-in-transaction timeout) → full rollback → the
+    # shared Supabase DB stays frozen at an old revision.
+    "options": (
+        "-c statement_timeout=600000 -c lock_timeout=120000 "
+        "-c idle_in_transaction_session_timeout=0"
+    ),
 }
 
 # Interpret the config file for Python logging.
@@ -96,6 +105,13 @@ def do_run_migrations(connection: Connection) -> None:
         # because the same backend connection is used for the entire transaction.
         connection.execute(text("SET LOCAL statement_timeout = '0'"))
         connection.execute(text("SET LOCAL lock_timeout = '120s'"))
+        # SET LOCAL has the highest precedence — it overrides the `postgres`
+        # role's 60s idle_in_transaction_session_timeout for THIS transaction,
+        # so a long mg01→head catch-up over the shared DB can't be killed for
+        # in-transaction idle. Belt-and-suspenders with the connect-arg option.
+        connection.execute(
+            text("SET LOCAL idle_in_transaction_session_timeout = '0'")
+        )
         context.run_migrations()
     print("[alembic] Migrations completed successfully", flush=True)
 

--- a/packages/api/app/routers/contents.py
+++ b/packages/api/app/routers/contents.py
@@ -1043,10 +1043,10 @@ async def _attach_deep_from_store(
             error=str(e),
         )
         # Clear the aborted transaction so request teardown stays clean.
-        try:
+        import contextlib
+
+        with contextlib.suppress(Exception):  # pragma: no cover - best-effort cleanup
             await db.rollback()
-        except Exception:  # pragma: no cover - best-effort cleanup
-            pass
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Pourquoi « Pas de recul » reste vide après #876

#876 a débloqué les déploiements (CI iOS verte) et le backend redéploie bien. **Mais la DB partagée Supabase reste gelée à `mg01`** (~10 migrations de retard) : `alembic upgrade head` est rejoué à chaque boot **et échoue**, l'app démarre quand même (fallback du `Dockerfile`). Donc la table `content_deep_recommendations` (migration `zz01`) n'est jamais créée → « Pas de recul » n'a aucune donnée à afficher.

## Cause-racine (confirmée en live)

Vérifié sur la DB de prod (lecture seule) + logs Postgres :
- `pg_roles` : le rôle **`postgres`** (utilisé par le backend) porte **`idle_in_transaction_session_timeout = 60s`** au niveau rôle (`ALTER ROLE`), alors que le réglage DB est `0`.
- `env.py` (`do_run_migrations`) joue **tout l'upgrade dans UNE seule transaction** ; ses `options` de connexion fixent `statement_timeout`/`lock_timeout` mais **pas** l'idle-in-transaction.
- Les logs Postgres ne montrent **aucune erreur DDL** (pas de « already exists », pas de « must be owner », pas d'ALTER en échec) — uniquement des **`FATAL: terminating connection due to idle-in-transaction timeout`**. Signature d'une transaction **tuée à 60s d'idle**, pas d'une migration cassée. → rollback complet → DB reste à `mg01`.

## Fix

Désactiver l'idle-in-transaction timeout **pour la session de migration uniquement** :
- option de connexion `-c idle_in_transaction_session_timeout=0` (`MIGRATION_CONNECT_ARGS`) ;
- `SET LOCAL idle_in_transaction_session_timeout = '0'` dans `do_run_migrations` (précédence maximale, surclasse le réglage de rôle), à côté des `SET LOCAL` statement/lock existants.

Aucune modification de la chaîne de migrations — uniquement des réglages de session. La chaîne `mg01→sec02` est inchangée (la CI `alembic-smoke` rejoue `upgrade head` contre une Postgres vide).

## Vérification
- `env.py` se charge (`alembic heads` → `sec02_new_public_rls`).
- `alembic-smoke` (CI) couvre l'upgrade complet depuis une DB vide, en exerçant le nouveau `SET LOCAL`.

## Après merge (ops, à confirmer)
1. Le boot Railway doit faire passer la DB partagée à `alembic_version = sec02_new_public_rls`. Je revérifie en live dès que c'est déployé (la table `content_deep_recommendations` doit exister et se peupler au prochain batch éditorial).
2. **Ne pas promouvoir en prod** tant que ce n'est pas vérifié (`production` partage la DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)