### PR TITLE
feat(tour): tour guidé post-onboarding (coach-mark 5 étapes)

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,66 +1,33 @@
-# Volet « Pas de recul » (deep reco) dans le reader — backend + mobile
+## Tour guidé Facteur (coach-mark post-onboarding)
 
-## Résumé
-Réactive le moteur « Pas de recul » (désactivé au post-unification cleanup) et
-l'expose **par article ouvert** : l'endpoint `GET /contents/{id}/perspectives`
-renvoie une recommandation d'article de fond (`deep_recommendation`), et le
-reader la rend tout en bas, sous la « Couverture médiatique ». Premier étage de
-la dimension « deep » de l'app. **Aucune migration Alembic.**
+Tour guidé en 5 étapes joué **une seule fois juste après l'onboarding**, qui pilote la vraie app pour présenter ses pages principales. Il s'insère **avant** les modales post-onboarding existantes (thème puis notifications).
 
-## Changements — Backend
-- **`deep_matcher.py`** : nouvelle méthode `match_for_content(content)` — variante
-  reader de `match_for_topics`. Dérive un pseudo-angle depuis l'article ouvert
-  (titre + topics + theme), réutilise tel quel `_load_deep_articles` / `_prefilter`
-  / `_expand_query` / `_llm_evaluate` / `_fallback_pick`. Exclut l'article ouvert
-  **et** tout article du même cluster (pas une autre dépêche du même évènement).
-  Helper `_entity_names` tolérant aux deux formats d'entités (JSON & `name:type`).
-- **`routers/contents.py`** : cache dédié `_deep_reco_cache` (TTL 2h) + sentinelle
-  `_DEEP_NO_MATCH` + garde in-flight. Le matching tourne en **background**
-  (`_compute_deep_reco_background`) car il fait 2 appels LLM — on ne bloque pas
-  l'ouverture du reader, exactement comme le pattern partiel/refresh des
-  perspectives. `deep_recommendation` (dict|null) + `deep_pending` (bool) sont
-  attachés aux 3 chemins de retour (cache hit / snapshot digest / live) et
-  préservés à travers le refresh background.
-- **`editorial_prompts.yaml`** : prompt `deep_matching` décommenté. **`config.py`** :
-  commentaire TODO nettoyé.
+### Parcours (6 états joués, 5 puces)
+1. **1/5** — hero « L'Essentiel du jour » + onglet Essentiel (scroll top).
+2. **2/5 (a)** — scroll vers la 1ʳᵉ section de la Tournée (`ensureVisible`).
+3. **2/5 (b)** — ouverture de la vraie feuille « Mes favoris », spotlight par-dessus.
+4. **3/5** — bascule onglet Flâner, voile plein, carte centrée.
+5. **4/5** — retour accueil, spotlight de l'avatar profil (Réglages).
+6. **5/5** — même avatar (Mon courrier), bouton « Terminer ».
+7. **done** — carte « C'est parti », puis main rendue aux modales.
 
-## Changements — Mobile
-- **`feed_repository.dart`** : modèle `DeepRecommendation` + champs
-  `deepRecommendation` / `deepPending` sur `PerspectivesResponse` (+ parsing JSON,
-  rétro-compatible : clés absentes ⇒ `null` / `false`).
-- **`deep_recommendation_card.dart`** (nouveau) : carte « Pas de recul »
-  (médaillon 🔭, titre, raison de match, source ; tap → ouvre l'article dans le
-  reader). Palette dérivée des tokens `colors.*` ⇒ cohérent clair/sombre/oled.
-- **`content_detail_screen.dart`** : rendu de la carte en bas du reader (gardé par
-  `deep_recommendation != null && !_isExternal`), `_openDeepReco()` (push route
-  `content/:id`), et refetch one-shot étendu à `deepPending` (pas de double appel
-  LLM-coûteux).
+### Architecture
+- **Machine à états Riverpod** (`GuidedTourController`, `keepAlive`) — survit aux changements d'onglet/feuilles, **ne touche jamais `BuildContext`**. `start(onComplete)` gate le flag « vu » (scopé user) ; `next()`/`skip()`/`finish()` → `done` + `onComplete` tiré une seule fois.
+- **Bridge racine** (`GuidedTourBridge`, monté une fois dans `MainShell`) — exécute les effets de bord (navigation, ouverture feuille, scroll) et insère l'`OverlayEntry` dans l'overlay **racine** (au-dessus de la feuille favoris qui vit en branche).
+- **Overlay** — scrim `#2C2A29` α0.72 + découpe spotlight (`Path`/`BlendMode.clear`, contour `#E8943F`), rect relu live depuis le `RenderBox` des `GlobalKey` à chaque frame (suit slide/scroll). Coach card : avatar Facteur, pastille « N/5 », titre Fraunces, corps DM Sans, 5 puces, Passer/Suivant/Terminer.
 
-## Contrat API (nouveaux champs de la réponse perspectives)
-```
-deep_recommendation: {
-  content_id, title, url, thumbnail_url, content_type,
-  source_id, source_name, source_logo_url, published_at,
-  match_reason, description
-} | null
-deep_pending: bool   # true = matching en cours en background → mobile doit refetch
-```
+### Garde « une seule fois »
+Double verrou : démarrage seulement depuis le chemin post-onboarding (`postOnboardingFlowPendingProvider`) **et** flag persistant `nudge.guided_tour.seen.<userId>` (namespace `nudge.`, scopé user comme `NudgeStorage`).
 
-## Tests
-- `tests/editorial/test_deep_matcher.py` : `TestMatchForContent` (sélection LLM,
-  exclusion self, exclusion même cluster, pool vide, pivot maigre, fallback no-LLM)
-  + `TestEntityNames`. **25/25 verts.**
-- `tests/routers/test_contents_deep_reco.py` (nouveau) : helpers `_deep_reco_to_dict`,
-  `_apply_deep_from_cache`, `_attach_deep_recommendation`. **8/8 verts.**
-- `deep_recommendation_card_test.dart` (nouveau) + `feed_repository_perspectives_test.dart`
-  (étendu : parsing `deep_recommendation` / `deep_pending`).
-- 1 seul head Alembic, aucune migration.
+### Fichiers
+- **Nouveaux** : `lib/features/tour/` (models/tour_step, providers/guided_tour_controller, tour_anchors, tour_strings, tour_ids, widgets/guided_tour_bridge|overlay|coach_card).
+- **Édités** : `flux_continu_screen.dart` (split `_runPostOnboardingFlow` → tour puis `_runPostOnboardingModals`, listen `tourScrollTargetProvider`, ancre 1ʳᵉ section), `essentiel_hi_fi_card.dart` (ancre hero), `main_shell.dart` (montage bridge + ancre avatar), `main_bottom_nav.dart` (ancre onglet), `manage_favorites_sheet.dart` (ancre feuille + note z-order), `navigation_providers.dart` (`tourScrollTargetProvider`), `changelog.json`.
 
-## Vérif manuelle suggérée (avant merge)
-`uvicorn` local + `curl /contents/{id}/perspectives` → `deep_pending:true` au 1er
-appel, puis `deep_recommendation` peuplé au 2e (article avec sujet couvert par une
-source `source_tier='deep'`) ; `null` sur un fait divers.
+### Tests
+- `test/features/tour/guided_tour_controller_test.dart` — séquence complète, displayIndex (2/5 mutualisé), skip/finish → done + flag persisté + onComplete une fois, no-op si déjà vu.
+- `test/features/tour/guided_tour_overlay_test.dart` — coach card (titre/pastille/puces/boutons), « Terminer » en dernière étape, carte de conclusion, voile plein sans ancre.
+- `flutter analyze` : 0 nouvelle erreur. Tests des fichiers touchés (essentiel_hi_fi_card, main_bottom_nav, flux_continu) : verts.
 
-## Suite
-- Chantier curation deep (séparé) : labelliser plus de sources `source_tier='deep'`
-  + chaînes YouTube + reportages.
+### Notes
+- Frontend pur, aucune migration / endpoint.
+- Reste à faire avant deploy : `/validate-feature` Playwright (handoff dans `.context/qa-handoff.md`).

--- a/.context/qa-handoff.md
+++ b/.context/qa-handoff.md
@@ -1,67 +1,58 @@
-# QA Handoff — Onboarding : polish du « cœur » sélection des sources
+# QA Handoff — Tour guidé Facteur (coach-mark post-onboarding)
 
-Branche : `boujonlaurin-dotcom/onboarding-source-selection-polish` (base `main`).
-Backend non touché. Feature UI only.
+> Rempli par l'agent dev. Input de `/validate-feature` (Playwright Agent CLI).
+
+## Feature développée
+Tour guidé en 5 étapes joué **une seule fois juste après l'onboarding**. Il pilote la vraie app (bascule d'onglet, ouvre la feuille « Mes favoris », scrolle l'Essentiel) et présente : l'Essentiel + ta Tournée, la réorganisation, Flâner, puis spotlight de l'avatar profil pour Réglages et Mon courrier. À la fin (« Terminer » ou « Passer »), la main est rendue aux modales post-onboarding existantes (thème puis notifications).
+
+## PR associée
+À créer vers `main` (`--base main`).
 
 ## Écrans impactés
+| Écran | Route | Modifié / Nouveau |
+|-------|-------|-------------------|
+| L'Essentiel (Flux Continu) | `/flux-continu` | Modifié (ancres hero + 1ʳᵉ section + avatar) |
+| Flâner | `/flaner` | Modifié (étape 3, voile centré) |
+| Feuille « Mes favoris » | bottom sheet (branche) | Modifié (ancre spotlight) |
+| Overlay tour guidé | overlay racine | Nouveau |
 
-1. **Swipe de calibration** (`SwipeDisambiguatorQuestion`, Q9c)
-2. **Page « Tes médias, sur mesure »** (`SourcesQuestion`, Q10)
+## Scénarios de test
 
-## Setup
+### Scénario 1 : Happy path (5 étapes complètes)
+1. Compléter l'onboarding jusqu'à l'écran de conclusion → arrivée sur L'Essentiel.
+2. **Étape 1/5** : coach card en bas, spotlight sur le hero « L'Essentiel du jour » + onglet Essentiel. Cliquer « Suivant ».
+3. **Étape 2/5 (a)** : l'app scrolle vers la 1ʳᵉ section de la Tournée, spotlight dessus. « Suivant ».
+4. **Étape 2/5 (b)** : la feuille « Mes favoris » s'ouvre, spotlight la cerne par-dessus. Pastille toujours « 2 / 5 ». « Suivant ».
+5. **Étape 3/5** : bascule sur Flâner, voile plein, coach card centrée. « Suivant ».
+6. **Étape 4/5** : retour Essentiel, spotlight de l'avatar profil (haut-droite). « Suivant ».
+7. **Étape 5/5** : même avatar profil, bouton « Terminer ».
+8. **Terminer** → carte « C'est parti ! » brève → puis enchaînement des modales thème puis notifications.
 
-- Build web Flutter, viewport mobile **390x844**, sémantique activée au boot
-  (cf. skill `facteur-qa-web`).
-- Parcourir l'onboarding jusqu'au swipe (répondre thèmes/sujets pour avoir des
-  groupes thématisés), puis continuer jusqu'à la page sur-mesure.
+**Attendu** : 5 puces de progression, pastille « N / 5 », pas d'écran gris, pas d'erreur console, pas de 4xx/5xx.
 
-## Scénarios — Swipe (B)
+### Scénario 2 : « Passer » à n'importe quelle étape
+1. Démarrer le tour, cliquer « Passer » dès l'étape 1.
+**Attendu** : overlay retiré, enchaînement direct vers les modales thème/notifications.
 
-- **En-tête dynamique (B.2)** : plus de titre statique « Quels médias suivre ? ».
-  Un en-tête par **groupe** s'affiche (ex. « L'actu au quotidien »,
-  « Des médias indépendants », « Pour aller au fond… », « Un autre point de
-  vue », ou thématisé « Pour creuser Tech & Innovation… »). Il **change** quand
-  on passe d'un bloc de cartes au suivant (transition douce).
-  - Edge : l'ordre des blocs suit les prefs — répondre « médias spécialisés »
-    (independent) doit mener avec indépendants/fond ; « grands médias »
-    (established) avec références/grands médias.
-- **Hint (B.1)** : sous la carte, texte renommé **« Touche pour ouvrir le
-  média »** (visible sur la 1ʳᵉ carte, disparaît au 1ᵉʳ geste), rapproché du bas
-  du deck.
-- **Centrage (B.3)** : le deck est centré verticalement (plus d'espace mort en
-  haut depuis la suppression du gros titre).
-- **Undo (B.4)** : 3 boutons ronds sur une ligne — **undo discret (plus petit,
-  gris) à gauche** de (X) et (♥). Invisible tant qu'aucun vote ; (X)/(♥) restent
-  centrés (placeholder symétrique). L'undo de l'overlay final reste inchangé.
+### Scénario 3 : Une seule fois
+1. Tour terminé, fermer/rouvrir l'app (même utilisateur).
+**Attendu** : le tour ne rejoue pas ; les modales post-onboarding (si encore dues) jouent directement.
 
-## Scénarios — Page sur-mesure (A)
-
-- **Déjà ajoutés (A.1)** : en tête de la section 1, puces **discrètes** (libellé
-  léger « Déjà ajoutés », logos ~18px), alimentées par les sources likées au
-  swipe. Ces sources sont hors carrousel et déjà cochées.
-- **Carrousels (A.2)** : sections 1 (suggestions) **et** 3 (catalogue) en
-  **carrousel horizontal** (swipe latéral, ~1,2 carte visible, peek sur la
-  suivante). Le filtre par thème (section 3) repart de la 1ʳᵉ carte.
-- **Cartes (A.3/A.4)** : cartes portrait — logo + nom + pastille de biais en
-  tête ; **aspects matchés** (tags : thème, « Spécialisé en X », « ≈ Similaire à
-  … », fiable/anti-bruit/serein) mis en valeur au cœur ; cercle de sélection
-  ≥44px ; tap carte → modale détail.
+### Scénario 4 : Edge — feuille favoris refermée au doigt (étape 2b)
+1. À l'étape « Compose ta Tournée », fermer la feuille par swipe vers le bas (au lieu de « Suivant »).
+**Attendu** : auto-avance vers l'étape Flâner (pas de voile orphelin bloquant).
 
 ## Critères d'acceptation
+- [ ] Le tour pilote réellement l'app entre les étapes.
+- [ ] Étapes 4 & 5 restent sur l'accueil et spotlight l'avatar profil (pas de navigation Settings/Courrier).
+- [ ] Joué une seule fois, post-onboarding, aucun point d'entrée « Revoir ».
+- [ ] Tour d'abord, puis modales thème/notifications.
+- [ ] Pas d'em-dash dans la copy (règle PO).
 
-- En-tête de swipe change visiblement entre groupes ; aucun em-dash.
-- Carrousels fluides, peek visible ; sélection/desélection OK ; modale détail OK.
-- Console sans erreurs ; pas de 4xx/5xx réseau inattendus.
+## Zones de risque
+- **Ancre pas encore layoutée** après bascule d'onglet (slide 260ms) / scroll → voile plein tant que la cible n'est pas mesurée/visible, rect recalculé chaque frame.
+- **Z-order** : overlay inséré dans l'overlay **racine** ; la feuille favoris reste en navigator de branche (ne PAS passer `useRootNavigator: true`).
+- **GlobalKeys uniques** : avatar + onglet Essentiel ancrés uniquement côté Essentiel (les deux branches sont montées simultanément).
 
-## Vérifs déjà passées (dev)
-
-- `flutter test test/features/onboarding` → **84 passed** (dont nouveaux tests
-  `buildSpanningGroups` : ordre par prefs, libellé thème vs pôle, dégradation).
-- `flutter analyze` sur les fichiers touchés → propre (seuls infos `withOpacity`
-  pré-existantes, conformes au reste du code).
-
-## Note hors-scope (à signaler)
-
-`apps/mobile/assets/changelog.json` était **JSON invalide sur `main`** (deux
-entrées `unreleased` fusionnées par un mauvais merge → parsing cassé). Réparé
-dans cette PR + ajout de l'entrée « Onboarding » de la feature.
+## Dépendances
+Aucune (frontend pur, persistance locale `SharedPreferences` clé `nudge.guided_tour.seen.<userId>`). Nécessite un compte qui vient de finir l'onboarding.

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -2,6 +2,10 @@
   "unreleased": [
     {
       "tag": "Onboarding",
+      "summary": "Un tour guidé te présente tes pages dès la première ouverture."
+    },
+    {
+      "tag": "Onboarding",
       "summary": "Sélection des médias plus fluide : davantage de suggestions, petites animations de validation à chaque étape, et un écran de fin qui va jusqu'au bout avant de t'emmener dans l'app."
     },
     {

--- a/apps/mobile/lib/core/providers/navigation_providers.dart
+++ b/apps/mobile/lib/core/providers/navigation_providers.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// Déclencheur de scroll-to-top pour l'onglet Flâner.
@@ -21,6 +22,13 @@ final essentielScrollTriggerProvider = StateProvider<int>((ref) => 0);
 final tourneeLastDedicatedSectionProvider = StateProvider<String?>(
   (ref) => null,
 );
+
+/// Cible de scroll demandée par le tour guidé : le bridge y pose la `GlobalKey`
+/// de la section à révéler (`tourActusSectionKey`) pendant l'étape « descends
+/// dans tes cartes ». `FluxContinuScreen` l'écoute et `ensureVisible` la cible,
+/// puis remet le provider à `null`. `StateProvider` plutôt qu'un trigger compteur
+/// car la valeur transporte la clé elle-même.
+final tourScrollTargetProvider = StateProvider<GlobalKey?>((ref) => null);
 
 /// Visibilité du footer (MainBottomNav) — masqué au scroll vers le bas, révélé
 /// au scroll vers le haut, partout dans l'app (comportement LinkedIn).

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -31,6 +31,8 @@ import '../../lettres/widgets/lettres_notification_banner.dart';
 import '../../notifications/widgets/notification_activation_modal.dart';
 import '../../notifications/widgets/notification_renudge_banner.dart';
 import '../../onboarding/widgets/theme_choice_bottom_sheet.dart';
+import '../../tour/providers/guided_tour_controller.dart';
+import '../../tour/tour_anchors.dart';
 import '../../well_informed/widgets/well_informed_prompt.dart';
 import '../../../shared/strings/loader_error_strings.dart';
 import '../models/flux_continu_models.dart';
@@ -908,12 +910,28 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   /// 3. la modal d'activation des notifications.
   /// La page Essentiel chargée sert de fond aux modales : à leur fermeture elle
   /// est révélée intacte (plus d'écran gris ni de contexte démonté).
+  /// Façade post-onboarding : consomme le flag (anti-replay), puis joue le tour
+  /// guidé **d'abord** ; à sa conclusion (`onComplete`, tiré une seule fois sur
+  /// finish/skip — ou immédiatement si le tour a déjà été vu), enchaîne les
+  /// modales (dialog customs échoués → thème → notif). `onComplete` est exécuté
+  /// par le controller (état Riverpod stable) : on re-garde `mounted` à l'entrée
+  /// de [_runPostOnboardingModals], jamais de `ref` après démontage.
   Future<void> _runPostOnboardingFlow() async {
     if (!mounted) return;
     final failedCustomTopics = ref.read(postOnboardingFlowPendingProvider);
     if (failedCustomTopics == null) return;
     // Consomme le flag immédiatement : un refetch/rebuild ne doit pas rejouer.
     ref.read(postOnboardingFlowPendingProvider.notifier).state = null;
+
+    await ref.read(guidedTourControllerProvider.notifier).start(
+          onComplete: () => unawaited(_runPostOnboardingModals(failedCustomTopics)),
+        );
+  }
+
+  /// Les modales historiques, jouées une fois le tour guidé conclu. Le `failed`
+  /// est capturé dans la closure `onComplete` pour survivre à la durée du tour.
+  Future<void> _runPostOnboardingModals(List<String> failedCustomTopics) async {
+    if (!mounted) return;
 
     if (mounted && failedCustomTopics.isNotEmpty) {
       // Dialog bloquant : les bottom sheets suivants poseraient un barrier qui
@@ -969,6 +987,25 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     ref.listen(tourneeLastDedicatedSectionProvider, (_, __) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _restoreLastDedicatedSection();
+      });
+    });
+    // Tour guidé (étape « descends dans tes cartes ») : le bridge pose la clé
+    // de la section à révéler ; on l'`ensureVisible` puis on remet à null.
+    ref.listen<GlobalKey?>(tourScrollTargetProvider, (_, key) {
+      if (key == null) return;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        final ctx = key.currentContext;
+        if (ctx != null) {
+          Scrollable.ensureVisible(
+            ctx,
+            duration: const Duration(milliseconds: 400),
+            curve: Curves.easeOutCubic,
+            alignment: 0.1,
+          );
+        }
+        if (mounted) {
+          ref.read(tourScrollTargetProvider.notifier).state = null;
+        }
       });
     });
     // Flow post-onboarding : joué une seule fois quand Essentiel a chargé ses
@@ -1287,7 +1324,11 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
         SliverToBoxAdapter(
           child: KeyedSubtree(
             key: _sectionKeys[i],
-            child: Column(
+            // Ancre du tour guidé (étape 2 — 1ʳᵉ section de contenu après le
+            // hero). `inlineTargetIndex` désigne déjà cette section.
+            child: KeyedSubtree(
+              key: i == inlineTargetIndex ? tourActusSectionKey : null,
+              child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
                 if (showInlineHere)
@@ -1348,6 +1389,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
                   ),
                 ),
               ],
+            ),
             ),
           ),
         ),

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -7,6 +7,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
+import '../../tour/tour_anchors.dart';
 import '../../settings/models/display_mode_spec.dart';
 import '../../settings/providers/display_mode_provider.dart';
 import '../models/flux_continu_models.dart';
@@ -45,7 +46,10 @@ class EssentielHiFiCard extends ConsumerWidget {
         ? articles.sublist(1, articles.length > 5 ? 5 : articles.length)
         : const <EssentielArticle>[];
 
-    return Container(
+    return KeyedSubtree(
+      // Ancre du tour guidé (étape 1 — hero « L'Essentiel du jour »).
+      key: tourEssentielHeroKey,
+      child: Container(
       margin: const EdgeInsets.fromLTRB(
         FacteurSpacing.space3,
         FacteurSpacing.space2,
@@ -94,6 +98,7 @@ class EssentielHiFiCard extends ConsumerWidget {
             ],
           ],
         ),
+      ),
       ),
     );
   }

--- a/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
@@ -20,6 +20,7 @@ import '../../my_interests/providers/user_sources_state_provider.dart';
 import '../../sources/models/source_model.dart';
 import '../../sources/providers/sources_providers.dart';
 import '../../sources/widgets/source_logo_avatar.dart';
+import '../../tour/tour_anchors.dart';
 import '../../veille/providers/veille_active_config_provider.dart';
 import '../../veille/providers/veille_themes_provider.dart';
 import '../providers/tournee_order_prefs_provider.dart' hide applyOrder;
@@ -50,6 +51,11 @@ Future<void> showManageFavoritesSheet(
   BuildContext context, {
   ManageFavoritesEntry entry = ManageFavoritesEntry.essentiel,
 }) {
+  // NB z-order : on N'utilise PAS `useRootNavigator: true` à dessein. La feuille
+  // vit ainsi dans le navigator de **branche**, ce qui laisse l'overlay racine
+  // du tour guidé ([tourFavorisSheetKey]) se rendre au-dessus pour la cerner
+  // (cf. plan tour guidé, étape 2). Repasser en root navigator casserait le
+  // spotlight de l'étape « Compose ta Tournée ».
   return showModalBottomSheet<void>(
     context: context,
     backgroundColor: Colors.transparent,
@@ -57,10 +63,13 @@ Future<void> showManageFavoritesSheet(
     enableDrag: true,
     isDismissible: true,
     barrierColor: Colors.black.withValues(alpha: 0.5),
-    builder: (ctx) => ClipRect(
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 6, sigmaY: 6),
-        child: _ManageFavoritesContent(entry: entry),
+    builder: (ctx) => KeyedSubtree(
+      key: tourFavorisSheetKey,
+      child: ClipRect(
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 6, sigmaY: 6),
+          child: _ManageFavoritesContent(entry: entry),
+        ),
       ),
     ),
   );

--- a/apps/mobile/lib/features/tour/models/tour_step.dart
+++ b/apps/mobile/lib/features/tour/models/tour_step.dart
@@ -1,0 +1,46 @@
+/// Étapes du tour guidé post-onboarding (cf. `Tour guidé Facteur.dc.html`).
+///
+/// 6 états sont **joués** ; le proto n'affiche que 5 puces de progression car le
+/// point « 2 / 5 » est partagé entre deux panneaux ([descendsCartes] qui montre
+/// les sections de la Tournée et [favorisSheet] qui présente la feuille « Mes
+/// favoris »). Le mapping vit dans [TourStepDisplay.displayIndex].
+enum TourStep {
+  /// 1/5 — hero « L'Essentiel du jour » (ta Tournée du jour).
+  essentielHero,
+
+  /// 2/5 (a) — invite à descendre dans les sections de la Tournée.
+  descendsCartes,
+
+  /// 2/5 (b) — feuille « Mes favoris » ouverte (réorganiser sa Tournée).
+  favorisSheet,
+
+  /// 3/5 — onglet Flâner.
+  flaner,
+
+  /// 4/5 — Réglages (spotlight de l'avatar profil, sans navigation réelle).
+  reglages,
+
+  /// 5/5 — Mon courrier (même avatar profil, dernière étape « Terminer »).
+  courrier,
+
+  /// Carte finale « C'est parti » avant de rendre la main aux modales.
+  done,
+}
+
+extension TourStepDisplay on TourStep {
+  /// Numéro affiché sur la pastille « N / 5 » du coach card. [descendsCartes] et
+  /// [favorisSheet] partagent le point 2 (cf. proto). [done] n'affiche pas de
+  /// pastille (carte de conclusion) → retourne le dernier index par défaut.
+  int get displayIndex => switch (this) {
+        TourStep.essentielHero => 1,
+        TourStep.descendsCartes => 2,
+        TourStep.favorisSheet => 2,
+        TourStep.flaner => 3,
+        TourStep.reglages => 4,
+        TourStep.courrier => 5,
+        TourStep.done => 5,
+      };
+
+  /// Nombre total de puces de progression (5, le point 2 étant mutualisé).
+  static const int totalSteps = 5;
+}

--- a/apps/mobile/lib/features/tour/providers/guided_tour_controller.dart
+++ b/apps/mobile/lib/features/tour/providers/guided_tour_controller.dart
@@ -1,0 +1,115 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../core/auth/auth_state.dart';
+import '../models/tour_step.dart';
+import '../tour_ids.dart';
+
+part 'guided_tour_controller.g.dart';
+
+/// Machine à états du tour guidé post-onboarding.
+///
+/// Vit au niveau application (`keepAlive`) pour survivre aux changements
+/// d'onglet et à l'ouverture/fermeture de feuilles pendant le tour. Le notifier
+/// **ne touche jamais à `BuildContext`** : tous les effets de bord (navigation,
+/// ouverture de feuille, scroll) sont exécutés par [GuidedTourBridge], monté au
+/// niveau racine et stable, qui écoute cet état.
+///
+/// `null` = inactif. La séquence jouée est :
+/// `essentielHero → descendsCartes → favorisSheet → flaner → reglages →
+/// courrier → done`. [skip] et [finish]/`next()` sur la dernière étape mènent
+/// tous deux à [TourStep.done], persistent le flag « vu » et tirent `onComplete`
+/// **une seule fois** (rend la main au flow des modales post-onboarding).
+@Riverpod(keepAlive: true)
+class GuidedTourController extends _$GuidedTourController {
+  VoidCallback? _onComplete;
+  bool _completed = false;
+  bool _starting = false;
+
+  /// Clé `nudge.<id>.seen.<userId>` — alignée sur `NudgeStorage._userSeenKey`
+  /// pour partager la sémantique scopée-user (un second compte revoit le tour).
+  String _seenKey(String userId) =>
+      'nudge.${TourIds.guidedTour}.seen.$userId';
+
+  String get _currentUserId =>
+      ref.read(authStateProvider).user?.id ?? 'anonymous';
+
+  @override
+  TourStep? build() => null;
+
+  /// Démarre le tour s'il n'a jamais été vu par l'utilisateur courant. Dans tous
+  /// les cas, [onComplete] finit par être appelé **exactement une fois** : soit
+  /// immédiatement (tour déjà vu), soit à la fin du tour ([finish]/[skip]).
+  ///
+  /// Idempotent : un second appel pendant qu'un tour tourne est ignoré.
+  Future<void> start({required VoidCallback onComplete}) async {
+    if (_starting || state != null) return;
+    _starting = true;
+    _onComplete = onComplete;
+    _completed = false;
+
+    final prefs = await SharedPreferences.getInstance();
+    final seen = prefs.getBool(_seenKey(_currentUserId)) ?? false;
+    if (seen) {
+      _starting = false;
+      _fireComplete();
+      return;
+    }
+    _starting = false;
+    state = TourStep.essentielHero;
+  }
+
+  /// Avance d'une étape ; sur la dernière ([TourStep.courrier]), termine.
+  void next() {
+    switch (state) {
+      case TourStep.essentielHero:
+        state = TourStep.descendsCartes;
+      case TourStep.descendsCartes:
+        state = TourStep.favorisSheet;
+      case TourStep.favorisSheet:
+        state = TourStep.flaner;
+      case TourStep.flaner:
+        state = TourStep.reglages;
+      case TourStep.reglages:
+        state = TourStep.courrier;
+      case TourStep.courrier:
+        finish();
+      case TourStep.done:
+      case null:
+        break;
+    }
+  }
+
+  /// « Passer » — saute directement à la conclusion.
+  void skip() => finish();
+
+  /// Termine le tour : carte de conclusion, persistance du flag, `onComplete`.
+  void finish() {
+    if (state == null || state == TourStep.done) return;
+    state = TourStep.done;
+    unawaited(_markSeen());
+    _fireComplete();
+  }
+
+  /// Retire la carte de conclusion (appelé par le bridge après son délai
+  /// d'affichage). Idempotent. `onComplete` a déjà été tiré par [finish].
+  void dismiss() {
+    state = null;
+  }
+
+  Future<void> _markSeen() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_seenKey(_currentUserId), true);
+  }
+
+  void _fireComplete() {
+    if (_completed) return;
+    _completed = true;
+    final cb = _onComplete;
+    _onComplete = null;
+    cb?.call();
+  }
+}

--- a/apps/mobile/lib/features/tour/providers/guided_tour_controller.g.dart
+++ b/apps/mobile/lib/features/tour/providers/guided_tour_controller.g.dart
@@ -1,0 +1,41 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'guided_tour_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$guidedTourControllerHash() =>
+    r'e8af36b7ec64fd7e0426f0e42682726bdfea0ee3';
+
+/// Machine à états du tour guidé post-onboarding.
+///
+/// Vit au niveau application (`keepAlive`) pour survivre aux changements
+/// d'onglet et à l'ouverture/fermeture de feuilles pendant le tour. Le notifier
+/// **ne touche jamais à `BuildContext`** : tous les effets de bord (navigation,
+/// ouverture de feuille, scroll) sont exécutés par [GuidedTourBridge], monté au
+/// niveau racine et stable, qui écoute cet état.
+///
+/// `null` = inactif. La séquence jouée est :
+/// `essentielHero → descendsCartes → favorisSheet → flaner → reglages →
+/// courrier → done`. [skip] et [finish]/`next()` sur la dernière étape mènent
+/// tous deux à [TourStep.done], persistent le flag « vu » et tirent `onComplete`
+/// **une seule fois** (rend la main au flow des modales post-onboarding).
+///
+/// Copied from [GuidedTourController].
+@ProviderFor(GuidedTourController)
+final guidedTourControllerProvider =
+    NotifierProvider<GuidedTourController, TourStep?>.internal(
+  GuidedTourController.new,
+  name: r'guidedTourControllerProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$guidedTourControllerHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$GuidedTourController = Notifier<TourStep?>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/apps/mobile/lib/features/tour/tour_anchors.dart
+++ b/apps/mobile/lib/features/tour/tour_anchors.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/widgets.dart';
+
+/// GlobalKeys partagées du tour guidé, posées sur les éléments réels de l'app
+/// que le spotlight vient cerner (pattern `feed_nudge_anchors.dart` : clés
+/// module-level, jamais dupliquées).
+///
+/// Le bridge ([GuidedTourBridge]) lit le `RenderBox` de chaque clé à chaque
+/// frame pour suivre l'élément pendant les slides d'onglet et les scrolls.
+
+/// Hero « L'Essentiel du jour » (carte hi-fi) — étape 1.
+final GlobalKey tourEssentielHeroKey = GlobalKey(
+  debugLabel: 'tourEssentielHeroKey',
+);
+
+/// Onglet « L'Essentiel » du footer — co-cible de l'étape 1.
+final GlobalKey tourEssentielFooterTabKey = GlobalKey(
+  debugLabel: 'tourEssentielFooterTabKey',
+);
+
+/// Première section de contenu de la Tournée (après le hero) — étape 2a.
+final GlobalKey tourActusSectionKey = GlobalKey(
+  debugLabel: 'tourActusSectionKey',
+);
+
+/// Avatar profil (haut-droite du header partagé) — étapes 4 & 5.
+final GlobalKey tourProfileAvatarKey = GlobalKey(
+  debugLabel: 'tourProfileAvatarKey',
+);
+
+/// Racine de la feuille « Mes favoris » ouverte — étape 2b. Le spotlight la
+/// cerne par-dessus : l'overlay est inséré dans l'overlay **racine** alors que
+/// la feuille vit dans le navigator de branche (cf. `manage_favorites_sheet.dart`).
+final GlobalKey tourFavorisSheetKey = GlobalKey(
+  debugLabel: 'tourFavorisSheetKey',
+);

--- a/apps/mobile/lib/features/tour/tour_ids.dart
+++ b/apps/mobile/lib/features/tour/tour_ids.dart
@@ -1,0 +1,12 @@
+/// Identifiants stables du tour guidé.
+///
+/// Le flag « déjà vu » est persisté sous `nudge.<id>.seen.<userId>` — on réutilise
+/// le namespace `nudge.` et la sémantique **scopée user** de `NudgeStorage`
+/// (`isSeenForUser` / `markSeenForUser`) pour qu'un second compte sur le même
+/// appareil revoie le tour.
+class TourIds {
+  TourIds._();
+
+  /// Tour guidé post-onboarding (5 étapes, joué une seule fois).
+  static const guidedTour = 'guided_tour';
+}

--- a/apps/mobile/lib/features/tour/tour_strings.dart
+++ b/apps/mobile/lib/features/tour/tour_strings.dart
@@ -1,0 +1,40 @@
+import 'models/tour_step.dart';
+
+/// Copies FR du tour guidé (pattern `onboarding_strings.dart` : `const`,
+/// regroupées). Ton chaleureux, tutoiement, sans em-dash (règle PO).
+class TourStrings {
+  TourStrings._();
+
+  static const String skip = 'Passer';
+  static const String next = 'Suivant';
+  static const String finish = 'Terminer';
+
+  /// Titre du coach card par étape.
+  static String title(TourStep step) => switch (step) {
+        TourStep.essentielHero => 'Ta Tournée du jour',
+        TourStep.descendsCartes => 'Tout ce qui compte aujourd\'hui',
+        TourStep.favorisSheet => 'Compose ta Tournée',
+        TourStep.flaner => 'Flâner, à ton rythme',
+        TourStep.reglages => 'Tes réglages',
+        TourStep.courrier => 'Mon courrier',
+        TourStep.done => 'C\'est parti !',
+      };
+
+  /// Corps du coach card par étape.
+  static String body(TourStep step) => switch (step) {
+        TourStep.essentielHero =>
+          'Chaque matin, L\'Essentiel réunit les quelques articles à ne pas manquer. C\'est ton point de départ.',
+        TourStep.descendsCartes =>
+          'En descendant, tu retrouves tes sujets et tes sources, rangés en sections.',
+        TourStep.favorisSheet =>
+          'Ici tu choisis et réorganises ce qui compose ta Tournée. Tout reste à toi.',
+        TourStep.flaner =>
+          'Envie d\'explorer plus large ? L\'onglet Flâner te laisse parcourir l\'actualité à ton rythme.',
+        TourStep.reglages =>
+          'Depuis ton profil, en haut à droite, tu ajustes tes réglages quand tu veux.',
+        TourStep.courrier =>
+          'Et toujours depuis ton profil, tu retrouves Mon courrier : tes articles sauvegardés et tes notes.',
+        TourStep.done =>
+          'Tu connais l\'essentiel. À toi de jouer, bonne lecture !',
+      };
+}

--- a/apps/mobile/lib/features/tour/widgets/guided_tour_bridge.dart
+++ b/apps/mobile/lib/features/tour/widgets/guided_tour_bridge.dart
@@ -1,0 +1,149 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../config/routes.dart';
+import '../../../core/providers/navigation_providers.dart';
+import '../../flux_continu/widgets/manage_favorites_sheet.dart';
+import '../models/tour_step.dart';
+import '../providers/guided_tour_controller.dart';
+import '../tour_anchors.dart';
+import 'guided_tour_overlay.dart';
+
+/// Pont racine du tour guidé : écoute [guidedTourControllerProvider] et exécute
+/// les effets de bord qui exigent un `BuildContext`/navigation (le notifier, lui,
+/// n'en touche jamais — cf. classe de bug `nudge_host.dart:35-38`).
+///
+/// Monté **une seule fois** dans `MainShell` (stable tant qu'on est dans le shell
+/// principal, jamais démonté pendant un changement d'onglet). Il insère un
+/// [OverlayEntry] dans l'overlay **racine** pour passer au-dessus de la feuille
+/// « Mes favoris » (qui vit dans le navigator de branche).
+class GuidedTourBridge extends ConsumerStatefulWidget {
+  const GuidedTourBridge({super.key});
+
+  @override
+  ConsumerState<GuidedTourBridge> createState() => _GuidedTourBridgeState();
+}
+
+class _GuidedTourBridgeState extends ConsumerState<GuidedTourBridge> {
+  OverlayEntry? _entry;
+  TourStep? _step;
+  List<GlobalKey> _targets = const [];
+  bool _centerCard = false;
+  bool _favSheetOpen = false;
+  Timer? _doneTimer;
+
+  @override
+  void dispose() {
+    _doneTimer?.cancel();
+    _entry?.remove();
+    _entry = null;
+    super.dispose();
+  }
+
+  void _onStep(TourStep? step) {
+    if (step == _step) return;
+    _step = step;
+
+    if (step == null) {
+      _doneTimer?.cancel();
+      _entry?.remove();
+      _entry = null;
+      return;
+    }
+
+    _ensureOverlay();
+    _applyStep(step);
+    _entry?.markNeedsBuild();
+  }
+
+  void _ensureOverlay() {
+    if (_entry != null) return;
+    final overlay = Overlay.of(context, rootOverlay: true);
+    _entry = OverlayEntry(
+      builder: (_) => GuidedTourOverlay(
+        step: _step ?? TourStep.essentielHero,
+        targets: _targets,
+        centerCard: _centerCard,
+        onSkip: () => ref.read(guidedTourControllerProvider.notifier).skip(),
+        onNext: () => ref.read(guidedTourControllerProvider.notifier).next(),
+      ),
+    );
+    overlay.insert(_entry!);
+  }
+
+  /// Effets de bord + cibles spotlight à l'entrée de chaque étape.
+  void _applyStep(TourStep step) {
+    _centerCard = false;
+    switch (step) {
+      case TourStep.essentielHero:
+        _targets = [tourEssentielHeroKey, tourEssentielFooterTabKey];
+        if (mounted) context.go(RoutePaths.fluxContinu);
+        _bumpEssentielScrollToTop();
+      case TourStep.descendsCartes:
+        _targets = [tourActusSectionKey];
+        ref.read(tourScrollTargetProvider.notifier).state = tourActusSectionKey;
+      case TourStep.favorisSheet:
+        _targets = [tourFavorisSheetKey];
+        _openFavoritesSheet();
+      case TourStep.flaner:
+        _targets = const [];
+        _centerCard = true;
+        _closeFavoritesSheetIfOpen();
+        if (mounted) context.go(RoutePaths.flaner);
+      case TourStep.reglages:
+        _targets = [tourProfileAvatarKey];
+        if (mounted) context.go(RoutePaths.fluxContinu);
+      case TourStep.courrier:
+        _targets = [tourProfileAvatarKey];
+      case TourStep.done:
+        _targets = const [];
+        _doneTimer?.cancel();
+        _doneTimer = Timer(const Duration(milliseconds: 1800), () {
+          ref.read(guidedTourControllerProvider.notifier).dismiss();
+        });
+    }
+  }
+
+  void _bumpEssentielScrollToTop() {
+    final notifier = ref.read(essentielScrollTriggerProvider.notifier);
+    notifier.state = notifier.state + 1;
+  }
+
+  /// Ouvre la vraie feuille « Mes favoris » sur le navigator de la branche
+  /// Essentiel (via le `context` du hero, encore monté). Si l'utilisateur la
+  /// referme au doigt avant de cliquer « Suivant », on auto-avance vers Flâner
+  /// (watchdog : on ne reste pas bloqué derrière un voile orphelin).
+  void _openFavoritesSheet() {
+    final branchCtx = tourEssentielHeroKey.currentContext;
+    if (branchCtx == null) return;
+    _favSheetOpen = true;
+    showManageFavoritesSheet(branchCtx).whenComplete(() {
+      _favSheetOpen = false;
+      if (!mounted) return;
+      // Fermeture initiée par l'utilisateur (pas par notre transition vers
+      // Flâner, qui a déjà changé l'état) → on enchaîne.
+      if (ref.read(guidedTourControllerProvider) == TourStep.favorisSheet) {
+        ref.read(guidedTourControllerProvider.notifier).next();
+      }
+    });
+  }
+
+  void _closeFavoritesSheetIfOpen() {
+    if (!_favSheetOpen) return;
+    final branchCtx = tourEssentielHeroKey.currentContext;
+    if (branchCtx != null) {
+      Navigator.of(branchCtx).maybePop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen<TourStep?>(guidedTourControllerProvider, (_, next) {
+      _onStep(next);
+    });
+    return const SizedBox.shrink();
+  }
+}

--- a/apps/mobile/lib/features/tour/widgets/guided_tour_coach_card.dart
+++ b/apps/mobile/lib/features/tour/widgets/guided_tour_coach_card.dart
@@ -1,0 +1,197 @@
+import 'package:flutter/material.dart';
+
+import '../../../config/theme.dart';
+import '../models/tour_step.dart';
+import '../tour_strings.dart';
+
+/// Coach card du tour guidé (cf. proto `Tour guidé Facteur.dc.html`).
+///
+/// Avatar Facteur rond + pastille « N / 5 », titre Fraunces, corps DM Sans,
+/// puces de progression et boutons Passer / Suivant (Terminer sur la dernière
+/// étape). La carte de conclusion ([TourStep.done]) masque puces et boutons.
+class GuidedTourCoachCard extends StatelessWidget {
+  final TourStep step;
+  final VoidCallback onSkip;
+  final VoidCallback onNext;
+
+  const GuidedTourCoachCard({
+    super.key,
+    required this.step,
+    required this.onSkip,
+    required this.onNext,
+  });
+
+  /// Contour orange du spotlight, repris pour la pastille et l'accent de carte.
+  static const Color _spotlight = Color(0xFFE8943F);
+
+  bool get _isDone => step == TourStep.done;
+  bool get _isLast => step == TourStep.courrier;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Material(
+      type: MaterialType.transparency,
+      child: Container(
+        decoration: BoxDecoration(
+          color: colors.surface,
+          borderRadius: BorderRadius.circular(FacteurRadius.large),
+          border: Border.all(color: colors.border, width: 0.6),
+          boxShadow: const [
+            BoxShadow(
+              color: Color(0x24000000),
+              blurRadius: 24,
+              offset: Offset(0, 8),
+            ),
+          ],
+        ),
+        padding: const EdgeInsets.all(FacteurSpacing.space4),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                _Avatar(badge: _isDone ? null : step.displayIndex),
+                const SizedBox(width: FacteurSpacing.space3),
+                Expanded(
+                  child: Text(
+                    TourStrings.title(step),
+                    style: FacteurTypography.serifTitle(colors.textPrimary),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: FacteurSpacing.space3),
+            Text(
+              TourStrings.body(step),
+              style: FacteurTypography.bodyMedium(colors.textSecondary),
+            ),
+            if (!_isDone) ...[
+              const SizedBox(height: FacteurSpacing.space4),
+              _ProgressDots(active: step.displayIndex),
+              const SizedBox(height: FacteurSpacing.space3),
+              Row(
+                children: [
+                  TextButton(
+                    onPressed: onSkip,
+                    child: Text(
+                      TourStrings.skip,
+                      style: FacteurTypography.labelLarge(colors.textSecondary),
+                    ),
+                  ),
+                  const Spacer(),
+                  FilledButton(
+                    onPressed: onNext,
+                    style: FilledButton.styleFrom(
+                      backgroundColor: colors.primary,
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(
+                        borderRadius:
+                            BorderRadius.circular(FacteurRadius.pill),
+                      ),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: FacteurSpacing.space6,
+                        vertical: FacteurSpacing.space3,
+                      ),
+                    ),
+                    child: Text(_isLast ? TourStrings.finish : TourStrings.next),
+                  ),
+                ],
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Avatar extends StatelessWidget {
+  /// Numéro de la pastille « N / 5 », ou `null` (carte de conclusion).
+  final int? badge;
+
+  const _Avatar({this.badge});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return SizedBox(
+      width: 48,
+      height: 48,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Container(
+            width: 48,
+            height: 48,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: colors.backgroundSecondary,
+              border: Border.all(
+                color: GuidedTourCoachCard._spotlight,
+                width: 1.5,
+              ),
+            ),
+            clipBehavior: Clip.antiAlias,
+            child: Image.asset(
+              'assets/notifications/facteur_avatar.png',
+              fit: BoxFit.cover,
+            ),
+          ),
+          if (badge != null)
+            Positioned(
+              right: -4,
+              bottom: -4,
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 6,
+                  vertical: 2,
+                ),
+                decoration: BoxDecoration(
+                  color: GuidedTourCoachCard._spotlight,
+                  borderRadius: BorderRadius.circular(FacteurRadius.pill),
+                  border: Border.all(color: colors.surface, width: 1.5),
+                ),
+                child: Text(
+                  '$badge / ${TourStepDisplay.totalSteps}',
+                  style: FacteurTypography.labelSmall(Colors.white),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProgressDots extends StatelessWidget {
+  /// Index 1-based de la puce active.
+  final int active;
+
+  const _ProgressDots({required this.active});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Row(
+      children: [
+        for (var i = 1; i <= TourStepDisplay.totalSteps; i++) ...[
+          AnimatedContainer(
+            duration: const Duration(milliseconds: 200),
+            width: i == active ? 18 : 7,
+            height: 7,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(FacteurRadius.pill),
+              color: i == active
+                  ? colors.primary
+                  : colors.textSecondary.withValues(alpha: 0.3),
+            ),
+          ),
+          if (i < TourStepDisplay.totalSteps) const SizedBox(width: 6),
+        ],
+      ],
+    );
+  }
+}

--- a/apps/mobile/lib/features/tour/widgets/guided_tour_overlay.dart
+++ b/apps/mobile/lib/features/tour/widgets/guided_tour_overlay.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/material.dart';
+
+import '../models/tour_step.dart';
+import 'guided_tour_coach_card.dart';
+
+/// Voile + découpe spotlight + coach card du tour guidé, rendu dans l'overlay
+/// **racine** (au-dessus de la feuille « Mes favoris » qui vit en branche).
+///
+/// La découpe suit l'élément cerné frame par frame (relecture live du
+/// `RenderBox` des [targets] via un ticker), pour rester collée pendant les
+/// slides d'onglet et les scrolls. Quand aucune cible n'est encore mesurée /
+/// visible (ou [TourStep.flaner] / [TourStep.done]), le voile est plein.
+class GuidedTourOverlay extends StatefulWidget {
+  final TourStep step;
+
+  /// Cibles à cerner. Vide → voile plein (étape sans ancre / attente d'ancre).
+  final List<GlobalKey> targets;
+
+  /// Centre le coach card verticalement (étape Flâner) au lieu de l'ancrer en
+  /// bas du téléphone.
+  final bool centerCard;
+
+  final VoidCallback onSkip;
+  final VoidCallback onNext;
+
+  const GuidedTourOverlay({
+    super.key,
+    required this.step,
+    required this.targets,
+    required this.onSkip,
+    required this.onNext,
+    this.centerCard = false,
+  });
+
+  @override
+  State<GuidedTourOverlay> createState() => _GuidedTourOverlayState();
+}
+
+class _GuidedTourOverlayState extends State<GuidedTourOverlay>
+    with SingleTickerProviderStateMixin {
+  // Ticker uniquement pour repeindre la découpe à chaque frame (suivi de
+  // l'élément pendant slide/scroll). Borné par la vie de l'overlay → pas de
+  // boucle d'animation orpheline.
+  late final AnimationController _ticker = AnimationController(
+    vsync: this,
+    duration: const Duration(seconds: 1),
+  )..repeat();
+
+  @override
+  void dispose() {
+    _ticker.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final media = MediaQuery.of(context);
+    final card = GuidedTourCoachCard(
+      step: widget.step,
+      onSkip: widget.onSkip,
+      onNext: widget.onNext,
+    );
+    return Stack(
+      children: [
+        // Voile + découpe. GestureDetector opaque : absorbe les taps (l'app
+        // dessous reste inerte) ; un tap hors carte est un no-op.
+        Positioned.fill(
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: () {},
+            child: CustomPaint(
+              painter: _SpotlightPainter(
+                repaint: _ticker,
+                targets: widget.targets,
+              ),
+            ),
+          ),
+        ),
+        if (widget.centerCard)
+          Positioned(
+            left: 24,
+            right: 24,
+            top: 0,
+            bottom: 0,
+            child: Center(child: card),
+          )
+        else
+          Positioned(
+            left: 16,
+            right: 16,
+            bottom: media.padding.bottom + 24,
+            child: card,
+          ),
+      ],
+    );
+  }
+}
+
+class _SpotlightPainter extends CustomPainter {
+  final List<GlobalKey> targets;
+
+  _SpotlightPainter({required Listenable repaint, required this.targets})
+      : super(repaint: repaint);
+
+  static const Color _scrim = Color(0xFF2C2A29);
+  static const Color _stroke = Color(0xFFE8943F);
+  static const double _pad = 8;
+  static const double _radius = 16;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final bounds = Offset.zero & size;
+    final holes = <RRect>[];
+    for (final key in targets) {
+      final rect = _rectFor(key, size);
+      if (rect != null) {
+        holes.add(
+          RRect.fromRectAndRadius(
+            rect.inflate(_pad),
+            const Radius.circular(_radius),
+          ),
+        );
+      }
+    }
+
+    canvas.saveLayer(bounds, Paint());
+    canvas.drawRect(bounds, Paint()..color = _scrim.withValues(alpha: 0.72));
+    final clear = Paint()..blendMode = BlendMode.clear;
+    for (final hole in holes) {
+      canvas.drawRRect(hole, clear);
+    }
+    canvas.restore();
+
+    final strokePaint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2
+      ..color = _stroke;
+    final glowPaint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 6
+      ..color = _stroke.withValues(alpha: 0.25)
+      ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 6);
+    for (final hole in holes) {
+      canvas.drawRRect(hole, glowPaint);
+      canvas.drawRRect(hole, strokePaint);
+    }
+  }
+
+  /// Rect global de la cible si elle est montée, mesurée et visible à l'écran.
+  Rect? _rectFor(GlobalKey key, Size screen) {
+    final ctx = key.currentContext;
+    if (ctx == null) return null;
+    final box = ctx.findRenderObject();
+    if (box is! RenderBox || !box.attached || !box.hasSize) return null;
+    final topLeft = box.localToGlobal(Offset.zero);
+    final rect = topLeft & box.size;
+    // Hors viewport vertical → pas de trou (sinon voile uniforme sans repère).
+    if (rect.bottom <= 0 || rect.top >= screen.height) return null;
+    return rect;
+  }
+
+  @override
+  bool shouldRepaint(_SpotlightPainter oldDelegate) =>
+      oldDelegate.targets != targets;
+}

--- a/apps/mobile/lib/shared/widgets/navigation/main_bottom_nav.dart
+++ b/apps/mobile/lib/shared/widgets/navigation/main_bottom_nav.dart
@@ -21,10 +21,14 @@ class MainBottomNav extends StatelessWidget {
   /// Appelé au tap d'un onglet (actif ou non). Le parent arbitre la suite.
   final ValueChanged<int> onSelect;
 
+  /// Ancre optionnelle du tour guidé posée sur l'onglet « L'Essentiel ».
+  final GlobalKey? essentielTabAnchorKey;
+
   const MainBottomNav({
     super.key,
     required this.currentIndex,
     required this.onSelect,
+    this.essentielTabAnchorKey,
   });
 
   static const BorderRadius _topRadius = BorderRadius.vertical(
@@ -70,10 +74,13 @@ class MainBottomNav extends StatelessWidget {
                 child: Row(
                   children: [
                     Expanded(
-                      child: _FooterTab(
-                        label: 'L’Essentiel',
-                        selected: currentIndex == 0,
-                        onTap: () => onSelect(0),
+                      child: KeyedSubtree(
+                        key: essentielTabAnchorKey,
+                        child: _FooterTab(
+                          label: 'L’Essentiel',
+                          selected: currentIndex == 0,
+                          onTap: () => onSelect(0),
+                        ),
                       ),
                     ),
                     Expanded(

--- a/apps/mobile/lib/shared/widgets/navigation/main_shell.dart
+++ b/apps/mobile/lib/shared/widgets/navigation/main_shell.dart
@@ -8,6 +8,8 @@ import '../../../core/providers/navigation_providers.dart';
 import '../../../features/app_update/providers/app_update_provider.dart';
 import '../../../features/feed/widgets/profile_avatar_button.dart';
 import '../../../features/gamification/widgets/streak_indicator.dart';
+import '../../../features/tour/tour_anchors.dart';
+import '../../../features/tour/widgets/guided_tour_bridge.dart';
 import '../../../widgets/design/facteur_logo.dart';
 import 'main_bottom_nav.dart';
 
@@ -26,7 +28,15 @@ class MainShell extends StatelessWidget {
   Widget build(BuildContext context) {
     return ColoredBox(
       color: context.facteurColors.backgroundPrimary,
-      child: navigationShell,
+      // [GuidedTourBridge] monté une seule fois ici (stable tant qu'on est dans
+      // le shell, jamais démonté au changement d'onglet) : il pilote le tour
+      // guidé post-onboarding via l'overlay racine.
+      child: Stack(
+        children: [
+          navigationShell,
+          const GuidedTourBridge(),
+        ],
+      ),
     );
   }
 }
@@ -65,6 +75,11 @@ class MainTabPageScaffold extends ConsumerWidget {
           offset: footerVisible ? Offset.zero : const Offset(0, 1),
           child: MainBottomNav(
             currentIndex: currentIndex,
+            // Ancre du tour guidé sur l'onglet Essentiel (co-cible de l'étape 1).
+            // Posée uniquement par le scaffold Essentiel : les deux branches
+            // restent montées (keepAlive), une clé partagée serait dupliquée.
+            essentielTabAnchorKey:
+                currentIndex == 0 ? tourEssentielFooterTabKey : null,
             onSelect: (index) {
               // Tout tap d'onglet redonne le footer (évite un footer « collé »
               // masqué au changement de page).
@@ -87,7 +102,10 @@ class MainTabPageScaffold extends ConsumerWidget {
       ),
       body: Column(
         children: [
-          const _SharedTopHeader(),
+          // L'ancre profil du tour guidé n'est posée que sur le header Essentiel
+          // (étapes 4/5 y naviguent) — clé unique malgré les deux branches
+          // montées simultanément.
+          _SharedTopHeader(attachTourAvatarKey: currentIndex == 0),
           Expanded(child: child),
         ],
       ),
@@ -101,7 +119,11 @@ class MainTabPageScaffold extends ConsumerWidget {
 /// Repris du header historique de `FluxContinuScreen` afin de garder l'apparence
 /// identique sur les deux pages racines.
 class _SharedTopHeader extends StatelessWidget {
-  const _SharedTopHeader();
+  /// Pose [tourProfileAvatarKey] autour de l'avatar profil (étapes 4/5 du tour
+  /// guidé). Activé sur le seul header Essentiel pour garder la clé unique.
+  final bool attachTourAvatarKey;
+
+  const _SharedTopHeader({this.attachTourAvatarKey = false});
 
   @override
   Widget build(BuildContext context) {
@@ -123,7 +145,9 @@ class _SharedTopHeader extends StatelessWidget {
             ),
             Align(
               alignment: Alignment.centerRight,
-              child: Consumer(
+              child: KeyedSubtree(
+                key: attachTourAvatarKey ? tourProfileAvatarKey : null,
+                child: Consumer(
                 builder: (context, ref, _) {
                   final hasUpdate =
                       ref
@@ -158,6 +182,7 @@ class _SharedTopHeader extends StatelessWidget {
                     ],
                   );
                 },
+                ),
               ),
             ),
           ],

--- a/apps/mobile/test/features/tour/guided_tour_controller_test.dart
+++ b/apps/mobile/test/features/tour/guided_tour_controller_test.dart
@@ -1,0 +1,125 @@
+import 'package:facteur/core/auth/auth_state.dart';
+import 'package:facteur/features/tour/models/tour_step.dart';
+import 'package:facteur/features/tour/providers/guided_tour_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Clé de persistance « vu » pour l'utilisateur anonyme (aucun user injecté →
+/// le controller retombe sur `'anonymous'`).
+const _seenKey = 'nudge.guided_tour.seen.anonymous';
+
+ProviderContainer _container() {
+  final container = ProviderContainer(
+    overrides: [
+      // Évite l'init Supabase du vrai notifier ; user null → userId 'anonymous'.
+      authStateProvider.overrideWith(
+        (ref) => AuthStateNotifier.test(const AuthState()),
+      ),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('start → essentielHero quand jamais vu', () async {
+    SharedPreferences.setMockInitialValues({});
+    final c = _container();
+    var completed = 0;
+    await c
+        .read(guidedTourControllerProvider.notifier)
+        .start(onComplete: () => completed++);
+
+    expect(c.read(guidedTourControllerProvider), TourStep.essentielHero);
+    expect(completed, 0, reason: 'onComplete ne se déclenche pas au démarrage');
+  });
+
+  test('next() parcourt toute la séquence puis termine', () async {
+    SharedPreferences.setMockInitialValues({});
+    final c = _container();
+    final notifier = c.read(guidedTourControllerProvider.notifier);
+    var completed = 0;
+    await notifier.start(onComplete: () => completed++);
+
+    notifier.next();
+    expect(c.read(guidedTourControllerProvider), TourStep.descendsCartes);
+    notifier.next();
+    expect(c.read(guidedTourControllerProvider), TourStep.favorisSheet);
+    notifier.next();
+    expect(c.read(guidedTourControllerProvider), TourStep.flaner);
+    notifier.next();
+    expect(c.read(guidedTourControllerProvider), TourStep.reglages);
+    notifier.next();
+    expect(c.read(guidedTourControllerProvider), TourStep.courrier);
+    // Dernière étape → conclusion + onComplete.
+    notifier.next();
+    expect(c.read(guidedTourControllerProvider), TourStep.done);
+    expect(completed, 1);
+  });
+
+  test('displayIndex mutualise le point 2 entre les deux panneaux', () {
+    expect(TourStep.essentielHero.displayIndex, 1);
+    expect(TourStep.descendsCartes.displayIndex, 2);
+    expect(TourStep.favorisSheet.displayIndex, 2);
+    expect(TourStep.flaner.displayIndex, 3);
+    expect(TourStep.reglages.displayIndex, 4);
+    expect(TourStep.courrier.displayIndex, 5);
+    expect(TourStepDisplay.totalSteps, 5);
+  });
+
+  test('finish() → done, flag persisté, onComplete une seule fois', () async {
+    SharedPreferences.setMockInitialValues({});
+    final c = _container();
+    final notifier = c.read(guidedTourControllerProvider.notifier);
+    var completed = 0;
+    await notifier.start(onComplete: () => completed++);
+
+    notifier.finish();
+    expect(c.read(guidedTourControllerProvider), TourStep.done);
+    // finish() idempotent : un second appel ne re-tire pas onComplete.
+    notifier.finish();
+    expect(completed, 1);
+
+    // Persistance asynchrone (unawaited dans finish).
+    await Future<void>.delayed(Duration.zero);
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getBool(_seenKey), true);
+  });
+
+  test('skip() → done + onComplete', () async {
+    SharedPreferences.setMockInitialValues({});
+    final c = _container();
+    final notifier = c.read(guidedTourControllerProvider.notifier);
+    var completed = 0;
+    await notifier.start(onComplete: () => completed++);
+
+    notifier.skip();
+    expect(c.read(guidedTourControllerProvider), TourStep.done);
+    expect(completed, 1);
+  });
+
+  test('dismiss() retire la carte de conclusion', () async {
+    SharedPreferences.setMockInitialValues({});
+    final c = _container();
+    final notifier = c.read(guidedTourControllerProvider.notifier);
+    await notifier.start(onComplete: () {});
+    notifier.finish();
+    notifier.dismiss();
+    expect(c.read(guidedTourControllerProvider), isNull);
+  });
+
+  test('start() no-op si déjà vu, mais onComplete tiré une fois', () async {
+    SharedPreferences.setMockInitialValues({_seenKey: true});
+    final c = _container();
+    var completed = 0;
+    await c
+        .read(guidedTourControllerProvider.notifier)
+        .start(onComplete: () => completed++);
+
+    expect(c.read(guidedTourControllerProvider), isNull);
+    expect(completed, 1, reason: 'rend la main directement aux modales');
+  });
+}

--- a/apps/mobile/test/features/tour/guided_tour_overlay_test.dart
+++ b/apps/mobile/test/features/tour/guided_tour_overlay_test.dart
@@ -1,0 +1,104 @@
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/tour/models/tour_step.dart';
+import 'package:facteur/features/tour/tour_strings.dart';
+import 'package:facteur/features/tour/widgets/guided_tour_coach_card.dart';
+import 'package:facteur/features/tour/widgets/guided_tour_overlay.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _host(Widget child) => MaterialApp(
+      theme: FacteurTheme.lightTheme,
+      home: Scaffold(body: child),
+    );
+
+void main() {
+  testWidgets('coach card affiche titre, pastille et puces', (tester) async {
+    await tester.pumpWidget(
+      _host(
+        GuidedTourCoachCard(
+          step: TourStep.essentielHero,
+          onSkip: () {},
+          onNext: () {},
+        ),
+      ),
+    );
+
+    expect(find.text(TourStrings.title(TourStep.essentielHero)), findsOneWidget);
+    expect(find.text('1 / 5'), findsOneWidget);
+    expect(find.text(TourStrings.next), findsOneWidget);
+    expect(find.text(TourStrings.skip), findsOneWidget);
+  });
+
+  testWidgets('« Suivant » et « Passer » remontent leurs callbacks',
+      (tester) async {
+    var next = 0;
+    var skip = 0;
+    await tester.pumpWidget(
+      _host(
+        GuidedTourCoachCard(
+          step: TourStep.descendsCartes,
+          onSkip: () => skip++,
+          onNext: () => next++,
+        ),
+      ),
+    );
+
+    await tester.tap(find.text(TourStrings.next));
+    await tester.tap(find.text(TourStrings.skip));
+    await tester.pump();
+
+    expect(next, 1);
+    expect(skip, 1);
+  });
+
+  testWidgets('dernière étape affiche « Terminer »', (tester) async {
+    await tester.pumpWidget(
+      _host(
+        GuidedTourCoachCard(
+          step: TourStep.courrier,
+          onSkip: () {},
+          onNext: () {},
+        ),
+      ),
+    );
+    expect(find.text(TourStrings.finish), findsOneWidget);
+    expect(find.text('5 / 5'), findsOneWidget);
+  });
+
+  testWidgets('carte de conclusion masque puces et boutons', (tester) async {
+    await tester.pumpWidget(
+      _host(
+        GuidedTourCoachCard(
+          step: TourStep.done,
+          onSkip: () {},
+          onNext: () {},
+        ),
+      ),
+    );
+    expect(find.text(TourStrings.title(TourStep.done)), findsOneWidget);
+    expect(find.text(TourStrings.next), findsNothing);
+    expect(find.text(TourStrings.finish), findsNothing);
+    expect(find.text(TourStrings.skip), findsNothing);
+  });
+
+  testWidgets('overlay sans ancre (Flâner) rend un voile plein sans crash',
+      (tester) async {
+    // NB : ticker en `repeat()` → JAMAIS de pumpAndSettle (ne se stabilise pas).
+    await tester.pumpWidget(
+      _host(
+        GuidedTourOverlay(
+          step: TourStep.flaner,
+          targets: const [],
+          centerCard: true,
+          onSkip: () {},
+          onNext: () {},
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 16));
+
+    expect(find.byType(CustomPaint), findsWidgets);
+    expect(find.text(TourStrings.title(TourStep.flaner)), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/docs/stories/core/24.1.tour-guide-post-onboarding.md
+++ b/docs/stories/core/24.1.tour-guide-post-onboarding.md
@@ -1,0 +1,38 @@
+# Story 24.1 — Tour guidé post-onboarding (coach-mark)
+
+**Type** : Feature
+**Statut** : Code + tests faits ; QA Playwright (`/validate-feature`) à faire ; PR `--base main` à ouvrir.
+
+## Objectif
+Qu'un nouvel utilisateur comprenne ses pages principales dès la première ouverture, sans se perdre, via un tour guidé en 5 étapes joué **une seule fois juste après l'onboarding**, qui pilote la vraie app.
+
+## Décisions PO (validées)
+1. Le tour pilote la vraie app entre les étapes (onglet Flâner, vraie feuille « Mes favoris », scroll Essentiel).
+2. Étapes 4 (Réglages) & 5 (Mon courrier) : on reste sur l'accueil et on spotlight l'avatar profil (pas de navigation réelle).
+3. Une seule fois, post-onboarding, aucun point d'entrée « Revoir le tour ».
+4. Tour d'abord, puis les modales post-onboarding existantes (thème, notifications).
+
+## Architecture
+- `GuidedTourController` (`@Riverpod(keepAlive)`) — machine à états, sans `BuildContext`. Séquence `essentielHero → descendsCartes → favorisSheet → flaner → reglages → courrier → done`. `displayIndex` mutualise le point « 2/5 » entre `descendsCartes` et `favorisSheet`.
+- `GuidedTourBridge` — monté une fois dans `MainShell`, exécute les effets de bord et gère l'`OverlayEntry` dans l'overlay **racine** (au-dessus de la feuille favoris en branche).
+- `GuidedTourOverlay` / `_SpotlightPainter` / `GuidedTourCoachCard` — voile + découpe spotlight live + coach card du proto.
+- Persistance : `nudge.guided_tour.seen.<userId>` (scopé user). Double verrou avec `postOnboardingFlowPendingProvider`.
+
+## Tâches
+- [x] Modèle `TourStep` + `displayIndex`.
+- [x] Controller (machine à états + flag once) + tests.
+- [x] Ancres (`tour_anchors.dart`) posées (hero, onglet Essentiel, 1ʳᵉ section, avatar, feuille favoris).
+- [x] Bridge racine + overlay + coach card.
+- [x] Split `_runPostOnboardingFlow` (tour → modales), listen `tourScrollTargetProvider`.
+- [x] Entrée changelog `unreleased`.
+- [x] Tests widget overlay/coach card.
+- [ ] `/validate-feature` Playwright.
+- [ ] PR `--base main`.
+
+## Vérification
+- `flutter analyze` : 0 nouvelle erreur.
+- `flutter test test/features/tour/` : 12/12 verts.
+- Tests des fichiers touchés (essentiel_hi_fi_card, main_bottom_nav, flux_continu) : verts.
+
+## Fichiers
+Voir `.context/pr-handoff.md`.


### PR DESCRIPTION
## Tour guidé Facteur (coach-mark post-onboarding)

Tour guidé en 5 étapes joué **une seule fois juste après l'onboarding**, qui pilote la vraie app pour présenter ses pages principales. Il s'insère **avant** les modales post-onboarding existantes (thème puis notifications).

### Parcours (6 états joués, 5 puces)
1. **1/5** — hero « L'Essentiel du jour » + onglet Essentiel (scroll top).
2. **2/5 (a)** — scroll vers la 1ʳᵉ section de la Tournée (`ensureVisible`).
3. **2/5 (b)** — ouverture de la vraie feuille « Mes favoris », spotlight par-dessus.
4. **3/5** — bascule onglet Flâner, voile plein, carte centrée.
5. **4/5** — retour accueil, spotlight de l'avatar profil (Réglages).
6. **5/5** — même avatar (Mon courrier), bouton « Terminer ».
7. **done** — carte « C'est parti », puis main rendue aux modales.

### Architecture
- **Machine à états Riverpod** (`GuidedTourController`, `keepAlive`) — survit aux changements d'onglet/feuilles, **ne touche jamais `BuildContext`**. `start(onComplete)` gate le flag « vu » (scopé user) ; `next()`/`skip()`/`finish()` → `done` + `onComplete` tiré une seule fois.
- **Bridge racine** (`GuidedTourBridge`, monté une fois dans `MainShell`) — exécute les effets de bord (navigation, ouverture feuille, scroll) et insère l'`OverlayEntry` dans l'overlay **racine** (au-dessus de la feuille favoris qui vit en branche).
- **Overlay** — scrim `#2C2A29` α0.72 + découpe spotlight (`Path`/`BlendMode.clear`, contour `#E8943F`), rect relu live depuis le `RenderBox` des `GlobalKey` à chaque frame (suit slide/scroll). Coach card : avatar Facteur, pastille « N/5 », titre Fraunces, corps DM Sans, 5 puces, Passer/Suivant/Terminer.

### Garde « une seule fois »
Double verrou : démarrage seulement depuis le chemin post-onboarding (`postOnboardingFlowPendingProvider`) **et** flag persistant `nudge.guided_tour.seen.<userId>` (namespace `nudge.`, scopé user comme `NudgeStorage`).

### Fichiers
- **Nouveaux** : `lib/features/tour/` (models/tour_step, providers/guided_tour_controller, tour_anchors, tour_strings, tour_ids, widgets/guided_tour_bridge|overlay|coach_card).
- **Édités** : `flux_continu_screen.dart` (split `_runPostOnboardingFlow` → tour puis `_runPostOnboardingModals`, listen `tourScrollTargetProvider`, ancre 1ʳᵉ section), `essentiel_hi_fi_card.dart` (ancre hero), `main_shell.dart` (montage bridge + ancre avatar), `main_bottom_nav.dart` (ancre onglet), `manage_favorites_sheet.dart` (ancre feuille + note z-order), `navigation_providers.dart` (`tourScrollTargetProvider`), `changelog.json`.

### Tests
- `test/features/tour/guided_tour_controller_test.dart` — séquence complète, displayIndex (2/5 mutualisé), skip/finish → done + flag persisté + onComplete une fois, no-op si déjà vu.
- `test/features/tour/guided_tour_overlay_test.dart` — coach card (titre/pastille/puces/boutons), « Terminer » en dernière étape, carte de conclusion, voile plein sans ancre.
- `flutter analyze` : 0 nouvelle erreur. Tests des fichiers touchés (essentiel_hi_fi_card, main_bottom_nav, flux_continu) : verts.

### Notes
- Frontend pur, aucune migration / endpoint.
- Reste à faire avant deploy : `/validate-feature` Playwright (handoff dans `.context/qa-handoff.md`).
