### PR TITLE
feat(sources): enhance source profile in reader

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Sources",
+      "summary": "Fiche source plus complète depuis un article : lecteurs, notes, description et reco réapparaissent, avec une échelle de fiabilité accessible d'un tap."
+    },
+    {
       "tag": "Onboarding",
       "summary": "Sélection des médias plus fluide : davantage de suggestions, petites animations de validation à chaque étape, et un écran de fin qui va jusqu'au bout avant de t'emmener dans l'app."
     },

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -307,8 +307,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
   /// Le wash du titre de référence se déclenche quand la couverture est prête
   /// (la section est désormais toujours dépliée — plus de toggle).
-  bool get _showPivot =>
-      _perspectivesStatus == PerspectivesSectionStatus.ready;
+  bool get _showPivot => _perspectivesStatus == PerspectivesSectionStatus.ready;
 
   List<Perspective> get _inlinePerspectives {
     final response = _perspectivesResponse;
@@ -332,8 +331,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
   // État réactif du bottom sheet « Analyse Facteur ». Le sheet écoute ce
   // notifier pour refléter loading → done/error sans rebuild de l'écran.
-  final ValueNotifier<AnalysisSheetData> _analysisSheetData =
-      ValueNotifier(const AnalysisSheetData());
+  final ValueNotifier<AnalysisSheetData> _analysisSheetData = ValueNotifier(
+    const AnalysisSheetData(),
+  );
 
   /// `true` lorsqu'on lit une "autre source" (perspective) : URL seule, pas de
   /// Content backend ⇒ pas de fetch / perspectives / tracking.
@@ -2443,166 +2443,133 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                     child: Row(
                       children: [
                         Flexible(
-                          child: GestureDetector(
-                            onTap: () => TopicChip.showArticleSheet(
-                              context,
-                              content,
-                              initialSection: ArticleSheetSection.source,
-                            ),
-                            behavior: HitTestBehavior.opaque,
-                            child: Row(
-                              children: [
-                                // Source logo (28px, fallback initiales)
-                                SourceLogoAvatar(
-                                  source: content.source,
-                                  size: 28,
-                                  radius: 10,
+                          child: Material(
+                            color: Colors.transparent,
+                            borderRadius: BorderRadius.circular(16),
+                            child: InkWell(
+                              borderRadius: BorderRadius.circular(16),
+                              onTap: () => TopicChip.showArticleSheet(
+                                context,
+                                content,
+                                initialSection: ArticleSheetSection.source,
+                              ),
+                              child: Ink(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 8,
+                                  vertical: 6,
                                 ),
-                                const SizedBox(width: 8),
-
-                                // Source Name + Time + Badges
-                                Flexible(
-                                  child: Column(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.start,
-                                    children: [
-                                      // Ligne 1 : Nom (mini-chip) + Badges
-                                      Row(
+                                decoration: BoxDecoration(
+                                  color: colors.backgroundSecondary,
+                                  borderRadius: BorderRadius.circular(16),
+                                  border: Border.all(
+                                    color: colors.border.withValues(alpha: 0.6),
+                                    width: 0.8,
+                                  ),
+                                ),
+                                child: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    SourceLogoAvatar(
+                                      source: content.source,
+                                      size: 26,
+                                      radius: 9,
+                                    ),
+                                    const SizedBox(width: 8),
+                                    Flexible(
+                                      child: Column(
+                                        mainAxisSize: MainAxisSize.min,
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.start,
                                         children: [
-                                          Flexible(
-                                            child: Opacity(
-                                              opacity: 0.9,
-                                              child: Container(
-                                                padding:
-                                                    const EdgeInsets.symmetric(
-                                                      horizontal: 6,
-                                                      vertical: 2,
-                                                    ),
-                                                decoration: BoxDecoration(
-                                                  color: Color.lerp(
-                                                    colors.backgroundSecondary,
-                                                    Colors.black,
-                                                    0.003,
-                                                  )!,
-                                                  borderRadius:
-                                                      BorderRadius.circular(8),
+                                          Text(
+                                            content.source.name,
+                                            style: textTheme.labelMedium
+                                                ?.copyWith(
+                                                  fontWeight: FontWeight.w700,
+                                                  color: colors.textPrimary,
                                                 ),
+                                            maxLines: 1,
+                                            overflow: TextOverflow.ellipsis,
+                                          ),
+                                          const SizedBox(height: 1),
+                                          Row(
+                                            mainAxisSize: MainAxisSize.min,
+                                            children: [
+                                              Icon(
+                                                PhosphorIcons.clock(
+                                                  PhosphorIconsStyle.regular,
+                                                ),
+                                                size: 11,
+                                                color: colors.textTertiary,
+                                              ),
+                                              const SizedBox(width: 3),
+                                              Flexible(
                                                 child: Text(
-                                                  content.source.name,
-                                                  style: textTheme.labelMedium
+                                                  timeago
+                                                      .format(
+                                                        content.publishedAt,
+                                                        locale: 'fr_short',
+                                                      )
+                                                      .replaceAll(
+                                                        'il y a ',
+                                                        '',
+                                                      ),
+                                                  style: textTheme.bodySmall
                                                       ?.copyWith(
-                                                        fontWeight:
-                                                            FontWeight.bold,
                                                         color:
-                                                            colors.textPrimary,
+                                                            colors.textTertiary,
+                                                        fontSize: 11,
                                                       ),
                                                   maxLines: 1,
                                                   overflow:
                                                       TextOverflow.ellipsis,
                                                 ),
                                               ),
-                                            ),
-                                          ),
-                                          // Étoile = indicateur non-cliquable
-                                          // accolé au nom (favori = pleine
-                                          // primary, suivi = creuse tertiary,
-                                          // non-suivi = rien). Le tap est géré
-                                          // par le GestureDetector parent →
-                                          // ouvre la modal source (le suivi /
-                                          // favori s'y font désormais).
-                                          if (effectiveState ==
-                                                  InterestState.favorite ||
-                                              effectiveState ==
-                                                  InterestState.followed) ...[
-                                            const SizedBox(width: 5),
-                                            Icon(
-                                              effectiveState ==
-                                                      InterestState.favorite
-                                                  ? PhosphorIcons.star(
-                                                      PhosphorIconsStyle.fill,
-                                                    )
-                                                  : PhosphorIcons.star(
-                                                      PhosphorIconsStyle.regular,
-                                                    ),
-                                              size: 14,
-                                              color: effectiveState ==
-                                                      InterestState.favorite
-                                                  ? colors.primary
-                                                  : colors.textTertiary,
-                                            ),
-                                          ],
-                                          // Editorial badge (digest articles)
-                                          if (content.editorialBadge !=
-                                              null) ...[
-                                            const SizedBox(width: 6),
-                                            EditorialBadge.chip(
-                                                  content.editorialBadge,
-                                                  context: context,
-                                                ) ??
-                                                const SizedBox.shrink(),
-                                          ],
-                                          // Gear icon — same scale as bias dot
-                                          const SizedBox(width: 4),
-                                          Material(
-                                            color: Colors.transparent,
-                                            shape: const CircleBorder(),
-                                            clipBehavior: Clip.antiAlias,
-                                            child: InkWell(
-                                              onTap: () =>
-                                                  TopicChip.showArticleSheet(
-                                                    context,
-                                                    content,
-                                                    initialSection:
-                                                        ArticleSheetSection
-                                                            .source,
-                                                  ),
-                                              child: Padding(
-                                                padding: const EdgeInsets.all(
-                                                  3,
-                                                ),
-                                                child: Icon(
-                                                  PhosphorIcons.gear(
-                                                    PhosphorIconsStyle.regular,
-                                                  ),
-                                                  size: 11,
-                                                  color: colors.textTertiary,
-                                                ),
-                                              ),
-                                            ),
+                                            ],
                                           ),
                                         ],
                                       ),
-                                      const SizedBox(height: 1),
-                                      // Ligne 2 : Temps relatif (icône + format court)
-                                      Row(
-                                        children: [
-                                          Icon(
-                                            PhosphorIcons.clock(
-                                              PhosphorIconsStyle.regular,
-                                            ),
-                                            size: 11,
-                                            color: colors.textTertiary,
-                                          ),
-                                          const SizedBox(width: 3),
-                                          Text(
-                                            timeago
-                                                .format(
-                                                  content.publishedAt,
-                                                  locale: 'fr_short',
-                                                )
-                                                .replaceAll('il y a ', ''),
-                                            style: textTheme.bodySmall
-                                                ?.copyWith(
-                                                  color: colors.textTertiary,
-                                                  fontSize: 11,
-                                                ),
-                                          ),
-                                        ],
+                                    ),
+                                    if (effectiveState ==
+                                            InterestState.favorite ||
+                                        effectiveState ==
+                                            InterestState.followed) ...[
+                                      const SizedBox(width: 6),
+                                      Icon(
+                                        effectiveState == InterestState.favorite
+                                            ? PhosphorIcons.star(
+                                                PhosphorIconsStyle.fill,
+                                              )
+                                            : PhosphorIcons.star(
+                                                PhosphorIconsStyle.regular,
+                                              ),
+                                        size: 14,
+                                        color:
+                                            effectiveState ==
+                                                InterestState.favorite
+                                            ? colors.primary
+                                            : colors.textTertiary,
                                       ),
                                     ],
-                                  ),
+                                    if (content.editorialBadge != null) ...[
+                                      const SizedBox(width: 6),
+                                      EditorialBadge.chip(
+                                            content.editorialBadge,
+                                            context: context,
+                                          ) ??
+                                          const SizedBox.shrink(),
+                                    ],
+                                    const SizedBox(width: 5),
+                                    Icon(
+                                      PhosphorIcons.caretRight(
+                                        PhosphorIconsStyle.regular,
+                                      ),
+                                      size: 13,
+                                      color: colors.textTertiary,
+                                    ),
+                                  ],
                                 ),
-                              ],
+                              ),
                             ),
                           ),
                         ),
@@ -2661,7 +2628,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       ],
     );
   }
-
 
   Widget _buildReadingProgressBar(FacteurColors colors) {
     return ValueListenableBuilder<double>(
@@ -2920,6 +2886,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                             bodyPlaceholder: !_contentResolved
                                 ? _buildArticleBodySkeleton(colors)
                                 : null,
+                            footerSpacing: isPartial
+                                ? 0
+                                : FacteurSpacing.space8,
                             footer: SizedBox(
                               height: _kFooterContentHeight + bottomInset,
                             ),
@@ -2943,24 +2912,29 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                               perspectives: _inlinePerspectives,
                               biasDistribution:
                                   _perspectivesResponse?.biasDistribution ??
-                                      const {},
+                                  const {},
                               keywords:
                                   _perspectivesResponse?.keywords ?? const [],
                               sourceBiasStance:
                                   _perspectivesResponse?.sourceBiasStance ??
-                                      'unknown',
+                                  'unknown',
                               sourceName: _content?.source.name ?? '',
                               contentId: widget.contentId,
                               comparisonQuality:
                                   _perspectivesResponse?.comparisonQuality ??
-                                      'low',
+                                  'low',
                               divergenceLevel:
                                   _perspectivesResponse?.divergenceLevel,
                               partial: _perspectivesResponse?.partial ?? false,
                               onOpenAnalysis: _openPerspectivesAnalysis,
                             ),
                           ),
-                          const SizedBox(height: FacteurSpacing.space4),
+                          SizedBox(
+                            height:
+                                _kFooterContentHeight +
+                                bottomInset +
+                                FacteurSpacing.space4,
+                          ),
                         ],
 
                         // ZONE 3: Transparent spacer — only after CTA tap to enable scroll animation.
@@ -3496,8 +3470,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                   const SizedBox(height: FacteurSpacing.space4),
                   DeepRecommendationCard(
                     reco: _perspectivesResponse!.deepRecommendation!,
-                    onTap: () =>
-                        _openDeepReco(_perspectivesResponse!.deepRecommendation!),
+                    onTap: () => _openDeepReco(
+                      _perspectivesResponse!.deepRecommendation!,
+                    ),
                   ),
                 ],
 

--- a/apps/mobile/lib/features/detail/widgets/article_reader_widget.dart
+++ b/apps/mobile/lib/features/detail/widgets/article_reader_widget.dart
@@ -13,7 +13,9 @@ class ArticleReaderWidget extends StatelessWidget {
   final void Function(String url)? onLinkTap;
   final Widget? header;
   final Widget? footer;
+  final double footerSpacing;
   final bool shrinkWrap;
+
   /// When non-null, replaces the HTML body with this widget (e.g. skeleton).
   final Widget? bodyPlaceholder;
 
@@ -25,6 +27,7 @@ class ArticleReaderWidget extends StatelessWidget {
     this.onLinkTap,
     this.header,
     this.footer,
+    this.footerSpacing = FacteurSpacing.space8,
     this.shrinkWrap = false,
     this.bodyPlaceholder,
   });
@@ -50,9 +53,9 @@ class ArticleReaderWidget extends StatelessWidget {
         if (bodyPlaceholder != null)
           bodyPlaceholder!
         else
-        Html(
-          data: content,
-          style: {
+          Html(
+            data: content,
+            style: {
               'body': Style(
                 fontSize: FontSize(17),
                 lineHeight: const LineHeight(1.7),
@@ -61,9 +64,7 @@ class ArticleReaderWidget extends StatelessWidget {
                 margin: Margins.zero,
                 padding: HtmlPaddings.zero,
               ),
-              'p': Style(
-                margin: Margins.only(bottom: 16),
-              ),
+              'p': Style(margin: Margins.only(bottom: 16)),
               'h1': Style(
                 fontSize: FontSize(24),
                 fontWeight: FontWeight.w600,
@@ -86,13 +87,11 @@ class ArticleReaderWidget extends StatelessWidget {
                 color: colors.textSecondary,
                 textDecoration: TextDecoration.none,
               ),
-              'img': Style(
-                margin: Margins.symmetric(vertical: 16),
-              ),
+              'img': Style(margin: Margins.symmetric(vertical: 16)),
               'blockquote': Style(
                 border: Border(
                   left: BorderSide(
-                    color: colors.primary.withOpacity(0.5),
+                    color: colors.primary.withValues(alpha: 0.5),
                     width: 3,
                   ),
                 ),
@@ -101,18 +100,10 @@ class ArticleReaderWidget extends StatelessWidget {
                 fontStyle: FontStyle.italic,
                 color: colors.textSecondary,
               ),
-              'ul': Style(
-                margin: Margins.only(bottom: 16),
-              ),
-              'ol': Style(
-                margin: Margins.only(bottom: 16),
-              ),
-              'li': Style(
-                margin: Margins.only(bottom: 8),
-              ),
-              'figure': Style(
-                margin: Margins.symmetric(vertical: 16),
-              ),
+              'ul': Style(margin: Margins.only(bottom: 16)),
+              'ol': Style(margin: Margins.only(bottom: 16)),
+              'li': Style(margin: Margins.only(bottom: 8)),
+              'figure': Style(margin: Margins.symmetric(vertical: 16)),
               'figcaption': Style(
                 fontSize: FontSize(14),
                 color: colors.textTertiary,
@@ -120,16 +111,9 @@ class ArticleReaderWidget extends StatelessWidget {
                 margin: Margins.only(top: 8),
               ),
               // Defensive: prevent leftover divs/iframes/asides from creating gaps
-              'div': Style(
-                margin: Margins.zero,
-                padding: HtmlPaddings.zero,
-              ),
-              'iframe': Style(
-                display: Display.none,
-              ),
-              'aside': Style(
-                display: Display.none,
-              ),
+              'div': Style(margin: Margins.zero, padding: HtmlPaddings.zero),
+              'iframe': Style(display: Display.none),
+              'aside': Style(display: Display.none),
             },
             onLinkTap: (url, _, __) async {
               if (url != null) {
@@ -144,12 +128,12 @@ class ArticleReaderWidget extends StatelessWidget {
               }
             },
           ),
-          if (footer != null) ...[
-            const SizedBox(height: FacteurSpacing.space8),
-            footer!,
-          ],
+        if (footer != null) ...[
+          if (footerSpacing > 0) SizedBox(height: footerSpacing),
+          footer!,
         ],
-      );
+      ],
+    );
 
     if (shrinkWrap) {
       return Padding(

--- a/apps/mobile/lib/features/sources/models/source_profile.dart
+++ b/apps/mobile/lib/features/sources/models/source_profile.dart
@@ -1,4 +1,5 @@
 import '../../feed/models/content_model.dart';
+import 'source_model.dart';
 
 /// Part d'un thème dans la couverture d'une source — fiche source v3
 /// (`GET /sources/{id}/profile`).
@@ -40,11 +41,20 @@ class SourceProfile {
   final int articles30d;
   final DateTime? oldestContentAt;
 
+  /// Source complète renvoyée par `/profile` ([SourceResponse] backend).
+  /// Contrairement au `SourceMini` léger qui ouvre la fiche depuis le reader,
+  /// elle porte `follower_count`, les scores A-E, `description`, la reco perso
+  /// et `premium_connection`. Nullable → rétro-compatible (tests / payloads
+  /// anciens sans ce champ). La fiche l'utilise pour enrichir l'affichage dès
+  /// que `/profile` répond.
+  final Source? source;
+
   const SourceProfile({
     this.recentArticles = const [],
     this.themeDistribution = const [],
     this.articles30d = 0,
     this.oldestContentAt,
+    this.source,
   });
 
   bool get hasCoverage => themeDistribution.isNotEmpty;
@@ -52,12 +62,16 @@ class SourceProfile {
 
   factory SourceProfile.fromJson(Map<String, dynamic> json) {
     final rawOldest = json['oldest_content_at'];
+    final rawSource = json['source'];
     return SourceProfile(
       recentArticles: _parseList(json['recent_articles'], Content.fromJson),
       themeDistribution:
           _parseList(json['theme_distribution'], ThemeShare.fromJson),
       articles30d: (json['articles_30d'] as num?)?.toInt() ?? 0,
       oldestContentAt: rawOldest is String ? DateTime.tryParse(rawOldest) : null,
+      source: rawSource is Map<String, dynamic>
+          ? Source.fromJson(rawSource)
+          : null,
     );
   }
 

--- a/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
@@ -158,6 +158,7 @@ class _FsBody extends ConsumerWidget {
     final preloaded = recentItems;
     if (preloaded != null) {
       return _assemble(
+        display: source,
         frequencyLabel: null,
         middle: [
           _FsCoverageFromProvider(source: source),
@@ -217,23 +218,57 @@ class _FsBody extends ConsumerWidget {
         ],
       ),
     );
-    return _assemble(frequencyLabel: frequencyLabel, middle: middle);
+    // Enrichit la fiche avec la source complète du profil (`/profile` renvoie
+    // un `SourceResponse` complet). Ouverte depuis le reader, le `source` initial
+    // est un `SourceMini` léger (lecteurs / scores / description / reco / premium
+    // absents). Dès que `/profile` répond, on superpose ces champs manquants —
+    // sans écraser l'état mutable réactif (`isTrusted`/`isMuted`/`hasSubscription`)
+    // qui vient du `liveSource` (`userSourcesProvider`) et doit rester synchro si
+    // l'utilisateur bascule suivi/masquage depuis la fiche. Loading/error :
+    // on garde le `source` léger inchangé.
+    final display = _enrich(source, profileAsync.valueOrNull?.source);
+    return _assemble(
+      display: display,
+      frequencyLabel: frequencyLabel,
+      middle: middle,
+    );
+  }
+
+  /// Superpose les champs descriptifs de [enriched] (depuis `/profile`) sur le
+  /// [base] réactif, en préservant l'état mutable de suivi/masquage du `base`.
+  Source _enrich(Source base, Source? enriched) {
+    if (enriched == null) return base;
+    return base.copyWith(
+      followerCount: enriched.followerCount,
+      description: enriched.description,
+      scoreIndependence: enriched.scoreIndependence,
+      scoreRigor: enriched.scoreRigor,
+      scoreUx: enriched.scoreUx,
+      reliabilityScore: enriched.reliabilityScore,
+      biasStance: enriched.biasStance,
+      biasOrigin: enriched.biasOrigin,
+      recommendedBy: enriched.recommendedBy,
+      recommendationReason: enriched.recommendationReason,
+      premiumConnection: enriched.premiumConnection,
+    );
   }
 
   /// Assemble la fiche autour d'une zone centrale variable. Header, éval,
   /// réglages et gestion sont communs aux trois états (data/loading/error).
+  /// [display] = source à afficher (enrichie via `/profile` quand disponible).
   Widget _assemble({
+    required Source display,
     required String? frequencyLabel,
     required List<Widget> middle,
   }) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        _FsHeader(source: source, frequencyLabel: frequencyLabel),
-        _FsEval(source: source),
+        _FsHeader(source: display, frequencyLabel: frequencyLabel),
+        _FsEval(source: display),
         ...middle,
-        if (source.isTrusted) _FsSettings(source: source),
-        _FsManage(source: source),
+        if (display.isTrusted) _FsSettings(source: display),
+        _FsManage(source: display),
       ],
     );
   }
@@ -466,6 +501,23 @@ class _FsEvalState extends State<_FsEval> {
                             letterSpacing: 0,
                           ),
                         ),
+                        const SizedBox(width: 4),
+                        // (i) discret : ouvre l'échelle de fiabilité sans
+                        // déclencher le toggle replier/déplier (le
+                        // GestureDetector gagne l'arène de gestes du tap).
+                        GestureDetector(
+                          behavior: HitTestBehavior.opaque,
+                          onTap: () => _showReliabilityScaleSheet(context),
+                          child: Padding(
+                            padding: const EdgeInsets.all(2),
+                            child: Icon(
+                              PhosphorIcons.info(PhosphorIconsStyle.regular),
+                              size: 14,
+                              color: colors.textTertiary,
+                              semanticLabel: 'Échelle de fiabilité',
+                            ),
+                          ),
+                        ),
                       ],
                     )
                   else
@@ -497,13 +549,7 @@ class _FsEvalState extends State<_FsEval> {
             Padding(
               padding: const EdgeInsets.fromLTRB(14, 2, 14, 14),
               child: hasEval
-                  ? _buildEvalBody(
-                      context,
-                      colors,
-                      textTheme,
-                      reliabilityLabel,
-                      reliabilityColor,
-                    )
+                  ? _buildEvalBody(context, colors, textTheme)
                   : _buildNotEvaluated(context, colors, textTheme),
             ),
         ],
@@ -515,8 +561,6 @@ class _FsEvalState extends State<_FsEval> {
     BuildContext context,
     FacteurColors colors,
     TextTheme textTheme,
-    String reliabilityLabel,
-    Color reliabilityColor,
   ) {
     final source = widget.source;
     final badges = <Widget>[];
@@ -540,21 +584,7 @@ class _FsEvalState extends State<_FsEval> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        _evalRow(
-          context,
-          'Fiabilité',
-          Text(
-            reliabilityLabel,
-            style: textTheme.labelMedium?.copyWith(
-              color: reliabilityColor,
-              fontWeight: FontWeight.w700,
-              fontSize: 12.5,
-              letterSpacing: 0,
-            ),
-          ),
-        ),
         if (badges.isNotEmpty) ...[
-          const SizedBox(height: 12),
           Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -601,6 +631,93 @@ class _FsEvalState extends State<_FsEval> {
         const SizedBox(height: 12),
         _buildFooter(context, colors, textTheme),
       ],
+    );
+  }
+
+  /// Mini feuille « Échelle de fiabilité » (idiome app). Trois lignes
+  /// explicatives, déclenchée par le `(i)` du résumé d'éval. Sortie du corps
+  /// déplié pour que la valeur de fiabilité n'apparaisse qu'une seule fois.
+  void _showReliabilityScaleSheet(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (sheetContext) {
+        final colors = sheetContext.facteurColors;
+        final textTheme = Theme.of(sheetContext).textTheme;
+
+        Widget item(String label, String description) {
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 6),
+            child: RichText(
+              text: TextSpan(
+                style: textTheme.bodyMedium?.copyWith(
+                  color: colors.textSecondary,
+                  height: 1.4,
+                  fontSize: 13.5,
+                  letterSpacing: 0,
+                ),
+                children: [
+                  TextSpan(
+                    text: label,
+                    style: TextStyle(
+                      color: colors.textPrimary,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  TextSpan(text: ' = $description'),
+                ],
+              ),
+            ),
+          );
+        }
+
+        return Container(
+          decoration: BoxDecoration(
+            color: colors.backgroundPrimary,
+            borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+          ),
+          child: SafeArea(
+            top: false,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.only(top: 10, bottom: 2),
+                  child: Center(
+                    child: Container(
+                      width: 40,
+                      height: 4,
+                      decoration: BoxDecoration(
+                        color: colors.textTertiary.withValues(alpha: 0.3),
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Échelle de fiabilité',
+                        style: FacteurTypography.serifTitle(
+                          colors.textPrimary,
+                        ).copyWith(fontSize: 18, letterSpacing: -0.3),
+                      ),
+                      const SizedBox(height: 14),
+                      item('Solide', 'fiabilité élevée'),
+                      item('Mitigée', 'points de vigilance'),
+                      item('Fragile', 'prudence renforcée'),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
     );
   }
 
@@ -696,13 +813,13 @@ class _FsGradeBadge extends StatelessWidget {
           decoration: BoxDecoration(
             color: color.withValues(alpha: 0.10),
             borderRadius: BorderRadius.circular(FacteurRadius.small),
-            border: Border.all(color: color.withValues(alpha: 0.34)),
+            border: Border.all(color: color.withValues(alpha: 0.22)),
           ),
           child: Text(
             grade,
             style: textTheme.labelMedium?.copyWith(
               color: color,
-              fontWeight: FontWeight.w800,
+              fontWeight: FontWeight.w700,
               fontSize: 13,
               letterSpacing: 0,
             ),
@@ -1972,15 +2089,18 @@ String _gradeForScore(double score) {
   return 'E';
 }
 
+/// Couleur de note A-E, sobre : positif (A/B), neutre (C), attention discrète
+/// (D/E → `warning`, pas `error` trop agressif pour un signal indicatif).
 Color _gradeColor(String grade, FacteurColors colors) {
   switch (grade) {
     case 'A':
     case 'B':
-      return colors.secondary;
+      return colors.success;
     case 'C':
+      return colors.textSecondary;
     case 'D':
     case 'E':
-      return colors.textTertiary;
+      return colors.warning;
     default:
       return colors.textTertiary;
   }

--- a/apps/mobile/test/features/detail/widgets/article_reader_widget_test.dart
+++ b/apps/mobile/test/features/detail/widgets/article_reader_widget_test.dart
@@ -1,0 +1,58 @@
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/detail/widgets/article_reader_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    theme: FacteurTheme.lightTheme,
+    home: Scaffold(body: child),
+  );
+}
+
+void main() {
+  group('ArticleReaderWidget footer spacing', () {
+    testWidgets('uses the default spacer before the footer', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          const ArticleReaderWidget(
+            title: 'Titre',
+            description: 'Description courte.',
+            footer: Text('Footer'),
+          ),
+        ),
+      );
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is SizedBox && widget.height == FacteurSpacing.space8,
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('Footer'), findsOneWidget);
+    });
+
+    testWidgets('can remove the spacer before the footer', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          const ArticleReaderWidget(
+            title: 'Titre',
+            description: 'Description courte.',
+            footerSpacing: 0,
+            footer: Text('Footer'),
+          ),
+        ),
+      );
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is SizedBox && widget.height == FacteurSpacing.space8,
+        ),
+        findsNothing,
+      );
+      expect(find.text('Footer'), findsOneWidget);
+    });
+  });
+}

--- a/apps/mobile/test/features/sources/widgets/source_detail_modal_test.dart
+++ b/apps/mobile/test/features/sources/widgets/source_detail_modal_test.dart
@@ -177,6 +177,10 @@ void main() {
         await tester.tap(find.text('Évaluation Facteur'));
         await tester.pumpAndSettle();
 
+        // The reliability scale is no longer inline (no duplicate): the eval
+        // value 'Solide' appears exactly once (in the collapsed summary).
+        expect(find.text('Solide'), findsOneWidget);
+        expect(find.text('Échelle de fiabilité'), findsNothing);
         expect(find.text('Indépendance'), findsOneWidget);
         expect(find.text('Rigueur'), findsOneWidget);
         expect(find.text('Accessibilité'), findsOneWidget);
@@ -187,7 +191,61 @@ void main() {
         expect(find.text('Voir la méthodologie'), findsOneWidget);
       });
 
-      testWidgets('premium block always visible when premiumConnection != null '
+      testWidgets(
+        'reliability (i) opens the scale sheet with the three explanations',
+        (tester) async {
+          final source = Source(
+            id: 'monde',
+            name: 'Le Monde',
+            type: SourceType.article,
+            reliabilityScore: 'high',
+          );
+
+          await tester.pumpWidget(_wrap(source: source));
+          await tester.pumpAndSettle();
+
+          // The (i) sits next to the reliability label in the collapsed summary.
+          final infoIcon = find.bySemanticsLabel('Échelle de fiabilité');
+          expect(infoIcon, findsOneWidget);
+
+          await tester.tap(infoIcon);
+          await tester.pumpAndSettle();
+
+          // Sheet titled + 3 explanations.
+          expect(find.text('Échelle de fiabilité'), findsOneWidget);
+          expect(
+            find.byWidgetPredicate(
+              (widget) =>
+                  widget is RichText &&
+                  widget.text.toPlainText() == 'Solide = fiabilité élevée',
+            ),
+            findsOneWidget,
+          );
+          expect(
+            find.byWidgetPredicate(
+              (widget) =>
+                  widget is RichText &&
+                  widget.text.toPlainText() ==
+                      'Mitigée = points de vigilance',
+            ),
+            findsOneWidget,
+          );
+          expect(
+            find.byWidgetPredicate(
+              (widget) =>
+                  widget is RichText &&
+                  widget.text.toPlainText() == 'Fragile = prudence renforcée',
+            ),
+            findsOneWidget,
+          );
+
+          // The eval stays collapsed: tapping (i) did not reveal the badges.
+          expect(find.text('Voir la méthodologie'), findsNothing);
+        },
+      );
+
+      testWidgets(
+          'premium block always visible when premiumConnection != null '
           'even when not followed', (tester) async {
         final source = Source(
           id: 'monde',
@@ -253,6 +311,54 @@ void main() {
         findsOneWidget,
       );
     });
+  });
+
+  group('SourceDetailModal — enrichissement via /profile (depuis le reader)', () {
+    testWidgets(
+      'light source (SourceMini) gains followers, scores and description '
+      'once /profile responds',
+      (tester) async {
+        // SourceMini léger tel que sérialisé par le reader : ni lecteurs,
+        // ni scores, ni description, éval inconnue.
+        final light = Source(
+          id: 'monde',
+          name: 'Le Monde',
+          type: SourceType.article,
+        );
+        // /profile renvoie la source complète.
+        final profile = SourceProfile(
+          source: Source(
+            id: 'monde',
+            name: 'Le Monde',
+            type: SourceType.article,
+            reliabilityScore: 'high',
+            followerCount: 1240,
+            description: 'Quotidien de référence.',
+            scoreIndependence: 0.55,
+            scoreRigor: 0.85,
+            scoreUx: 0.70,
+          ),
+        );
+
+        await tester.pumpWidget(_wrap(source: light, profile: profile));
+        await tester.pumpAndSettle();
+
+        // Signal lecteurs + description réapparaissent.
+        expect(find.textContaining('lecteurs'), findsOneWidget);
+        expect(find.text('Quotidien de référence.'), findsOneWidget);
+
+        // L'éval enrichie expose les badges A-E une fois dépliée.
+        await tester.tap(find.text('Évaluation Facteur'));
+        await tester.pumpAndSettle();
+        expect(find.text('Indépendance'), findsOneWidget);
+        expect(find.text('Rigueur'), findsOneWidget);
+        expect(find.text('Accessibilité'), findsOneWidget);
+        // 0.85 → A, 0.70 → B, 0.55 → C.
+        expect(find.text('A'), findsOneWidget);
+        expect(find.text('B'), findsOneWidget);
+        expect(find.text('C'), findsOneWidget);
+      },
+    );
   });
 
   group('SourceDetailModal — couverture (mode normal, profil unifié)', () {


### PR DESCRIPTION
## What

Enhanced the source detail modal when opened from an article with complete source information, including:
- Full source profile from `/profile` endpoint enriching light source data
- Follower count, description, and reliability scale display
- Separate info modal for the reliability scale (Solide/Mitigée/Fragile)
- Improved source chip UI in article header with Material Design ripple effect

## Why

Previously, the source sheet opened from a reader showed only minimal source information (light SourceMini). This PR restores full source context (readers, description, evaluation scores) as soon as the `/profile` endpoint responds, without blocking the initial open.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Maintenance / Refactor

## Testing

- Flutter tests pass (1232+ tests, pre-existing smoke test failure unrelated to changes)
- flutter analyze: clean
- New tests added for article reader widget footer spacing and source enrichment from profile
- Manual verification: source detail modal shows enriched data, reliability scale sheet opens on (i) tap

## Changes

- `apps/mobile/lib/features/sources/models/source_profile.dart`: Added full `source` field to SourceProfile
- `apps/mobile/lib/features/sources/widgets/source_detail_modal.dart`: Enrichment logic, reliability scale sheet modal, improved grade color mapping
- `apps/mobile/lib/features/detail/screens/content_detail_screen.dart`: Refactored source chip to Material/InkWell pattern, added footer spacing support
- `apps/mobile/lib/features/detail/widgets/article_reader_widget.dart`: Added `footerSpacing` parameter
- `apps/mobile/assets/changelog.json`: Added user-facing changelog entry
- New test files for UI validation

Code quality improvements applied:
- Removed unnecessary Color.lerp() computation (efficiency fix)
- Simplified footer spacing logic with new parameter