### PR TITLE
fix(mobile): modals/permissions intempestives, nudge scroll, modal affichage, logo

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,11 +1,18 @@
 {
   "unreleased": [
     {
+      "tag": "Notifications",
+      "summary": "Fini les demandes d'autorisation à répétition : Facteur ne te sollicite plus qu'une fois, et plus jamais pendant ta lecture."
+    },
+    {
       "tag": "Tournée",
       "summary": "Ouverture nettement plus rapide : tes sections apparaissent l'une après l'autre dès qu'elles sont prêtes, au lieu d'attendre que tout charge d'un coup."
     },
     {
+      "tag": "Tournée",
       "summary": "La fin de tournée est plus incarnée : un récap de ce que tu as lu et des idées d'activités à faire maintenant, hors de l'écran. L'aperçu au long-press marche aussi sur ton Essentiel et dans tous les carrousels d'articles."
+    },
+    {
       "tag": "Sources",
       "summary": "Fiche source plus complète depuis un article : lecteurs, notes, description et reco réapparaissent, avec une échelle de fiabilité accessible d'un tap."
     },

--- a/apps/mobile/lib/core/nudges/widgets/nudge_host.dart
+++ b/apps/mobile/lib/core/nudges/widgets/nudge_host.dart
@@ -81,6 +81,7 @@ class _NudgeHostState extends ConsumerState<NudgeHost> {
   }
 
   Future<void> _waitForAnchor(String id, int generation) async {
+    double? lastY;
     for (var attempt = 0; attempt < 60; attempt++) {
       await Future<void>.delayed(
         attempt == 0 ? Duration.zero : const Duration(milliseconds: 100),
@@ -98,28 +99,39 @@ class _NudgeHostState extends ConsumerState<NudgeHost> {
         return;
       }
       final anchor = _anchorFor(id, currentLocation);
-      // N'afficher que si l'ancre est réellement visible à l'écran : un
-      // spotlight sur une cible hors viewport peint le voile plein écran sans
-      // trou ni bulle accessibles → utilisateur bloqué derrière un voile
-      // uniforme (freeze au refresh de l'Essentiel).
-      if (anchor != null && _isAnchorOnScreen(anchor)) {
-        _showSpotlight(id, anchor);
+      // Mesure unique du render box : Y du haut de l'ancre si elle est montée,
+      // mesurée ET entièrement visible, sinon null. Deux raisons de ne pas
+      // afficher :
+      // - hors viewport → le spotlight peint le voile plein écran sans trou ni
+      //   bulle accessibles → utilisateur bloqué (freeze au refresh Essentiel) ;
+      // - en plein scroll → l'overlay fige les coordonnées à la création, donc
+      //   un Y qui bouge entre deux sondages (~100 ms) décalerait voile/trou.
+      // On exige donc une ancre visible ET stable (même Y sur deux sondages
+      // consécutifs) avant d'afficher (cf. bug-modals-intrusives).
+      final y = anchor == null ? null : _onScreenAnchorTopY(anchor);
+      if (y != null && lastY != null && (y - lastY).abs() < 1.0) {
+        _showSpotlight(id, anchor!);
         unawaited(_watchAnchorWhileShown(id, anchor));
         return;
       }
+      lastY = y;
     }
   }
 
-  /// Vrai si la cible est montée, mesurée et entièrement visible verticalement
-  /// (il faut aussi la place pour le trou du spotlight et la bulle).
-  bool _isAnchorOnScreen(GlobalKey anchor) {
+  /// Position Y globale (haut de l'ancre) si elle est montée, mesurée ET
+  /// entièrement visible verticalement (il faut aussi la place pour le trou du
+  /// spotlight et la bulle), sinon `null`. Une seule mesure du render box sert
+  /// à la fois à décider de l'affichage et à détecter un scroll (Y qui varie
+  /// entre deux sondages).
+  double? _onScreenAnchorTopY(GlobalKey anchor) {
     final ctx = anchor.currentContext;
-    if (ctx == null || !mounted) return false;
+    if (ctx == null || !mounted) return null;
     final box = ctx.findRenderObject();
-    if (box is! RenderBox || !box.attached || !box.hasSize) return false;
-    final topLeft = box.localToGlobal(Offset.zero);
-    final screen = MediaQuery.sizeOf(context);
-    return topLeft.dy >= 0 && topLeft.dy + box.size.height <= screen.height;
+    if (box is! RenderBox || !box.attached || !box.hasSize) return null;
+    final topY = box.localToGlobal(Offset.zero).dy;
+    final screenHeight = MediaQuery.sizeOf(context).height;
+    if (topY < 0 || topY + box.size.height > screenHeight) return null;
+    return topY;
   }
 
   /// Tant que le spotlight est affiché, vérifie que sa cible existe toujours :
@@ -130,7 +142,12 @@ class _NudgeHostState extends ConsumerState<NudgeHost> {
     while (mounted && _current != null && _shownForId == id) {
       await Future<void>.delayed(const Duration(milliseconds: 300));
       if (!mounted || _current == null || _shownForId != id) return;
-      if (anchor.currentContext == null) {
+      // `_onScreenAnchorTopY` renvoie null si la cible est démontée (rebuild des
+      // sections au pull-to-refresh) OU déplacée hors viewport (scroll pendant
+      // l'affichage) : l'overlay garde alors les coordonnées figées à la
+      // création → voile/trou décalés. On ferme proprement sans markSeen
+      // (l'utilisateur n'a pas eu le temps de lire) — cf. bug-modals-intrusives.
+      if (_onScreenAnchorTopY(anchor) == null) {
         _closeSpotlight(id, markSeen: false);
         return;
       }

--- a/apps/mobile/lib/core/services/push_notification_service.dart
+++ b/apps/mobile/lib/core/services/push_notification_service.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 import 'package:timezone/timezone.dart' as tz;
 import 'package:timezone/data/latest.dart' as tz_data;
 import 'package:flutter_timezone/flutter_timezone.dart';
@@ -94,32 +95,45 @@ class PushNotificationService {
     return true;
   }
 
-  Future<bool> requestExactAlarmPermission() async {
-    final androidPlugin = _plugin.resolvePlatformSpecificImplementation<
-        AndroidFlutterLocalNotificationsPlugin>();
-    if (androidPlugin != null) {
-      final canSchedule =
-          await androidPlugin.canScheduleExactNotifications() ?? false;
-      if (!canSchedule) {
-        final granted =
-            await androidPlugin.requestExactAlarmsPermission() ?? false;
-        debugPrint(
-            'PushNotificationService: Exact alarm permission requested: $granted');
-        return granted;
-      }
-      return true;
-    }
-    return true;
-  }
+  /// Clé Hive (box `settings`) : marque qu'on a déjà ouvert au moins une fois
+  /// l'écran système « Alarmes et rappels ». Garde one-shot pour les chemins
+  /// automatiques — le pop-up ne doit jamais se rouvrir tout seul après un 1er
+  /// refus (cf. bug-modals-intrusives).
+  static const exactAlarmAskedKey = 'notif_exact_alarm_asked';
 
-  Future<bool> ensureExactAlarmPermission() async {
+  /// Ouvre l'écran système Android « Alarmes et rappels » pour demander la
+  /// permission d'alarme exacte (une `Activity` séparée).
+  ///
+  /// [userInitiated] : `true` UNIQUEMENT quand l'appel découle d'une action
+  /// utilisateur explicite (modal d'activation, toggle Réglages) — l'écran OS
+  /// est alors (ré)ouvert même après un refus précédent. `false` (défaut) pour
+  /// tout chemin automatique : une garde Hive one-shot ([exactAlarmAskedKey])
+  /// empêche de rouvrir l'écran après une 1ère demande, et la planification
+  /// retombe silencieusement en mode inexact.
+  Future<bool> requestExactAlarmPermission({bool userInitiated = false}) async {
     final androidPlugin = _plugin.resolvePlatformSpecificImplementation<
         AndroidFlutterLocalNotificationsPlugin>();
     if (androidPlugin == null) return true;
+
     final canSchedule =
         await androidPlugin.canScheduleExactNotifications() ?? false;
     if (canSchedule) return true;
-    return await androidPlugin.requestExactAlarmsPermission() ?? false;
+
+    final box = await Hive.openBox<dynamic>('settings');
+    if (!userInitiated &&
+        (box.get(exactAlarmAskedKey, defaultValue: false) as bool)) {
+      debugPrint(
+        'PushNotificationService: exact alarm already requested once - '
+        'skip auto re-prompt (inexact scheduling)',
+      );
+      return false;
+    }
+
+    await box.put(exactAlarmAskedKey, true);
+    final granted = await androidPlugin.requestExactAlarmsPermission() ?? false;
+    debugPrint(
+        'PushNotificationService: Exact alarm permission requested: $granted');
+    return granted;
   }
 
   // --- Copy variants -------------------------------------------------------

--- a/apps/mobile/lib/core/services/server_push_service.dart
+++ b/apps/mobile/lib/core/services/server_push_service.dart
@@ -127,7 +127,9 @@ class ServerPushService {
     if (!enabled) return;
     final slot = NotifTimeSlotX.fromWire(box.get('notif_time_slot') as String?);
     final localPush = PushNotificationService();
-    await localPush.ensureExactAlarmPermission();
+    // Pas de demande exact-alarm automatique ici (rejouée à chaque FCM raté →
+    // pop-up « Alarmes et rappels » intempestif, cf. bug-modals-intrusives).
+    // Planification directe : retombe en mode inexact si la permission manque.
     await localPush.scheduleDailyDigestNotification(
       timeSlot: slot,
       variant: NotifVariant.variantA,

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:haptic_feedback/haptic_feedback.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/routes.dart';
@@ -32,6 +33,7 @@ import '../../lettres/widgets/lettres_notification_banner.dart';
 import '../../notifications/widgets/notification_activation_modal.dart';
 import '../../notifications/widgets/notification_renudge_banner.dart';
 import '../../onboarding/widgets/theme_choice_bottom_sheet.dart';
+import '../../settings/widgets/display_mode_bottom_sheet.dart';
 import '../../tour/providers/guided_tour_controller.dart';
 import '../../tour/tour_anchors.dart';
 import '../../well_informed/widgets/well_informed_prompt.dart';
@@ -959,6 +961,22 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
 
     if (mounted) {
       await showThemeChoiceBottomSheet(context, ref);
+    }
+
+    // Modal de choix d'affichage (Normal / Minimaliste / Ludique), jouée une
+    // seule fois en fin d'onboarding, entre le thème et la modal notif. Gardée
+    // par un flag Hive persistant (belt-and-suspenders : ce flow ne tourne déjà
+    // qu'une fois). Sheet dismissible (pas de barrier non-fermable) → non
+    // intrusive, conforme à la directive PO « conservateur ».
+    if (mounted) {
+      final settingsBox = await Hive.openBox<dynamic>('settings');
+      final displayModeModalSeen =
+          settingsBox.get('display_mode_modal_seen', defaultValue: false)
+              as bool;
+      if (!displayModeModalSeen && mounted) {
+        await showDisplayModeBottomSheet(context, ref);
+        await settingsBox.put('display_mode_modal_seen', true);
+      }
     }
 
     if (mounted) {

--- a/apps/mobile/lib/features/notifications/widgets/notification_activation_modal.dart
+++ b/apps/mobile/lib/features/notifications/widgets/notification_activation_modal.dart
@@ -106,7 +106,11 @@ class _NotificationActivationModalState
 
     final granted = await PushNotificationService().requestPermission();
     if (granted) {
-      await PushNotificationService().requestExactAlarmPermission();
+      // Action utilisateur explicite (confirmation de la modal) : on autorise
+      // l'ouverture de l'écran OS « Alarmes et rappels » même après un refus
+      // antérieur (cf. garde one-shot requestExactAlarmPermission).
+      await PushNotificationService()
+          .requestExactAlarmPermission(userInitiated: true);
     }
 
     if (widget.trigger == ActivationTrigger.veille) {

--- a/apps/mobile/lib/features/settings/providers/notifications_settings_provider.dart
+++ b/apps/mobile/lib/features/settings/providers/notifications_settings_provider.dart
@@ -355,7 +355,7 @@ class NotificationsSettingsNotifier
       final pushService = PushNotificationService();
       final granted = await pushService.requestPermission();
       if (!granted) return;
-      await pushService.requestExactAlarmPermission();
+      await pushService.requestExactAlarmPermission(userInitiated: true);
     }
     await _commit(state.copyWith(goodNewsEnabled: value));
   }
@@ -385,7 +385,7 @@ class NotificationsSettingsNotifier
       final pushService = PushNotificationService();
       final granted = await pushService.requestPermission();
       if (!granted) return;
-      await pushService.requestExactAlarmPermission();
+      await pushService.requestExactAlarmPermission(userInitiated: true);
     }
     await _commit(state.copyWith(notifVeilleEnabled: value));
   }

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -346,8 +346,14 @@ Future<void> _initDeferredServices({required PostHogService posthog}) async {
     await pushNotificationService.init();
 
     final settingsBox = Hive.box<dynamic>('settings');
+    // Opt-in STRICT : sur install fraîche (clé Hive absente, avant toute
+    // réponse à la modal d'activation) le push est considéré désactivé.
+    // `defaultValue: false` aligne cette lecture sur les deux autres
+    // (_registerServerPushIfEnabled + server_push_service) — sinon le boot
+    // croyait le push actif et déclenchait scheduling + permissions
+    // (pop-up « Alarmes et rappels » intempestif, cf. bug-modals-intrusives).
     final pushEnabled = settingsBox.get('push_notifications_enabled',
-        defaultValue: true) as bool;
+        defaultValue: false) as bool;
     bootPushEnabledHive = pushEnabled;
 
     // Diagnostic + scheduling sont indépendants : collecter le diagnostic
@@ -363,7 +369,12 @@ Future<void> _initDeferredServices({required PostHogService posthog}) async {
       if (serverRegistered) {
         await pushNotificationService.cancelDigestNotification();
       } else {
-        await pushNotificationService.ensureExactAlarmPermission();
+        // Planification directe : AUCUNE demande de permission exact-alarm
+        // automatique. Si la permission n'est pas accordée, la notif tombe
+        // silencieusement en mode inexact (cf. scheduleDailyDigestNotification).
+        // Le pop-up OS « Alarmes et rappels » ne doit jamais se rouvrir tout
+        // seul (bug-modals-intrusives) ; l'opt-in exact-alarm est strictement
+        // initié par l'utilisateur (modal d'activation / Réglages).
         final scheduled =
             await pushNotificationService.scheduleDailyDigestNotification(
           variant: NotifVariant.variantA,
@@ -371,15 +382,8 @@ Future<void> _initDeferredServices({required PostHogService posthog}) async {
         );
         if (!scheduled) {
           debugPrint(
-            'Main: WARNING — digest notification scheduling failed, retrying...',
+            'Main: WARNING - digest notification scheduling failed (inexact)',
           );
-          await pushNotificationService.requestExactAlarmPermission();
-          final retryOk =
-              await pushNotificationService.scheduleDailyDigestNotification(
-            variant: NotifVariant.variantA,
-            timeSlot: timeSlot,
-          );
-          debugPrint('Main: Retry result: $retryOk');
         }
       }
     }

--- a/apps/mobile/lib/widgets/design/facteur_logo.dart
+++ b/apps/mobile/lib/widgets/design/facteur_logo.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 import 'package:facteur/config/theme.dart';
@@ -21,11 +22,32 @@ class FacteurLogo extends StatelessWidget {
   Widget build(BuildContext context) {
     final effectiveColor = color ?? context.facteurColors.textPrimary;
     final colors = context.facteurColors;
-    const logoPath = 'assets/icons/logo_facteur_ui.png';
-    const fallbackLogoPath = 'assets/icons/logo_facteur_ui.png';
+    // Logo officiel (SVG vectoriel), pas la variante app-icon. Le PNG
+    // `fallbackLogoPath` sert de repli errorBuilder pour la branche bitmap.
+    const logoPath = 'assets/icons/logo_officiel.svg';
+    const fallbackLogoPath = 'assets/icons/facteur_logo.png';
     final logoSize = size * 1.7;
 
+    // [filterColor] n'est passé que lorsqu'un `color` custom est demandé
+    // (effectiveColor != textPrimary) ; par défaut, aucun filtre → le logo
+    // officiel est rendu dans ses vraies couleurs.
     Widget buildLogoImage(String path, [Color? filterColor]) {
+      final colorFilter = filterColor != null
+          ? ColorFilter.mode(filterColor, BlendMode.srcIn)
+          : null;
+
+      if (path.endsWith('.svg')) {
+        return SvgPicture.asset(
+          path,
+          width: logoSize,
+          height: logoSize,
+          fit: BoxFit.contain,
+          colorFilter: colorFilter,
+          placeholderBuilder: (_) =>
+              SizedBox(width: logoSize, height: logoSize),
+        );
+      }
+
       final img = Image.asset(
         path,
         width: logoSize,
@@ -42,11 +64,8 @@ class FacteurLogo extends StatelessWidget {
           filterQuality: FilterQuality.high,
         ),
       );
-      if (filterColor != null) {
-        return ColorFiltered(
-          colorFilter: ColorFilter.mode(filterColor, BlendMode.srcIn),
-          child: img,
-        );
+      if (colorFilter != null) {
+        return ColorFiltered(colorFilter: colorFilter, child: img);
       }
       return img;
     }

--- a/apps/mobile/test/features/release_notes/changelog_asset_test.dart
+++ b/apps/mobile/test/features/release_notes/changelog_asset_test.dart
@@ -1,0 +1,46 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Garde-fou sur l'asset changelog **bundlé** (pas un stub).
+///
+/// Une fusion qui colle deux entrées en un seul objet malformé (virgule
+/// manquante / clés dupliquées, cf. corruption introduite par #881) casse
+/// silencieusement le parsing de la modal « Quoi de neuf » en prod. Ce test
+/// échoue dès que `assets/changelog.json` n'est plus un JSON valide et bien
+/// formé.
+void main() {
+  test('bundled changelog.json is valid JSON', () {
+    final raw = File('assets/changelog.json').readAsStringSync();
+    expect(() => jsonDecode(raw), returnsNormally);
+  });
+
+  test('every unreleased entry has a non-empty summary', () {
+    final decoded =
+        jsonDecode(File('assets/changelog.json').readAsStringSync())
+            as Map<String, dynamic>;
+
+    final unreleased = decoded['unreleased'] as List<dynamic>;
+    expect(unreleased, isNotEmpty);
+    for (final entry in unreleased) {
+      final map = entry as Map<String, dynamic>;
+      expect(map['summary'], isA<String>(),
+          reason: 'chaque entrée unreleased doit porter un summary (string)');
+      expect((map['summary'] as String).trim(), isNotEmpty);
+    }
+  });
+
+  test('every released block is well-formed', () {
+    final decoded =
+        jsonDecode(File('assets/changelog.json').readAsStringSync())
+            as Map<String, dynamic>;
+
+    final released = decoded['released'] as List<dynamic>;
+    for (final release in released) {
+      final map = release as Map<String, dynamic>;
+      expect(map['version'], isA<String>());
+      expect(map['entries'], isA<List<dynamic>>());
+    }
+  });
+}

--- a/apps/mobile/test/widgets/design/facteur_logo_test.dart
+++ b/apps/mobile/test/widgets/design/facteur_logo_test.dart
@@ -1,0 +1,47 @@
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/widgets/design/facteur_logo.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+/// Bug 4 : le widget doit rendre le **logo officiel** (SVG vectoriel), pas la
+/// variante app-icon PNG perdue par #882, et ne teinter le logo que lorsqu'une
+/// couleur custom est explicitement demandée.
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  Widget host(Widget child) => MaterialApp(
+        theme: FacteurTheme.lightTheme,
+        home: Scaffold(body: Center(child: child)),
+      );
+
+  testWidgets('renders the official SVG logo by default (no color filter)',
+      (tester) async {
+    await tester.pumpWidget(host(const FacteurLogo()));
+
+    final svg = tester.widget<SvgPicture>(find.byType(SvgPicture));
+    final loader = svg.bytesLoader as SvgAssetLoader;
+    expect(loader.assetName, 'assets/icons/logo_officiel.svg');
+    // Par défaut (effectiveColor == textPrimary), pas de teinte : le logo
+    // est rendu dans ses vraies couleurs.
+    expect(svg.colorFilter, isNull);
+  });
+
+  testWidgets('applies a color filter when a custom color is passed',
+      (tester) async {
+    await tester.pumpWidget(host(const FacteurLogo(color: Color(0xFFFF0000))));
+
+    final svg = tester.widget<SvgPicture>(find.byType(SvgPicture));
+    expect(svg.colorFilter, isNotNull);
+  });
+
+  testWidgets('showText:false renders the icon only', (tester) async {
+    await tester.pumpWidget(host(const FacteurLogo(showText: false)));
+
+    expect(find.byType(SvgPicture), findsOneWidget);
+    expect(find.text('Facteur'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Quoi
Corrige 4 régressions UX signalées par le PO sur la dernière version installée :
1. **CRITIQUE — pop-up notifications/alarmes intempestif** qui réapparaissait en boucle pendant la lecture jusqu'à acceptation forcée.
2. **Nudge spotlight (long-press)** mal placé si on scrolle pendant/juste avant son apparition.
3. **Modal de choix d'affichage** des articles jamais montée (le PO ne l'avait jamais vue).
4. **Logo** : la variante app-icon était affichée à la place du logo officiel.

## Pourquoi
- **Bug 1 (racine)** : `push_notifications_enabled` était lu avec `defaultValue: true` au boot (incohérent avec les 2 autres lectures à `false`), donc sur install fraîche le boot croyait le push actif et déclenchait scheduling + permissions. En plus, l'écran système Android « Alarmes et rappels » était (ré)ouvert automatiquement par 3 chemins (boot, retry de scheduling, fallback FCM raté) tant que la permission était refusée → réouverture « sans arrêt ».
- **Bug 2** : la position de l'ancre n'était vérifiée qu'une fois ; un scroll pendant l'anim de focus décalait voile/trou, et le watchdog ne fermait pas si l'ancre sortait du viewport.
- **Bug 3** : `_runPostOnboardingModals` n'appelait jamais `showDisplayModeBottomSheet` (qui existait pourtant).
- **Bug 4** : la commit #882 a perdu le branchement SVG et codé en dur le PNG app-icon.

## Comment c'est corrigé (conservateur, opt-in strict)
- **Bug 1** : `defaultValue: false` (aligné) ; suppression de **toute** demande exact-alarm automatique (boot `main.dart` + fallback `server_push_service`) → planification directe en mode **inexact** silencieux si la permission manque ; garde Hive one-shot `notif_exact_alarm_asked` dans `requestExactAlarmPermission`, avec bypass `userInitiated: true` réservé aux **seuls** appels initiés par l'utilisateur (modal d'activation + toggles Réglages). Aucun chemin automatique ne peut plus rouvrir le pop-up.
- **Bug 2** : `nudge_host` n'affiche le spotlight que sur une ancre **visible ET stable** (même Y sur deux sondages ~100 ms, pas en plein scroll) et le ferme proprement (sans `markSeen`) si l'ancre sort de l'écran pendant l'affichage. Mesure du render box mutualisée en un seul helper.
- **Bug 3** : sheet jouée **une fois** en fin d'onboarding (entre thème et notif), gardée par le flag Hive `display_mode_modal_seen`. Sheet dismissible → non intrusive.
- **Bug 4** : `logoPath` → `assets/icons/logo_officiel.svg`, rendu SVG (`flutter_svg`) restauré ; `colorFilter` appliqué **uniquement** si un `color` custom est passé (sinon vraies couleurs) ; fallback PNG.
- **Bonus** : réparation de `assets/changelog.json` (JSON corrompu par la fusion #881 — deux entrées collées en un objet malformé, qui cassait silencieusement la modal « Quoi de neuf ») + entrée changelog `Notifications`.

## Comment ça a été vérifié
- [x] `flutter analyze` — 0 nouvelle issue (17 lints `info` pré-existants sur des lignes non touchées)
- [x] `flutter test` (suite complète) — 1280 OK / 23 échecs **tous pré-existants** (Hive/Supabase/Firebase non init ; aucun dans un fichier touché)
- [x] Nouveaux tests : validité du `changelog.json` bundlé + rendu du logo officiel (asset SVG exact, filtre couleur conditionnel)
- [x] `/simplify` passé (consolidation de la double mesure render box dans `nudge_host`)
- [ ] **À faire côté PO avant deploy** : smoke Android on-device (`flutter build apk --debug --flavor staging`) — le pop-up exact-alarm est **Android-only**, non vérifiable en test/web : install fraîche → aucun pop-up alarmes spontané ; refus modal notif → pas de réapparition pendant la lecture.

## Zones à risque
- Boot notifications (`main.dart` `_initDeferredServices`) et chaîne push (`push_notification_service` / `server_push_service`) — changements gardés, planification dégradée en inexact sans permission.
- Flux post-onboarding (`flux_continu_screen`) — nouvelle étape modale gardée par flag.
- Note : l'asset `logo_officiel.svg` contient un `<filter>` non supporté par flutter_svg (notice non bloquante) — à valider visuellement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)