### PR TITLE
fix(flux-continu): Tournée fiable (seed coquilles + retry) — favoris absents & thème 1 carte

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Tournée",
+      "summary": "Tournée du jour plus fiable : tes thèmes et sources favoris s'affichent du premier coup."
+    },
+    {
       "tag": "Notifications",
       "summary": "Fini les demandes d'autorisation à répétition : Facteur ne te sollicite plus qu'une fois, et plus jamais pendant ta lecture."
     },

--- a/apps/mobile/lib/features/feed/widgets/feed_filter_bar.dart
+++ b/apps/mobile/lib/features/feed/widgets/feed_filter_bar.dart
@@ -284,7 +284,9 @@ class _SearchTrigger extends StatelessWidget {
         width: 34,
         child: Icon(
           PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.regular),
-          size: 16,
+          // Loupe agrandie (16 → 22) : l'état inactif n'affiche que l'icône
+          // (pas de placeholder), la boîte 34×34 l'accueille largement.
+          size: 22,
           color: colors.textSecondary,
         ),
       ),

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -74,14 +74,15 @@ const String _kBonnesBlurb = 'Un peu de douceur...';
 const int _kActusMinTopics = 2;
 
 /// Hard cap on the number of favorite theme sections rendered in the tournée.
-/// Mirrors `kFavoriteCap = 7` in the my_interests provider — the value is
-/// duplicated here only because the maps key by sectionKey and we slice the
-/// favorite list during composition. Keep aligned with the backend constant.
-const int _kMaxFavoriteSections = 7;
+/// **Source de vérité unique** = [kTourneeVisibleCap] (cap d'affichage global de
+/// la Tournée) : il ne doit jamais plafonner les thèmes **sous** ce cap, sinon un
+/// mix thèmes+sources serait silencieusement tronqué avant même le cap
+/// d'affichage. Aliasé (pas dupliqué) pour rester synchronisé par construction.
+const int _kMaxFavoriteSections = kTourneeVisibleCap;
 
 /// Hard cap on the number of favorite SOURCE sections rendered in the tournée
-/// (PR « Sources dans la Tournée »). Parité avec les thèmes.
-const int _kMaxFavoriteSourceSections = 7;
+/// (PR « Sources dans la Tournée »). Parité avec les thèmes ([kTourneeVisibleCap]).
+const int _kMaxFavoriteSourceSections = kTourneeVisibleCap;
 
 /// Number of items requested per page for each theme section of the Tournée
 /// (initial load + each "loadMoreTheme" call). When the backend returns
@@ -475,9 +476,20 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     final favoriteSources = _pickFavoriteSources();
     _lastSourceFavorites = favoriteSources;
 
-    // Sections thèmes/sources/suggérées vidées d'abord — peuplées en phase 2 si fetch.
-    _themes = const [];
-    _sources = const [];
+    // Seed de **coquilles** AVANT le fan-out (fix « Tournée figée » + « thème à
+    // 1 carte »). L'ordre de la Tournée (`_orderedTourneeKeys`) est dérivé des
+    // sections déjà présentes dans `_themes`/`_sources` : sans seed, une section
+    // dont le fan-out (sérialisé sous l'unique worker) n'a pas encore (ou pas)
+    // abouti n'a **pas de clé** → elle disparaît de l'ordre, et seuls les blocs
+    // éditoriaux restent. En seedant les en-têtes des favoris **résolus** (mêmes
+    // label/accent que le rendu réel, items vides), l'ordre reflète **toujours**
+    // les préférences ; le fan-out remplace ensuite chaque coquille en place par
+    // `sectionKey` (upsert), un fetch raté laissant la coquille (état vide géré
+    // par `SectionBlock`) plutôt qu'une section absente. Réservé aux favoris
+    // **explicites** : un compte neuf (fallback canonique) garde l'ancien
+    // comportement (thèmes pauvres droppés, pas d'empty-state non choisi).
+    _themes = picked.isFallback ? const [] : _shellThemeSections(favorites);
+    _sources = _shellSourceSections(favoriteSources);
     _suggested = const [];
     _closingDismissed = await _loadClosingDismissedForToday();
     unawaited(_purgeOldPrefsKeys());
@@ -594,13 +606,20 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
 
   /// Coquilles de sections thème/sujet/veille pour le squelette, dérivées des
   /// favoris locaux (réutilise `_pickFavorites` + les mêmes label/accent que
-  /// [_fetchThemeSections]). `topFallback` vide ⇒ comptes neufs voient les
+  /// [_shellThemeSections]). `topFallback` vide ⇒ comptes neufs voient les
   /// thèmes canoniques (tech/env/science), ce qui rend une structure utile.
-  List<FeedThemeSection> _skeletonThemeSections() {
-    final picked = _pickFavorites(const <TopTheme>[]);
+  List<FeedThemeSection> _skeletonThemeSections() =>
+      _shellThemeSections(_pickFavorites(const <TopTheme>[]).refs);
+
+  /// Coquilles (en-têtes vides) des sections thème/sujet/veille pour [refs],
+  /// dans l'ordre fourni. Partagé par le squelette de démarrage
+  /// ([_skeletonThemeSections]) et le **seed pré-fan-out** ([_buildStateFromPayload]) :
+  /// même label/accent que le rendu réel, `items` vide, `hasMore: false`. Le
+  /// fan-out remplace ensuite chaque coquille en place (cf. [_upsertByKey]).
+  List<FeedThemeSection> _shellThemeSections(List<FavoriteRef> refs) {
     final interestsState = ref.read(userInterestsProvider).valueOrNull;
     final sections = <FeedThemeSection>[];
-    for (final favRef in picked.refs) {
+    for (final favRef in refs) {
       final FeedThemeSection? shell = switch (favRef) {
         ThemeFavoriteRef(:final slug) => FeedThemeSection(
             kind: SectionKind.theme,
@@ -645,9 +664,15 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   }
 
   /// Coquilles de sections source pour le squelette, résolues via le même
-  /// catalogue/sélection que [_fetchSourceSections] (label/logo/accent réels).
-  List<FeedThemeSection> _skeletonSourceSections() {
-    final favs = _pickFavoriteSources();
+  /// catalogue/sélection que [_shellSourceSections] (label/logo/accent réels).
+  List<FeedThemeSection> _skeletonSourceSections() =>
+      _shellSourceSections(_pickFavoriteSources());
+
+  /// Coquilles (en-têtes vides) des sections source pour [favs], dans l'ordre
+  /// fourni. Partagé par le squelette et le **seed pré-fan-out** : label/logo/
+  /// accent réels (catalogue `userSourcesProvider`), `items` vide. Un favori
+  /// dont la source n'est pas (encore) au catalogue est ignoré ce cycle.
+  List<FeedThemeSection> _shellSourceSections(List<SourceFavoriteRef> favs) {
     if (favs.isEmpty) return const [];
     final catalog =
         ref.read(userSourcesProvider).valueOrNull ?? const <Source>[];
@@ -1281,7 +1306,8 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   ///
   /// `isFallback` indique si les `refs` thème renvoyés sont des thèmes canoniques
   /// (compte neuf) plutôt que des favoris explicites — consommé par
-  /// [_fetchThemeSections] pour décider de l'affichage d'un empty-state.
+  /// [_buildStateFromPayload] (pas de seed de coquilles pour le fallback) et le
+  /// fan-out (`isExplicitFavorite`) pour décider de l'affichage d'un empty-state.
   ({List<FavoriteRef> refs, bool isFallback}) _pickFavorites(
     List<TopTheme> topFallback,
   ) {
@@ -1349,37 +1375,9 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     );
   }
 
-  /// Fetches one FeedResponse per favorite ref in parallel and turns them
-  /// into FeedThemeSections. Un favori thème **explicite**
-  /// ([isExplicitFavorite] = true) est toujours rendu (empty-state si vide) ;
-  /// les thèmes de **fallback** (compte neuf) sont coupés sous 2 items pour
-  /// garder la Tournée par défaut utile sans afficher d'empty-state non choisi.
-  Future<List<FeedThemeSection>> _fetchThemeSections(
-    List<FavoriteRef> favorites,
-    bool isSerene, {
-    bool isExplicitFavorite = true,
-  }) async {
-    if (favorites.isEmpty) return const [];
-    final interestsState = ref.read(userInterestsProvider).valueOrNull;
-    final feeds = await Future.wait(
-      favorites.map((favRef) => _fetchOneTheme(favRef, isSerene)),
-    );
-    final sections = <FeedThemeSection>[];
-    for (var i = 0; i < favorites.length; i++) {
-      final section = _buildFavoriteThemeSection(
-        favorites[i],
-        feeds[i],
-        isExplicitFavorite: isExplicitFavorite,
-        interestsState: interestsState,
-      );
-      if (section != null) sections.add(section);
-    }
-    return sections;
-  }
-
   /// Construit la section d'un favori thème / sujet / veille à partir de son
-  /// `FeedResponse` déjà fetché. Extrait de [_fetchThemeSections] pour être
-  /// partagé avec le fan-out progressif ([_fanOutSectionsProgressive]).
+  /// `FeedResponse` déjà fetché. Partagé par le fan-out progressif
+  /// ([_fanOutSectionsProgressive]) et le refetch ([_refetchThemesOnly]).
   FeedThemeSection? _buildFavoriteThemeSection(
     FavoriteRef favRef,
     FeedResponse? feed, {
@@ -1432,7 +1430,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     // 24h window + user_subtopics boost" for the Tournée du jour theme
     // sections (vs. the unrestricted exploration mode used by feed chips).
     return switch (favRef) {
-      ThemeFavoriteRef(:final slug) => _safe<FeedResponse>(
+      ThemeFavoriteRef(:final slug) => _fetchWithRetry<FeedResponse>(
           () => _feedRepo.getFeed(
             page: 1,
             limit: _kThemeSectionPageLimit,
@@ -1445,7 +1443,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       // Backend `/api/feed` accepts a UUID stringified in the `topic` param
       // (story 22.1) — looked up against `user_topic_profiles` scoped on the
       // current user, so no cross-user leak.
-      CustomTopicFavoriteRef(:final id) => _safe<FeedResponse>(
+      CustomTopicFavoriteRef(:final id) => _fetchWithRetry<FeedResponse>(
           () => _feedRepo.getFeed(
             page: 1,
             limit: _kThemeSectionPageLimit,
@@ -1458,7 +1456,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       // Story 23.2 PR-4 : la veille est résolue via `/api/veille/feed`,
       // exposée par FluxContinuRepository.getVeilleFeedItems (normalise la
       // réponse en FeedResponse Content-compatible).
-      VeilleFavoriteRef() => _safe<FeedResponse>(
+      VeilleFavoriteRef() => _fetchWithRetry<FeedResponse>(
           () => ref.read(fluxContinuRepositoryProvider).getVeilleFeedItems(
                 limit: _kThemeSectionPageLimit,
                 serein: isSerene,
@@ -1526,40 +1524,11 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
         .toList(growable: false);
   }
 
-  /// Résout chaque source favorite en `Source` complet (nom + logo + thème)
-  /// via le catalogue `userSourcesProvider`, puis fetch en parallèle le top
-  /// classé (mêmes piliers que les thèmes, `personalized: true`). Les favoris
-  /// dont la source n'est pas (encore) dans le catalogue sont ignorés ce cycle.
-  Future<List<FeedThemeSection>> _fetchSourceSections(
-    List<SourceFavoriteRef> favs,
-    bool isSerene,
-  ) async {
-    if (favs.isEmpty) return const [];
-    final catalog =
-        ref.read(userSourcesProvider).valueOrNull ?? const <Source>[];
-    final sourceById = {for (final s in catalog) s.id: s};
-    final resolved = <Source>[];
-    for (final fav in favs) {
-      final src = sourceById[fav.sourceId];
-      if (src != null) resolved.add(src);
-    }
-    if (resolved.isEmpty) return const [];
-    final feeds = await Future.wait(
-      resolved.map((src) => _fetchOneSource(src.id, isSerene)),
-    );
-    final sections = <FeedThemeSection>[];
-    for (var i = 0; i < resolved.length; i++) {
-      final section = _buildSourceSection(feed: feeds[i], source: resolved[i]);
-      if (section != null) sections.add(section);
-    }
-    return sections;
-  }
-
   Future<FeedResponse?> _fetchOneSource(String sourceId, bool isSerene) {
     // `personalized: true` + `source_id` ⇒ backend route vers le scoring
     // piliers (fenêtre adaptative 24→48→72h), mêmes critères que les sections
     // thème. Flâner appelle sans `personalized` → reste chronologique.
-    return _safe<FeedResponse>(
+    return _fetchWithRetry<FeedResponse>(
       () => _feedRepo.getFeed(
         page: 1,
         limit: _kThemeSectionPageLimit,
@@ -1690,8 +1659,8 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
         ref.read(userSourcesProvider).valueOrNull ?? const <Source>[];
     final sourceById = {for (final s in catalog) s.id: s};
 
-    // Sources favorites résolues au catalogue (mêmes règles que
-    // [_fetchSourceSections] : un favori absent du catalogue est ignoré).
+    // Sources favorites résolues au catalogue (un favori absent du catalogue
+    // est ignoré ce cycle, comme pour les coquilles seedées).
     final resolvedSources = <Source>[
       for (final fav in favoriteSources)
         if (sourceById[fav.sourceId] != null) sourceById[fav.sourceId]!,
@@ -1724,14 +1693,17 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
                 isExplicitFavorite: isExplicitFavorite,
                 interestsState: interestsState,
               ),
-              (section) => _themes = [..._themes, section],
+              // Upsert par clé : remplace la coquille seedée à sa position
+              // d'origine (ordre préservé) au lieu d'append (sinon doublon
+              // coquille + contenu).
+              (section) => _themes = _upsertByKey(_themes, section),
             ),
       // Sources favorites.
       for (final src in resolvedSources)
         () => sectionTask(
               () => _fetchOneSource(src.id, isSerene),
               (feed) => _buildSourceSection(feed: feed, source: src),
-              (section) => _sources = [..._sources, section],
+              (section) => _sources = _upsertByKey(_sources, section),
             ),
       // Suggérées « Choisie pour vous ».
       for (final s in usableSuggestions)
@@ -1751,6 +1723,32 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     // Recompose final : garantit un état cohérent même si toutes les tâches
     // ont renvoyé une section nulle (rien émis dans la boucle).
     emit();
+  }
+
+  /// Remplace, dans [list], la section de même `sectionKey` que [section] par
+  /// [section] **à sa position d'origine** ; l'ajoute en queue si absente. Le
+  /// fan-out s'en sert pour substituer une coquille seedée par son contenu sans
+  /// dupliquer la section ni déplacer son rang (l'ordre de la Tournée est dérivé
+  /// de ce rang dans `_orderedTourneeKeys`).
+  List<FeedThemeSection> _upsertByKey(
+    List<FeedThemeSection> list,
+    FeedThemeSection section,
+  ) {
+    final key = sectionKey(section);
+    final idx = list.indexWhere((s) => sectionKey(s) == key);
+    if (idx < 0) return [...list, section];
+    final next = [...list];
+    next[idx] = section;
+    return next;
+  }
+
+  /// `true` ssi [list] contient déjà une section de même `sectionKey` que
+  /// [section]. Sert aux chemins de refetch à n'upserter qu'une coquille encore
+  /// présente (replace-only), pour ne pas réintroduire un favori retiré par un
+  /// refetch concurrent.
+  bool _hasSectionKey(List<FeedThemeSection> list, FeedThemeSection section) {
+    final key = sectionKey(section);
+    return list.any((s) => sectionKey(s) == key);
   }
 
   /// Exécute [tasks] avec au plus [maxConcurrent] en vol simultanément, en
@@ -2002,17 +2000,64 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   }
 
   /// Replays only the theme-section fetches against the new favorite list.
-  /// Saves the cost of refetching the digest, which doesn't depend on
-  /// favorites.
+  /// Saves the cost of refetching the digest, which doesn't depend on favorites.
+  ///
+  /// Même discipline que le fan-out de cold-open (**seed coquille → fetch →
+  /// remplace en place**) : on seede d'abord les en-têtes pour [picked] en
+  /// **conservant** le contenu déjà chargé (pas de clignotement contenu→vide sur
+  /// un favori inchangé) — l'en-tête d'un favori **ajouté** apparaît donc tout de
+  /// suite, un favori **retiré** disparaît, puis chaque section est remplacée par
+  /// son contenu frais au fur et à mesure (`_fetchOneTheme` retry compris). Un
+  /// fetch lent/raté laisse la coquille au lieu d'une section manquante.
   Future<void> _refetchThemesOnly(List<FavoriteRef> nextFavorites) async {
     final isSerene = ref.read(sereinToggleProvider).enabled;
     final picked = _pickExplicitFavorites(nextFavorites);
-    final themes = await _fetchThemeSections(picked, isSerene);
     _lastFavorites = picked;
-    _themes = themes;
-    final current = state.valueOrNull;
-    if (current == null) return;
-    state = AsyncData(_compose(isSerene));
+    _themes = _reseedShells(_themes, _shellThemeSections(picked));
+    if (state.valueOrNull != null) {
+      state = AsyncData(_compose(isSerene));
+    }
+    final interestsState = ref.read(userInterestsProvider).valueOrNull;
+    await _runWithConcurrency(
+      [
+        for (final favRef in picked)
+          () async {
+            final section = _buildFavoriteThemeSection(
+              favRef,
+              await _fetchOneTheme(favRef, isSerene),
+              isExplicitFavorite: true,
+              interestsState: interestsState,
+            );
+            // Remplace **uniquement** une coquille encore présente : si un
+            // refetch concurrent a retiré ce favori entre-temps, on n'ajoute pas
+            // sa section en retard (sinon un favori retiré clignote de retour).
+            if (section != null && _hasSectionKey(_themes, section)) {
+              _themes = _upsertByKey(_themes, section);
+            }
+            if (state.valueOrNull != null) {
+              state = AsyncData(_compose(isSerene));
+            }
+          },
+      ],
+      _kPhase2FanoutConcurrency,
+    );
+  }
+
+  /// Fusionne [freshShells] avec le contenu déjà chargé dans [existing] : pour
+  /// chaque coquille fraîche (dans l'ordre des prefs), **conserve** la section de
+  /// même `sectionKey` déjà présente, sinon garde la coquille. Évite le
+  /// clignotement contenu→vide→contenu d'un reseed nu sur ajout/retrait d'un
+  /// favori. Partagé par les reseeds thème ([_refetchThemesOnly]) et source
+  /// ([_refetchSourcesOnly]).
+  List<FeedThemeSection> _reseedShells(
+    List<FeedThemeSection> existing,
+    List<FeedThemeSection> freshShells,
+  ) {
+    final existingByKey = {for (final s in existing) sectionKey(s): s};
+    return [
+      for (final shell in freshShells)
+        existingByKey[sectionKey(shell)] ?? shell,
+    ];
   }
 
   bool _favoriteListsEqual(List<FavoriteRef> a, List<FavoriteRef> b) {
@@ -2025,13 +2070,42 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
 
   /// Replays only the source-section fetches against the new favorite-source
   /// list. Le digest et les thèmes ne dépendent pas des sources favorites.
+  /// Même discipline progressive que [_refetchThemesOnly] (seed coquille en
+  /// conservant le contenu chargé → fetch → remplace en place).
   Future<void> _refetchSourcesOnly(List<SourceFavoriteRef> picked) async {
     final isSerene = ref.read(sereinToggleProvider).enabled;
-    _sources = await _fetchSourceSections(picked, isSerene);
     _lastSourceFavorites = picked;
-    final current = state.valueOrNull;
-    if (current == null) return;
-    state = AsyncData(_compose(isSerene));
+    _sources = _reseedShells(_sources, _shellSourceSections(picked));
+    if (state.valueOrNull != null) {
+      state = AsyncData(_compose(isSerene));
+    }
+    final catalog =
+        ref.read(userSourcesProvider).valueOrNull ?? const <Source>[];
+    final sourceById = {for (final s in catalog) s.id: s};
+    final resolved = <Source>[
+      for (final fav in picked)
+        if (sourceById[fav.sourceId] != null) sourceById[fav.sourceId]!,
+    ];
+    await _runWithConcurrency(
+      [
+        for (final src in resolved)
+          () async {
+            final section = _buildSourceSection(
+              feed: await _fetchOneSource(src.id, isSerene),
+              source: src,
+            );
+            // Replace-only (cf. [_refetchThemesOnly]) : ignore une source
+            // retirée par un refetch concurrent pendant son fetch en vol.
+            if (section != null && _hasSectionKey(_sources, section)) {
+              _sources = _upsertByKey(_sources, section);
+            }
+            if (state.valueOrNull != null) {
+              state = AsyncData(_compose(isSerene));
+            }
+          },
+      ],
+      _kPhase2FanoutConcurrency,
+    );
   }
 
   /// `SourceFavoriteRef.==` ne compare que `sourceId` ; on compare aussi la
@@ -2061,5 +2135,36 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       debugPrint('FluxContinu: $label failed: $e');
       return fallback;
     }
+  }
+
+  /// Wrap d'un fetch réseau **brut** (repo) avec retry borné des erreurs
+  /// **transitoires**. Un `throw` (HTTP 5xx/401/timeout/déconnexion) est retryé
+  /// jusqu'à [maxAttempts] avec un court [backoff] ; une réponse **200 même
+  /// vide** ne **throw pas** → renvoyée telle quelle sans retry (un feed
+  /// légitimement vide n'est pas une erreur). Renvoie `null` en dernier recours
+  /// (comme [_safe]), donc les builders gèrent l'absence comme un état vide.
+  ///
+  /// Distinct de [_safe], qui ne sait pas distinguer « erreur » de « vide » et
+  /// n'avale qu'une seule tentative : sous la charge sérialisée d'un fetch perso
+  /// (unique worker uvicorn), un échec transitoire laissait sinon la section
+  /// sous-remplie (0/1 carte) pour tout le cycle (bugs « Tournée figée » et
+  /// « thème à 1 carte »).
+  Future<T?> _fetchWithRetry<T>(
+    Future<T?> Function() fn,
+    String label, {
+    int maxAttempts = 2,
+    Duration backoff = const Duration(milliseconds: 250),
+  }) async {
+    for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        return await fn();
+      } catch (e) {
+        debugPrint(
+            'FluxContinu: $label failed (attempt $attempt/$maxAttempts): $e');
+        if (attempt >= maxAttempts) return null;
+        await Future<void>.delayed(backoff);
+      }
+    }
+    return null;
   }
 }

--- a/apps/mobile/lib/features/flux_continu/providers/tournee_order_prefs_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/tournee_order_prefs_provider.dart
@@ -32,7 +32,7 @@ const _kLegacyVeilleHiddenKey = 'tournee_veille_hidden_v1';
 const _kTourneeCustomizedKey = 'tournee_customized_v1';
 
 /// Cap d'affichage de la Tournée du jour, partagé provider + composer.
-const int kTourneeVisibleCap = 7;
+const int kTourneeVisibleCap = 10;
 
 /// Clé d'un thème favori dans l'ordre Tournée (= `sectionKey` d'une section thème).
 String tourneeThemeKey(String slug) => 'theme:$slug';

--- a/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
@@ -36,8 +36,15 @@ import 'choice_tile.dart';
 /// scrolle vers la section Flâner à l'ouverture — le contenu est identique.
 enum ManageFavoritesEntry { essentiel, flaner }
 
-/// Accent des Actus du jour (aligné provider Tournée).
+/// Accent des Actus du jour (aligné provider Tournée). Sert aussi d'**identité
+/// « Essentiel »** dans cette sheet (en-tête + puces « → Essentiel »).
 const Color _kEssentielAccent = Color(0xFFB0470A);
+
+/// Identité visuelle **« Flâner »** dans cette sheet : le brun du bandeau de la
+/// page Flâner (déjà reconnaissable). Colore l'en-tête « Onglets de ta page
+/// Flâner » et les puces « → Flâner », pour que la destination d'un déplacement
+/// soit lisible par sa couleur (et plus par celle, arbitraire, de la carte).
+const Color _kFlanerAccent = Color(0xFF5D4037);
 
 /// Accent des Bonnes Nouvelles (aligné provider Tournée).
 const Color _kBonnesAccent = Color(0xFF2E7D32);
@@ -694,6 +701,7 @@ class _ManageFavoritesContentState
                   counter:
                       '${essentielOrdered.length.clamp(0, kTourneeVisibleCap)}'
                       '/$kTourneeVisibleCap',
+                  accent: _kEssentielAccent,
                   colors: colors,
                 ),
                 const SizedBox(height: 8),
@@ -708,6 +716,8 @@ class _ManageFavoritesContentState
                     colors: colors,
                     cap: kTourneeVisibleCap,
                     capLabel: 'Hors Tournée du jour ($kTourneeVisibleCap)',
+                    // Destination du déplacement = Flâner ⇒ puces brun Flâner.
+                    moveAccent: _kFlanerAccent,
                     onReorder: (oldIndex, newIndex) {
                       final reordered = [...essentielOrdered];
                       if (newIndex > oldIndex) newIndex -= 1;
@@ -733,6 +743,7 @@ class _ManageFavoritesContentState
                   counter:
                       '${flanerOrdered.length.clamp(0, kMaxFavoriteTabs)}'
                       '/$kMaxFavoriteTabs',
+                  accent: _kFlanerAccent,
                   colors: colors,
                 ),
                 const SizedBox(height: 8),
@@ -748,6 +759,8 @@ class _ManageFavoritesContentState
                     colors: colors,
                     cap: kMaxFavoriteTabs,
                     capLabel: 'Hors onglets ($kMaxFavoriteTabs)',
+                    // Destination du déplacement = Essentiel ⇒ puces ocre.
+                    moveAccent: _kEssentielAccent,
                     onReorder: (oldIndex, newIndex) {
                       final reordered = [...flanerOrdered];
                       if (newIndex > oldIndex) newIndex -= 1;
@@ -906,6 +919,10 @@ class _FavList extends StatelessWidget {
   final IconData moveIcon;
   final String moveTooltip;
   final String moveLabel;
+
+  /// Couleur de la puce de déplacement = identité du **mode de destination**
+  /// (brun Flâner / ocre Essentiel), pas la couleur de la carte (cf. [_MoveChip]).
+  final Color moveAccent;
   final void Function(_FavItem item) onMove;
   final void Function(_FavItem item)? onSubjectVeille;
 
@@ -919,6 +936,7 @@ class _FavList extends StatelessWidget {
     required this.moveIcon,
     required this.moveTooltip,
     required this.moveLabel,
+    required this.moveAccent,
     required this.onMove,
     this.onSubjectVeille,
   });
@@ -952,6 +970,7 @@ class _FavList extends StatelessWidget {
               moveIcon: moveIcon,
               moveTooltip: moveTooltip,
               moveLabel: moveLabel,
+              moveAccent: moveAccent,
               onRemove: () => onRemove(item),
               onMove: () => onMove(item),
               onSubjectVeille: onSubjectVeille == null
@@ -1014,6 +1033,7 @@ class _FavRow extends StatelessWidget {
   final IconData moveIcon;
   final String moveTooltip;
   final String moveLabel;
+  final Color moveAccent;
   final VoidCallback onRemove;
   final VoidCallback onMove;
   final VoidCallback? onSubjectVeille;
@@ -1026,6 +1046,7 @@ class _FavRow extends StatelessWidget {
     required this.moveIcon,
     required this.moveTooltip,
     required this.moveLabel,
+    required this.moveAccent,
     required this.onRemove,
     required this.onMove,
     this.onSubjectVeille,
@@ -1106,7 +1127,10 @@ class _FavRow extends StatelessWidget {
                   icon: moveIcon,
                   label: moveLabel,
                   tooltip: moveTooltip,
-                  accent: item.accent,
+                  // Couleur du mode de destination (Flâner brun / Essentiel
+                  // ocre), pas celle de la carte : « Flâner » devient
+                  // reconnaissable à sa teinte.
+                  accent: moveAccent,
                   onTap: onMove,
                 ),
               _RowIconButton(
@@ -1522,9 +1546,14 @@ class _VeilleTile extends StatelessWidget {
 class _SectionLabel extends StatelessWidget {
   final String label;
 
-  /// Compteur discret affiché en suffixe (ex. « · 5/7 ») rappelant le cap de
+  /// Compteur discret affiché en suffixe (ex. « · 5/10 ») rappelant le cap de
   /// la section. `null` → pas de compteur (ex. en-têtes AJOUTER / GÉRER).
   final String? counter;
+
+  /// Teinte d'identité de la section (ocre Essentiel / brun Flâner). `null` →
+  /// gris tertiaire neutre (en-têtes AJOUTER / GÉRER). Renforce le code couleur
+  /// des puces de déplacement (cf. [_MoveChip]).
+  final Color? accent;
   final FacteurColors colors;
 
   const _SectionLabel({
@@ -1532,12 +1561,13 @@ class _SectionLabel extends StatelessWidget {
     required this.label,
     required this.colors,
     this.counter,
+    this.accent,
   });
 
   @override
   Widget build(BuildContext context) {
     final labelStyle = Theme.of(context).textTheme.labelSmall?.copyWith(
-      color: colors.textTertiary,
+      color: accent ?? colors.textTertiary,
       fontWeight: FontWeight.w700,
       letterSpacing: 1.2,
     );
@@ -1548,7 +1578,13 @@ class _SectionLabel extends StatelessWidget {
       children: [
         Flexible(child: Text(label, style: labelStyle)),
         const SizedBox(width: 6),
-        Text('· $counter', style: labelStyle?.copyWith(letterSpacing: 0.2)),
+        Text(
+          '· $counter',
+          style: labelStyle?.copyWith(
+            letterSpacing: 0.2,
+            color: accent?.withValues(alpha: 0.7) ?? colors.textTertiary,
+          ),
+        ),
       ],
     );
   }

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_progressive_fanout_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_progressive_fanout_test.dart
@@ -307,11 +307,21 @@ void main() {
 
     // Poll the live value (Riverpod coalesces listener notifications, so we
     // sample like `settle` does) while releasing sections one at a time.
+    //
+    // Avec le seed de coquilles, les 4 sections sont présentes dès le 1er rendu
+    // non-squelette (en-têtes vides) : le signal « progressif » porte donc sur
+    // le **remplissage du contenu** (sections à `items` non vide), pas sur le
+    // nombre de sections — qui vaut 4 dès le départ.
     final counts = <int>[];
     void record() {
       final v = container.read(fluxContinuProvider).valueOrNull;
       if (v != null && !v.isSkeleton) {
-        counts.add(v.sections.whereType<FeedThemeSection>().length);
+        counts.add(
+          v.sections
+              .whereType<FeedThemeSection>()
+              .where((s) => s.items.isNotEmpty)
+              .length,
+        );
       }
     }
 
@@ -328,13 +338,183 @@ void main() {
     await pumpEventQueue(times: 5);
     record();
 
-    // At least one intermediate sample had 1..3 sections (progressive fill),
-    // not a single jump straight from 0 to 4.
+    // At least one intermediate sample had 1..3 FILLED sections (progressive
+    // fill), not a single jump straight from 0 to 4 filled.
     expect(
       counts.any((c) => c > 0 && c < 4),
       isTrue,
-      reason: 'expected an intermediate state before all 4 sections arrived',
+      reason: 'expected an intermediate state before all 4 sections filled',
     );
     expect(counts.last, 4);
   });
+
+  // ── Fan-out résilient (fix « Tournée figée » + « thème à 1 carte ») ─────────
+
+  test(
+    'order reflects declared favorites BEFORE any fetch resolves (shells seeded)',
+    () async {
+      // Tous les fetchs thème pendouillent (gated, jamais complétés) : aucune
+      // section n'a encore de contenu. L'ordre de la Tournée doit malgré tout
+      // refléter les favoris déclarés (en-têtes seedés, items vides) — c'est le
+      // cœur du fix « ordre figé » : la clé d'une section n'attend plus son fetch.
+      final gates = <Completer<void>>[];
+      when(
+        () => feedRepo.getFeed(
+          page: any(named: 'page'),
+          limit: any(named: 'limit'),
+          theme: any(named: 'theme'),
+          serein: any(named: 'serein'),
+          personalized: any(named: 'personalized'),
+        ),
+      ).thenAnswer((_) async {
+        final gate = Completer<void>();
+        gates.add(gate);
+        await gate.future;
+        return _feedResponseWith(3);
+      });
+
+      final container = makeContainer(
+        _interestsState(favorites: themeFavorites(3)),
+      );
+      addTearDown(container.dispose);
+
+      container.read(fluxContinuProvider);
+      // Draine le bootstrap (squelette → rendu base + seed des coquilles) SANS
+      // libérer la moindre gate.
+      for (var step = 0; step < 20; step++) {
+        await pumpEventQueue(times: 3);
+      }
+
+      final value = container.read(fluxContinuProvider).valueOrNull;
+      expect(value, isNotNull);
+      expect(value!.isSkeleton, isFalse);
+      final themes = value.sections.whereType<FeedThemeSection>().toList();
+      // Les 3 en-têtes favoris sont présents, dans l'ordre déclaré, items vides.
+      expect(themes.map((s) => s.themeSlug).toList(), [
+        'theme0',
+        'theme1',
+        'theme2',
+      ]);
+      expect(themes.every((s) => s.items.isEmpty), isTrue);
+
+      // Libère les gates pour ne pas laisser de timers/futures en suspens.
+      for (final gate in gates) {
+        gate.complete();
+      }
+      await pumpEventQueue(times: 5);
+    },
+  );
+
+  test(
+    'a transient throw is retried → section fills with the full page (not 0/1)',
+    () async {
+      // 1er appel throw (erreur transitoire : 503/401/timeout), 2e réussit. Sans
+      // retry, `_safe` avalait l'erreur → section vide/à 1 carte pour le cycle.
+      var calls = 0;
+      when(
+        () => feedRepo.getFeed(
+          page: any(named: 'page'),
+          limit: any(named: 'limit'),
+          theme: any(named: 'theme'),
+          serein: any(named: 'serein'),
+          personalized: any(named: 'personalized'),
+        ),
+      ).thenAnswer((_) async {
+        calls++;
+        if (calls == 1) throw Exception('transient 503');
+        return _feedResponseWith(10);
+      });
+
+      final container = makeContainer(
+        _interestsState(favorites: themeFavorites(1)),
+      );
+      addTearDown(container.dispose);
+
+      container.read(fluxContinuProvider);
+      // Le retry attend un backoff **réel** (~250ms) avant la 2e tentative ;
+      // `settle` romprait pendant cette fenêtre stable (état coquille inchangé).
+      // On laisse donc passer du temps réel, puis on draine.
+      for (var i = 0; i < 6; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 80));
+        await pumpEventQueue(times: 3);
+      }
+      final theme = container
+          .read(fluxContinuProvider)
+          .requireValue
+          .sections
+          .whereType<FeedThemeSection>()
+          .single;
+      expect(
+        theme.items,
+        hasLength(10),
+        reason: '1ère tentative en échec, retry réussi avec la page pleine',
+      );
+      // Exactement 2 tentatives (1 throw + 1 succès), pas plus.
+      verify(
+        () => feedRepo.getFeed(
+          page: any(named: 'page'),
+          limit: any(named: 'limit'),
+          theme: any(named: 'theme'),
+          serein: any(named: 'serein'),
+          personalized: any(named: 'personalized'),
+        ),
+      ).called(2);
+    },
+  );
+
+  test(
+    'upsert by key replaces the shell in place → no duplicate section per key',
+    () async {
+      // Ids distincts par appel pour qu'aucune section ne soit vidée par la
+      // dédup inter-sections — on veut le signal « la coquille a reçu son
+      // contenu », pas un artefact de dédup.
+      var callIdx = 0;
+      when(
+        () => feedRepo.getFeed(
+          page: any(named: 'page'),
+          limit: any(named: 'limit'),
+          theme: any(named: 'theme'),
+          serein: any(named: 'serein'),
+          personalized: any(named: 'personalized'),
+        ),
+      ).thenAnswer((_) async {
+        final idx = callIdx++;
+        return FeedResponse(
+          items: List.generate(
+            3,
+            (i) => Content(
+              id: 'call${idx}_item$i',
+              title: 't',
+              url: 'https://x.test/$idx/$i',
+              contentType: ContentType.article,
+              publishedAt: DateTime(2026, 1, 1),
+              source: Source(id: 's', name: 'S', type: SourceType.article),
+            ),
+          ),
+          pagination: Pagination(page: 1, perPage: 10, total: 0, hasNext: false),
+          carousels: const [],
+        );
+      });
+
+      final container = makeContainer(
+        _interestsState(favorites: themeFavorites(4)),
+      );
+      addTearDown(container.dispose);
+
+      final state = await settle(container);
+      final themes = state.sections.whereType<FeedThemeSection>().toList();
+      // 4 favoris → exactement 4 sections : la coquille a été remplacée en place,
+      // pas append (sinon 8 sections / clés dupliquées).
+      expect(themes, hasLength(4));
+      // Ordre déclaré préservé + aucune clé en double.
+      expect(themes.map((s) => s.themeSlug).toList(), [
+        'theme0',
+        'theme1',
+        'theme2',
+        'theme3',
+      ]);
+      // Chaque coquille a bien reçu son contenu (upsert effectif).
+      expect(themes.every((s) => s.items.isNotEmpty), isTrue);
+    },
+  );
 }

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
@@ -500,7 +500,7 @@ void main() {
       );
     });
 
-    test('7 favorites cap (8th ignored)', () async {
+    test('10 favorites cap (11th ignored)', () async {
       SharedPreferences.setMockInitialValues(<String, Object>{});
       when(
         () => feedRepo.getFeed(
@@ -512,17 +512,12 @@ void main() {
         ),
       ).thenAnswer((_) async => _feedResponseWith(3));
 
+      // 11 favoris thème (slugs arbitraires — `visualFor` a un fallback) : le cap
+      // [_kMaxFavoriteSections] = 10 garde les 10 premiers, le 11e est ignoré.
       final container = makeContainer(
         interests: _interestsState(
-          favorites: const [
-            ThemeFavoriteRef(slug: 'tech'),
-            ThemeFavoriteRef(slug: 'science'),
-            ThemeFavoriteRef(slug: 'culture'),
-            ThemeFavoriteRef(slug: 'economy'),
-            ThemeFavoriteRef(slug: 'politics'),
-            ThemeFavoriteRef(slug: 'sport'),
-            ThemeFavoriteRef(slug: 'environment'),
-            ThemeFavoriteRef(slug: 'society'), // 8th — must be dropped
+          favorites: [
+            for (var i = 0; i < 11; i++) ThemeFavoriteRef(slug: 'theme$i'),
           ],
         ),
       );
@@ -533,15 +528,7 @@ void main() {
           .whereType<FeedThemeSection>()
           .map((s) => s.themeSlug)
           .toList();
-      expect(slugs, [
-        'tech',
-        'science',
-        'culture',
-        'economy',
-        'politics',
-        'sport',
-        'environment',
-      ]);
+      expect(slugs, [for (var i = 0; i < 10; i++) 'theme$i']);
     });
   });
 
@@ -1418,21 +1405,28 @@ void main() {
         final skeletonIdx = captured.indexWhere((s) => s.isSkeleton);
         expect(skeletonIdx, greaterThanOrEqualTo(0));
 
-        // base-only : contenu réel (Actus du jour) mais ENCORE aucune section
-        // thème (le fan-out de phase 2 n'a pas répondu).
+        // base-only : la section thème 'tech' existe déjà (en-tête seedé) mais
+        // reste une COQUILLE vide — le fan-out de phase 2 n'a pas encore
+        // répondu. Avec le seed de coquilles, le signal « progressif » porte sur
+        // le remplissage du contenu, pas sur la présence de la section.
         final baseIdx = captured.indexWhere(
           (s) =>
               !s.isSkeleton &&
-              s.sections.isNotEmpty &&
-              s.sections.whereType<FeedThemeSection>().isEmpty,
+              s.sections.whereType<FeedThemeSection>().isNotEmpty &&
+              s.sections
+                  .whereType<FeedThemeSection>()
+                  .every((t) => t.items.isEmpty),
         );
         expect(baseIdx, greaterThan(skeletonIdx),
-            reason:
-                'le haut de page réel remplace le squelette avant le fan-out');
+            reason: 'les en-têtes (haut de page + coquilles favoris) remplacent '
+                'le squelette avant le remplissage du fan-out');
 
-        // complet : la section thème 'tech' est présente, après le base-only.
+        // complet : la section thème 'tech' est REMPLIE (items non vides),
+        // après le base-only.
         final fullIdx = captured.lastIndexWhere(
-          (s) => s.sections.whereType<FeedThemeSection>().isNotEmpty,
+          (s) => s.sections
+              .whereType<FeedThemeSection>()
+              .any((t) => t.items.isNotEmpty),
         );
         expect(fullIdx, greaterThan(baseIdx));
         expect(finalState.isSkeleton, isFalse);

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_sources_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_sources_test.dart
@@ -318,7 +318,7 @@ void main() {
 
   test(
       'plusieurs sources favorites respectent l\'ordre par position et le '
-      'cap (parité thèmes = 7)', () async {
+      'cap (parité thèmes = 10)', () async {
     stubFeed(
       themeIds: const {},
       sourceIds: {
@@ -330,6 +330,9 @@ void main() {
         'f': ['f1', 'f2'],
         'g': ['g1', 'g2'],
         'h': ['h1', 'h2'],
+        'i': ['i1', 'i2'],
+        'j': ['j1', 'j2'],
+        'k': ['k1', 'k2'],
       },
     );
     final container = await buildContainer(
@@ -343,6 +346,9 @@ void main() {
         SourceFavoriteRef(sourceId: 'e', position: 4),
         SourceFavoriteRef(sourceId: 'h', position: 7),
         SourceFavoriteRef(sourceId: 'g', position: 6),
+        SourceFavoriteRef(sourceId: 'j', position: 9),
+        SourceFavoriteRef(sourceId: 'i', position: 8),
+        SourceFavoriteRef(sourceId: 'k', position: 10),
       ]),
       catalog: [
         _source('a'),
@@ -353,6 +359,9 @@ void main() {
         _source('f'),
         _source('g'),
         _source('h'),
+        _source('i'),
+        _source('j'),
+        _source('k'),
       ],
       tourneeOrder: const [
         'source:a',
@@ -363,6 +372,9 @@ void main() {
         'source:f',
         'source:g',
         'source:h',
+        'source:i',
+        'source:j',
+        'source:k',
       ],
     );
     addTearDown(container.dispose);
@@ -373,7 +385,7 @@ void main() {
         .map((s) => s.sourceId)
         .toList();
 
-    // Triées par position (a..h) puis capées à 7 → a,b,c,d,e,f,g.
-    expect(sources, ['a', 'b', 'c', 'd', 'e', 'f', 'g']);
+    // Triées par position (a..k) puis capées à 10 → a,b,c,d,e,f,g,h,i,j.
+    expect(sources, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
   });
 }

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_tournee_order_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_tournee_order_test.dart
@@ -1,6 +1,6 @@
 // PR 2 — couverture du bloc favori UNIFIÉ de la Tournée composé par le
 // FluxContinuNotifier : ordre 100 % libre (thèmes + sources + veille mélangés
-// via « Composer ma Tournée »), cap d'affichage 7, exclusion des sujets perso,
+// via « Composer ma Tournée »), cap d'affichage 10, exclusion des sujets perso,
 // et masquage de la veille (veilleHidden).
 import 'dart:io';
 
@@ -393,7 +393,7 @@ void main() {
       },
     );
 
-    test('cap 7 unifié : 5 thèmes + Actus + Grille coupent Bonnes', () async {
+    test('cap 10 unifié : 8 thèmes + Actus + Grille coupent Bonnes', () async {
       stubDigest();
       stubFeed(
         themeIds: {
@@ -402,6 +402,9 @@ void main() {
           'economy': ['e1'],
           'politics': ['p1'],
           'tech': ['t1'],
+          'science': ['sc1'],
+          'environment': ['en1'],
+          'international': ['in1'],
         },
       );
       final container = await buildContainer(
@@ -412,6 +415,9 @@ void main() {
             ThemeFavoriteRef(slug: 'economy'),
             ThemeFavoriteRef(slug: 'politics'),
             ThemeFavoriteRef(slug: 'tech'),
+            ThemeFavoriteRef(slug: 'science'),
+            ThemeFavoriteRef(slug: 'environment'),
+            ThemeFavoriteRef(slug: 'international'),
           ],
         ),
         sourcesState: _sourcesState(),
@@ -428,14 +434,17 @@ void main() {
         'theme:economy',
         'theme:politics',
         'theme:tech',
+        'theme:science',
+        'theme:environment',
+        'theme:international',
         kTourneeActusKey,
       ]);
-      expect(state.grilleSlotIndex, 6);
+      expect(state.grilleSlotIndex, 9);
       expect(
         state.sections.map(sectionKey),
         isNot(contains(kTourneeBonnesKey)),
-        reason: 'Bonnes est 8e dans la liste unifiée (5 thèmes+Actus+Grille) '
-            'et tombe sous le cap de 7',
+        reason: 'Bonnes est 11e dans la liste unifiée (8 thèmes+Actus+Grille) '
+            'et tombe sous le cap de 10',
       );
     });
 
@@ -569,8 +578,8 @@ void main() {
   });
 
   test(
-      'cap d\'affichage 7 : 4 thèmes + 3 sources + veille (8 candidats) → '
-      'seulement 7 sections, veille (en queue par défaut) coupée', () async {
+      'cap d\'affichage 10 : 7 thèmes + 3 sources + veille (11 candidats) → '
+      'seulement 10 sections, veille (en queue par défaut) coupée', () async {
     // Story 10.2 — les sources doivent être en mode « Essentiel » (clé dans
     // l'ordre) pour entrer dans la Tournée ; on garde l'ordre par défaut
     // (thèmes avant sources) en plaçant les clés thème d'abord.
@@ -580,6 +589,9 @@ void main() {
         'theme:culture',
         'theme:economy',
         'theme:politics',
+        'theme:tech',
+        'theme:science',
+        'theme:environment',
         'source:a',
         'source:b',
         'source:c',
@@ -591,6 +603,9 @@ void main() {
         'culture': ['c1', 'c2'],
         'economy': ['e1', 'e2'],
         'politics': ['p1', 'p2'],
+        'tech': ['t1', 't2'],
+        'science': ['sc1', 'sc2'],
+        'environment': ['en1', 'en2'],
       },
       sourceIds: {
         'a': ['a1'],
@@ -605,6 +620,9 @@ void main() {
           ThemeFavoriteRef(slug: 'culture'),
           ThemeFavoriteRef(slug: 'economy'),
           ThemeFavoriteRef(slug: 'politics'),
+          ThemeFavoriteRef(slug: 'tech'),
+          ThemeFavoriteRef(slug: 'science'),
+          ThemeFavoriteRef(slug: 'environment'),
         ],
       ),
       sourcesState: _sourcesState(
@@ -624,16 +642,19 @@ void main() {
 
     expect(
       sections,
-      hasLength(7),
-      reason: 'cap d\'affichage de la Tournée = 7',
+      hasLength(10),
+      reason: 'cap d\'affichage de la Tournée = 10',
     );
     expect(
       sections.where((s) => s.kind == SectionKind.veille),
       isEmpty,
-      reason: 'ordre par défaut thèmes→sources→veille → veille en 8e, coupée',
+      reason: 'ordre par défaut thèmes→sources→veille → veille en 11e, coupée',
     );
-    // Ordre par défaut : 4 thèmes puis 3 sources (a, b, c) ; veille tombe.
+    // Ordre par défaut : 7 thèmes puis 3 sources (a, b, c) ; veille tombe.
     expect(sections.map((s) => s.kind).toList(), [
+      SectionKind.theme,
+      SectionKind.theme,
+      SectionKind.theme,
       SectionKind.theme,
       SectionKind.theme,
       SectionKind.theme,
@@ -691,7 +712,7 @@ void main() {
     'veille en tête d\'ordre : présente dans le cap, un autre item tombe',
     () async {
       // Story 10.2 — sources en mode « Essentiel » (clés dans l'ordre) ; veille
-      // remontée en tête. 8 candidats → cap 7, veille première (source c tombe).
+      // remontée en tête. 11 candidats → cap 10, veille première (source c tombe).
       SharedPreferences.setMockInitialValues(<String, Object>{
         'tournee_order_v1': [
           'veille',
@@ -699,6 +720,9 @@ void main() {
           'theme:culture',
           'theme:economy',
           'theme:politics',
+          'theme:tech',
+          'theme:science',
+          'theme:environment',
           'source:a',
           'source:b',
           'source:c',
@@ -710,6 +734,9 @@ void main() {
           'culture': ['c1', 'c2'],
           'economy': ['e1', 'e2'],
           'politics': ['p1', 'p2'],
+          'tech': ['t1', 't2'],
+          'science': ['sc1', 'sc2'],
+          'environment': ['en1', 'en2'],
         },
         sourceIds: {
           'a': ['a1'],
@@ -724,6 +751,9 @@ void main() {
             ThemeFavoriteRef(slug: 'culture'),
             ThemeFavoriteRef(slug: 'economy'),
             ThemeFavoriteRef(slug: 'politics'),
+            ThemeFavoriteRef(slug: 'tech'),
+            ThemeFavoriteRef(slug: 'science'),
+            ThemeFavoriteRef(slug: 'environment'),
           ],
         ),
         sourcesState: _sourcesState(
@@ -741,7 +771,7 @@ void main() {
       await settle(container);
       final sections = favoriteSections(container);
 
-      expect(sections, hasLength(7));
+      expect(sections, hasLength(10));
       expect(
         sections.first.kind,
         SectionKind.veille,

--- a/apps/mobile/test/features/flux_continu/widgets/manage_favorites_sheet_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/manage_favorites_sheet_test.dart
@@ -1,7 +1,7 @@
 // Story 10.2 — sheet unifiée « Mes favoris » : deux sections (Essentiel /
 // Flâner), appartenance exclusive des sources (la clé `source:` dans
 // `tournee_order_v1` ⇒ Essentiel, sinon Flâner), déplacement de mode, funnel
-// veille sur les sujets, et caps 7/10 par section.
+// veille sur les sujets, et caps 10/10 par section.
 import 'package:facteur/config/routes.dart';
 import 'package:facteur/config/theme.dart';
 import 'package:facteur/features/digest/providers/serein_toggle_provider.dart';
@@ -352,8 +352,9 @@ void main() {
   });
 
   testWidgets(
-      '« Hors Tournée du jour (7) » apparaît au-delà de 7 sections Essentiel',
+      '« Hors Tournée du jour (10) » apparaît au-delà de 10 sections Essentiel',
       (tester) async {
+    // 9 thèmes favoris + Actus + Bonnes = 11 blocs Essentiel → au-delà du cap 10.
     await _openSheet(
       tester,
       interests: _interests(favorites: const [
@@ -365,14 +366,15 @@ void main() {
         ThemeFavoriteRef(slug: 'international'),
         ThemeFavoriteRef(slug: 'economy'),
         ThemeFavoriteRef(slug: 'culture'),
+        ThemeFavoriteRef(slug: 'sport'),
       ]),
       sources: _sources(),
     );
 
-    // Le cap (élargi 5 → 7) est explicité entre parenthèses.
-    expect(find.text('Hors Tournée du jour (7)'), findsOneWidget);
+    // Le cap (élargi → 10) est explicité entre parenthèses.
+    expect(find.text('Hors Tournée du jour (10)'), findsOneWidget);
     // Le compteur de l'en-tête reflète aussi le cap.
-    expect(find.text('· 7/7'), findsOneWidget);
+    expect(find.text('· 10/10'), findsOneWidget);
   });
 
   testWidgets(


### PR DESCRIPTION
## Quoi
Deux bugs Essentiel de **même racine** (fan-out Phase 2 fragile de `flux_continu_provider.dart`) corrigés côté mobile :
- **Tournée du jour figée** : favoris thèmes/sources absents, seuls les blocs éditoriaux (Actus / Bonnes Nouvelles) restaient.
- **Thème à 1 carte** (ex. Technologie) alors que le backend renvoie bien ~10 articles.

L'ordre de la Tournée (`_orderedTourneeKeys`) dérive des sections **déjà fetchées** ; une section dont le fetch timeout/401 était avalé par `_safe` (sans retry) disparaissait tout le cycle.

**Fix (mobile-only) :**
- **Seed de coquilles** (en-têtes favoris résolus, items vides) **avant** le fan-out, réservé aux favoris explicites ⇒ l'ordre reflète **toujours** les prefs.
- **Upsert par `sectionKey`** (`_upsertByKey` / `_hasSectionKey`) : un fetch raté laisse la coquille (empty-state) au lieu d'une section absente.
- **`_fetchWithRetry`** (2 tentatives, backoff 250 ms) sur les appels repo bruts : throw transitoire retryé, 200 vide accepté sans retry.
- Même discipline progressive dans `_refetchThemesOnly` / `_refetchSourcesOnly`.
- Cap Tournée **7 → 10** (`kTourneeVisibleCap`, source de vérité unique pour les caps favoris).
- Tweaks UI : identité « Flâner » (brun) sur en-têtes + puces de déplacement de `manage_favorites_sheet` ; loupe Search 16 → 22.

## Pourquoi
Vérifié en prod (Supabase) : **pas** une famine backend, **pas** un collapse du fit — le backend renvoie bien le contenu. La fragilité était dans le fan-out client (1 worker uvicorn, recos perso sérialisées) + l'absence de retry/seed.

## Comment ça a été vérifié
- [x] `flutter test` ciblé flux_continu (67 tests) — vert
- [x] `flutter analyze` fichiers touchés — 0 issue
- [x] `/simplify` passé (cap source unique + `_reseedShells` générique)
- [ ] Playwright `/validate-feature` — non lancé (logique-provider couverte par tests unitaires + tweaks visuels mineurs)
- N/A backend / Alembic / migration

## Zones à risque
`flux_continu_provider.dart` — cold-open (`_buildStateFromPayload`) + refetch favoris (`_refetchThemesOnly` / `_refetchSourcesOnly`).
