### PR TITLE
fix(flux-continu): Tournée — favoris denses remontent + thèmes maigres complétés

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Tournée",
+      "summary": "Tournée du jour plus fiable : tes thèmes et sources favoris s'affichent du premier coup."
+    },
+    {
       "tag": "Notifications",
       "summary": "Fini les demandes d'autorisation à répétition : Facteur ne te sollicite plus qu'une fois, et plus jamais pendant ta lecture."
     },

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -2,6 +2,10 @@
   "unreleased": [
     {
       "tag": "Tournée",
+      "summary": "Tes sections favorites les mieux fournies remontent en haut, et celles à un seul article sont complétées automatiquement."
+    },
+    {
+      "tag": "Tournée",
       "summary": "Tournée du jour plus fiable : tes thèmes et sources favoris s'affichent du premier coup."
     },
     {

--- a/apps/mobile/lib/features/feed/widgets/feed_filter_bar.dart
+++ b/apps/mobile/lib/features/feed/widgets/feed_filter_bar.dart
@@ -284,7 +284,9 @@ class _SearchTrigger extends StatelessWidget {
         width: 34,
         child: Icon(
           PhosphorIcons.magnifyingGlass(PhosphorIconsStyle.regular),
-          size: 16,
+          // Loupe agrandie (16 → 22) : l'état inactif n'affiche que l'icône
+          // (pas de placeholder), la boîte 34×34 l'accueille largement.
+          size: 22,
           color: colors.textSecondary,
         ),
       ),

--- a/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
+++ b/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
@@ -338,6 +338,13 @@ class FeedThemeSection extends FluxSection {
   /// que le backend a reculé jusqu'à 30 j → bannière « Pas d'article récent. ».
   final bool noRecentSource;
 
+  /// Cohérence Tournée : true quand cette section favorite **maigre** (≤1
+  /// survivant post-dédup) a été **enrichie** (réinjection des articles déjà
+  /// renvoyés par le backend mais strippés par la dédup) et/ou doit porter le
+  /// CTA « Ajouter plus de sources » (thèmes). Dérivé à chaque `_compose` (jamais
+  /// persisté dans `_themes`/`_sources`) — ne survit donc pas hors d'un recompose.
+  final bool underfilled;
+
   const FeedThemeSection({
     required super.kind,
     required super.label,
@@ -354,6 +361,7 @@ class FeedThemeSection extends FluxSection {
     this.origin = SectionOrigin.validated,
     this.reason,
     this.noRecentSource = false,
+    this.underfilled = false,
     super.blurb,
     super.illustrationAsset,
   });
@@ -375,6 +383,7 @@ class FeedThemeSection extends FluxSection {
     // au défaut à chaque recompose — le piège le plus facile à introduire.
     int? coreVisibleCount,
     bool? noRecentSource,
+    bool? underfilled,
   }) {
     return FeedThemeSection(
       kind: kind,
@@ -395,6 +404,7 @@ class FeedThemeSection extends FluxSection {
       origin: origin,
       reason: reason,
       noRecentSource: noRecentSource ?? this.noRecentSource,
+      underfilled: underfilled ?? this.underfilled,
       blurb: blurb,
       illustrationAsset: illustrationAsset,
     );
@@ -499,6 +509,13 @@ class FluxContinuState {
   /// `false` ; le screen rend un scaffold placeholder tant qu'il est `true`.
   final bool isSkeleton;
 
+  /// Cohérence Tournée — `sectionKey` des sections favorites (thème/source)
+  /// **maigres** (≤1 survivant post-dédup) du cycle courant, qu'elles soient
+  /// affichées ou poussées hors cap. Source unique consommée par la modal
+  /// « Mes favoris » pour signaler les favoris peu fournis. Vide tant que rien
+  /// n'est classé (squelette / aucun favori résolu).
+  final Set<String> thinFavoriteKeys;
+
   const FluxContinuState({
     this.sections = const [],
     this.grilleSlotIndex,
@@ -509,6 +526,7 @@ class FluxContinuState {
     this.isLoading = true,
     this.error,
     this.isSkeleton = false,
+    this.thinFavoriteKeys = const {},
   });
 
   FluxContinuState copyWith({
@@ -522,6 +540,7 @@ class FluxContinuState {
     Object? error,
     bool clearError = false,
     bool? isSkeleton,
+    Set<String>? thinFavoriteKeys,
   }) {
     return FluxContinuState(
       sections: sections ?? this.sections,
@@ -533,6 +552,7 @@ class FluxContinuState {
       isLoading: isLoading ?? this.isLoading,
       error: clearError ? null : (error ?? this.error),
       isSkeleton: isSkeleton ?? this.isSkeleton,
+      thinFavoriteKeys: thinFavoriteKeys ?? this.thinFavoriteKeys,
     );
   }
 

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -165,6 +165,15 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
 
   bool _closingPersistQueued = false;
 
+  /// `sectionKey` des sections favorites (thème/source/veille) dont le fetch du
+  /// fan-out a **résolu** ce cycle (réponse arrivée, vide ou non). La
+  /// classification maigre/riche ([_classifyFavoriteSections]) n'inspecte que ces
+  /// clés : une coquille seedée non encore résolue (0 item au boot) ne doit pas
+  /// être classée maigre → faux positif de dépriorisation/CTA. Réinitialisé au
+  /// reseed complet ([_buildStateFromPayload]), augmenté au fil du fan-out et des
+  /// refetch partiels.
+  final Set<String> _resolvedSectionKeys = <String>{};
+
   /// True du tout début de [build] jusqu'à la fin du 1er [_fetchAll]. Pendant
   /// cette fenêtre, l'état affiché peut être un **squelette** (sections vides) :
   /// les listeners de prefs ne doivent donc ni recomposer (le dédup viderait les
@@ -491,6 +500,10 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     _themes = picked.isFallback ? const [] : _shellThemeSections(favorites);
     _sources = _shellSourceSections(favoriteSources);
     _suggested = const [];
+    // Reseed complet ⇒ les coquilles ne sont pas encore résolues : on repart
+    // d'une classification vierge (aucune section maigre tant que le fan-out /
+    // le chemin cache n'a pas confirmé un contenu réel).
+    _resolvedSectionKeys.clear();
     _closingDismissed = await _loadClosingDismissedForToday();
     unawaited(_purgeOldPrefsKeys());
 
@@ -699,6 +712,17 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     final tournee = ref.read(tourneeOrderPrefsProvider);
     final grilleAvailable = ref.read(grilleProvider).valueOrNull?.today != null;
     final sectionByKey = _tourneeSectionByKey();
+
+    // Cohérence Tournée — classification maigre/riche sur l'ordre par défaut
+    // **non cappé** (la maigreur ne se connaît qu'après dédup, cf. plan). Elle
+    // pilote ensuite la dépriorisation des clés de l'ordre réel.
+    final (:thinKeys, :richCount) = _classifyFavoriteSections(
+      isSerene: isSerene,
+      tournee: tournee,
+      sectionByKey: sectionByKey,
+    );
+    final demote = richCount >= kThinDemotionRichThreshold;
+
     final orderedKeys = _orderedTourneeKeys(
       isSerene: isSerene,
       customized: tournee.customized,
@@ -706,6 +730,8 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       grilleAvailable: grilleAvailable,
       hiddenKeys: tournee.hiddenKeys,
       order: tournee.order,
+      thinKeys: thinKeys,
+      demote: demote,
     );
 
     // « Cartes ≤ écran » : décidé côté provider par estimation conservatrice
@@ -722,9 +748,18 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
         if (key != kTourneeGrilleKey && sectionByKey[key] != null)
           sectionByKey[key]!,
     ];
+    // Dédup réel (ordre dépriorisé) en capturant les retirés par section, puis
+    // réinjection (backfill) des sections favorites maigres **affichées**.
+    final removedByKey = <String, List<Content>>{};
+    final deduped = _dedupeSectionsInOrder(
+      _filterSections(rawOrdered),
+      removedByKey: removedByKey,
+    );
     final finalSections = _capSectionsToFit(
-      _dropEmptySuggested(
-        _dedupeSectionsInOrder(_filterSections(rawOrdered)),
+      _backfillThinSections(
+        _dropEmptySuggested(deduped),
+        thinKeys,
+        removedByKey,
       ),
       usableHeight,
     );
@@ -741,6 +776,103 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       dismissedIds: Set.unmodifiable(_dismissedIds),
       quote: _quote,
       isLoading: false,
+      // Toutes les clés maigres (affichées ou hors cap) → la modal sait
+      // lesquelles signaler.
+      thinFavoriteKeys: thinKeys,
+    );
+  }
+
+  /// Classifie les sections **favorites** (thème/source validés) en maigres
+  /// (≤ [kThinSectionMaxItems] survivants post-dédup) / riches (≥
+  /// [kRichSectionMinItems]) sur l'ordre par défaut **non cappé**. Exclut
+  /// veille / éditorial / suggérées / Grille. N'inspecte que les sections au
+  /// fetch résolu ([_resolvedSectionKeys]) → pas de faux positif sur des
+  /// coquilles de boot.
+  ({Set<String> thinKeys, int richCount}) _classifyFavoriteSections({
+    required bool isSerene,
+    required TourneeOrderState tournee,
+    required Map<String, FluxSection> sectionByKey,
+  }) {
+    final favKeys = <String>{
+      for (final s in _themes)
+        if (s.kind == SectionKind.theme) sectionKey(s),
+      for (final s in _sources) sectionKey(s),
+    };
+    final eligible = {
+      for (final k in favKeys)
+        if (_resolvedSectionKeys.contains(k) && sectionByKey.containsKey(k)) k,
+    };
+    if (eligible.isEmpty) return (thinKeys: const <String>{}, richCount: 0);
+
+    final orderedKeys = _orderedTourneeKeys(
+      isSerene: isSerene,
+      customized: tournee.customized,
+      sectionByKey: sectionByKey,
+      grilleAvailable: false,
+      hiddenKeys: tournee.hiddenKeys,
+      order: tournee.order,
+      cap: null, // passe non cappée : la maigreur se mesure sur tout l'ordre
+    );
+    final rawOrdered = <FluxSection>[
+      if (_essentiel != null) _essentiel!,
+      for (final key in orderedKeys)
+        if (key != kTourneeGrilleKey && sectionByKey[key] != null)
+          sectionByKey[key]!,
+    ];
+    final deduped = _dedupeSectionsInOrder(_filterSections(rawOrdered));
+
+    final thinKeys = <String>{};
+    var richCount = 0;
+    for (final s in deduped) {
+      if (s is! FeedThemeSection) continue;
+      final k = sectionKey(s);
+      if (!eligible.contains(k)) continue;
+      final n = s.items.length;
+      if (n <= kThinSectionMaxItems) {
+        thinKeys.add(k);
+      } else if (n >= kRichSectionMinItems) {
+        richCount++;
+      }
+    }
+    return (thinKeys: thinKeys, richCount: richCount);
+  }
+
+  /// Réinjecte dans chaque section favorite **maigre affichée** (clé ∈
+  /// [thinKeys]) des articles strippés par la dédup ([removedByKey]) jusqu'à
+  /// [kRichSectionMinItems], et marque la section `underfilled` (pilote le CTA
+  /// thème « Ajouter plus de sources »). Doublons inter-sections assumés (PO) ;
+  /// dédup intra-section préservée. Une source maigre sans retirés garde son
+  /// filet d'empty-state existant.
+  List<FluxSection> _backfillThinSections(
+    List<FluxSection> sections,
+    Set<String> thinKeys,
+    Map<String, List<Content>> removedByKey,
+  ) {
+    if (thinKeys.isEmpty) return sections;
+    return [
+      for (final s in sections)
+        if (s is FeedThemeSection && thinKeys.contains(sectionKey(s)))
+          _backfillOneThinSection(s, removedByKey[sectionKey(s)] ?? const [])
+        else
+          s,
+    ];
+  }
+
+  FeedThemeSection _backfillOneThinSection(
+    FeedThemeSection s,
+    List<Content> removed,
+  ) {
+    final seen = {for (final c in s.items) c.id};
+    final additions = <Content>[];
+    for (final c in removed) {
+      if (s.items.length + additions.length >= kRichSectionMinItems) break;
+      if (seen.add(c.id)) additions.add(c);
+    }
+    // `underfilled` toujours vrai (section maigre affichée) → CTA thème même si
+    // rien n'a pu être réinjecté ; `items` n'est touché que s'il y a des ajouts.
+    return s.copyWith(
+      items: additions.isEmpty ? null : [...s.items, ...additions],
+      underfilled: true,
     );
   }
 
@@ -937,7 +1069,15 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   /// tourne que si des articles ont été dismissed), donc les champs de
   /// pagination de [FeedThemeSection] sont préservés via [FeedThemeSection.copyWith]
   /// — sinon « Voir +10 » serait réinitialisé à chaque recompose.
-  List<FluxSection> _dedupeSectionsInOrder(List<FluxSection> sections) {
+  /// [removedByKey] (optionnel) collecte, par `sectionKey` de section
+  /// [FeedThemeSection], les `Content` **strippés** par la dédup (déjà vus plus
+  /// haut). Sert à la réinjection (backfill) des sections favorites maigres dans
+  /// [_compose] : on y repioche des articles ≤72h déjà renvoyés par le backend
+  /// (doublons inter-sections assumés, décision PO).
+  List<FluxSection> _dedupeSectionsInOrder(
+    List<FluxSection> sections, {
+    Map<String, List<Content>>? removedByKey,
+  }) {
     final seen = <String>{};
     final result = <FluxSection>[];
     for (final s in sections) {
@@ -974,11 +1114,15 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
             ),
           );
         case FeedThemeSection(:final items):
-          result.add(
-            s.copyWith(
-              items: items.where((c) => seen.add(c.id)).toList(growable: false),
-            ),
-          );
+          final kept = <Content>[];
+          final removed = <Content>[];
+          for (final c in items) {
+            (seen.add(c.id) ? kept : removed).add(c);
+          }
+          if (removedByKey != null && removed.isNotEmpty) {
+            removedByKey[sectionKey(s)] = removed;
+          }
+          result.add(s.copyWith(items: kept));
       }
     }
     return result;
@@ -1407,6 +1551,15 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     };
   }
 
+  /// `sectionKey` de la section que rendra [favRef] (thème/sujet/veille) — aligné
+  /// sur [sectionKey] pour servir de clé `_resolvedSectionKeys` même quand le
+  /// fetch renvoie une section nulle (aucune section à inspecter alors).
+  String _favRefSectionKey(FavoriteRef favRef) => switch (favRef) {
+        ThemeFavoriteRef(:final slug) => tourneeThemeKey(slug),
+        CustomTopicFavoriteRef(:final id) => 'topic:$id',
+        VeilleFavoriteRef() => kTourneeVeilleKey,
+      };
+
   List<FavoriteRef> _pickExplicitFavorites(List<FavoriteRef> favorites) {
     VeilleFavoriteRef? veilleRef;
     final nonVeille = <FavoriteRef>[];
@@ -1675,10 +1828,14 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     Future<void> sectionTask(
       Future<FeedResponse?> Function() fetch,
       FeedThemeSection? Function(FeedResponse? feed) build,
-      void Function(FeedThemeSection section) append,
-    ) async {
+      void Function(FeedThemeSection section) append, {
+      required String resolvedKey,
+    }) async {
       final section = build(await fetch());
       if (section != null) append(section);
+      // Fetch résolu (vide ou non) : la classification maigre/riche peut
+      // désormais inspecter cette clé (cf. [_resolvedSectionKeys]).
+      _resolvedSectionKeys.add(resolvedKey);
       emit();
     }
 
@@ -1697,6 +1854,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
               // d'origine (ordre préservé) au lieu d'append (sinon doublon
               // coquille + contenu).
               (section) => _themes = _upsertByKey(_themes, section),
+              resolvedKey: _favRefSectionKey(favRef),
             ),
       // Sources favorites.
       for (final src in resolvedSources)
@@ -1704,8 +1862,10 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
               () => _fetchOneSource(src.id, isSerene),
               (feed) => _buildSourceSection(feed: feed, source: src),
               (section) => _sources = _upsertByKey(_sources, section),
+              resolvedKey: tourneeSourceKey(src.id),
             ),
-      // Suggérées « Choisie pour vous ».
+      // Suggérées « Choisie pour vous » (hors classification maigre/riche, mais
+      // marquées résolues sans effet — clé suggérée non favorite).
       for (final s in usableSuggestions)
         () => sectionTask(
               () => (s.kind == 'source' && s.sourceId != null)
@@ -1716,6 +1876,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
                     ),
               (feed) => _buildSuggestedSection(s, feed, sourceById),
               (section) => _suggested = [..._suggested, section],
+              resolvedKey: _suggestionKey(s),
             ),
     ];
 
@@ -1857,6 +2018,16 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     required bool grilleAvailable,
     required Set<String> hiddenKeys,
     required List<String> order,
+    // Cohérence Tournée : clés favorites maigres + bascule de dépriorisation.
+    // Quand [demote], les favoris maigres sont stable-partitionnés **après** les
+    // riches dans le bloc favori (ordre relatif préservé) → le contenu dense
+    // remonte au-dessus du pli. N'affecte que l'ordre **par défaut** : un ordre
+    // personnalisé (`customized`) reste sticky via `applyOrder`.
+    Set<String> thinKeys = const {},
+    bool demote = false,
+    // `null` ⇒ aucun cap (passe de classification non cappée) ; sinon plafonne à
+    // [cap] après réordonnancement (seul un surplus coupe les maigres dépriorisés).
+    int? cap = kTourneeVisibleCap,
   }) {
     final themeKeys = [
       for (final section in _themes)
@@ -1873,7 +2044,19 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     // personnalisé (`customized`) est respecté tel quel par `applyOrder`.
     final orderedThemeKeys =
         customized ? themeKeys : _biasThemeKeysByMostFollowed(themeKeys);
-    final favoriteKeys = [...orderedThemeKeys, ...sourceKeys, ...veilleKeys];
+    var favoriteKeys = [...orderedThemeKeys, ...sourceKeys, ...veilleKeys];
+    // Dépriorisation : partition **stable** riches-d'abord / maigres-ensuite du
+    // bloc favori. La veille (jamais dans `thinKeys` — exclue de la
+    // classification) reste dans le groupe « non maigre ». Ordre relatif
+    // conservé dans chaque groupe.
+    if (demote && thinKeys.isNotEmpty) {
+      favoriteKeys = [
+        for (final k in favoriteKeys)
+          if (!thinKeys.contains(k)) k,
+        for (final k in favoriteKeys)
+          if (thinKeys.contains(k)) k,
+      ];
+    }
     // Story 22.3 — clés des sections « Choisie pour vous », best-first par
     // daily_rank (`_suggested` arrive déjà trié du backend). Insérées APRÈS les
     // validées (jamais devant) et dédupliquées contre elles : un compte
@@ -1920,7 +2103,9 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       ordered.insert(actusIndex >= 0 ? actusIndex + 1 : 0, kTourneeGrilleKey);
     }
 
-    return ordered.take(kTourneeVisibleCap).toList(growable: false);
+    return cap == null
+        ? ordered.toList(growable: false)
+        : ordered.take(cap).toList(growable: false);
   }
 
   /// Renvoie [themeKeys] avec, en tête, la clé du thème auquel l'utilisateur a
@@ -2034,6 +2219,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
             if (section != null && _hasSectionKey(_themes, section)) {
               _themes = _upsertByKey(_themes, section);
             }
+            _resolvedSectionKeys.add(_favRefSectionKey(favRef));
             if (state.valueOrNull != null) {
               state = AsyncData(_compose(isSerene));
             }
@@ -2099,6 +2285,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
             if (section != null && _hasSectionKey(_sources, section)) {
               _sources = _upsertByKey(_sources, section);
             }
+            _resolvedSectionKeys.add(tourneeSourceKey(src.id));
             if (state.valueOrNull != null) {
               state = AsyncData(_compose(isSerene));
             }

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -74,14 +74,15 @@ const String _kBonnesBlurb = 'Un peu de douceur...';
 const int _kActusMinTopics = 2;
 
 /// Hard cap on the number of favorite theme sections rendered in the tournée.
-/// Mirrors `kFavoriteCap = 7` in the my_interests provider — the value is
-/// duplicated here only because the maps key by sectionKey and we slice the
-/// favorite list during composition. Keep aligned with the backend constant.
-const int _kMaxFavoriteSections = 7;
+/// **Source de vérité unique** = [kTourneeVisibleCap] (cap d'affichage global de
+/// la Tournée) : il ne doit jamais plafonner les thèmes **sous** ce cap, sinon un
+/// mix thèmes+sources serait silencieusement tronqué avant même le cap
+/// d'affichage. Aliasé (pas dupliqué) pour rester synchronisé par construction.
+const int _kMaxFavoriteSections = kTourneeVisibleCap;
 
 /// Hard cap on the number of favorite SOURCE sections rendered in the tournée
-/// (PR « Sources dans la Tournée »). Parité avec les thèmes.
-const int _kMaxFavoriteSourceSections = 7;
+/// (PR « Sources dans la Tournée »). Parité avec les thèmes ([kTourneeVisibleCap]).
+const int _kMaxFavoriteSourceSections = kTourneeVisibleCap;
 
 /// Number of items requested per page for each theme section of the Tournée
 /// (initial load + each "loadMoreTheme" call). When the backend returns
@@ -475,9 +476,20 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     final favoriteSources = _pickFavoriteSources();
     _lastSourceFavorites = favoriteSources;
 
-    // Sections thèmes/sources/suggérées vidées d'abord — peuplées en phase 2 si fetch.
-    _themes = const [];
-    _sources = const [];
+    // Seed de **coquilles** AVANT le fan-out (fix « Tournée figée » + « thème à
+    // 1 carte »). L'ordre de la Tournée (`_orderedTourneeKeys`) est dérivé des
+    // sections déjà présentes dans `_themes`/`_sources` : sans seed, une section
+    // dont le fan-out (sérialisé sous l'unique worker) n'a pas encore (ou pas)
+    // abouti n'a **pas de clé** → elle disparaît de l'ordre, et seuls les blocs
+    // éditoriaux restent. En seedant les en-têtes des favoris **résolus** (mêmes
+    // label/accent que le rendu réel, items vides), l'ordre reflète **toujours**
+    // les préférences ; le fan-out remplace ensuite chaque coquille en place par
+    // `sectionKey` (upsert), un fetch raté laissant la coquille (état vide géré
+    // par `SectionBlock`) plutôt qu'une section absente. Réservé aux favoris
+    // **explicites** : un compte neuf (fallback canonique) garde l'ancien
+    // comportement (thèmes pauvres droppés, pas d'empty-state non choisi).
+    _themes = picked.isFallback ? const [] : _shellThemeSections(favorites);
+    _sources = _shellSourceSections(favoriteSources);
     _suggested = const [];
     _closingDismissed = await _loadClosingDismissedForToday();
     unawaited(_purgeOldPrefsKeys());
@@ -594,13 +606,20 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
 
   /// Coquilles de sections thème/sujet/veille pour le squelette, dérivées des
   /// favoris locaux (réutilise `_pickFavorites` + les mêmes label/accent que
-  /// [_fetchThemeSections]). `topFallback` vide ⇒ comptes neufs voient les
+  /// [_shellThemeSections]). `topFallback` vide ⇒ comptes neufs voient les
   /// thèmes canoniques (tech/env/science), ce qui rend une structure utile.
-  List<FeedThemeSection> _skeletonThemeSections() {
-    final picked = _pickFavorites(const <TopTheme>[]);
+  List<FeedThemeSection> _skeletonThemeSections() =>
+      _shellThemeSections(_pickFavorites(const <TopTheme>[]).refs);
+
+  /// Coquilles (en-têtes vides) des sections thème/sujet/veille pour [refs],
+  /// dans l'ordre fourni. Partagé par le squelette de démarrage
+  /// ([_skeletonThemeSections]) et le **seed pré-fan-out** ([_buildStateFromPayload]) :
+  /// même label/accent que le rendu réel, `items` vide, `hasMore: false`. Le
+  /// fan-out remplace ensuite chaque coquille en place (cf. [_upsertByKey]).
+  List<FeedThemeSection> _shellThemeSections(List<FavoriteRef> refs) {
     final interestsState = ref.read(userInterestsProvider).valueOrNull;
     final sections = <FeedThemeSection>[];
-    for (final favRef in picked.refs) {
+    for (final favRef in refs) {
       final FeedThemeSection? shell = switch (favRef) {
         ThemeFavoriteRef(:final slug) => FeedThemeSection(
             kind: SectionKind.theme,
@@ -645,9 +664,15 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   }
 
   /// Coquilles de sections source pour le squelette, résolues via le même
-  /// catalogue/sélection que [_fetchSourceSections] (label/logo/accent réels).
-  List<FeedThemeSection> _skeletonSourceSections() {
-    final favs = _pickFavoriteSources();
+  /// catalogue/sélection que [_shellSourceSections] (label/logo/accent réels).
+  List<FeedThemeSection> _skeletonSourceSections() =>
+      _shellSourceSections(_pickFavoriteSources());
+
+  /// Coquilles (en-têtes vides) des sections source pour [favs], dans l'ordre
+  /// fourni. Partagé par le squelette et le **seed pré-fan-out** : label/logo/
+  /// accent réels (catalogue `userSourcesProvider`), `items` vide. Un favori
+  /// dont la source n'est pas (encore) au catalogue est ignoré ce cycle.
+  List<FeedThemeSection> _shellSourceSections(List<SourceFavoriteRef> favs) {
     if (favs.isEmpty) return const [];
     final catalog =
         ref.read(userSourcesProvider).valueOrNull ?? const <Source>[];
@@ -1281,7 +1306,8 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   ///
   /// `isFallback` indique si les `refs` thème renvoyés sont des thèmes canoniques
   /// (compte neuf) plutôt que des favoris explicites — consommé par
-  /// [_fetchThemeSections] pour décider de l'affichage d'un empty-state.
+  /// [_buildStateFromPayload] (pas de seed de coquilles pour le fallback) et le
+  /// fan-out (`isExplicitFavorite`) pour décider de l'affichage d'un empty-state.
   ({List<FavoriteRef> refs, bool isFallback}) _pickFavorites(
     List<TopTheme> topFallback,
   ) {
@@ -1349,37 +1375,9 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     );
   }
 
-  /// Fetches one FeedResponse per favorite ref in parallel and turns them
-  /// into FeedThemeSections. Un favori thème **explicite**
-  /// ([isExplicitFavorite] = true) est toujours rendu (empty-state si vide) ;
-  /// les thèmes de **fallback** (compte neuf) sont coupés sous 2 items pour
-  /// garder la Tournée par défaut utile sans afficher d'empty-state non choisi.
-  Future<List<FeedThemeSection>> _fetchThemeSections(
-    List<FavoriteRef> favorites,
-    bool isSerene, {
-    bool isExplicitFavorite = true,
-  }) async {
-    if (favorites.isEmpty) return const [];
-    final interestsState = ref.read(userInterestsProvider).valueOrNull;
-    final feeds = await Future.wait(
-      favorites.map((favRef) => _fetchOneTheme(favRef, isSerene)),
-    );
-    final sections = <FeedThemeSection>[];
-    for (var i = 0; i < favorites.length; i++) {
-      final section = _buildFavoriteThemeSection(
-        favorites[i],
-        feeds[i],
-        isExplicitFavorite: isExplicitFavorite,
-        interestsState: interestsState,
-      );
-      if (section != null) sections.add(section);
-    }
-    return sections;
-  }
-
   /// Construit la section d'un favori thème / sujet / veille à partir de son
-  /// `FeedResponse` déjà fetché. Extrait de [_fetchThemeSections] pour être
-  /// partagé avec le fan-out progressif ([_fanOutSectionsProgressive]).
+  /// `FeedResponse` déjà fetché. Partagé par le fan-out progressif
+  /// ([_fanOutSectionsProgressive]) et le refetch ([_refetchThemesOnly]).
   FeedThemeSection? _buildFavoriteThemeSection(
     FavoriteRef favRef,
     FeedResponse? feed, {
@@ -1432,7 +1430,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     // 24h window + user_subtopics boost" for the Tournée du jour theme
     // sections (vs. the unrestricted exploration mode used by feed chips).
     return switch (favRef) {
-      ThemeFavoriteRef(:final slug) => _safe<FeedResponse>(
+      ThemeFavoriteRef(:final slug) => _fetchWithRetry<FeedResponse>(
           () => _feedRepo.getFeed(
             page: 1,
             limit: _kThemeSectionPageLimit,
@@ -1445,7 +1443,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       // Backend `/api/feed` accepts a UUID stringified in the `topic` param
       // (story 22.1) — looked up against `user_topic_profiles` scoped on the
       // current user, so no cross-user leak.
-      CustomTopicFavoriteRef(:final id) => _safe<FeedResponse>(
+      CustomTopicFavoriteRef(:final id) => _fetchWithRetry<FeedResponse>(
           () => _feedRepo.getFeed(
             page: 1,
             limit: _kThemeSectionPageLimit,
@@ -1458,7 +1456,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       // Story 23.2 PR-4 : la veille est résolue via `/api/veille/feed`,
       // exposée par FluxContinuRepository.getVeilleFeedItems (normalise la
       // réponse en FeedResponse Content-compatible).
-      VeilleFavoriteRef() => _safe<FeedResponse>(
+      VeilleFavoriteRef() => _fetchWithRetry<FeedResponse>(
           () => ref.read(fluxContinuRepositoryProvider).getVeilleFeedItems(
                 limit: _kThemeSectionPageLimit,
                 serein: isSerene,
@@ -1526,40 +1524,11 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
         .toList(growable: false);
   }
 
-  /// Résout chaque source favorite en `Source` complet (nom + logo + thème)
-  /// via le catalogue `userSourcesProvider`, puis fetch en parallèle le top
-  /// classé (mêmes piliers que les thèmes, `personalized: true`). Les favoris
-  /// dont la source n'est pas (encore) dans le catalogue sont ignorés ce cycle.
-  Future<List<FeedThemeSection>> _fetchSourceSections(
-    List<SourceFavoriteRef> favs,
-    bool isSerene,
-  ) async {
-    if (favs.isEmpty) return const [];
-    final catalog =
-        ref.read(userSourcesProvider).valueOrNull ?? const <Source>[];
-    final sourceById = {for (final s in catalog) s.id: s};
-    final resolved = <Source>[];
-    for (final fav in favs) {
-      final src = sourceById[fav.sourceId];
-      if (src != null) resolved.add(src);
-    }
-    if (resolved.isEmpty) return const [];
-    final feeds = await Future.wait(
-      resolved.map((src) => _fetchOneSource(src.id, isSerene)),
-    );
-    final sections = <FeedThemeSection>[];
-    for (var i = 0; i < resolved.length; i++) {
-      final section = _buildSourceSection(feed: feeds[i], source: resolved[i]);
-      if (section != null) sections.add(section);
-    }
-    return sections;
-  }
-
   Future<FeedResponse?> _fetchOneSource(String sourceId, bool isSerene) {
     // `personalized: true` + `source_id` ⇒ backend route vers le scoring
     // piliers (fenêtre adaptative 24→48→72h), mêmes critères que les sections
     // thème. Flâner appelle sans `personalized` → reste chronologique.
-    return _safe<FeedResponse>(
+    return _fetchWithRetry<FeedResponse>(
       () => _feedRepo.getFeed(
         page: 1,
         limit: _kThemeSectionPageLimit,
@@ -1690,8 +1659,8 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
         ref.read(userSourcesProvider).valueOrNull ?? const <Source>[];
     final sourceById = {for (final s in catalog) s.id: s};
 
-    // Sources favorites résolues au catalogue (mêmes règles que
-    // [_fetchSourceSections] : un favori absent du catalogue est ignoré).
+    // Sources favorites résolues au catalogue (un favori absent du catalogue
+    // est ignoré ce cycle, comme pour les coquilles seedées).
     final resolvedSources = <Source>[
       for (final fav in favoriteSources)
         if (sourceById[fav.sourceId] != null) sourceById[fav.sourceId]!,
@@ -1724,14 +1693,17 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
                 isExplicitFavorite: isExplicitFavorite,
                 interestsState: interestsState,
               ),
-              (section) => _themes = [..._themes, section],
+              // Upsert par clé : remplace la coquille seedée à sa position
+              // d'origine (ordre préservé) au lieu d'append (sinon doublon
+              // coquille + contenu).
+              (section) => _themes = _upsertByKey(_themes, section),
             ),
       // Sources favorites.
       for (final src in resolvedSources)
         () => sectionTask(
               () => _fetchOneSource(src.id, isSerene),
               (feed) => _buildSourceSection(feed: feed, source: src),
-              (section) => _sources = [..._sources, section],
+              (section) => _sources = _upsertByKey(_sources, section),
             ),
       // Suggérées « Choisie pour vous ».
       for (final s in usableSuggestions)
@@ -1751,6 +1723,32 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     // Recompose final : garantit un état cohérent même si toutes les tâches
     // ont renvoyé une section nulle (rien émis dans la boucle).
     emit();
+  }
+
+  /// Remplace, dans [list], la section de même `sectionKey` que [section] par
+  /// [section] **à sa position d'origine** ; l'ajoute en queue si absente. Le
+  /// fan-out s'en sert pour substituer une coquille seedée par son contenu sans
+  /// dupliquer la section ni déplacer son rang (l'ordre de la Tournée est dérivé
+  /// de ce rang dans `_orderedTourneeKeys`).
+  List<FeedThemeSection> _upsertByKey(
+    List<FeedThemeSection> list,
+    FeedThemeSection section,
+  ) {
+    final key = sectionKey(section);
+    final idx = list.indexWhere((s) => sectionKey(s) == key);
+    if (idx < 0) return [...list, section];
+    final next = [...list];
+    next[idx] = section;
+    return next;
+  }
+
+  /// `true` ssi [list] contient déjà une section de même `sectionKey` que
+  /// [section]. Sert aux chemins de refetch à n'upserter qu'une coquille encore
+  /// présente (replace-only), pour ne pas réintroduire un favori retiré par un
+  /// refetch concurrent.
+  bool _hasSectionKey(List<FeedThemeSection> list, FeedThemeSection section) {
+    final key = sectionKey(section);
+    return list.any((s) => sectionKey(s) == key);
   }
 
   /// Exécute [tasks] avec au plus [maxConcurrent] en vol simultanément, en
@@ -2002,17 +2000,64 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   }
 
   /// Replays only the theme-section fetches against the new favorite list.
-  /// Saves the cost of refetching the digest, which doesn't depend on
-  /// favorites.
+  /// Saves the cost of refetching the digest, which doesn't depend on favorites.
+  ///
+  /// Même discipline que le fan-out de cold-open (**seed coquille → fetch →
+  /// remplace en place**) : on seede d'abord les en-têtes pour [picked] en
+  /// **conservant** le contenu déjà chargé (pas de clignotement contenu→vide sur
+  /// un favori inchangé) — l'en-tête d'un favori **ajouté** apparaît donc tout de
+  /// suite, un favori **retiré** disparaît, puis chaque section est remplacée par
+  /// son contenu frais au fur et à mesure (`_fetchOneTheme` retry compris). Un
+  /// fetch lent/raté laisse la coquille au lieu d'une section manquante.
   Future<void> _refetchThemesOnly(List<FavoriteRef> nextFavorites) async {
     final isSerene = ref.read(sereinToggleProvider).enabled;
     final picked = _pickExplicitFavorites(nextFavorites);
-    final themes = await _fetchThemeSections(picked, isSerene);
     _lastFavorites = picked;
-    _themes = themes;
-    final current = state.valueOrNull;
-    if (current == null) return;
-    state = AsyncData(_compose(isSerene));
+    _themes = _reseedShells(_themes, _shellThemeSections(picked));
+    if (state.valueOrNull != null) {
+      state = AsyncData(_compose(isSerene));
+    }
+    final interestsState = ref.read(userInterestsProvider).valueOrNull;
+    await _runWithConcurrency(
+      [
+        for (final favRef in picked)
+          () async {
+            final section = _buildFavoriteThemeSection(
+              favRef,
+              await _fetchOneTheme(favRef, isSerene),
+              isExplicitFavorite: true,
+              interestsState: interestsState,
+            );
+            // Remplace **uniquement** une coquille encore présente : si un
+            // refetch concurrent a retiré ce favori entre-temps, on n'ajoute pas
+            // sa section en retard (sinon un favori retiré clignote de retour).
+            if (section != null && _hasSectionKey(_themes, section)) {
+              _themes = _upsertByKey(_themes, section);
+            }
+            if (state.valueOrNull != null) {
+              state = AsyncData(_compose(isSerene));
+            }
+          },
+      ],
+      _kPhase2FanoutConcurrency,
+    );
+  }
+
+  /// Fusionne [freshShells] avec le contenu déjà chargé dans [existing] : pour
+  /// chaque coquille fraîche (dans l'ordre des prefs), **conserve** la section de
+  /// même `sectionKey` déjà présente, sinon garde la coquille. Évite le
+  /// clignotement contenu→vide→contenu d'un reseed nu sur ajout/retrait d'un
+  /// favori. Partagé par les reseeds thème ([_refetchThemesOnly]) et source
+  /// ([_refetchSourcesOnly]).
+  List<FeedThemeSection> _reseedShells(
+    List<FeedThemeSection> existing,
+    List<FeedThemeSection> freshShells,
+  ) {
+    final existingByKey = {for (final s in existing) sectionKey(s): s};
+    return [
+      for (final shell in freshShells)
+        existingByKey[sectionKey(shell)] ?? shell,
+    ];
   }
 
   bool _favoriteListsEqual(List<FavoriteRef> a, List<FavoriteRef> b) {
@@ -2025,13 +2070,42 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
 
   /// Replays only the source-section fetches against the new favorite-source
   /// list. Le digest et les thèmes ne dépendent pas des sources favorites.
+  /// Même discipline progressive que [_refetchThemesOnly] (seed coquille en
+  /// conservant le contenu chargé → fetch → remplace en place).
   Future<void> _refetchSourcesOnly(List<SourceFavoriteRef> picked) async {
     final isSerene = ref.read(sereinToggleProvider).enabled;
-    _sources = await _fetchSourceSections(picked, isSerene);
     _lastSourceFavorites = picked;
-    final current = state.valueOrNull;
-    if (current == null) return;
-    state = AsyncData(_compose(isSerene));
+    _sources = _reseedShells(_sources, _shellSourceSections(picked));
+    if (state.valueOrNull != null) {
+      state = AsyncData(_compose(isSerene));
+    }
+    final catalog =
+        ref.read(userSourcesProvider).valueOrNull ?? const <Source>[];
+    final sourceById = {for (final s in catalog) s.id: s};
+    final resolved = <Source>[
+      for (final fav in picked)
+        if (sourceById[fav.sourceId] != null) sourceById[fav.sourceId]!,
+    ];
+    await _runWithConcurrency(
+      [
+        for (final src in resolved)
+          () async {
+            final section = _buildSourceSection(
+              feed: await _fetchOneSource(src.id, isSerene),
+              source: src,
+            );
+            // Replace-only (cf. [_refetchThemesOnly]) : ignore une source
+            // retirée par un refetch concurrent pendant son fetch en vol.
+            if (section != null && _hasSectionKey(_sources, section)) {
+              _sources = _upsertByKey(_sources, section);
+            }
+            if (state.valueOrNull != null) {
+              state = AsyncData(_compose(isSerene));
+            }
+          },
+      ],
+      _kPhase2FanoutConcurrency,
+    );
   }
 
   /// `SourceFavoriteRef.==` ne compare que `sourceId` ; on compare aussi la
@@ -2061,5 +2135,36 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       debugPrint('FluxContinu: $label failed: $e');
       return fallback;
     }
+  }
+
+  /// Wrap d'un fetch réseau **brut** (repo) avec retry borné des erreurs
+  /// **transitoires**. Un `throw` (HTTP 5xx/401/timeout/déconnexion) est retryé
+  /// jusqu'à [maxAttempts] avec un court [backoff] ; une réponse **200 même
+  /// vide** ne **throw pas** → renvoyée telle quelle sans retry (un feed
+  /// légitimement vide n'est pas une erreur). Renvoie `null` en dernier recours
+  /// (comme [_safe]), donc les builders gèrent l'absence comme un état vide.
+  ///
+  /// Distinct de [_safe], qui ne sait pas distinguer « erreur » de « vide » et
+  /// n'avale qu'une seule tentative : sous la charge sérialisée d'un fetch perso
+  /// (unique worker uvicorn), un échec transitoire laissait sinon la section
+  /// sous-remplie (0/1 carte) pour tout le cycle (bugs « Tournée figée » et
+  /// « thème à 1 carte »).
+  Future<T?> _fetchWithRetry<T>(
+    Future<T?> Function() fn,
+    String label, {
+    int maxAttempts = 2,
+    Duration backoff = const Duration(milliseconds: 250),
+  }) async {
+    for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        return await fn();
+      } catch (e) {
+        debugPrint(
+            'FluxContinu: $label failed (attempt $attempt/$maxAttempts): $e');
+        if (attempt >= maxAttempts) return null;
+        await Future<void>.delayed(backoff);
+      }
+    }
+    return null;
   }
 }

--- a/apps/mobile/lib/features/flux_continu/providers/tournee_order_prefs_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/tournee_order_prefs_provider.dart
@@ -34,6 +34,15 @@ const _kTourneeCustomizedKey = 'tournee_customized_v1';
 /// Cap d'affichage de la Tournée du jour, partagé provider + composer.
 const int kTourneeVisibleCap = 10;
 
+/// Seuils de cohérence d'affichage des sections favorites (thème/source) après
+/// la dédup inter-sections. Une section **maigre** (≤ [kThinSectionMaxItems]
+/// survivants) est dépriorisée sous les **riches** (≥ [kRichSectionMinItems])
+/// quand au moins [kThinDemotionRichThreshold] sections riches existent — pour
+/// que le contenu dense remonte au-dessus du pli. Ajustables.
+const int kThinSectionMaxItems = 1; // ≤1 article après dédup = « maigre »
+const int kRichSectionMinItems = 2; // ≥2 articles = « riche »
+const int kThinDemotionRichThreshold = 5; // dépriorise si ≥5 sections riches
+
 /// Clé d'un thème favori dans l'ordre Tournée (= `sectionKey` d'une section thème).
 String tourneeThemeKey(String slug) => 'theme:$slug';
 

--- a/apps/mobile/lib/features/flux_continu/providers/tournee_order_prefs_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/tournee_order_prefs_provider.dart
@@ -32,7 +32,7 @@ const _kLegacyVeilleHiddenKey = 'tournee_veille_hidden_v1';
 const _kTourneeCustomizedKey = 'tournee_customized_v1';
 
 /// Cap d'affichage de la Tournée du jour, partagé provider + composer.
-const int kTourneeVisibleCap = 7;
+const int kTourneeVisibleCap = 10;
 
 /// Clé d'un thème favori dans l'ordre Tournée (= `sectionKey` d'une section thème).
 String tourneeThemeKey(String slug) => 'theme:$slug';

--- a/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
@@ -36,8 +36,15 @@ import 'choice_tile.dart';
 /// scrolle vers la section Flâner à l'ouverture — le contenu est identique.
 enum ManageFavoritesEntry { essentiel, flaner }
 
-/// Accent des Actus du jour (aligné provider Tournée).
+/// Accent des Actus du jour (aligné provider Tournée). Sert aussi d'**identité
+/// « Essentiel »** dans cette sheet (en-tête + puces « → Essentiel »).
 const Color _kEssentielAccent = Color(0xFFB0470A);
+
+/// Identité visuelle **« Flâner »** dans cette sheet : le brun du bandeau de la
+/// page Flâner (déjà reconnaissable). Colore l'en-tête « Onglets de ta page
+/// Flâner » et les puces « → Flâner », pour que la destination d'un déplacement
+/// soit lisible par sa couleur (et plus par celle, arbitraire, de la carte).
+const Color _kFlanerAccent = Color(0xFF5D4037);
 
 /// Accent des Bonnes Nouvelles (aligné provider Tournée).
 const Color _kBonnesAccent = Color(0xFF2E7D32);
@@ -694,6 +701,7 @@ class _ManageFavoritesContentState
                   counter:
                       '${essentielOrdered.length.clamp(0, kTourneeVisibleCap)}'
                       '/$kTourneeVisibleCap',
+                  accent: _kEssentielAccent,
                   colors: colors,
                 ),
                 const SizedBox(height: 8),
@@ -708,6 +716,8 @@ class _ManageFavoritesContentState
                     colors: colors,
                     cap: kTourneeVisibleCap,
                     capLabel: 'Hors Tournée du jour ($kTourneeVisibleCap)',
+                    // Destination du déplacement = Flâner ⇒ puces brun Flâner.
+                    moveAccent: _kFlanerAccent,
                     onReorder: (oldIndex, newIndex) {
                       final reordered = [...essentielOrdered];
                       if (newIndex > oldIndex) newIndex -= 1;
@@ -733,6 +743,7 @@ class _ManageFavoritesContentState
                   counter:
                       '${flanerOrdered.length.clamp(0, kMaxFavoriteTabs)}'
                       '/$kMaxFavoriteTabs',
+                  accent: _kFlanerAccent,
                   colors: colors,
                 ),
                 const SizedBox(height: 8),
@@ -748,6 +759,8 @@ class _ManageFavoritesContentState
                     colors: colors,
                     cap: kMaxFavoriteTabs,
                     capLabel: 'Hors onglets ($kMaxFavoriteTabs)',
+                    // Destination du déplacement = Essentiel ⇒ puces ocre.
+                    moveAccent: _kEssentielAccent,
                     onReorder: (oldIndex, newIndex) {
                       final reordered = [...flanerOrdered];
                       if (newIndex > oldIndex) newIndex -= 1;
@@ -906,6 +919,10 @@ class _FavList extends StatelessWidget {
   final IconData moveIcon;
   final String moveTooltip;
   final String moveLabel;
+
+  /// Couleur de la puce de déplacement = identité du **mode de destination**
+  /// (brun Flâner / ocre Essentiel), pas la couleur de la carte (cf. [_MoveChip]).
+  final Color moveAccent;
   final void Function(_FavItem item) onMove;
   final void Function(_FavItem item)? onSubjectVeille;
 
@@ -919,6 +936,7 @@ class _FavList extends StatelessWidget {
     required this.moveIcon,
     required this.moveTooltip,
     required this.moveLabel,
+    required this.moveAccent,
     required this.onMove,
     this.onSubjectVeille,
   });
@@ -952,6 +970,7 @@ class _FavList extends StatelessWidget {
               moveIcon: moveIcon,
               moveTooltip: moveTooltip,
               moveLabel: moveLabel,
+              moveAccent: moveAccent,
               onRemove: () => onRemove(item),
               onMove: () => onMove(item),
               onSubjectVeille: onSubjectVeille == null
@@ -1014,6 +1033,7 @@ class _FavRow extends StatelessWidget {
   final IconData moveIcon;
   final String moveTooltip;
   final String moveLabel;
+  final Color moveAccent;
   final VoidCallback onRemove;
   final VoidCallback onMove;
   final VoidCallback? onSubjectVeille;
@@ -1026,6 +1046,7 @@ class _FavRow extends StatelessWidget {
     required this.moveIcon,
     required this.moveTooltip,
     required this.moveLabel,
+    required this.moveAccent,
     required this.onRemove,
     required this.onMove,
     this.onSubjectVeille,
@@ -1106,7 +1127,10 @@ class _FavRow extends StatelessWidget {
                   icon: moveIcon,
                   label: moveLabel,
                   tooltip: moveTooltip,
-                  accent: item.accent,
+                  // Couleur du mode de destination (Flâner brun / Essentiel
+                  // ocre), pas celle de la carte : « Flâner » devient
+                  // reconnaissable à sa teinte.
+                  accent: moveAccent,
                   onTap: onMove,
                 ),
               _RowIconButton(
@@ -1522,9 +1546,14 @@ class _VeilleTile extends StatelessWidget {
 class _SectionLabel extends StatelessWidget {
   final String label;
 
-  /// Compteur discret affiché en suffixe (ex. « · 5/7 ») rappelant le cap de
+  /// Compteur discret affiché en suffixe (ex. « · 5/10 ») rappelant le cap de
   /// la section. `null` → pas de compteur (ex. en-têtes AJOUTER / GÉRER).
   final String? counter;
+
+  /// Teinte d'identité de la section (ocre Essentiel / brun Flâner). `null` →
+  /// gris tertiaire neutre (en-têtes AJOUTER / GÉRER). Renforce le code couleur
+  /// des puces de déplacement (cf. [_MoveChip]).
+  final Color? accent;
   final FacteurColors colors;
 
   const _SectionLabel({
@@ -1532,12 +1561,13 @@ class _SectionLabel extends StatelessWidget {
     required this.label,
     required this.colors,
     this.counter,
+    this.accent,
   });
 
   @override
   Widget build(BuildContext context) {
     final labelStyle = Theme.of(context).textTheme.labelSmall?.copyWith(
-      color: colors.textTertiary,
+      color: accent ?? colors.textTertiary,
       fontWeight: FontWeight.w700,
       letterSpacing: 1.2,
     );
@@ -1548,7 +1578,13 @@ class _SectionLabel extends StatelessWidget {
       children: [
         Flexible(child: Text(label, style: labelStyle)),
         const SizedBox(width: 6),
-        Text('· $counter', style: labelStyle?.copyWith(letterSpacing: 0.2)),
+        Text(
+          '· $counter',
+          style: labelStyle?.copyWith(
+            letterSpacing: 0.2,
+            color: accent?.withValues(alpha: 0.7) ?? colors.textTertiary,
+          ),
+        ),
       ],
     );
   }

--- a/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
@@ -23,6 +23,7 @@ import '../../sources/widgets/source_logo_avatar.dart';
 import '../../tour/tour_anchors.dart';
 import '../../veille/providers/veille_active_config_provider.dart';
 import '../../veille/providers/veille_themes_provider.dart';
+import '../providers/flux_continu_provider.dart' show fluxContinuProvider;
 import '../providers/tournee_order_prefs_provider.dart' hide applyOrder;
 import '../providers/tournee_smart_arrangement_provider.dart';
 import '../utils/theme_color_mapping.dart';
@@ -462,6 +463,11 @@ class _ManageFavoritesContentState
     final tournee = ref.watch(tourneeOrderPrefsProvider);
     final tabOrder = ref.watch(tabOrderPrefsProvider);
     final isSerene = ref.watch(sereinToggleProvider).enabled;
+    // Cohérence Tournée — clés favorites maigres (peu d'articles aujourd'hui).
+    // Set vide si la Tournée n'est pas (encore) chargée → aucun indicateur
+    // (dégradation propre).
+    final thinKeys = ref.watch(fluxContinuProvider).valueOrNull?.thinFavoriteKeys ??
+        const <String>{};
 
     // ── Membership ────────────────────────────────────────────────────────
     final favoriteThemeSlugs = <String>[
@@ -716,6 +722,7 @@ class _ManageFavoritesContentState
                     colors: colors,
                     cap: kTourneeVisibleCap,
                     capLabel: 'Hors Tournée du jour ($kTourneeVisibleCap)',
+                    thinKeys: thinKeys,
                     // Destination du déplacement = Flâner ⇒ puces brun Flâner.
                     moveAccent: _kFlanerAccent,
                     onReorder: (oldIndex, newIndex) {
@@ -759,6 +766,9 @@ class _ManageFavoritesContentState
                     colors: colors,
                     cap: kMaxFavoriteTabs,
                     capLabel: 'Hors onglets ($kMaxFavoriteTabs)',
+                    // Les favoris Flâner ne sont pas dans la Tournée → aucune clé
+                    // ne matche, mais on garde le câblage uniforme.
+                    thinKeys: thinKeys,
                     // Destination du déplacement = Essentiel ⇒ puces ocre.
                     moveAccent: _kEssentielAccent,
                     onReorder: (oldIndex, newIndex) {
@@ -926,6 +936,9 @@ class _FavList extends StatelessWidget {
   final void Function(_FavItem item) onMove;
   final void Function(_FavItem item)? onSubjectVeille;
 
+  /// Clés favorites maigres (Tournée) → micro-indicateur « Peu d'articles ».
+  final Set<String> thinKeys;
+
   const _FavList({
     required this.items,
     required this.colors,
@@ -938,6 +951,7 @@ class _FavList extends StatelessWidget {
     required this.moveLabel,
     required this.moveAccent,
     required this.onMove,
+    this.thinKeys = const {},
     this.onSubjectVeille,
   });
 
@@ -967,6 +981,7 @@ class _FavList extends StatelessWidget {
               index: index,
               dimmed: dimmed,
               colors: colors,
+              thin: thinKeys.contains(item.key),
               moveIcon: moveIcon,
               moveTooltip: moveTooltip,
               moveLabel: moveLabel,
@@ -1030,6 +1045,10 @@ class _FavRow extends StatelessWidget {
   final int index;
   final bool dimmed;
   final FacteurColors colors;
+
+  /// Cohérence Tournée — ce favori a peu d'articles aujourd'hui (≤1 survivant
+  /// post-dédup) → micro-indicateur ambre près du libellé.
+  final bool thin;
   final IconData moveIcon;
   final String moveTooltip;
   final String moveLabel;
@@ -1049,6 +1068,7 @@ class _FavRow extends StatelessWidget {
     required this.moveAccent,
     required this.onRemove,
     required this.onMove,
+    this.thin = false,
     this.onSubjectVeille,
   });
 
@@ -1093,7 +1113,7 @@ class _FavRow extends StatelessWidget {
                             style: const TextStyle(fontSize: 16),
                           ),
                         const SizedBox(width: 10),
-                        Expanded(
+                        Flexible(
                           child: Text(
                             item.label,
                             style: TextStyle(
@@ -1105,6 +1125,11 @@ class _FavRow extends StatelessWidget {
                             overflow: TextOverflow.ellipsis,
                           ),
                         ),
+                        if (thin) ...[
+                          const SizedBox(width: 6),
+                          const _ThinBadge(),
+                        ],
+                        const Spacer(),
                       ],
                     ),
                   ),
@@ -1159,6 +1184,52 @@ class _FavRow extends StatelessWidget {
               ),
             ],
           ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Micro-indicateur « Peu d'articles » d'un favori maigre (≤1 survivant
+/// post-dédup ce jour). Pilule ambre discrète réutilisant le style des badges
+/// existants (cf. `_SuggestedBadge`/`_MoveChip`). Signale dans la modal les
+/// favoris peu fournis — surtout visibles dans la zone « Hors Tournée du jour ».
+class _ThinBadge extends StatelessWidget {
+  const _ThinBadge();
+
+  // Ambre : aligné sur les tons d'avertissement doux de l'app.
+  static const Color _amber = Color(0xFFB45309);
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: 'Peu d\'articles aujourd\'hui',
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(7, 3, 8, 3),
+        decoration: BoxDecoration(
+          color: _amber.withValues(alpha: 0.10),
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(color: _amber.withValues(alpha: 0.30), width: 0.8),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              PhosphorIcons.warningCircle(PhosphorIconsStyle.fill),
+              size: 11,
+              color: _amber,
+            ),
+            const SizedBox(width: 4),
+            const Text(
+              'Peu d\'articles',
+              style: TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                letterSpacing: 0.1,
+                color: _amber,
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -235,7 +235,11 @@ class SectionBlock extends StatelessWidget {
                 onLongPressConversion: onLongPressConversion,
               ),
         ];
-      case FeedThemeSection(:final items, :final coreVisibleCount):
+      case FeedThemeSection(
+          :final items,
+          :final coreVisibleCount,
+          :final underfilled,
+        ):
         // Story 23.4 — la section veille reste visible même vide : on rend un
         // placeholder + CTA réglages au lieu de cartes.
         if (items.isEmpty && section.kind == SectionKind.veille) {
@@ -337,6 +341,15 @@ class SectionBlock extends StatelessWidget {
                 onSwipeConversion: onSwipeConversion,
                 onLongPressConversion: onLongPressConversion,
               ),
+          // Cohérence Tournée — un thème **maigre affiché** (≤1 survivant après
+          // dédup, enrichi par réinjection) porte en pied un CTA pour étoffer la
+          // section. Distinct de l'empty-state (items vides) au-dessus.
+          if (section.kind == SectionKind.theme && underfilled)
+            _FavoriteEmptyState(
+              ctaIcon: Icons.add_rounded,
+              ctaLabel: 'Ajouter plus de sources',
+              onCta: onAddSources,
+            ),
         ];
     }
   }
@@ -397,12 +410,15 @@ class _VeilleEmptyState extends StatelessWidget {
 /// sections source (« Voir toute la curation ») et thème (« Ajouter des
 /// sources » → « Composer ma Tournée »).
 class _FavoriteEmptyState extends StatelessWidget {
-  final String message;
+  /// Message d'accroche. `null` ⇒ variante **CTA seul** (pied d'une section
+  /// maigre déjà remplie : pas de message, juste le bouton « Ajouter plus de
+  /// sources »).
+  final String? message;
   final IconData ctaIcon;
   final String ctaLabel;
   final VoidCallback? onCta;
   const _FavoriteEmptyState({
-    required this.message,
+    this.message,
     required this.ctaIcon,
     required this.ctaLabel,
     this.onCta,
@@ -412,7 +428,7 @@ class _FavoriteEmptyState extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       margin: const EdgeInsets.fromLTRB(12, 0, 12, 4),
-      padding: const EdgeInsets.fromLTRB(16, 18, 16, 14),
+      padding: EdgeInsets.fromLTRB(16, message == null ? 10 : 18, 16, 10),
       decoration: BoxDecoration(
         color: Colors.white.withValues(alpha: 0.5),
         borderRadius: BorderRadius.circular(12),
@@ -421,16 +437,17 @@ class _FavoriteEmptyState extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            message,
-            style: const TextStyle(
-              fontSize: 14,
-              height: 1.4,
-              color: Color(0xFF5D5B5A),
+          if (message != null)
+            Text(
+              message!,
+              style: const TextStyle(
+                fontSize: 14,
+                height: 1.4,
+                color: Color(0xFF5D5B5A),
+              ),
             ),
-          ),
           if (onCta != null) ...[
-            const SizedBox(height: 8),
+            if (message != null) const SizedBox(height: 8),
             Align(
               alignment: Alignment.centerLeft,
               child: TextButton.icon(

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_progressive_fanout_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_progressive_fanout_test.dart
@@ -307,11 +307,21 @@ void main() {
 
     // Poll the live value (Riverpod coalesces listener notifications, so we
     // sample like `settle` does) while releasing sections one at a time.
+    //
+    // Avec le seed de coquilles, les 4 sections sont présentes dès le 1er rendu
+    // non-squelette (en-têtes vides) : le signal « progressif » porte donc sur
+    // le **remplissage du contenu** (sections à `items` non vide), pas sur le
+    // nombre de sections — qui vaut 4 dès le départ.
     final counts = <int>[];
     void record() {
       final v = container.read(fluxContinuProvider).valueOrNull;
       if (v != null && !v.isSkeleton) {
-        counts.add(v.sections.whereType<FeedThemeSection>().length);
+        counts.add(
+          v.sections
+              .whereType<FeedThemeSection>()
+              .where((s) => s.items.isNotEmpty)
+              .length,
+        );
       }
     }
 
@@ -328,13 +338,183 @@ void main() {
     await pumpEventQueue(times: 5);
     record();
 
-    // At least one intermediate sample had 1..3 sections (progressive fill),
-    // not a single jump straight from 0 to 4.
+    // At least one intermediate sample had 1..3 FILLED sections (progressive
+    // fill), not a single jump straight from 0 to 4 filled.
     expect(
       counts.any((c) => c > 0 && c < 4),
       isTrue,
-      reason: 'expected an intermediate state before all 4 sections arrived',
+      reason: 'expected an intermediate state before all 4 sections filled',
     );
     expect(counts.last, 4);
   });
+
+  // ── Fan-out résilient (fix « Tournée figée » + « thème à 1 carte ») ─────────
+
+  test(
+    'order reflects declared favorites BEFORE any fetch resolves (shells seeded)',
+    () async {
+      // Tous les fetchs thème pendouillent (gated, jamais complétés) : aucune
+      // section n'a encore de contenu. L'ordre de la Tournée doit malgré tout
+      // refléter les favoris déclarés (en-têtes seedés, items vides) — c'est le
+      // cœur du fix « ordre figé » : la clé d'une section n'attend plus son fetch.
+      final gates = <Completer<void>>[];
+      when(
+        () => feedRepo.getFeed(
+          page: any(named: 'page'),
+          limit: any(named: 'limit'),
+          theme: any(named: 'theme'),
+          serein: any(named: 'serein'),
+          personalized: any(named: 'personalized'),
+        ),
+      ).thenAnswer((_) async {
+        final gate = Completer<void>();
+        gates.add(gate);
+        await gate.future;
+        return _feedResponseWith(3);
+      });
+
+      final container = makeContainer(
+        _interestsState(favorites: themeFavorites(3)),
+      );
+      addTearDown(container.dispose);
+
+      container.read(fluxContinuProvider);
+      // Draine le bootstrap (squelette → rendu base + seed des coquilles) SANS
+      // libérer la moindre gate.
+      for (var step = 0; step < 20; step++) {
+        await pumpEventQueue(times: 3);
+      }
+
+      final value = container.read(fluxContinuProvider).valueOrNull;
+      expect(value, isNotNull);
+      expect(value!.isSkeleton, isFalse);
+      final themes = value.sections.whereType<FeedThemeSection>().toList();
+      // Les 3 en-têtes favoris sont présents, dans l'ordre déclaré, items vides.
+      expect(themes.map((s) => s.themeSlug).toList(), [
+        'theme0',
+        'theme1',
+        'theme2',
+      ]);
+      expect(themes.every((s) => s.items.isEmpty), isTrue);
+
+      // Libère les gates pour ne pas laisser de timers/futures en suspens.
+      for (final gate in gates) {
+        gate.complete();
+      }
+      await pumpEventQueue(times: 5);
+    },
+  );
+
+  test(
+    'a transient throw is retried → section fills with the full page (not 0/1)',
+    () async {
+      // 1er appel throw (erreur transitoire : 503/401/timeout), 2e réussit. Sans
+      // retry, `_safe` avalait l'erreur → section vide/à 1 carte pour le cycle.
+      var calls = 0;
+      when(
+        () => feedRepo.getFeed(
+          page: any(named: 'page'),
+          limit: any(named: 'limit'),
+          theme: any(named: 'theme'),
+          serein: any(named: 'serein'),
+          personalized: any(named: 'personalized'),
+        ),
+      ).thenAnswer((_) async {
+        calls++;
+        if (calls == 1) throw Exception('transient 503');
+        return _feedResponseWith(10);
+      });
+
+      final container = makeContainer(
+        _interestsState(favorites: themeFavorites(1)),
+      );
+      addTearDown(container.dispose);
+
+      container.read(fluxContinuProvider);
+      // Le retry attend un backoff **réel** (~250ms) avant la 2e tentative ;
+      // `settle` romprait pendant cette fenêtre stable (état coquille inchangé).
+      // On laisse donc passer du temps réel, puis on draine.
+      for (var i = 0; i < 6; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 80));
+        await pumpEventQueue(times: 3);
+      }
+      final theme = container
+          .read(fluxContinuProvider)
+          .requireValue
+          .sections
+          .whereType<FeedThemeSection>()
+          .single;
+      expect(
+        theme.items,
+        hasLength(10),
+        reason: '1ère tentative en échec, retry réussi avec la page pleine',
+      );
+      // Exactement 2 tentatives (1 throw + 1 succès), pas plus.
+      verify(
+        () => feedRepo.getFeed(
+          page: any(named: 'page'),
+          limit: any(named: 'limit'),
+          theme: any(named: 'theme'),
+          serein: any(named: 'serein'),
+          personalized: any(named: 'personalized'),
+        ),
+      ).called(2);
+    },
+  );
+
+  test(
+    'upsert by key replaces the shell in place → no duplicate section per key',
+    () async {
+      // Ids distincts par appel pour qu'aucune section ne soit vidée par la
+      // dédup inter-sections — on veut le signal « la coquille a reçu son
+      // contenu », pas un artefact de dédup.
+      var callIdx = 0;
+      when(
+        () => feedRepo.getFeed(
+          page: any(named: 'page'),
+          limit: any(named: 'limit'),
+          theme: any(named: 'theme'),
+          serein: any(named: 'serein'),
+          personalized: any(named: 'personalized'),
+        ),
+      ).thenAnswer((_) async {
+        final idx = callIdx++;
+        return FeedResponse(
+          items: List.generate(
+            3,
+            (i) => Content(
+              id: 'call${idx}_item$i',
+              title: 't',
+              url: 'https://x.test/$idx/$i',
+              contentType: ContentType.article,
+              publishedAt: DateTime(2026, 1, 1),
+              source: Source(id: 's', name: 'S', type: SourceType.article),
+            ),
+          ),
+          pagination: Pagination(page: 1, perPage: 10, total: 0, hasNext: false),
+          carousels: const [],
+        );
+      });
+
+      final container = makeContainer(
+        _interestsState(favorites: themeFavorites(4)),
+      );
+      addTearDown(container.dispose);
+
+      final state = await settle(container);
+      final themes = state.sections.whereType<FeedThemeSection>().toList();
+      // 4 favoris → exactement 4 sections : la coquille a été remplacée en place,
+      // pas append (sinon 8 sections / clés dupliquées).
+      expect(themes, hasLength(4));
+      // Ordre déclaré préservé + aucune clé en double.
+      expect(themes.map((s) => s.themeSlug).toList(), [
+        'theme0',
+        'theme1',
+        'theme2',
+        'theme3',
+      ]);
+      // Chaque coquille a bien reçu son contenu (upsert effectif).
+      expect(themes.every((s) => s.items.isNotEmpty), isTrue);
+    },
+  );
 }

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
@@ -500,7 +500,7 @@ void main() {
       );
     });
 
-    test('7 favorites cap (8th ignored)', () async {
+    test('10 favorites cap (11th ignored)', () async {
       SharedPreferences.setMockInitialValues(<String, Object>{});
       when(
         () => feedRepo.getFeed(
@@ -512,17 +512,12 @@ void main() {
         ),
       ).thenAnswer((_) async => _feedResponseWith(3));
 
+      // 11 favoris thème (slugs arbitraires — `visualFor` a un fallback) : le cap
+      // [_kMaxFavoriteSections] = 10 garde les 10 premiers, le 11e est ignoré.
       final container = makeContainer(
         interests: _interestsState(
-          favorites: const [
-            ThemeFavoriteRef(slug: 'tech'),
-            ThemeFavoriteRef(slug: 'science'),
-            ThemeFavoriteRef(slug: 'culture'),
-            ThemeFavoriteRef(slug: 'economy'),
-            ThemeFavoriteRef(slug: 'politics'),
-            ThemeFavoriteRef(slug: 'sport'),
-            ThemeFavoriteRef(slug: 'environment'),
-            ThemeFavoriteRef(slug: 'society'), // 8th — must be dropped
+          favorites: [
+            for (var i = 0; i < 11; i++) ThemeFavoriteRef(slug: 'theme$i'),
           ],
         ),
       );
@@ -533,15 +528,7 @@ void main() {
           .whereType<FeedThemeSection>()
           .map((s) => s.themeSlug)
           .toList();
-      expect(slugs, [
-        'tech',
-        'science',
-        'culture',
-        'economy',
-        'politics',
-        'sport',
-        'environment',
-      ]);
+      expect(slugs, [for (var i = 0; i < 10; i++) 'theme$i']);
     });
   });
 
@@ -1418,21 +1405,28 @@ void main() {
         final skeletonIdx = captured.indexWhere((s) => s.isSkeleton);
         expect(skeletonIdx, greaterThanOrEqualTo(0));
 
-        // base-only : contenu réel (Actus du jour) mais ENCORE aucune section
-        // thème (le fan-out de phase 2 n'a pas répondu).
+        // base-only : la section thème 'tech' existe déjà (en-tête seedé) mais
+        // reste une COQUILLE vide — le fan-out de phase 2 n'a pas encore
+        // répondu. Avec le seed de coquilles, le signal « progressif » porte sur
+        // le remplissage du contenu, pas sur la présence de la section.
         final baseIdx = captured.indexWhere(
           (s) =>
               !s.isSkeleton &&
-              s.sections.isNotEmpty &&
-              s.sections.whereType<FeedThemeSection>().isEmpty,
+              s.sections.whereType<FeedThemeSection>().isNotEmpty &&
+              s.sections
+                  .whereType<FeedThemeSection>()
+                  .every((t) => t.items.isEmpty),
         );
         expect(baseIdx, greaterThan(skeletonIdx),
-            reason:
-                'le haut de page réel remplace le squelette avant le fan-out');
+            reason: 'les en-têtes (haut de page + coquilles favoris) remplacent '
+                'le squelette avant le remplissage du fan-out');
 
-        // complet : la section thème 'tech' est présente, après le base-only.
+        // complet : la section thème 'tech' est REMPLIE (items non vides),
+        // après le base-only.
         final fullIdx = captured.lastIndexWhere(
-          (s) => s.sections.whereType<FeedThemeSection>().isNotEmpty,
+          (s) => s.sections
+              .whereType<FeedThemeSection>()
+              .any((t) => t.items.isNotEmpty),
         );
         expect(fullIdx, greaterThan(baseIdx));
         expect(finalState.isSkeleton, isFalse);

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_sources_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_sources_test.dart
@@ -3,8 +3,6 @@
 // (après les thèmes), dédup inter-sections, et état vide « toujours visible ».
 import 'dart:io';
 
-import 'package:facteur/features/digest/models/digest_models.dart';
-import 'package:facteur/features/digest/models/dual_digest_response.dart';
 import 'package:facteur/features/digest/providers/digest_provider.dart';
 import 'package:facteur/features/digest/providers/serein_toggle_provider.dart';
 import 'package:facteur/features/digest/repositories/digest_repository.dart';
@@ -13,6 +11,8 @@ import 'package:facteur/features/feed/providers/feed_provider.dart';
 import 'package:facteur/features/feed/repositories/feed_repository.dart';
 import 'package:facteur/features/flux_continu/models/flux_continu_models.dart';
 import 'package:facteur/features/flux_continu/providers/flux_continu_provider.dart';
+import 'package:facteur/features/flux_continu/providers/tournee_order_prefs_provider.dart'
+    show kTourneeVisibleCap, kRichSectionMinItems;
 import 'package:facteur/features/settings/models/display_mode_spec.dart';
 import 'package:facteur/features/settings/providers/display_mode_provider.dart';
 import 'package:facteur/features/flux_continu/repositories/essentiel_repository.dart';
@@ -264,8 +264,11 @@ void main() {
       themeIds: {
         'tech': ['shared', 't2']
       },
+      // src1 garde 2 survivants uniques (a2/a3) après dédup ⇒ section **riche**,
+      // donc pas de réinjection (backfill) qui repiocherait l'article partagé :
+      // on teste ici la seule règle de dédup (le thème au-dessus gagne).
       sourceIds: {
-        'src1': ['shared', 'a2']
+        'src1': ['shared', 'a2', 'a3']
       },
     );
     final container = await buildContainer(
@@ -286,7 +289,7 @@ void main() {
     expect(theme.items.map((c) => c.id), contains('shared'));
     expect(source.items.map((c) => c.id), isNot(contains('shared')),
         reason: 'le thème au-dessus gagne l\'article partagé');
-    expect(source.items.map((c) => c.id), ['a2']);
+    expect(source.items.map((c) => c.id), ['a2', 'a3']);
   });
 
   test(
@@ -387,5 +390,220 @@ void main() {
 
     // Triées par position (a..k) puis capées à 10 → a,b,c,d,e,f,g,h,i,j.
     expect(sources, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
+  });
+
+  // ── Cohérence Tournée : dépriorisation / enrichissement des maigres ────────
+  group('cohérence Tournée (maigre/riche)', () {
+    test(
+        'classification : un favori à 1 survivant ∈ thinFavoriteKeys ; '
+        'à ≥2 absent', () async {
+      stubFeed(
+        themeIds: {
+          'tech': ['t1', 't2'] // riche (2)
+        },
+        sourceIds: {
+          'src1': ['b1'] // maigre (1)
+        },
+      );
+      final container = await buildContainer(
+        interests: _interestsState(favorites: [ThemeFavoriteRef(slug: 'tech')]),
+        sourcesState: _sourcesState(
+          favorites: [SourceFavoriteRef(sourceId: 'src1', position: 0)],
+        ),
+        catalog: [_source('src1', theme: 'society')],
+        tourneeOrder: const ['theme:tech', 'source:src1'],
+      );
+      addTearDown(container.dispose);
+
+      final state = await settle(container);
+      expect(state.thinFavoriteKeys, contains('source:src1'));
+      expect(state.thinFavoriteKeys, isNot(contains('theme:tech')));
+
+      // La section riche n'est jamais marquée underfilled.
+      final theme = feedSections(container)
+          .firstWhere((s) => s.kind == SectionKind.theme);
+      expect(theme.underfilled, isFalse);
+    });
+
+    test(
+        'dépriorisation : 5 riches + 1 maigre → le maigre passe après les '
+        'riches (gate ≥5)', () async {
+      stubFeed(
+        themeIds: {
+          'tech': ['tc1', 'tc2'],
+          'science': ['sc1', 'sc2'],
+          'culture': ['cu1'], // maigre
+          'economy': ['ec1', 'ec2'],
+          'politics': ['po1', 'po2'],
+          'environment': ['en1', 'en2'],
+        },
+        sourceIds: const {},
+      );
+      final container = await buildContainer(
+        interests: _interestsState(
+          favorites: const [
+            ThemeFavoriteRef(slug: 'tech'),
+            ThemeFavoriteRef(slug: 'science'),
+            ThemeFavoriteRef(slug: 'culture'),
+            ThemeFavoriteRef(slug: 'economy'),
+            ThemeFavoriteRef(slug: 'politics'),
+            ThemeFavoriteRef(slug: 'environment'),
+          ],
+        ),
+        sourcesState: _sourcesState(),
+        catalog: const [],
+      );
+      addTearDown(container.dispose);
+
+      await settle(container);
+      final order = feedSections(container)
+          .where((s) => s.kind == SectionKind.theme)
+          .map((s) => s.themeSlug)
+          .toList();
+      // 5 riches d'abord (ordre relatif préservé), le maigre 'culture' en fin.
+      expect(order, [
+        'tech',
+        'science',
+        'economy',
+        'politics',
+        'environment',
+        'culture',
+      ]);
+    });
+
+    test('gate ≥5 : 4 riches + 1 maigre → ordre inchangé', () async {
+      stubFeed(
+        themeIds: {
+          'tech': ['tc1', 'tc2'],
+          'science': ['sc1', 'sc2'],
+          'culture': ['cu1'], // maigre, en 3ᵉ position
+          'economy': ['ec1', 'ec2'],
+          'politics': ['po1', 'po2'],
+        },
+        sourceIds: const {},
+      );
+      final container = await buildContainer(
+        interests: _interestsState(
+          favorites: const [
+            ThemeFavoriteRef(slug: 'tech'),
+            ThemeFavoriteRef(slug: 'science'),
+            ThemeFavoriteRef(slug: 'culture'),
+            ThemeFavoriteRef(slug: 'economy'),
+            ThemeFavoriteRef(slug: 'politics'),
+          ],
+        ),
+        sourcesState: _sourcesState(),
+        catalog: const [],
+      );
+      addTearDown(container.dispose);
+
+      await settle(container);
+      final order = feedSections(container)
+          .where((s) => s.kind == SectionKind.theme)
+          .map((s) => s.themeSlug)
+          .toList();
+      // 4 riches < seuil ⇒ pas de dépriorisation : 'culture' reste en place.
+      expect(order, ['tech', 'science', 'culture', 'economy', 'politics']);
+    });
+
+    test(
+        'cap : >10 favoris dont un maigre → le maigre est coupé des sections '
+        'mais présent dans thinFavoriteKeys', () async {
+      stubFeed(
+        themeIds: {
+          'tech': ['tc1', 'tc2'],
+          'science': ['sc1', 'sc2'],
+          'economy': ['ec1', 'ec2'],
+          'politics': ['po1', 'po2'],
+          'environment': ['en1', 'en2'],
+          'culture': ['cu1'], // maigre → dépriorisé en fin → coupé par le cap
+        },
+        sourceIds: {
+          'a': ['a1', 'a2'],
+          'b': ['b1', 'b2'],
+          'c': ['c1', 'c2'],
+          'd': ['d1', 'd2'],
+          'e': ['e1', 'e2'],
+        },
+      );
+      final container = await buildContainer(
+        interests: _interestsState(
+          favorites: const [
+            ThemeFavoriteRef(slug: 'tech'),
+            ThemeFavoriteRef(slug: 'science'),
+            ThemeFavoriteRef(slug: 'economy'),
+            ThemeFavoriteRef(slug: 'politics'),
+            ThemeFavoriteRef(slug: 'environment'),
+            ThemeFavoriteRef(slug: 'culture'),
+          ],
+        ),
+        sourcesState: _sourcesState(
+          favorites: const [
+            SourceFavoriteRef(sourceId: 'a', position: 0),
+            SourceFavoriteRef(sourceId: 'b', position: 1),
+            SourceFavoriteRef(sourceId: 'c', position: 2),
+            SourceFavoriteRef(sourceId: 'd', position: 3),
+            SourceFavoriteRef(sourceId: 'e', position: 4),
+          ],
+        ),
+        catalog: [
+          _source('a'),
+          _source('b'),
+          _source('c'),
+          _source('d'),
+          _source('e'),
+        ],
+        tourneeOrder: const [
+          'source:a',
+          'source:b',
+          'source:c',
+          'source:d',
+          'source:e',
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final state = await settle(container);
+      final slugs = feedSections(container)
+          .where((s) => s.kind == SectionKind.theme)
+          .map((s) => s.themeSlug)
+          .toList();
+      // 11 favoris (5 sources + 6 thèmes), cap 10 ⇒ le maigre 'culture'
+      // (dépriorisé en dernier) est coupé, mais reste signalé pour la modal.
+      expect(state.sections.length, kTourneeVisibleCap);
+      expect(slugs, isNot(contains('culture')));
+      expect(state.thinFavoriteKeys, contains('theme:culture'));
+    });
+
+    test(
+        'backfill : une source maigre affichée est réinjectée jusqu\'à 2 items '
+        '+ underfilled (doublons inter-sections tolérés)', () async {
+      stubFeed(
+        themeIds: {
+          'tech': ['s1', 's2'] // riche, gagne s1/s2
+        },
+        sourceIds: {
+          'src1': ['s1', 's2'] // tout partagé → 0 survivant → maigre
+        },
+      );
+      final container = await buildContainer(
+        interests: _interestsState(favorites: [ThemeFavoriteRef(slug: 'tech')]),
+        sourcesState: _sourcesState(
+          favorites: [SourceFavoriteRef(sourceId: 'src1', position: 0)],
+        ),
+        catalog: [_source('src1', theme: 'society')],
+        tourneeOrder: const ['theme:tech', 'source:src1'],
+      );
+      addTearDown(container.dispose);
+
+      final state = await settle(container);
+      final source = feedSections(container)
+          .firstWhere((s) => s.kind == SectionKind.source);
+      // Réinjection bornée à kRichSectionMinItems (2), depuis les retirés.
+      expect(source.items.length, kRichSectionMinItems);
+      expect(source.items.map((c) => c.id), containsAll(['s1', 's2']));
+      expect(source.underfilled, isTrue);
+      expect(state.thinFavoriteKeys, contains('source:src1'));
+    });
   });
 }

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_sources_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_sources_test.dart
@@ -318,7 +318,7 @@ void main() {
 
   test(
       'plusieurs sources favorites respectent l\'ordre par position et le '
-      'cap (parité thèmes = 7)', () async {
+      'cap (parité thèmes = 10)', () async {
     stubFeed(
       themeIds: const {},
       sourceIds: {
@@ -330,6 +330,9 @@ void main() {
         'f': ['f1', 'f2'],
         'g': ['g1', 'g2'],
         'h': ['h1', 'h2'],
+        'i': ['i1', 'i2'],
+        'j': ['j1', 'j2'],
+        'k': ['k1', 'k2'],
       },
     );
     final container = await buildContainer(
@@ -343,6 +346,9 @@ void main() {
         SourceFavoriteRef(sourceId: 'e', position: 4),
         SourceFavoriteRef(sourceId: 'h', position: 7),
         SourceFavoriteRef(sourceId: 'g', position: 6),
+        SourceFavoriteRef(sourceId: 'j', position: 9),
+        SourceFavoriteRef(sourceId: 'i', position: 8),
+        SourceFavoriteRef(sourceId: 'k', position: 10),
       ]),
       catalog: [
         _source('a'),
@@ -353,6 +359,9 @@ void main() {
         _source('f'),
         _source('g'),
         _source('h'),
+        _source('i'),
+        _source('j'),
+        _source('k'),
       ],
       tourneeOrder: const [
         'source:a',
@@ -363,6 +372,9 @@ void main() {
         'source:f',
         'source:g',
         'source:h',
+        'source:i',
+        'source:j',
+        'source:k',
       ],
     );
     addTearDown(container.dispose);
@@ -373,7 +385,7 @@ void main() {
         .map((s) => s.sourceId)
         .toList();
 
-    // Triées par position (a..h) puis capées à 7 → a,b,c,d,e,f,g.
-    expect(sources, ['a', 'b', 'c', 'd', 'e', 'f', 'g']);
+    // Triées par position (a..k) puis capées à 10 → a,b,c,d,e,f,g,h,i,j.
+    expect(sources, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
   });
 }

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_tournee_order_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_tournee_order_test.dart
@@ -1,6 +1,6 @@
 // PR 2 — couverture du bloc favori UNIFIÉ de la Tournée composé par le
 // FluxContinuNotifier : ordre 100 % libre (thèmes + sources + veille mélangés
-// via « Composer ma Tournée »), cap d'affichage 7, exclusion des sujets perso,
+// via « Composer ma Tournée »), cap d'affichage 10, exclusion des sujets perso,
 // et masquage de la veille (veilleHidden).
 import 'dart:io';
 
@@ -393,7 +393,7 @@ void main() {
       },
     );
 
-    test('cap 7 unifié : 5 thèmes + Actus + Grille coupent Bonnes', () async {
+    test('cap 10 unifié : 8 thèmes + Actus + Grille coupent Bonnes', () async {
       stubDigest();
       stubFeed(
         themeIds: {
@@ -402,6 +402,9 @@ void main() {
           'economy': ['e1'],
           'politics': ['p1'],
           'tech': ['t1'],
+          'science': ['sc1'],
+          'environment': ['en1'],
+          'international': ['in1'],
         },
       );
       final container = await buildContainer(
@@ -412,6 +415,9 @@ void main() {
             ThemeFavoriteRef(slug: 'economy'),
             ThemeFavoriteRef(slug: 'politics'),
             ThemeFavoriteRef(slug: 'tech'),
+            ThemeFavoriteRef(slug: 'science'),
+            ThemeFavoriteRef(slug: 'environment'),
+            ThemeFavoriteRef(slug: 'international'),
           ],
         ),
         sourcesState: _sourcesState(),
@@ -428,14 +434,17 @@ void main() {
         'theme:economy',
         'theme:politics',
         'theme:tech',
+        'theme:science',
+        'theme:environment',
+        'theme:international',
         kTourneeActusKey,
       ]);
-      expect(state.grilleSlotIndex, 6);
+      expect(state.grilleSlotIndex, 9);
       expect(
         state.sections.map(sectionKey),
         isNot(contains(kTourneeBonnesKey)),
-        reason: 'Bonnes est 8e dans la liste unifiée (5 thèmes+Actus+Grille) '
-            'et tombe sous le cap de 7',
+        reason: 'Bonnes est 11e dans la liste unifiée (8 thèmes+Actus+Grille) '
+            'et tombe sous le cap de 10',
       );
     });
 
@@ -569,8 +578,8 @@ void main() {
   });
 
   test(
-      'cap d\'affichage 7 : 4 thèmes + 3 sources + veille (8 candidats) → '
-      'seulement 7 sections, veille (en queue par défaut) coupée', () async {
+      'cap d\'affichage 10 : 7 thèmes + 3 sources + veille (11 candidats) → '
+      'seulement 10 sections, veille (en queue par défaut) coupée', () async {
     // Story 10.2 — les sources doivent être en mode « Essentiel » (clé dans
     // l'ordre) pour entrer dans la Tournée ; on garde l'ordre par défaut
     // (thèmes avant sources) en plaçant les clés thème d'abord.
@@ -580,6 +589,9 @@ void main() {
         'theme:culture',
         'theme:economy',
         'theme:politics',
+        'theme:tech',
+        'theme:science',
+        'theme:environment',
         'source:a',
         'source:b',
         'source:c',
@@ -591,6 +603,9 @@ void main() {
         'culture': ['c1', 'c2'],
         'economy': ['e1', 'e2'],
         'politics': ['p1', 'p2'],
+        'tech': ['t1', 't2'],
+        'science': ['sc1', 'sc2'],
+        'environment': ['en1', 'en2'],
       },
       sourceIds: {
         'a': ['a1'],
@@ -605,6 +620,9 @@ void main() {
           ThemeFavoriteRef(slug: 'culture'),
           ThemeFavoriteRef(slug: 'economy'),
           ThemeFavoriteRef(slug: 'politics'),
+          ThemeFavoriteRef(slug: 'tech'),
+          ThemeFavoriteRef(slug: 'science'),
+          ThemeFavoriteRef(slug: 'environment'),
         ],
       ),
       sourcesState: _sourcesState(
@@ -624,16 +642,19 @@ void main() {
 
     expect(
       sections,
-      hasLength(7),
-      reason: 'cap d\'affichage de la Tournée = 7',
+      hasLength(10),
+      reason: 'cap d\'affichage de la Tournée = 10',
     );
     expect(
       sections.where((s) => s.kind == SectionKind.veille),
       isEmpty,
-      reason: 'ordre par défaut thèmes→sources→veille → veille en 8e, coupée',
+      reason: 'ordre par défaut thèmes→sources→veille → veille en 11e, coupée',
     );
-    // Ordre par défaut : 4 thèmes puis 3 sources (a, b, c) ; veille tombe.
+    // Ordre par défaut : 7 thèmes puis 3 sources (a, b, c) ; veille tombe.
     expect(sections.map((s) => s.kind).toList(), [
+      SectionKind.theme,
+      SectionKind.theme,
+      SectionKind.theme,
       SectionKind.theme,
       SectionKind.theme,
       SectionKind.theme,
@@ -691,7 +712,7 @@ void main() {
     'veille en tête d\'ordre : présente dans le cap, un autre item tombe',
     () async {
       // Story 10.2 — sources en mode « Essentiel » (clés dans l'ordre) ; veille
-      // remontée en tête. 8 candidats → cap 7, veille première (source c tombe).
+      // remontée en tête. 11 candidats → cap 10, veille première (source c tombe).
       SharedPreferences.setMockInitialValues(<String, Object>{
         'tournee_order_v1': [
           'veille',
@@ -699,6 +720,9 @@ void main() {
           'theme:culture',
           'theme:economy',
           'theme:politics',
+          'theme:tech',
+          'theme:science',
+          'theme:environment',
           'source:a',
           'source:b',
           'source:c',
@@ -710,6 +734,9 @@ void main() {
           'culture': ['c1', 'c2'],
           'economy': ['e1', 'e2'],
           'politics': ['p1', 'p2'],
+          'tech': ['t1', 't2'],
+          'science': ['sc1', 'sc2'],
+          'environment': ['en1', 'en2'],
         },
         sourceIds: {
           'a': ['a1'],
@@ -724,6 +751,9 @@ void main() {
             ThemeFavoriteRef(slug: 'culture'),
             ThemeFavoriteRef(slug: 'economy'),
             ThemeFavoriteRef(slug: 'politics'),
+            ThemeFavoriteRef(slug: 'tech'),
+            ThemeFavoriteRef(slug: 'science'),
+            ThemeFavoriteRef(slug: 'environment'),
           ],
         ),
         sourcesState: _sourcesState(
@@ -741,7 +771,7 @@ void main() {
       await settle(container);
       final sections = favoriteSections(container);
 
-      expect(sections, hasLength(7));
+      expect(sections, hasLength(10));
       expect(
         sections.first.kind,
         SectionKind.veille,

--- a/apps/mobile/test/features/flux_continu/widgets/manage_favorites_sheet_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/manage_favorites_sheet_test.dart
@@ -1,7 +1,7 @@
 // Story 10.2 — sheet unifiée « Mes favoris » : deux sections (Essentiel /
 // Flâner), appartenance exclusive des sources (la clé `source:` dans
 // `tournee_order_v1` ⇒ Essentiel, sinon Flâner), déplacement de mode, funnel
-// veille sur les sujets, et caps 7/10 par section.
+// veille sur les sujets, et caps 10/10 par section.
 import 'package:facteur/config/routes.dart';
 import 'package:facteur/config/theme.dart';
 import 'package:facteur/features/digest/providers/serein_toggle_provider.dart';
@@ -352,8 +352,9 @@ void main() {
   });
 
   testWidgets(
-      '« Hors Tournée du jour (7) » apparaît au-delà de 7 sections Essentiel',
+      '« Hors Tournée du jour (10) » apparaît au-delà de 10 sections Essentiel',
       (tester) async {
+    // 9 thèmes favoris + Actus + Bonnes = 11 blocs Essentiel → au-delà du cap 10.
     await _openSheet(
       tester,
       interests: _interests(favorites: const [
@@ -365,14 +366,15 @@ void main() {
         ThemeFavoriteRef(slug: 'international'),
         ThemeFavoriteRef(slug: 'economy'),
         ThemeFavoriteRef(slug: 'culture'),
+        ThemeFavoriteRef(slug: 'sport'),
       ]),
       sources: _sources(),
     );
 
-    // Le cap (élargi 5 → 7) est explicité entre parenthèses.
-    expect(find.text('Hors Tournée du jour (7)'), findsOneWidget);
+    // Le cap (élargi → 10) est explicité entre parenthèses.
+    expect(find.text('Hors Tournée du jour (10)'), findsOneWidget);
     // Le compteur de l'en-tête reflète aussi le cap.
-    expect(find.text('· 7/7'), findsOneWidget);
+    expect(find.text('· 10/10'), findsOneWidget);
   });
 
   testWidgets(


### PR DESCRIPTION
## Quoi

Cohérence d'affichage de la **Tournée du jour** après la dédup inter-sections, suite au fix « Tournée fiable » (seed coquilles + retry) du commit précédent :

- **Classification maigre/riche** des sections favorites (maigre = ≤1 article post-dédup, riche = ≥2), calculée sur l'ordre par défaut **non cappé**. N'inspecte que les sections au fetch **résolu** (`_resolvedSectionKeys`) → aucune coquille de boot classée maigre par erreur.
- **Dépriorisation stable** : les favoris maigres passent sous les riches dans l'ordre par défaut quand ≥5 sections riches existent. Le contenu dense remonte au-dessus du pli. L'ordre personnalisé reste respecté tel quel.
- **Backfill** des thèmes maigres affichés : réinjection d'articles strippés par la dédup (doublons inter-sections assumés, décision PO) + CTA « Ajouter plus de sources ».
- **Modal « Mes favoris »** : micro-indicateur ambre « Peu d'articles » sur les favoris maigres.

## Pourquoi

Après le fix de fiabilité, des sections favorites pouvaient rester maigres (1 carte) ou pousser du contenu dense sous le pli. Cette PR remonte le contenu dense, complète les thèmes maigres, et signale dans la modal les favoris peu fournis.

## Comment ça a été vérifié

- [x] `flutter test test/features/flux_continu` — 283 tests OK
- [x] `flutter analyze lib/features/flux_continu` — 0 issue (lib)
- [x] Imports inutilisés retirés du test touché
- [x] `/simplify` passé (4 agents reuse/simplification/efficiency/altitude — code jugé propre)

## Zones à risque

- `flux_continu_provider._compose` (chemin chaud, rejoué à chaque recompose) — double passe d'ordering/dédup assumée (coût négligeable, validé par la revue efficiency).
- Ordering Tournée (`_orderedTourneeKeys`) : nouveau param `cap` nullable + partition de dépriorisation, n'affecte que l'ordre par défaut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
