### PR TITLE
fix(flux-continu): Tournée — favoris denses remontent + thèmes maigres complétés

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -3,6 +3,12 @@
     {
       "tag": "Lecture",
       "summary": "Carrousels plus nets : le bas des cartes ne se coupe plus quand leurs tailles diffèrent, et les points de défilement respirent mieux."
+    },
+    {
+      "tag": "Tournée",
+      "summary": "Tes sections favorites les mieux fournies remontent en haut, et celles à un seul article sont complétées automatiquement."
+    },
+    {
       "tag": "Tournée",
       "summary": "Tournée du jour plus fiable : tes thèmes et sources favoris s'affichent du premier coup."
     },

--- a/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
+++ b/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
@@ -338,6 +338,13 @@ class FeedThemeSection extends FluxSection {
   /// que le backend a reculé jusqu'à 30 j → bannière « Pas d'article récent. ».
   final bool noRecentSource;
 
+  /// Cohérence Tournée : true quand cette section favorite **maigre** (≤1
+  /// survivant post-dédup) a été **enrichie** (réinjection des articles déjà
+  /// renvoyés par le backend mais strippés par la dédup) et/ou doit porter le
+  /// CTA « Ajouter plus de sources » (thèmes). Dérivé à chaque `_compose` (jamais
+  /// persisté dans `_themes`/`_sources`) — ne survit donc pas hors d'un recompose.
+  final bool underfilled;
+
   const FeedThemeSection({
     required super.kind,
     required super.label,
@@ -354,6 +361,7 @@ class FeedThemeSection extends FluxSection {
     this.origin = SectionOrigin.validated,
     this.reason,
     this.noRecentSource = false,
+    this.underfilled = false,
     super.blurb,
     super.illustrationAsset,
   });
@@ -375,6 +383,7 @@ class FeedThemeSection extends FluxSection {
     // au défaut à chaque recompose — le piège le plus facile à introduire.
     int? coreVisibleCount,
     bool? noRecentSource,
+    bool? underfilled,
   }) {
     return FeedThemeSection(
       kind: kind,
@@ -395,6 +404,7 @@ class FeedThemeSection extends FluxSection {
       origin: origin,
       reason: reason,
       noRecentSource: noRecentSource ?? this.noRecentSource,
+      underfilled: underfilled ?? this.underfilled,
       blurb: blurb,
       illustrationAsset: illustrationAsset,
     );
@@ -499,6 +509,13 @@ class FluxContinuState {
   /// `false` ; le screen rend un scaffold placeholder tant qu'il est `true`.
   final bool isSkeleton;
 
+  /// Cohérence Tournée — `sectionKey` des sections favorites (thème/source)
+  /// **maigres** (≤1 survivant post-dédup) du cycle courant, qu'elles soient
+  /// affichées ou poussées hors cap. Source unique consommée par la modal
+  /// « Mes favoris » pour signaler les favoris peu fournis. Vide tant que rien
+  /// n'est classé (squelette / aucun favori résolu).
+  final Set<String> thinFavoriteKeys;
+
   const FluxContinuState({
     this.sections = const [],
     this.grilleSlotIndex,
@@ -509,6 +526,7 @@ class FluxContinuState {
     this.isLoading = true,
     this.error,
     this.isSkeleton = false,
+    this.thinFavoriteKeys = const {},
   });
 
   FluxContinuState copyWith({
@@ -522,6 +540,7 @@ class FluxContinuState {
     Object? error,
     bool clearError = false,
     bool? isSkeleton,
+    Set<String>? thinFavoriteKeys,
   }) {
     return FluxContinuState(
       sections: sections ?? this.sections,
@@ -533,6 +552,7 @@ class FluxContinuState {
       isLoading: isLoading ?? this.isLoading,
       error: clearError ? null : (error ?? this.error),
       isSkeleton: isSkeleton ?? this.isSkeleton,
+      thinFavoriteKeys: thinFavoriteKeys ?? this.thinFavoriteKeys,
     );
   }
 

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -165,6 +165,15 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
 
   bool _closingPersistQueued = false;
 
+  /// `sectionKey` des sections favorites (thème/source/veille) dont le fetch du
+  /// fan-out a **résolu** ce cycle (réponse arrivée, vide ou non). La
+  /// classification maigre/riche ([_classifyFavoriteSections]) n'inspecte que ces
+  /// clés : une coquille seedée non encore résolue (0 item au boot) ne doit pas
+  /// être classée maigre → faux positif de dépriorisation/CTA. Réinitialisé au
+  /// reseed complet ([_buildStateFromPayload]), augmenté au fil du fan-out et des
+  /// refetch partiels.
+  final Set<String> _resolvedSectionKeys = <String>{};
+
   /// True du tout début de [build] jusqu'à la fin du 1er [_fetchAll]. Pendant
   /// cette fenêtre, l'état affiché peut être un **squelette** (sections vides) :
   /// les listeners de prefs ne doivent donc ni recomposer (le dédup viderait les
@@ -491,6 +500,10 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     _themes = picked.isFallback ? const [] : _shellThemeSections(favorites);
     _sources = _shellSourceSections(favoriteSources);
     _suggested = const [];
+    // Reseed complet ⇒ les coquilles ne sont pas encore résolues : on repart
+    // d'une classification vierge (aucune section maigre tant que le fan-out /
+    // le chemin cache n'a pas confirmé un contenu réel).
+    _resolvedSectionKeys.clear();
     _closingDismissed = await _loadClosingDismissedForToday();
     unawaited(_purgeOldPrefsKeys());
 
@@ -699,6 +712,17 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     final tournee = ref.read(tourneeOrderPrefsProvider);
     final grilleAvailable = ref.read(grilleProvider).valueOrNull?.today != null;
     final sectionByKey = _tourneeSectionByKey();
+
+    // Cohérence Tournée — classification maigre/riche sur l'ordre par défaut
+    // **non cappé** (la maigreur ne se connaît qu'après dédup, cf. plan). Elle
+    // pilote ensuite la dépriorisation des clés de l'ordre réel.
+    final (:thinKeys, :richCount) = _classifyFavoriteSections(
+      isSerene: isSerene,
+      tournee: tournee,
+      sectionByKey: sectionByKey,
+    );
+    final demote = richCount >= kThinDemotionRichThreshold;
+
     final orderedKeys = _orderedTourneeKeys(
       isSerene: isSerene,
       customized: tournee.customized,
@@ -706,6 +730,8 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       grilleAvailable: grilleAvailable,
       hiddenKeys: tournee.hiddenKeys,
       order: tournee.order,
+      thinKeys: thinKeys,
+      demote: demote,
     );
 
     // « Cartes ≤ écran » : décidé côté provider par estimation conservatrice
@@ -722,9 +748,18 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
         if (key != kTourneeGrilleKey && sectionByKey[key] != null)
           sectionByKey[key]!,
     ];
+    // Dédup réel (ordre dépriorisé) en capturant les retirés par section, puis
+    // réinjection (backfill) des sections favorites maigres **affichées**.
+    final removedByKey = <String, List<Content>>{};
+    final deduped = _dedupeSectionsInOrder(
+      _filterSections(rawOrdered),
+      removedByKey: removedByKey,
+    );
     final finalSections = _capSectionsToFit(
-      _dropEmptySuggested(
-        _dedupeSectionsInOrder(_filterSections(rawOrdered)),
+      _backfillThinSections(
+        _dropEmptySuggested(deduped),
+        thinKeys,
+        removedByKey,
       ),
       usableHeight,
     );
@@ -741,6 +776,103 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       dismissedIds: Set.unmodifiable(_dismissedIds),
       quote: _quote,
       isLoading: false,
+      // Toutes les clés maigres (affichées ou hors cap) → la modal sait
+      // lesquelles signaler.
+      thinFavoriteKeys: thinKeys,
+    );
+  }
+
+  /// Classifie les sections **favorites** (thème/source validés) en maigres
+  /// (≤ [kThinSectionMaxItems] survivants post-dédup) / riches (≥
+  /// [kRichSectionMinItems]) sur l'ordre par défaut **non cappé**. Exclut
+  /// veille / éditorial / suggérées / Grille. N'inspecte que les sections au
+  /// fetch résolu ([_resolvedSectionKeys]) → pas de faux positif sur des
+  /// coquilles de boot.
+  ({Set<String> thinKeys, int richCount}) _classifyFavoriteSections({
+    required bool isSerene,
+    required TourneeOrderState tournee,
+    required Map<String, FluxSection> sectionByKey,
+  }) {
+    final favKeys = <String>{
+      for (final s in _themes)
+        if (s.kind == SectionKind.theme) sectionKey(s),
+      for (final s in _sources) sectionKey(s),
+    };
+    final eligible = {
+      for (final k in favKeys)
+        if (_resolvedSectionKeys.contains(k) && sectionByKey.containsKey(k)) k,
+    };
+    if (eligible.isEmpty) return (thinKeys: const <String>{}, richCount: 0);
+
+    final orderedKeys = _orderedTourneeKeys(
+      isSerene: isSerene,
+      customized: tournee.customized,
+      sectionByKey: sectionByKey,
+      grilleAvailable: false,
+      hiddenKeys: tournee.hiddenKeys,
+      order: tournee.order,
+      cap: null, // passe non cappée : la maigreur se mesure sur tout l'ordre
+    );
+    final rawOrdered = <FluxSection>[
+      if (_essentiel != null) _essentiel!,
+      for (final key in orderedKeys)
+        if (key != kTourneeGrilleKey && sectionByKey[key] != null)
+          sectionByKey[key]!,
+    ];
+    final deduped = _dedupeSectionsInOrder(_filterSections(rawOrdered));
+
+    final thinKeys = <String>{};
+    var richCount = 0;
+    for (final s in deduped) {
+      if (s is! FeedThemeSection) continue;
+      final k = sectionKey(s);
+      if (!eligible.contains(k)) continue;
+      final n = s.items.length;
+      if (n <= kThinSectionMaxItems) {
+        thinKeys.add(k);
+      } else if (n >= kRichSectionMinItems) {
+        richCount++;
+      }
+    }
+    return (thinKeys: thinKeys, richCount: richCount);
+  }
+
+  /// Réinjecte dans chaque section favorite **maigre affichée** (clé ∈
+  /// [thinKeys]) des articles strippés par la dédup ([removedByKey]) jusqu'à
+  /// [kRichSectionMinItems], et marque la section `underfilled` (pilote le CTA
+  /// thème « Ajouter plus de sources »). Doublons inter-sections assumés (PO) ;
+  /// dédup intra-section préservée. Une source maigre sans retirés garde son
+  /// filet d'empty-state existant.
+  List<FluxSection> _backfillThinSections(
+    List<FluxSection> sections,
+    Set<String> thinKeys,
+    Map<String, List<Content>> removedByKey,
+  ) {
+    if (thinKeys.isEmpty) return sections;
+    return [
+      for (final s in sections)
+        if (s is FeedThemeSection && thinKeys.contains(sectionKey(s)))
+          _backfillOneThinSection(s, removedByKey[sectionKey(s)] ?? const [])
+        else
+          s,
+    ];
+  }
+
+  FeedThemeSection _backfillOneThinSection(
+    FeedThemeSection s,
+    List<Content> removed,
+  ) {
+    final seen = {for (final c in s.items) c.id};
+    final additions = <Content>[];
+    for (final c in removed) {
+      if (s.items.length + additions.length >= kRichSectionMinItems) break;
+      if (seen.add(c.id)) additions.add(c);
+    }
+    // `underfilled` toujours vrai (section maigre affichée) → CTA thème même si
+    // rien n'a pu être réinjecté ; `items` n'est touché que s'il y a des ajouts.
+    return s.copyWith(
+      items: additions.isEmpty ? null : [...s.items, ...additions],
+      underfilled: true,
     );
   }
 
@@ -937,7 +1069,15 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   /// tourne que si des articles ont été dismissed), donc les champs de
   /// pagination de [FeedThemeSection] sont préservés via [FeedThemeSection.copyWith]
   /// — sinon « Voir +10 » serait réinitialisé à chaque recompose.
-  List<FluxSection> _dedupeSectionsInOrder(List<FluxSection> sections) {
+  /// [removedByKey] (optionnel) collecte, par `sectionKey` de section
+  /// [FeedThemeSection], les `Content` **strippés** par la dédup (déjà vus plus
+  /// haut). Sert à la réinjection (backfill) des sections favorites maigres dans
+  /// [_compose] : on y repioche des articles ≤72h déjà renvoyés par le backend
+  /// (doublons inter-sections assumés, décision PO).
+  List<FluxSection> _dedupeSectionsInOrder(
+    List<FluxSection> sections, {
+    Map<String, List<Content>>? removedByKey,
+  }) {
     final seen = <String>{};
     final result = <FluxSection>[];
     for (final s in sections) {
@@ -974,11 +1114,15 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
             ),
           );
         case FeedThemeSection(:final items):
-          result.add(
-            s.copyWith(
-              items: items.where((c) => seen.add(c.id)).toList(growable: false),
-            ),
-          );
+          final kept = <Content>[];
+          final removed = <Content>[];
+          for (final c in items) {
+            (seen.add(c.id) ? kept : removed).add(c);
+          }
+          if (removedByKey != null && removed.isNotEmpty) {
+            removedByKey[sectionKey(s)] = removed;
+          }
+          result.add(s.copyWith(items: kept));
       }
     }
     return result;
@@ -1407,6 +1551,15 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     };
   }
 
+  /// `sectionKey` de la section que rendra [favRef] (thème/sujet/veille) — aligné
+  /// sur [sectionKey] pour servir de clé `_resolvedSectionKeys` même quand le
+  /// fetch renvoie une section nulle (aucune section à inspecter alors).
+  String _favRefSectionKey(FavoriteRef favRef) => switch (favRef) {
+        ThemeFavoriteRef(:final slug) => tourneeThemeKey(slug),
+        CustomTopicFavoriteRef(:final id) => 'topic:$id',
+        VeilleFavoriteRef() => kTourneeVeilleKey,
+      };
+
   List<FavoriteRef> _pickExplicitFavorites(List<FavoriteRef> favorites) {
     VeilleFavoriteRef? veilleRef;
     final nonVeille = <FavoriteRef>[];
@@ -1675,10 +1828,14 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     Future<void> sectionTask(
       Future<FeedResponse?> Function() fetch,
       FeedThemeSection? Function(FeedResponse? feed) build,
-      void Function(FeedThemeSection section) append,
-    ) async {
+      void Function(FeedThemeSection section) append, {
+      required String resolvedKey,
+    }) async {
       final section = build(await fetch());
       if (section != null) append(section);
+      // Fetch résolu (vide ou non) : la classification maigre/riche peut
+      // désormais inspecter cette clé (cf. [_resolvedSectionKeys]).
+      _resolvedSectionKeys.add(resolvedKey);
       emit();
     }
 
@@ -1697,6 +1854,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
               // d'origine (ordre préservé) au lieu d'append (sinon doublon
               // coquille + contenu).
               (section) => _themes = _upsertByKey(_themes, section),
+              resolvedKey: _favRefSectionKey(favRef),
             ),
       // Sources favorites.
       for (final src in resolvedSources)
@@ -1704,8 +1862,10 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
               () => _fetchOneSource(src.id, isSerene),
               (feed) => _buildSourceSection(feed: feed, source: src),
               (section) => _sources = _upsertByKey(_sources, section),
+              resolvedKey: tourneeSourceKey(src.id),
             ),
-      // Suggérées « Choisie pour vous ».
+      // Suggérées « Choisie pour vous » (hors classification maigre/riche, mais
+      // marquées résolues sans effet — clé suggérée non favorite).
       for (final s in usableSuggestions)
         () => sectionTask(
               () => (s.kind == 'source' && s.sourceId != null)
@@ -1716,6 +1876,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
                     ),
               (feed) => _buildSuggestedSection(s, feed, sourceById),
               (section) => _suggested = [..._suggested, section],
+              resolvedKey: _suggestionKey(s),
             ),
     ];
 
@@ -1857,6 +2018,16 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     required bool grilleAvailable,
     required Set<String> hiddenKeys,
     required List<String> order,
+    // Cohérence Tournée : clés favorites maigres + bascule de dépriorisation.
+    // Quand [demote], les favoris maigres sont stable-partitionnés **après** les
+    // riches dans le bloc favori (ordre relatif préservé) → le contenu dense
+    // remonte au-dessus du pli. N'affecte que l'ordre **par défaut** : un ordre
+    // personnalisé (`customized`) reste sticky via `applyOrder`.
+    Set<String> thinKeys = const {},
+    bool demote = false,
+    // `null` ⇒ aucun cap (passe de classification non cappée) ; sinon plafonne à
+    // [cap] après réordonnancement (seul un surplus coupe les maigres dépriorisés).
+    int? cap = kTourneeVisibleCap,
   }) {
     final themeKeys = [
       for (final section in _themes)
@@ -1873,7 +2044,19 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     // personnalisé (`customized`) est respecté tel quel par `applyOrder`.
     final orderedThemeKeys =
         customized ? themeKeys : _biasThemeKeysByMostFollowed(themeKeys);
-    final favoriteKeys = [...orderedThemeKeys, ...sourceKeys, ...veilleKeys];
+    var favoriteKeys = [...orderedThemeKeys, ...sourceKeys, ...veilleKeys];
+    // Dépriorisation : partition **stable** riches-d'abord / maigres-ensuite du
+    // bloc favori. La veille (jamais dans `thinKeys` — exclue de la
+    // classification) reste dans le groupe « non maigre ». Ordre relatif
+    // conservé dans chaque groupe.
+    if (demote && thinKeys.isNotEmpty) {
+      favoriteKeys = [
+        for (final k in favoriteKeys)
+          if (!thinKeys.contains(k)) k,
+        for (final k in favoriteKeys)
+          if (thinKeys.contains(k)) k,
+      ];
+    }
     // Story 22.3 — clés des sections « Choisie pour vous », best-first par
     // daily_rank (`_suggested` arrive déjà trié du backend). Insérées APRÈS les
     // validées (jamais devant) et dédupliquées contre elles : un compte
@@ -1920,7 +2103,9 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       ordered.insert(actusIndex >= 0 ? actusIndex + 1 : 0, kTourneeGrilleKey);
     }
 
-    return ordered.take(kTourneeVisibleCap).toList(growable: false);
+    return cap == null
+        ? ordered.toList(growable: false)
+        : ordered.take(cap).toList(growable: false);
   }
 
   /// Renvoie [themeKeys] avec, en tête, la clé du thème auquel l'utilisateur a
@@ -2034,6 +2219,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
             if (section != null && _hasSectionKey(_themes, section)) {
               _themes = _upsertByKey(_themes, section);
             }
+            _resolvedSectionKeys.add(_favRefSectionKey(favRef));
             if (state.valueOrNull != null) {
               state = AsyncData(_compose(isSerene));
             }
@@ -2099,6 +2285,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
             if (section != null && _hasSectionKey(_sources, section)) {
               _sources = _upsertByKey(_sources, section);
             }
+            _resolvedSectionKeys.add(tourneeSourceKey(src.id));
             if (state.valueOrNull != null) {
               state = AsyncData(_compose(isSerene));
             }

--- a/apps/mobile/lib/features/flux_continu/providers/tournee_order_prefs_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/tournee_order_prefs_provider.dart
@@ -34,6 +34,15 @@ const _kTourneeCustomizedKey = 'tournee_customized_v1';
 /// Cap d'affichage de la Tournée du jour, partagé provider + composer.
 const int kTourneeVisibleCap = 10;
 
+/// Seuils de cohérence d'affichage des sections favorites (thème/source) après
+/// la dédup inter-sections. Une section **maigre** (≤ [kThinSectionMaxItems]
+/// survivants) est dépriorisée sous les **riches** (≥ [kRichSectionMinItems])
+/// quand au moins [kThinDemotionRichThreshold] sections riches existent — pour
+/// que le contenu dense remonte au-dessus du pli. Ajustables.
+const int kThinSectionMaxItems = 1; // ≤1 article après dédup = « maigre »
+const int kRichSectionMinItems = 2; // ≥2 articles = « riche »
+const int kThinDemotionRichThreshold = 5; // dépriorise si ≥5 sections riches
+
 /// Clé d'un thème favori dans l'ordre Tournée (= `sectionKey` d'une section thème).
 String tourneeThemeKey(String slug) => 'theme:$slug';
 

--- a/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
@@ -23,6 +23,7 @@ import '../../sources/widgets/source_logo_avatar.dart';
 import '../../tour/tour_anchors.dart';
 import '../../veille/providers/veille_active_config_provider.dart';
 import '../../veille/providers/veille_themes_provider.dart';
+import '../providers/flux_continu_provider.dart' show fluxContinuProvider;
 import '../providers/tournee_order_prefs_provider.dart' hide applyOrder;
 import '../providers/tournee_smart_arrangement_provider.dart';
 import '../utils/theme_color_mapping.dart';
@@ -462,6 +463,11 @@ class _ManageFavoritesContentState
     final tournee = ref.watch(tourneeOrderPrefsProvider);
     final tabOrder = ref.watch(tabOrderPrefsProvider);
     final isSerene = ref.watch(sereinToggleProvider).enabled;
+    // Cohérence Tournée — clés favorites maigres (peu d'articles aujourd'hui).
+    // Set vide si la Tournée n'est pas (encore) chargée → aucun indicateur
+    // (dégradation propre).
+    final thinKeys = ref.watch(fluxContinuProvider).valueOrNull?.thinFavoriteKeys ??
+        const <String>{};
 
     // ── Membership ────────────────────────────────────────────────────────
     final favoriteThemeSlugs = <String>[
@@ -716,6 +722,7 @@ class _ManageFavoritesContentState
                     colors: colors,
                     cap: kTourneeVisibleCap,
                     capLabel: 'Hors Tournée du jour ($kTourneeVisibleCap)',
+                    thinKeys: thinKeys,
                     // Destination du déplacement = Flâner ⇒ puces brun Flâner.
                     moveAccent: _kFlanerAccent,
                     onReorder: (oldIndex, newIndex) {
@@ -759,6 +766,9 @@ class _ManageFavoritesContentState
                     colors: colors,
                     cap: kMaxFavoriteTabs,
                     capLabel: 'Hors onglets ($kMaxFavoriteTabs)',
+                    // Les favoris Flâner ne sont pas dans la Tournée → aucune clé
+                    // ne matche, mais on garde le câblage uniforme.
+                    thinKeys: thinKeys,
                     // Destination du déplacement = Essentiel ⇒ puces ocre.
                     moveAccent: _kEssentielAccent,
                     onReorder: (oldIndex, newIndex) {
@@ -926,6 +936,9 @@ class _FavList extends StatelessWidget {
   final void Function(_FavItem item) onMove;
   final void Function(_FavItem item)? onSubjectVeille;
 
+  /// Clés favorites maigres (Tournée) → micro-indicateur « Peu d'articles ».
+  final Set<String> thinKeys;
+
   const _FavList({
     required this.items,
     required this.colors,
@@ -938,6 +951,7 @@ class _FavList extends StatelessWidget {
     required this.moveLabel,
     required this.moveAccent,
     required this.onMove,
+    this.thinKeys = const {},
     this.onSubjectVeille,
   });
 
@@ -967,6 +981,7 @@ class _FavList extends StatelessWidget {
               index: index,
               dimmed: dimmed,
               colors: colors,
+              thin: thinKeys.contains(item.key),
               moveIcon: moveIcon,
               moveTooltip: moveTooltip,
               moveLabel: moveLabel,
@@ -1030,6 +1045,10 @@ class _FavRow extends StatelessWidget {
   final int index;
   final bool dimmed;
   final FacteurColors colors;
+
+  /// Cohérence Tournée — ce favori a peu d'articles aujourd'hui (≤1 survivant
+  /// post-dédup) → micro-indicateur ambre près du libellé.
+  final bool thin;
   final IconData moveIcon;
   final String moveTooltip;
   final String moveLabel;
@@ -1049,6 +1068,7 @@ class _FavRow extends StatelessWidget {
     required this.moveAccent,
     required this.onRemove,
     required this.onMove,
+    this.thin = false,
     this.onSubjectVeille,
   });
 
@@ -1093,7 +1113,7 @@ class _FavRow extends StatelessWidget {
                             style: const TextStyle(fontSize: 16),
                           ),
                         const SizedBox(width: 10),
-                        Expanded(
+                        Flexible(
                           child: Text(
                             item.label,
                             style: TextStyle(
@@ -1105,6 +1125,11 @@ class _FavRow extends StatelessWidget {
                             overflow: TextOverflow.ellipsis,
                           ),
                         ),
+                        if (thin) ...[
+                          const SizedBox(width: 6),
+                          const _ThinBadge(),
+                        ],
+                        const Spacer(),
                       ],
                     ),
                   ),
@@ -1159,6 +1184,52 @@ class _FavRow extends StatelessWidget {
               ),
             ],
           ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Micro-indicateur « Peu d'articles » d'un favori maigre (≤1 survivant
+/// post-dédup ce jour). Pilule ambre discrète réutilisant le style des badges
+/// existants (cf. `_SuggestedBadge`/`_MoveChip`). Signale dans la modal les
+/// favoris peu fournis — surtout visibles dans la zone « Hors Tournée du jour ».
+class _ThinBadge extends StatelessWidget {
+  const _ThinBadge();
+
+  // Ambre : aligné sur les tons d'avertissement doux de l'app.
+  static const Color _amber = Color(0xFFB45309);
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: 'Peu d\'articles aujourd\'hui',
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(7, 3, 8, 3),
+        decoration: BoxDecoration(
+          color: _amber.withValues(alpha: 0.10),
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(color: _amber.withValues(alpha: 0.30), width: 0.8),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              PhosphorIcons.warningCircle(PhosphorIconsStyle.fill),
+              size: 11,
+              color: _amber,
+            ),
+            const SizedBox(width: 4),
+            const Text(
+              'Peu d\'articles',
+              style: TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                letterSpacing: 0.1,
+                color: _amber,
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -235,7 +235,11 @@ class SectionBlock extends StatelessWidget {
                 onLongPressConversion: onLongPressConversion,
               ),
         ];
-      case FeedThemeSection(:final items, :final coreVisibleCount):
+      case FeedThemeSection(
+          :final items,
+          :final coreVisibleCount,
+          :final underfilled,
+        ):
         // Story 23.4 — la section veille reste visible même vide : on rend un
         // placeholder + CTA réglages au lieu de cartes.
         if (items.isEmpty && section.kind == SectionKind.veille) {
@@ -337,6 +341,15 @@ class SectionBlock extends StatelessWidget {
                 onSwipeConversion: onSwipeConversion,
                 onLongPressConversion: onLongPressConversion,
               ),
+          // Cohérence Tournée — un thème **maigre affiché** (≤1 survivant après
+          // dédup, enrichi par réinjection) porte en pied un CTA pour étoffer la
+          // section. Distinct de l'empty-state (items vides) au-dessus.
+          if (section.kind == SectionKind.theme && underfilled)
+            _FavoriteEmptyState(
+              ctaIcon: Icons.add_rounded,
+              ctaLabel: 'Ajouter plus de sources',
+              onCta: onAddSources,
+            ),
         ];
     }
   }
@@ -397,12 +410,15 @@ class _VeilleEmptyState extends StatelessWidget {
 /// sections source (« Voir toute la curation ») et thème (« Ajouter des
 /// sources » → « Composer ma Tournée »).
 class _FavoriteEmptyState extends StatelessWidget {
-  final String message;
+  /// Message d'accroche. `null` ⇒ variante **CTA seul** (pied d'une section
+  /// maigre déjà remplie : pas de message, juste le bouton « Ajouter plus de
+  /// sources »).
+  final String? message;
   final IconData ctaIcon;
   final String ctaLabel;
   final VoidCallback? onCta;
   const _FavoriteEmptyState({
-    required this.message,
+    this.message,
     required this.ctaIcon,
     required this.ctaLabel,
     this.onCta,
@@ -412,7 +428,7 @@ class _FavoriteEmptyState extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       margin: const EdgeInsets.fromLTRB(12, 0, 12, 4),
-      padding: const EdgeInsets.fromLTRB(16, 18, 16, 14),
+      padding: EdgeInsets.fromLTRB(16, message == null ? 10 : 18, 16, 10),
       decoration: BoxDecoration(
         color: Colors.white.withValues(alpha: 0.5),
         borderRadius: BorderRadius.circular(12),
@@ -421,16 +437,17 @@ class _FavoriteEmptyState extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            message,
-            style: const TextStyle(
-              fontSize: 14,
-              height: 1.4,
-              color: Color(0xFF5D5B5A),
+          if (message != null)
+            Text(
+              message!,
+              style: const TextStyle(
+                fontSize: 14,
+                height: 1.4,
+                color: Color(0xFF5D5B5A),
+              ),
             ),
-          ),
           if (onCta != null) ...[
-            const SizedBox(height: 8),
+            if (message != null) const SizedBox(height: 8),
             Align(
               alignment: Alignment.centerLeft,
               child: TextButton.icon(

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_sources_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_sources_test.dart
@@ -3,8 +3,6 @@
 // (après les thèmes), dédup inter-sections, et état vide « toujours visible ».
 import 'dart:io';
 
-import 'package:facteur/features/digest/models/digest_models.dart';
-import 'package:facteur/features/digest/models/dual_digest_response.dart';
 import 'package:facteur/features/digest/providers/digest_provider.dart';
 import 'package:facteur/features/digest/providers/serein_toggle_provider.dart';
 import 'package:facteur/features/digest/repositories/digest_repository.dart';
@@ -13,6 +11,8 @@ import 'package:facteur/features/feed/providers/feed_provider.dart';
 import 'package:facteur/features/feed/repositories/feed_repository.dart';
 import 'package:facteur/features/flux_continu/models/flux_continu_models.dart';
 import 'package:facteur/features/flux_continu/providers/flux_continu_provider.dart';
+import 'package:facteur/features/flux_continu/providers/tournee_order_prefs_provider.dart'
+    show kTourneeVisibleCap, kRichSectionMinItems;
 import 'package:facteur/features/settings/models/display_mode_spec.dart';
 import 'package:facteur/features/settings/providers/display_mode_provider.dart';
 import 'package:facteur/features/flux_continu/repositories/essentiel_repository.dart';
@@ -264,8 +264,11 @@ void main() {
       themeIds: {
         'tech': ['shared', 't2']
       },
+      // src1 garde 2 survivants uniques (a2/a3) après dédup ⇒ section **riche**,
+      // donc pas de réinjection (backfill) qui repiocherait l'article partagé :
+      // on teste ici la seule règle de dédup (le thème au-dessus gagne).
       sourceIds: {
-        'src1': ['shared', 'a2']
+        'src1': ['shared', 'a2', 'a3']
       },
     );
     final container = await buildContainer(
@@ -286,7 +289,7 @@ void main() {
     expect(theme.items.map((c) => c.id), contains('shared'));
     expect(source.items.map((c) => c.id), isNot(contains('shared')),
         reason: 'le thème au-dessus gagne l\'article partagé');
-    expect(source.items.map((c) => c.id), ['a2']);
+    expect(source.items.map((c) => c.id), ['a2', 'a3']);
   });
 
   test(
@@ -387,5 +390,220 @@ void main() {
 
     // Triées par position (a..k) puis capées à 10 → a,b,c,d,e,f,g,h,i,j.
     expect(sources, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
+  });
+
+  // ── Cohérence Tournée : dépriorisation / enrichissement des maigres ────────
+  group('cohérence Tournée (maigre/riche)', () {
+    test(
+        'classification : un favori à 1 survivant ∈ thinFavoriteKeys ; '
+        'à ≥2 absent', () async {
+      stubFeed(
+        themeIds: {
+          'tech': ['t1', 't2'] // riche (2)
+        },
+        sourceIds: {
+          'src1': ['b1'] // maigre (1)
+        },
+      );
+      final container = await buildContainer(
+        interests: _interestsState(favorites: [ThemeFavoriteRef(slug: 'tech')]),
+        sourcesState: _sourcesState(
+          favorites: [SourceFavoriteRef(sourceId: 'src1', position: 0)],
+        ),
+        catalog: [_source('src1', theme: 'society')],
+        tourneeOrder: const ['theme:tech', 'source:src1'],
+      );
+      addTearDown(container.dispose);
+
+      final state = await settle(container);
+      expect(state.thinFavoriteKeys, contains('source:src1'));
+      expect(state.thinFavoriteKeys, isNot(contains('theme:tech')));
+
+      // La section riche n'est jamais marquée underfilled.
+      final theme = feedSections(container)
+          .firstWhere((s) => s.kind == SectionKind.theme);
+      expect(theme.underfilled, isFalse);
+    });
+
+    test(
+        'dépriorisation : 5 riches + 1 maigre → le maigre passe après les '
+        'riches (gate ≥5)', () async {
+      stubFeed(
+        themeIds: {
+          'tech': ['tc1', 'tc2'],
+          'science': ['sc1', 'sc2'],
+          'culture': ['cu1'], // maigre
+          'economy': ['ec1', 'ec2'],
+          'politics': ['po1', 'po2'],
+          'environment': ['en1', 'en2'],
+        },
+        sourceIds: const {},
+      );
+      final container = await buildContainer(
+        interests: _interestsState(
+          favorites: const [
+            ThemeFavoriteRef(slug: 'tech'),
+            ThemeFavoriteRef(slug: 'science'),
+            ThemeFavoriteRef(slug: 'culture'),
+            ThemeFavoriteRef(slug: 'economy'),
+            ThemeFavoriteRef(slug: 'politics'),
+            ThemeFavoriteRef(slug: 'environment'),
+          ],
+        ),
+        sourcesState: _sourcesState(),
+        catalog: const [],
+      );
+      addTearDown(container.dispose);
+
+      await settle(container);
+      final order = feedSections(container)
+          .where((s) => s.kind == SectionKind.theme)
+          .map((s) => s.themeSlug)
+          .toList();
+      // 5 riches d'abord (ordre relatif préservé), le maigre 'culture' en fin.
+      expect(order, [
+        'tech',
+        'science',
+        'economy',
+        'politics',
+        'environment',
+        'culture',
+      ]);
+    });
+
+    test('gate ≥5 : 4 riches + 1 maigre → ordre inchangé', () async {
+      stubFeed(
+        themeIds: {
+          'tech': ['tc1', 'tc2'],
+          'science': ['sc1', 'sc2'],
+          'culture': ['cu1'], // maigre, en 3ᵉ position
+          'economy': ['ec1', 'ec2'],
+          'politics': ['po1', 'po2'],
+        },
+        sourceIds: const {},
+      );
+      final container = await buildContainer(
+        interests: _interestsState(
+          favorites: const [
+            ThemeFavoriteRef(slug: 'tech'),
+            ThemeFavoriteRef(slug: 'science'),
+            ThemeFavoriteRef(slug: 'culture'),
+            ThemeFavoriteRef(slug: 'economy'),
+            ThemeFavoriteRef(slug: 'politics'),
+          ],
+        ),
+        sourcesState: _sourcesState(),
+        catalog: const [],
+      );
+      addTearDown(container.dispose);
+
+      await settle(container);
+      final order = feedSections(container)
+          .where((s) => s.kind == SectionKind.theme)
+          .map((s) => s.themeSlug)
+          .toList();
+      // 4 riches < seuil ⇒ pas de dépriorisation : 'culture' reste en place.
+      expect(order, ['tech', 'science', 'culture', 'economy', 'politics']);
+    });
+
+    test(
+        'cap : >10 favoris dont un maigre → le maigre est coupé des sections '
+        'mais présent dans thinFavoriteKeys', () async {
+      stubFeed(
+        themeIds: {
+          'tech': ['tc1', 'tc2'],
+          'science': ['sc1', 'sc2'],
+          'economy': ['ec1', 'ec2'],
+          'politics': ['po1', 'po2'],
+          'environment': ['en1', 'en2'],
+          'culture': ['cu1'], // maigre → dépriorisé en fin → coupé par le cap
+        },
+        sourceIds: {
+          'a': ['a1', 'a2'],
+          'b': ['b1', 'b2'],
+          'c': ['c1', 'c2'],
+          'd': ['d1', 'd2'],
+          'e': ['e1', 'e2'],
+        },
+      );
+      final container = await buildContainer(
+        interests: _interestsState(
+          favorites: const [
+            ThemeFavoriteRef(slug: 'tech'),
+            ThemeFavoriteRef(slug: 'science'),
+            ThemeFavoriteRef(slug: 'economy'),
+            ThemeFavoriteRef(slug: 'politics'),
+            ThemeFavoriteRef(slug: 'environment'),
+            ThemeFavoriteRef(slug: 'culture'),
+          ],
+        ),
+        sourcesState: _sourcesState(
+          favorites: const [
+            SourceFavoriteRef(sourceId: 'a', position: 0),
+            SourceFavoriteRef(sourceId: 'b', position: 1),
+            SourceFavoriteRef(sourceId: 'c', position: 2),
+            SourceFavoriteRef(sourceId: 'd', position: 3),
+            SourceFavoriteRef(sourceId: 'e', position: 4),
+          ],
+        ),
+        catalog: [
+          _source('a'),
+          _source('b'),
+          _source('c'),
+          _source('d'),
+          _source('e'),
+        ],
+        tourneeOrder: const [
+          'source:a',
+          'source:b',
+          'source:c',
+          'source:d',
+          'source:e',
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final state = await settle(container);
+      final slugs = feedSections(container)
+          .where((s) => s.kind == SectionKind.theme)
+          .map((s) => s.themeSlug)
+          .toList();
+      // 11 favoris (5 sources + 6 thèmes), cap 10 ⇒ le maigre 'culture'
+      // (dépriorisé en dernier) est coupé, mais reste signalé pour la modal.
+      expect(state.sections.length, kTourneeVisibleCap);
+      expect(slugs, isNot(contains('culture')));
+      expect(state.thinFavoriteKeys, contains('theme:culture'));
+    });
+
+    test(
+        'backfill : une source maigre affichée est réinjectée jusqu\'à 2 items '
+        '+ underfilled (doublons inter-sections tolérés)', () async {
+      stubFeed(
+        themeIds: {
+          'tech': ['s1', 's2'] // riche, gagne s1/s2
+        },
+        sourceIds: {
+          'src1': ['s1', 's2'] // tout partagé → 0 survivant → maigre
+        },
+      );
+      final container = await buildContainer(
+        interests: _interestsState(favorites: [ThemeFavoriteRef(slug: 'tech')]),
+        sourcesState: _sourcesState(
+          favorites: [SourceFavoriteRef(sourceId: 'src1', position: 0)],
+        ),
+        catalog: [_source('src1', theme: 'society')],
+        tourneeOrder: const ['theme:tech', 'source:src1'],
+      );
+      addTearDown(container.dispose);
+
+      final state = await settle(container);
+      final source = feedSections(container)
+          .firstWhere((s) => s.kind == SectionKind.source);
+      // Réinjection bornée à kRichSectionMinItems (2), depuis les retirés.
+      expect(source.items.length, kRichSectionMinItems);
+      expect(source.items.map((c) => c.id), containsAll(['s1', 's2']));
+      expect(source.underfilled, isTrue);
+      expect(state.thinFavoriteKeys, contains('source:src1'));
+    });
   });
 }


### PR DESCRIPTION
## Quoi

Cohérence d'affichage de la **Tournée du jour** après la dédup inter-sections, suite au fix « Tournée fiable » (seed coquilles + retry) du commit précédent :

- **Classification maigre/riche** des sections favorites (maigre = ≤1 article post-dédup, riche = ≥2), calculée sur l'ordre par défaut **non cappé**. N'inspecte que les sections au fetch **résolu** (`_resolvedSectionKeys`) → aucune coquille de boot classée maigre par erreur.
- **Dépriorisation stable** : les favoris maigres passent sous les riches dans l'ordre par défaut quand ≥5 sections riches existent. Le contenu dense remonte au-dessus du pli. L'ordre personnalisé reste respecté tel quel.
- **Backfill** des thèmes maigres affichés : réinjection d'articles strippés par la dédup (doublons inter-sections assumés, décision PO) + CTA « Ajouter plus de sources ».
- **Modal « Mes favoris »** : micro-indicateur ambre « Peu d'articles » sur les favoris maigres.

## Pourquoi

Après le fix de fiabilité, des sections favorites pouvaient rester maigres (1 carte) ou pousser du contenu dense sous le pli. Cette PR remonte le contenu dense, complète les thèmes maigres, et signale dans la modal les favoris peu fournis.

## Comment ça a été vérifié

- [x] `flutter test test/features/flux_continu` — 283 tests OK
- [x] `flutter analyze lib/features/flux_continu` — 0 issue (lib)
- [x] Imports inutilisés retirés du test touché
- [x] `/simplify` passé (4 agents reuse/simplification/efficiency/altitude — code jugé propre)

## Zones à risque

- `flux_continu_provider._compose` (chemin chaud, rejoué à chaque recompose) — double passe d'ordering/dédup assumée (coût négligeable, validé par la revue efficiency).
- Ordering Tournée (`_orderedTourneeKeys`) : nouveau param `cap` nullable + partition de dépriorisation, n'affecte que l'ordre par défaut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
