### PR TITLE
feat(essentiel): Tournée vise ~8 sections + mode serein recharge fiable

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Tournée",
+      "summary": "Ta Tournée du jour propose plus de sujets, choisis pour toi par le Facteur."
+    },
+    {
       "tag": "Lecture",
       "summary": "Carrousels plus nets : le bas des cartes ne se coupe plus quand leurs tailles diffèrent, et les points de défilement respirent mieux."
     },

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -388,7 +388,10 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
         fallback: const <TopTheme>[],
       ),
       _safe<List<EssentielArticle>>(
-        () async => (await _essentielRepo.fetch()) ?? const [],
+        // Passe le mode explicitement : `isSerene` est posé en synchrone avant
+        // l'`invalidateSelf` du listener serein, donc à jour ici — pas de
+        // dépendance à la persistance DB de la préférence au moment du refetch.
+        () async => (await _essentielRepo.fetch(serein: isSerene)) ?? const [],
         'fetchEssentiel',
         fallback: const <EssentielArticle>[],
       ),

--- a/apps/mobile/lib/features/flux_continu/providers/tournee_order_prefs_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/tournee_order_prefs_provider.dart
@@ -32,7 +32,12 @@ const _kLegacyVeilleHiddenKey = 'tournee_veille_hidden_v1';
 const _kTourneeCustomizedKey = 'tournee_customized_v1';
 
 /// Cap d'affichage de la Tournée du jour, partagé provider + composer.
-const int kTourneeVisibleCap = 10;
+///
+/// Couvre favoris + suggestions « Choisie pour vous » + cartes éditoriales
+/// (Actus, Bonnes, Grille) — pas la carte hi-fi Essentiel du haut, rendue à
+/// part. Dimensionné pour la cible backend de ~8 sections thématiques :
+/// 8 thématiques + Actus + Bonnes + Grille = 11, + marge.
+const int kTourneeVisibleCap = 13;
 
 /// Seuils de cohérence d'affichage des sections favorites (thème/source) après
 /// la dédup inter-sections. Une section **maigre** (≤ [kThinSectionMaxItems]

--- a/apps/mobile/lib/features/flux_continu/repositories/essentiel_repository.dart
+++ b/apps/mobile/lib/features/flux_continu/repositories/essentiel_repository.dart
@@ -21,9 +21,16 @@ class EssentielRepository {
   /// Renvoie la liste des articles de l'Essentiel, ou `null` si l'endpoint
   /// n'a rien servi (202 ou erreur réseau). Le provider décide alors s'il
   /// veut fallback ou afficher une section vide.
-  Future<List<EssentielArticle>?> fetch() async {
+  ///
+  /// [serein] force le mode côté backend (`?serein=`) au lieu de dépendre de la
+  /// persistance DB de la préférence : évite la race au toggle (refetch avant
+  /// que la préférence soit écrite). Absent ⇒ le backend lit la préférence DB.
+  Future<List<EssentielArticle>?> fetch({bool? serein}) async {
     try {
-      final response = await _apiClient.dio.get<dynamic>('essentiel');
+      final response = await _apiClient.dio.get<dynamic>(
+        'essentiel',
+        queryParameters: {if (serein != null) 'serein': serein},
+      );
       if (response.statusCode == 202) {
         return null;
       }

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_progressive_fanout_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_progressive_fanout_test.dart
@@ -46,7 +46,7 @@ class _MockFluxContinuRepository extends Mock
 
 class _StubEssentielRepository implements EssentielRepository {
   @override
-  Future<List<EssentielArticle>?> fetch() async => const [];
+  Future<List<EssentielArticle>?> fetch({bool? serein}) async => const [];
 }
 
 class _NoGrilleRepository implements GrilleRepository {

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
@@ -39,7 +39,7 @@ class _MockFluxContinuRepository extends Mock
 
 class _StubEssentielRepository implements EssentielRepository {
   @override
-  Future<List<EssentielArticle>?> fetch() async => const [];
+  Future<List<EssentielArticle>?> fetch({bool? serein}) async => const [];
 }
 
 class _NoGrilleRepository implements GrilleRepository {
@@ -1473,7 +1473,7 @@ class _OneArticleEssentielRepository implements EssentielRepository {
   final EssentielArticle _article;
 
   @override
-  Future<List<EssentielArticle>?> fetch() async => [
+  Future<List<EssentielArticle>?> fetch({bool? serein}) async => [
         _article,
         EssentielArticle(
           contentId: '${_article.contentId}-filler-1',
@@ -1504,5 +1504,5 @@ class _FixedEssentielRepository implements EssentielRepository {
   final List<EssentielArticle> _articles;
 
   @override
-  Future<List<EssentielArticle>?> fetch() async => _articles;
+  Future<List<EssentielArticle>?> fetch({bool? serein}) async => _articles;
 }

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_sources_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_sources_test.dart
@@ -40,7 +40,7 @@ class _MockFluxContinuRepository extends Mock
 
 class _StubEssentielRepository implements EssentielRepository {
   @override
-  Future<List<EssentielArticle>?> fetch() async => const [];
+  Future<List<EssentielArticle>?> fetch({bool? serein}) async => const [];
 }
 
 class _StubUserInterestsNotifier extends UserInterestsNotifier {
@@ -321,7 +321,7 @@ void main() {
 
   test(
       'plusieurs sources favorites respectent l\'ordre par position et le '
-      'cap (parité thèmes = 10)', () async {
+      'cap (parité thèmes = 13)', () async {
     stubFeed(
       themeIds: const {},
       sourceIds: {
@@ -336,6 +336,9 @@ void main() {
         'i': ['i1', 'i2'],
         'j': ['j1', 'j2'],
         'k': ['k1', 'k2'],
+        'l': ['l1', 'l2'],
+        'm': ['m1', 'm2'],
+        'n': ['n1', 'n2'],
       },
     );
     final container = await buildContainer(
@@ -352,6 +355,9 @@ void main() {
         SourceFavoriteRef(sourceId: 'j', position: 9),
         SourceFavoriteRef(sourceId: 'i', position: 8),
         SourceFavoriteRef(sourceId: 'k', position: 10),
+        SourceFavoriteRef(sourceId: 'l', position: 11),
+        SourceFavoriteRef(sourceId: 'm', position: 12),
+        SourceFavoriteRef(sourceId: 'n', position: 13),
       ]),
       catalog: [
         _source('a'),
@@ -365,6 +371,9 @@ void main() {
         _source('i'),
         _source('j'),
         _source('k'),
+        _source('l'),
+        _source('m'),
+        _source('n'),
       ],
       tourneeOrder: const [
         'source:a',
@@ -378,6 +387,9 @@ void main() {
         'source:i',
         'source:j',
         'source:k',
+        'source:l',
+        'source:m',
+        'source:n',
       ],
     );
     addTearDown(container.dispose);
@@ -388,8 +400,11 @@ void main() {
         .map((s) => s.sourceId)
         .toList();
 
-    // Triées par position (a..k) puis capées à 10 → a,b,c,d,e,f,g,h,i,j.
-    expect(sources, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
+    // Triées par position (a..n) puis capées à 13 → a..m.
+    expect(
+      sources,
+      ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'],
+    );
   });
 
   // ── Cohérence Tournée : dépriorisation / enrichissement des maigres ────────
@@ -507,7 +522,7 @@ void main() {
     });
 
     test(
-        'cap : >10 favoris dont un maigre → le maigre est coupé des sections '
+        'cap : >13 favoris dont un maigre → le maigre est coupé des sections '
         'mais présent dans thinFavoriteKeys', () async {
       stubFeed(
         themeIds: {
@@ -524,6 +539,9 @@ void main() {
           'c': ['c1', 'c2'],
           'd': ['d1', 'd2'],
           'e': ['e1', 'e2'],
+          'f': ['f1', 'f2'],
+          'g': ['g1', 'g2'],
+          'h': ['h1', 'h2'],
         },
       );
       final container = await buildContainer(
@@ -544,6 +562,9 @@ void main() {
             SourceFavoriteRef(sourceId: 'c', position: 2),
             SourceFavoriteRef(sourceId: 'd', position: 3),
             SourceFavoriteRef(sourceId: 'e', position: 4),
+            SourceFavoriteRef(sourceId: 'f', position: 5),
+            SourceFavoriteRef(sourceId: 'g', position: 6),
+            SourceFavoriteRef(sourceId: 'h', position: 7),
           ],
         ),
         catalog: [
@@ -552,6 +573,9 @@ void main() {
           _source('c'),
           _source('d'),
           _source('e'),
+          _source('f'),
+          _source('g'),
+          _source('h'),
         ],
         tourneeOrder: const [
           'source:a',
@@ -559,6 +583,9 @@ void main() {
           'source:c',
           'source:d',
           'source:e',
+          'source:f',
+          'source:g',
+          'source:h',
         ],
       );
       addTearDown(container.dispose);
@@ -568,7 +595,7 @@ void main() {
           .where((s) => s.kind == SectionKind.theme)
           .map((s) => s.themeSlug)
           .toList();
-      // 11 favoris (5 sources + 6 thèmes), cap 10 ⇒ le maigre 'culture'
+      // 14 favoris (8 sources + 6 thèmes), cap 13 ⇒ le maigre 'culture'
       // (dépriorisé en dernier) est coupé, mais reste signalé pour la modal.
       expect(state.sections.length, kTourneeVisibleCap);
       expect(slugs, isNot(contains('culture')));

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_tournee_order_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_tournee_order_test.dart
@@ -1,6 +1,6 @@
 // PR 2 — couverture du bloc favori UNIFIÉ de la Tournée composé par le
 // FluxContinuNotifier : ordre 100 % libre (thèmes + sources + veille mélangés
-// via « Composer ma Tournée »), cap d'affichage 10, exclusion des sujets perso,
+// via « Composer ma Tournée »), cap d'affichage 13, exclusion des sujets perso,
 // et masquage de la veille (veilleHidden).
 import 'dart:io';
 
@@ -49,7 +49,7 @@ class _MockFluxContinuRepository extends Mock
 
 class _StubEssentielRepository implements EssentielRepository {
   @override
-  Future<List<EssentielArticle>?> fetch() async => const [];
+  Future<List<EssentielArticle>?> fetch({bool? serein}) async => const [];
 }
 
 class _StubUserInterestsNotifier extends UserInterestsNotifier {
@@ -393,7 +393,8 @@ void main() {
       },
     );
 
-    test('cap 10 unifié : 8 thèmes + Actus + Grille coupent Bonnes', () async {
+    test('cap 13 : 8 thèmes + Actus + Grille + Bonnes tiennent (rien coupé)',
+        () async {
       stubDigest();
       stubFeed(
         themeIds: {
@@ -428,6 +429,7 @@ void main() {
 
       final state = await settle(container);
 
+      // 8 thèmes + Actus + Grille + Bonnes = 11 items ≤ cap 13 → tout tient.
       expect(state.sections.map(sectionKey).toList(), [
         'theme:society',
         'theme:culture',
@@ -438,13 +440,14 @@ void main() {
         'theme:environment',
         'theme:international',
         kTourneeActusKey,
+        kTourneeBonnesKey,
       ]);
       expect(state.grilleSlotIndex, 9);
       expect(
         state.sections.map(sectionKey),
-        isNot(contains(kTourneeBonnesKey)),
-        reason: 'Bonnes est 11e dans la liste unifiée (8 thèmes+Actus+Grille) '
-            'et tombe sous le cap de 10',
+        contains(kTourneeBonnesKey),
+        reason: '8 thèmes + Actus + Grille + Bonnes = 11 items tiennent sous le '
+            'cap de 13 (Bonnes n\'est plus coupée)',
       );
     });
 
@@ -578,8 +581,8 @@ void main() {
   });
 
   test(
-      'cap d\'affichage 10 : 7 thèmes + 3 sources + veille (11 candidats) → '
-      'seulement 10 sections, veille (en queue par défaut) coupée', () async {
+      'cap d\'affichage 13 : 7 thèmes + 6 sources + veille (14 candidats) → '
+      'seulement 13 sections, veille (en queue par défaut) coupée', () async {
     // Story 10.2 — les sources doivent être en mode « Essentiel » (clé dans
     // l'ordre) pour entrer dans la Tournée ; on garde l'ordre par défaut
     // (thèmes avant sources) en plaçant les clés thème d'abord.
@@ -595,6 +598,9 @@ void main() {
         'source:a',
         'source:b',
         'source:c',
+        'source:d',
+        'source:e',
+        'source:f',
       ],
     });
     stubFeed(
@@ -611,6 +617,9 @@ void main() {
         'a': ['a1'],
         'b': ['b1'],
         'c': ['c9'],
+        'd': ['d1'],
+        'e': ['e9'],
+        'f': ['f1'],
       },
     );
     final container = await buildContainer(
@@ -630,9 +639,19 @@ void main() {
           SourceFavoriteRef(sourceId: 'a', position: 0),
           SourceFavoriteRef(sourceId: 'b', position: 1),
           SourceFavoriteRef(sourceId: 'c', position: 2),
+          SourceFavoriteRef(sourceId: 'd', position: 3),
+          SourceFavoriteRef(sourceId: 'e', position: 4),
+          SourceFavoriteRef(sourceId: 'f', position: 5),
         ],
       ),
-      catalog: [source('a'), source('b'), source('c')],
+      catalog: [
+        source('a'),
+        source('b'),
+        source('c'),
+        source('d'),
+        source('e'),
+        source('f'),
+      ],
       veilleCfg: _veilleCfg(),
     );
     addTearDown(container.dispose);
@@ -642,15 +661,15 @@ void main() {
 
     expect(
       sections,
-      hasLength(10),
-      reason: 'cap d\'affichage de la Tournée = 10',
+      hasLength(13),
+      reason: 'cap d\'affichage de la Tournée = 13',
     );
     expect(
       sections.where((s) => s.kind == SectionKind.veille),
       isEmpty,
-      reason: 'ordre par défaut thèmes→sources→veille → veille en 11e, coupée',
+      reason: 'ordre par défaut thèmes→sources→veille → veille en 14e, coupée',
     );
-    // Ordre par défaut : 7 thèmes puis 3 sources (a, b, c) ; veille tombe.
+    // Ordre par défaut : 7 thèmes puis 6 sources (a..f) ; veille tombe.
     expect(sections.map((s) => s.kind).toList(), [
       SectionKind.theme,
       SectionKind.theme,
@@ -662,12 +681,15 @@ void main() {
       SectionKind.source,
       SectionKind.source,
       SectionKind.source,
+      SectionKind.source,
+      SectionKind.source,
+      SectionKind.source,
     ]);
     expect(
       sections
           .where((s) => s.kind == SectionKind.source)
           .map((s) => s.sourceId),
-      ['a', 'b', 'c'],
+      ['a', 'b', 'c', 'd', 'e', 'f'],
     );
   });
 
@@ -712,7 +734,7 @@ void main() {
     'veille en tête d\'ordre : présente dans le cap, un autre item tombe',
     () async {
       // Story 10.2 — sources en mode « Essentiel » (clés dans l'ordre) ; veille
-      // remontée en tête. 11 candidats → cap 10, veille première (source c tombe).
+      // remontée en tête. 14 candidats → cap 13, veille première (source f tombe).
       SharedPreferences.setMockInitialValues(<String, Object>{
         'tournee_order_v1': [
           'veille',
@@ -726,6 +748,9 @@ void main() {
           'source:a',
           'source:b',
           'source:c',
+          'source:d',
+          'source:e',
+          'source:f',
         ],
       });
       stubFeed(
@@ -742,6 +767,9 @@ void main() {
           'a': ['a1'],
           'b': ['b1'],
           'c': ['c9'],
+          'd': ['d1'],
+          'e': ['e9'],
+          'f': ['f1'],
         },
       );
       final container = await buildContainer(
@@ -761,9 +789,19 @@ void main() {
             SourceFavoriteRef(sourceId: 'a', position: 0),
             SourceFavoriteRef(sourceId: 'b', position: 1),
             SourceFavoriteRef(sourceId: 'c', position: 2),
+            SourceFavoriteRef(sourceId: 'd', position: 3),
+            SourceFavoriteRef(sourceId: 'e', position: 4),
+            SourceFavoriteRef(sourceId: 'f', position: 5),
           ],
         ),
-        catalog: [source('a'), source('b'), source('c')],
+        catalog: [
+          source('a'),
+          source('b'),
+          source('c'),
+          source('d'),
+          source('e'),
+          source('f'),
+        ],
         veilleCfg: _veilleCfg(),
       );
       addTearDown(container.dispose);
@@ -771,7 +809,7 @@ void main() {
       await settle(container);
       final sections = favoriteSections(container);
 
-      expect(sections, hasLength(10));
+      expect(sections, hasLength(13));
       expect(
         sections.first.kind,
         SectionKind.veille,

--- a/apps/mobile/test/features/flux_continu/widgets/manage_favorites_sheet_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/manage_favorites_sheet_test.dart
@@ -1,7 +1,7 @@
 // Story 10.2 — sheet unifiée « Mes favoris » : deux sections (Essentiel /
 // Flâner), appartenance exclusive des sources (la clé `source:` dans
 // `tournee_order_v1` ⇒ Essentiel, sinon Flâner), déplacement de mode, funnel
-// veille sur les sujets, et caps 10/10 par section.
+// veille sur les sujets, et caps 13/10 (Essentiel/Flâner) par section.
 import 'package:facteur/config/routes.dart';
 import 'package:facteur/config/theme.dart';
 import 'package:facteur/features/digest/providers/serein_toggle_provider.dart';
@@ -352,9 +352,14 @@ void main() {
   });
 
   testWidgets(
-      '« Hors Tournée du jour (10) » apparaît au-delà de 10 sections Essentiel',
+      '« Hors Tournée du jour (13) » apparaît au-delà de 13 sections Essentiel',
       (tester) async {
-    // 9 thèmes favoris + Actus + Bonnes = 11 blocs Essentiel → au-delà du cap 10.
+    // 9 thèmes + 3 sources + Actus + Bonnes = 14 blocs Essentiel → au-delà du
+    // cap 13. Les sources sont en mode Essentiel via leur clé `source:` dans
+    // `tournee_order_v1`.
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      'tournee_order_v1': ['source:s1', 'source:s2', 'source:s3'],
+    });
     await _openSheet(
       tester,
       interests: _interests(favorites: const [
@@ -368,13 +373,22 @@ void main() {
         ThemeFavoriteRef(slug: 'culture'),
         ThemeFavoriteRef(slug: 'sport'),
       ]),
-      sources: _sources(),
+      sources: _sources(favorites: const [
+        SourceFavoriteRef(sourceId: 's1', position: 0),
+        SourceFavoriteRef(sourceId: 's2', position: 1),
+        SourceFavoriteRef(sourceId: 's3', position: 2),
+      ]),
+      catalog: [
+        _source('s1', 'Le Monde'),
+        _source('s2', 'Mediapart'),
+        _source('s3', 'Le Figaro'),
+      ],
     );
 
-    // Le cap (élargi → 10) est explicité entre parenthèses.
-    expect(find.text('Hors Tournée du jour (10)'), findsOneWidget);
+    // Le cap (élargi → 13) est explicité entre parenthèses.
+    expect(find.text('Hors Tournée du jour (13)'), findsOneWidget);
     // Le compteur de l'en-tête reflète aussi le cap.
-    expect(find.text('· 10/10'), findsOneWidget);
+    expect(find.text('· 13/13'), findsOneWidget);
   });
 
   testWidgets(

--- a/packages/api/app/routers/essentiel.py
+++ b/packages/api/app/routers/essentiel.py
@@ -47,6 +47,14 @@ async def get_essentiel(
     target_date: date | None = Query(
         None, description="Date for essentiel (default: today)"
     ),
+    serein: bool | None = Query(
+        None,
+        description=(
+            "Force le mode serein (true/false). Absent ⇒ lecture de la "
+            "préférence DB. Permet au client de demander le bon mode sans "
+            "dépendre de la persistance de la préférence au moment du refetch."
+        ),
+    ),
     db: AsyncSession = Depends(get_db),
     current_user_id: str = Depends(get_current_user_id),
 ):
@@ -62,7 +70,13 @@ async def get_essentiel(
     start = time.monotonic()
 
     service = DigestService(db)
-    serein_enabled = await service.get_user_serein_enabled(user_uuid)
+    # Override explicite par le client (symétrie avec `?serein=` du feed) ;
+    # fallback DB conservé pour rétrocompat des clients qui ne l'envoient pas.
+    serein_enabled = (
+        serein
+        if serein is not None
+        else await service.get_user_serein_enabled(user_uuid)
+    )
     digest = await read_digest_or_fallback(
         db, user_uuid, effective_date, is_serene=serein_enabled
     )

--- a/packages/api/app/routers/users.py
+++ b/packages/api/app/routers/users.py
@@ -504,24 +504,25 @@ async def _arrange_tournee(
     user_uuid: UUID,
     validated: list[TopThemeResponse],
 ) -> list[TopThemeResponse]:
-    """Affecte les `daily_rank` aux validées et complète les slots restants par
-    des sections « Choisie pour vous » (Story 22.3).
+    """Affecte les `daily_rank` aux validées et **complète** jusqu'à la cible
+    `TOURNEE_TARGET_SECTIONS` par des sections « Choisie pour vous » (Story 22.3).
 
     Les validées gardent leur ordre d'entrée (jamais réordonnées/masquées ici) ;
-    les suggérées remplissent `min(SUBCAP, slots restants)` derrière elles, déjà
-    triées best-first pour aujourd'hui par `TourneeSuggester`. No-op si le toggle
-    est off, s'il ne reste aucun slot, ou si le pool est vide (jour pauvre).
+    les suggérées **s'ajoutent** derrière elles jusqu'à atteindre la cible
+    (additif, pas un reliquat du plafond favoris), déjà triées best-first pour
+    aujourd'hui par `TourneeSuggester`. Un compte à 7 favoris reçoit donc 1
+    suggestion, un compte à 0 favori jusqu'à `TOURNEE_TARGET_SECTIONS`. No-op si
+    le toggle est off, si la cible est déjà atteinte, ou si le pool est vide.
     """
-    from app.constants import FAVORITE_CAP
+    from app.services.recommendation.scoring_config import ScoringWeights
 
     for rank, item in enumerate(validated):
         item.daily_rank = rank
 
-    remaining = FAVORITE_CAP - len(validated)
+    remaining = max(0, ScoringWeights.TOURNEE_TARGET_SECTIONS - len(validated))
     if remaining <= 0 or not await _smart_arrangement_enabled(db, user_uuid):
         return validated
 
-    from app.services.recommendation.scoring_config import ScoringWeights
     from app.services.recommendation.tournee_suggester import TourneeSuggester
 
     sub_cap = min(ScoringWeights.TOURNEE_SUGGEST_SUBCAP, remaining)

--- a/packages/api/app/services/recommendation/scoring_config.py
+++ b/packages/api/app/services/recommendation/scoring_config.py
@@ -430,7 +430,9 @@ class ScoringWeights:
 
     # Plancher de contenu : un candidat avec moins de N articles récents (14 j)
     # est écarté (jour pauvre → moins de suggestions, jamais d'empty-state suggéré).
-    TOURNEE_SUGGEST_CONTENT_FLOOR = 3
+    # Abaissé 3 → 2 : élargit le pool pour que la cible `TOURNEE_TARGET_SECTIONS`
+    # reste atteignable les jours pauvres (tunable).
+    TOURNEE_SUGGEST_CONTENT_FLOOR = 2
 
     # Saturation log de la composante `quantity` : au-delà, le nb d'articles
     # n'augmente plus le score (évite qu'un thème bavard domine).
@@ -440,8 +442,20 @@ class ScoringWeights:
     # jour, varié le lendemain, sans réordonner brutalement).
     TOURNEE_SUGGEST_TEMPERATURE = 0.10
 
-    # Plafond de sections « Choisie pour vous » (thèmes + sources confondus).
-    TOURNEE_SUGGEST_SUBCAP = 4
+    # Cible de sections thématiques de la Tournée (favoris validés + suggestions
+    # « Choisie pour vous » confondus). Seul knob du nombre moyen : les
+    # suggestions **complètent** les favoris jusqu'à cette cible (additif), au
+    # lieu de remplir le reliquat du plafond favoris. Les cartes éditoriales
+    # (Actus, Bonnes, Grille) s'ajoutent par-dessus.
+    TOURNEE_TARGET_SECTIONS = 8
+
+    # Plafond dur de sections « Choisie pour vous » (thèmes + sources confondus)
+    # par arrangement. Levier *distinct* de la cible : aligné sur
+    # `TOURNEE_TARGET_SECTIONS` (donc non contraignant tant qu'ils sont égaux —
+    # un compte neuf est complété jusqu'à la cible), mais permet de plafonner les
+    # suggestions *sous* la cible sans toucher au nombre de sections visé
+    # (ex. cible 10 mais au plus 8 suggérées).
+    TOURNEE_SUGGEST_SUBCAP = 8
 
     # Fenêtre de récence (jours) du comptage d'articles par candidat (aligné
     # sur le filtre 14 j du fallback `get_top_themes`).

--- a/packages/api/scripts/apply_source_descriptions.py
+++ b/packages/api/scripts/apply_source_descriptions.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Application de descriptions de sources (texte SEUL) — SANS LLM, SANS toucher au biais.
+
+Pendant de `apply_source_evaluations.py`, mais **chirurgical** : lit un artefact
+`{"descriptions": [{"source_id", "name"?, "description"}]}` et n'écrit QUE la
+colonne `description`. Ne touche **jamais** `bias_stance`, `reliability_score`,
+`score_*`, ni surtout `bias_origin` — donc sûr pour les sources
+`bias_origin='curated'` (biais verrouillé PO) qui ont aujourd'hui une description
+courte/nulle. Refuse une `description` contenant un tiret cadratin (règle PO copy
+user-facing). **Dry-run par défaut**, `--apply` gardé (prod-guard + backup JSON),
+idempotent (no-op si la description est déjà identique).
+
+Usage :
+    cd packages/api
+    python3 scripts/apply_source_descriptions.py --artifact ../../sources/source_descriptions_curated.json
+    python3 scripts/apply_source_descriptions.py --artifact ... --apply --allow-prod  # prod (gated PO)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import UUID
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlalchemy import text
+
+from app.config import get_settings
+from app.database import async_session_maker, engine
+from scripts.cleanup_orphan_sources import _is_test_db
+
+_BANNED_DESC = ("—", "&mdash;", "&#8212;")  # tiret cadratin interdit (copy user)
+
+
+@dataclass
+class DescChange:
+    source_id: str
+    name: str | None
+    old: str | None
+    new: str
+
+
+def _load_descriptions(path: Path) -> list[dict]:
+    raw = json.loads(path.read_text())
+    items = raw.get("descriptions", raw.get("evaluations", []))
+    out: list[dict] = []
+    for it in items:
+        sid = it["source_id"]
+        desc = it.get("description")
+        if not desc or not desc.strip():
+            raise ValueError(f"description vide pour {sid}")
+        if any(tok in desc for tok in _BANNED_DESC):
+            raise ValueError(f"tiret cadratin interdit dans description de {sid}")
+        out.append({"source_id": sid, "description": desc})
+    return out
+
+
+async def _load_current(session, ids: list[str]) -> dict[str, dict]:
+    if not ids:
+        return {}
+    result = await session.execute(
+        text("SELECT id, name, description FROM sources WHERE id = ANY(:ids)"),
+        {"ids": [UUID(i) for i in ids]},
+    )
+    return {str(m["id"]): dict(m) for m in result.mappings()}
+
+
+def compute_changes(
+    items: list[dict], current: dict[str, dict]
+) -> tuple[list[DescChange], list[str]]:
+    writes: list[DescChange] = []
+    missing: list[str] = []
+    for it in items:
+        cur = current.get(it["source_id"])
+        if cur is None:
+            missing.append(it["source_id"])
+            continue
+        if (cur["description"] or "") == it["description"]:
+            continue  # idempotent no-op
+        writes.append(
+            DescChange(
+                source_id=it["source_id"],
+                name=cur["name"],
+                old=cur["description"],
+                new=it["description"],
+            )
+        )
+    return writes, missing
+
+
+async def _write(session, writes: list[DescChange]) -> None:
+    stmt = text("UPDATE sources SET description = :description WHERE id = :id")
+    for c in writes:
+        await session.execute(
+            stmt, {"description": c.new, "id": UUID(c.source_id)}
+        )
+
+
+def render_report(writes: list[DescChange], missing: list[str]) -> str:
+    lines = ["=" * 78, "APPLY DESCRIPTIONS (texte seul, dry-run)", "=" * 78]
+    lines.append(f"À écrire : {len(writes)} | introuvables : {len(missing)}")
+    lines.append("-" * 78)
+    for c in writes:
+        old_len = len(c.old or "")
+        lines.append(
+            f"• {c.name} ({c.source_id})\n"
+            f"    desc : {old_len}c -> {len(c.new)}c | {c.new[:90]}…"
+        )
+    if missing:
+        lines.append("-" * 78)
+        lines.append("Introuvables : " + ", ".join(missing))
+    lines.append("=" * 78)
+    return "\n".join(lines)
+
+
+def _backup_path() -> Path:
+    ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    return (
+        Path(__file__).resolve().parents[3]
+        / ".context"
+        / f"apply_descriptions_backup_{ts}.json"
+    )
+
+
+async def run(artifact_path: Path, *, apply: bool, allow_prod: bool) -> int:
+    settings = get_settings()
+    db_url = settings.database_url or ""
+    is_test = _is_test_db(db_url)
+    print(f"DB cible : {db_url.split('@')[-1] if '@' in db_url else db_url}  (test={is_test})")
+    if apply and not is_test and not allow_prod:
+        print("\nABORT : --apply contre une DB non-test sans --allow-prod (gated PO).")
+        return 2
+
+    items = _load_descriptions(artifact_path)
+    ids = [it["source_id"] for it in items]
+
+    async with async_session_maker() as session:
+        try:
+            current = await _load_current(session, ids)
+            writes, missing = compute_changes(items, current)
+
+            bpath = _backup_path()
+            bpath.parent.mkdir(parents=True, exist_ok=True)
+            bpath.write_text(
+                json.dumps(
+                    {
+                        "generated_at": datetime.now(UTC).isoformat(),
+                        "before": [
+                            {"source_id": c.source_id, "name": c.name, "old": c.old}
+                            for c in writes
+                        ],
+                    },
+                    indent=2,
+                    ensure_ascii=False,
+                )
+            )
+            print(f"Backup écrit : {bpath}")
+            print(render_report(writes, missing))
+
+            if not apply:
+                print("\n(dry-run — aucune mutation. Relance avec --apply.)")
+                return 0
+
+            await _write(session, writes)
+            await session.commit()
+            print(f"\nAPPLIQUÉ : {len(writes)} descriptions écrites (description seule).")
+            return 0
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await engine.dispose()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, required=True)
+    parser.add_argument("--apply", action="store_true", help="exécute (défaut: dry-run)")
+    parser.add_argument("--allow-prod", action="store_true", help="autorise --apply en prod")
+    args = parser.parse_args()
+    sys.exit(asyncio.run(run(args.artifact, apply=args.apply, allow_prod=args.allow_prod)))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/tests/routers/test_top_themes_suggestions.py
+++ b/packages/api/tests/routers/test_top_themes_suggestions.py
@@ -140,8 +140,13 @@ async def test_disabled_via_preference(configured_user, db_session):
 
 
 @pytest.mark.asyncio
-async def test_seven_favorites_leaves_no_room(db_session):
-    """7 favoris validés → aucun slot restant → aucune suggérée."""
+async def test_seven_favorites_leaves_one_suggestion_slot(db_session):
+    """7 favoris validés → la cible additive (8) laisse 1 slot → 1 suggérée.
+
+    Sous le mécanisme additif (`TOURNEE_TARGET_SECTIONS=8`), un compte à 7
+    favoris (plafond `FAVORITE_CAP`) reçoit exactement 1 suggestion, au lieu de
+    plafonner à 7 comme avec l'ancien reliquat de plafond favoris.
+    """
     user_id = uuid4()
     db_session.add(UserProfile(user_id=user_id, onboarding_completed=True))
     slugs = ["tech", "science", "society", "culture", "economy", "politics", "sport"]
@@ -157,7 +162,7 @@ async def test_seven_favorites_leaves_no_room(db_session):
                 state=InterestState.FOLLOWED,
             )
         )
-    # Une source suivie qui pourrait être suggérée s'il restait de la place.
+    # Une source suivie qui comble l'unique slot restant.
     src = _source("Extra", "international")
     db_session.add(src)
     await db_session.flush()
@@ -186,8 +191,15 @@ async def test_seven_favorites_leaves_no_room(db_session):
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             resp = await ac.get("/api/users/top-themes")
         body = resp.json()
-        assert len(body) == 7
-        assert all(t["origin"] == "validated" for t in body)
+        validated = [t for t in body if t["origin"] == "validated"]
+        suggested = [t for t in body if t["origin"] == "suggested"]
+        # 7 validés (plafond favoris) + 1 suggéré (cible additive 8).
+        assert len(validated) == 7
+        assert len(suggested) == 1
+        assert len(body) == 8
+        # Le slot restant est comblé par la source internationale suivie.
+        assert suggested[0]["kind"] == "source"
+        assert suggested[0]["source_id"] == str(src.id)
     finally:
         app.dependency_overrides.pop(get_current_user_id, None)
         app.dependency_overrides.pop(get_db, None)

--- a/packages/api/tests/scripts/test_apply_source_descriptions.py
+++ b/packages/api/tests/scripts/test_apply_source_descriptions.py
@@ -1,0 +1,72 @@
+"""Tests pour scripts/apply_source_descriptions.py (apply description-only).
+
+Couvre : compute_changes écrit un diff ; no-op idempotent si description
+identique ; source introuvable listée ; _load_descriptions rejette em-dash et
+description vide. Tout est pur (pas de DB).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.apply_source_descriptions import (
+    _load_descriptions,
+    compute_changes,
+)
+
+SID = "11111111-1111-1111-1111-111111111111"
+SID2 = "22222222-2222-2222-2222-222222222222"
+
+
+def test_compute_writes_when_description_differs():
+    items = [{"source_id": SID, "description": "Une description complète et factuelle."}]
+    current = {SID: {"name": "Le Monde", "description": "court"}}
+    writes, missing = compute_changes(items, current)
+    assert len(writes) == 1
+    assert writes[0].old == "court"
+    assert writes[0].new == "Une description complète et factuelle."
+    assert missing == []
+
+
+def test_compute_idempotent_noop_when_identical():
+    same = "Description identique."
+    items = [{"source_id": SID, "description": same}]
+    current = {SID: {"name": "X", "description": same}}
+    writes, missing = compute_changes(items, current)
+    assert writes == []
+    assert missing == []
+
+
+def test_compute_reports_missing_source():
+    items = [{"source_id": SID2, "description": "peu importe"}]
+    writes, missing = compute_changes(items, {})
+    assert writes == []
+    assert missing == [SID2]
+
+
+def test_load_descriptions_rejects_em_dash(tmp_path: Path):
+    p = tmp_path / "d.json"
+    p.write_text(
+        json.dumps({"descriptions": [{"source_id": SID, "description": "a — b"}]})
+    )
+    with pytest.raises(ValueError, match="tiret cadratin"):
+        _load_descriptions(p)
+
+
+def test_load_descriptions_rejects_empty(tmp_path: Path):
+    p = tmp_path / "d.json"
+    p.write_text(json.dumps({"descriptions": [{"source_id": SID, "description": "  "}]}))
+    with pytest.raises(ValueError, match="vide"):
+        _load_descriptions(p)
+
+
+def test_load_descriptions_accepts_evaluations_key(tmp_path: Path):
+    p = tmp_path / "d.json"
+    p.write_text(
+        json.dumps({"evaluations": [{"source_id": SID, "description": "ok valable"}]})
+    )
+    items = _load_descriptions(p)
+    assert items == [{"source_id": SID, "description": "ok valable"}]

--- a/packages/api/tests/test_essentiel_endpoint.py
+++ b/packages/api/tests/test_essentiel_endpoint.py
@@ -932,6 +932,44 @@ async def test_get_essentiel_serein_user_fetches_serein_digest(
     assert mock_read.await_args.kwargs["is_serene"] is True
 
 
+@pytest.mark.asyncio
+async def test_get_essentiel_serein_query_param_overrides_db(auth_override: UUID):
+    """`?serein=` prime sur la préférence DB et court-circuite sa lecture.
+
+    Corrige la race au toggle : le client envoie le mode voulu sans dépendre de
+    la persistance DB de la préférence au moment du refetch. La préférence DB
+    n'est même pas consultée quand la query est fournie.
+    """
+    # 3 sujets distincts → 3 articles, au-dessus du plancher ESSENTIEL_MIN_ARTICLES.
+    topics = [
+        _make_topic(rank=i + 1, label=f"T{i + 1}", n_articles=2) for i in range(3)
+    ]
+    digest = _make_digest(topics)
+
+    for query_value, expected in (("true", True), ("false", False)):
+        with (
+            patch(
+                "app.routers.essentiel.read_digest_or_fallback",
+                new=AsyncMock(return_value=digest),
+            ) as mock_read,
+            patch(
+                "app.routers.essentiel.fetch_user_essentiel_context",
+                new=AsyncMock(return_value=EssentielUserContext()),
+            ),
+            # La DB renvoie l'INVERSE de la query → prouve que la query prime.
+            patch(
+                "app.routers.essentiel.DigestService.get_user_serein_enabled",
+                new=AsyncMock(return_value=not expected),
+            ) as mock_db,
+        ):
+            async with _client() as client:
+                resp = await client.get(f"/api/essentiel?serein={query_value}")
+
+        assert resp.status_code == 200
+        assert mock_read.await_args.kwargs["is_serene"] is expected
+        mock_db.assert_not_awaited()
+
+
 # ─── Story 9.4 — Durcissement des filtres ────────────────────────────────
 
 

--- a/sources/source_descriptions_curated.json
+++ b/sources/source_descriptions_curated.json
@@ -1,0 +1,271 @@
+{
+  "generated_at": "2026-06-25",
+  "model": "claude-opus-4-8 (7 sous-agents WebSearch), description-only",
+  "_note": "Descriptions completes (3-4 phrases) pour 66 sources curated a description courte/nulle. DESCRIPTION SEULE : bias_origin=curated et le biais PO sont PRESERVES (apply via apply_source_descriptions.py, jamais apply_source_evaluations.py). Gate PO.",
+  "descriptions": [
+    {
+      "source_id": "f04aa2ab-99c5-43d1-94d6-1e9379f79496",
+      "description": "Acrimed (Action critique médias) est un observatoire critique des médias français, fondé en 1996 dans le sillage des mouvements sociaux de 1995. L'association indépendante analyse le traitement de l'information par la presse, la radio et la télévision, en dénonçant ce qu'elle considère comme l'emprise économique et publicitaire sur le journalisme. Elle publie articles, émissions et la revue Médiacritique(s), et vit essentiellement de l'adhésion de ses membres pour préserver son indépendance financière."
+    },
+    {
+      "source_id": "dab433f1-3058-41cb-a3e2-d744dfe6d0f7",
+      "description": "Amnesty International est une organisation non gouvernementale mondiale de défense des droits humains, fondée en 1961 par l'avocat britannique Peter Benenson. Présente dans plus de 150 pays, elle mène enquêtes, campagnes et plaidoyer contre la torture, la peine de mort, les disparitions forcées et les atteintes à la liberté d'expression. Son flux reprend ses communiqués et rapports d'investigation. Lauréate du prix Nobel de la paix en 1977, elle revendique son indépendance des gouvernements et des intérêts économiques en s'appuyant sur les dons de ses membres."
+    },
+    {
+      "source_id": "bbad58f4-c9cb-4de5-b8cd-6df0bc0ca86e",
+      "description": "AOC, pour Analyse Opinion Critique, est un quotidien d'idées en ligne lancé en 2018 par Sylvain Bourmeau, journaliste et enseignant. La publication propose chaque jour un article d'analyse, une opinion et une critique, signés en grande partie par des universitaires, des chercheurs et des écrivains. Sa ligne se distingue par des textes longs et exigeants sur les sciences humaines, la politique et la culture. Le modèle repose sur l'abonnement, sans publicité, pour financer une production intellectuelle au format revue."
+    },
+    {
+      "source_id": "eff41953-29c8-42dd-bbd5-4d0c1249889d",
+      "description": "AprèsLaBière est une chaîne YouTube et un média animé par Jean-Lou Fourquet, qui propose une réflexion accessible sur la philosophie politique, le numérique et les rapports de pouvoir. Le format mêle vidéos, conférences filmées, podcast et newsletter, avec une attention particulière portée à l'influence des géants technologiques et de l'intelligence artificielle sur la société. Le projet, prolongé par le blog apreslabiere.fr, cherche à vulgariser des questions complexes pour un large public, hors des cadres médiatiques traditionnels."
+    },
+    {
+      "source_id": "fa5e156c-39d1-4cf3-adb9-4d106a80288d",
+      "description": "Arrêt sur images est un site français de critique des médias fondé par Daniel Schneidermann, héritier de l'émission éponyme diffusée sur France 5 jusqu'en 2007. Devenu pure player en ligne, il décrypte le traitement de l'actualité par la télévision, la presse et les réseaux sociaux, ainsi que les coulisses du journalisme. Le média fonctionne intégralement sur abonnement, sans publicité ni actionnaire extérieur, ce qui lui permet de revendiquer une totale indépendance éditoriale et financière."
+    },
+    {
+      "source_id": "56e3fc84-1781-4187-93f2-76b5a01b122a",
+      "description": "Basta! est un média indépendant français en ligne, spécialisé dans les enquêtes sociales, environnementales et démocratiques. Édité par une structure à but non lucratif, il privilégie le journalisme de terrain sur les conditions de travail, les luttes citoyennes, l'écologie et les pratiques des grandes entreprises. La rédaction met en avant son absence d'actionnaires privés et de publicité, son financement reposant sur les dons et le soutien des lecteurs. Le média est connu pour des outils comme l'observatoire des multinationales."
+    },
+    {
+      "source_id": "d0a970de-878b-4332-84ad-ae4e680f952a",
+      "description": "Blast est un média audiovisuel indépendant français cofondé en 2021 par le journaliste Denis Robert, organisé en société coopérative d'intérêt collectif (SCIC). Cette structure et son financement par le public, via dons et abonnements, visent à garantir son indépendance capitalistique vis-à-vis des grands groupes. Sa ligne éditoriale assumée et militante donne une large place aux enquêtes, aux questions sociales, écologiques et politiques. Le média se présente comme une web TV de contre-pouvoir, parfois au cœur de controverses."
+    },
+    {
+      "source_id": "5790ea77-18f8-4c92-ab8b-35a10fcc3f63",
+      "description": "Bon Pote est un média français consacré à l'urgence climatique et écologique, créé par Thomas Wagner. Le site s'appuie sur un sourcing scientifique rigoureux, citant études et rapports comme ceux du GIEC, pour vulgariser les enjeux climatiques et combattre le greenwashing. Le ton se veut à la fois incarné et pédagogique, à destination d'un public souhaitant comprendre et agir. Le projet, longtemps porté de façon bénévole, fonctionne sans publicité et revendique son indépendance vis-à-vis des annonceurs."
+    },
+    {
+      "source_id": "24eb8e05-51c2-4c49-83ae-d20be98a300f",
+      "description": "Chez Anatole est une chaîne YouTube de vulgarisation créée par Anatole Chouard, ingénieur diplômé de l'École polytechnique. Elle propose des analyses de fond sur l'écologie, la science et les enjeux de société, en s'appuyant notamment sur des documents de référence comme les rapports du GIEC ou le rapport Meadows sur les limites à la croissance. Le créateur a collaboré avec le Cnam autour de formats associant micros-trottoirs et interventions d'experts, afin de relier les questions scientifiques aux débats citoyens."
+    },
+    {
+      "source_id": "f07f88dc-ddc5-4dbe-b951-1bf90e89eb86",
+      "description": "CNEWS est une chaîne d'information en continu française, propriété du groupe Canal+, lui-même contrôlé par la holding Vivendi de l'homme d'affaires Vincent Bolloré. Née en 2017 de la transformation de l'ancienne chaîne i-Télé, elle accorde une place centrale aux talk-shows, aux débats d'opinion et aux faits divers. La chaîne est devenue l'une des plus regardées de la TNT info, tout en faisant l'objet de mises en demeure de l'Arcom au sujet du pluralisme et du temps de parole."
+    },
+    {
+      "source_id": "2ebeea2f-7fe2-448f-92a0-c445b6bb5690",
+      "description": "Contrepoints est un média en ligne francophone fondé en 2009, animé par l'association loi 1901 Liberaux.org et entièrement financé par ses lecteurs et donateurs, sans publicité intrusive ni actionnaire industriel. Il publie des analyses économiques, politiques et de société ancrées dans la tradition du libéralisme classique et de l'école autrichienne. Le site repose largement sur des contributeurs bénévoles, économistes, entrepreneurs et universitaires, et revendique son indépendance vis-à-vis des partis. Fait moins connu : il se présente comme le premier quotidien libéral de langue française sur Internet."
+    },
+    {
+      "source_id": "5ac7541a-5d6f-4127-8bba-5f53842944d5",
+      "description": "Courrier International est un hebdomadaire français lancé en 1990, propriété du groupe Le Monde, dont la particularité est de traduire et republier des articles issus de centaines de journaux du monde entier. Sa ligne consiste à offrir un regard pluraliste sur l'actualité internationale en confrontant les points de vue de la presse étrangère. La rédaction sélectionne, traduit et contextualise des contenus venus de tous les continents plutôt que de produire ses propres reportages. Fait notable : le titre a été cofondé par Jacques Rosselin et son modèle de revue de presse mondiale reste assez singulier dans le paysage médiatique."
+    },
+    {
+      "source_id": "311ccd27-3b26-489d-8530-079b3c1ef882",
+      "description": "Éthique et tac est une chaîne YouTube francophone consacrée à l'écologie, à la sobriété et aux enjeux de société liés à l'environnement, à l'énergie et à la consommation. Elle propose un format quotidien mêlant vulgarisation scientifique, actualité et réflexion citoyenne, avec un ton engagé en faveur de la transition écologique. La chaîne fonctionne de façon indépendante et s'appuie sur le soutien direct de sa communauté, notamment via des plateformes de financement participatif. Elle dispose aussi de son propre site, ethiqueettac.com, et décline ses contenus sur plusieurs réseaux."
+    },
+    {
+      "source_id": "5d269a77-263a-4b6e-9390-7fd559174d3a",
+      "description": "Europe 1 est une radio généraliste privée française historique, créée en 1955, longtemps pionnière de la radio périphérique et des grandes émissions d'information. Elle appartient au groupe Lagardère, passé sous le contrôle de Vivendi, holding dirigée par Vincent Bolloré, ce qui a accompagné un net repositionnement éditorial vers l'opinion et un rapprochement avec la chaîne CNews. La station couvre l'actualité politique, sociale et culturelle avec un format mêlant journaux, débats et talk-shows. Fait notable : Europe 1 émet depuis ses débuts en partie depuis le territoire allemand de la Sarre, d'où son indicatif d'origine."
+    },
+    {
+      "source_id": "1b8dde5f-7641-4ebc-bf3a-07bebdaf8ffb",
+      "description": "Fouloscopie est une chaîne YouTube de vulgarisation scientifique créée par Mehdi Moussaïd, chercheur en sciences du comportement à l'Institut Max Planck pour le développement humain de Berlin. Elle est consacrée à l'étude des foules et des dynamiques collectives, des mouvements de panique aux biais cognitifs en passant par les comportements grégaires. Le format associe rigueur académique, expériences menées avec l'audience et démonstrations visuelles accessibles au grand public. Fait notable : le nom et la démarche ont aussi donné lieu à un ouvrage de l'auteur, prolongeant la recherche par la médiation scientifique."
+    },
+    {
+      "source_id": "b9becd34-46a9-44a7-8896-b6bbf07ae2dc",
+      "description": "France Culture est la chaîne culturelle et intellectuelle du service public radiophonique français, éditée par Radio France et financée par le budget public. Sa programmation couvre la philosophie, l'histoire, les sciences, la littérature, les arts et les sciences sociales, à travers émissions, documentaires et entretiens approfondis. Sur le web, elle prolonge ses contenus par des articles et analyses de fond visant un public exigeant. Fait notable : héritière de la Chaîne nationale, elle est l'une des plus anciennes antennes thématiques de la radio publique française."
+    },
+    {
+      "source_id": "4be55729-cd84-46d2-9119-644349118373",
+      "description": "France Info est le média d'information en continu du service public français, fruit d'une coopération entre France Télévisions, Radio France, l'INA et France Médias Monde. Son site francetvinfo.fr propose une actualité gratuite, sans mur payant, axée sur l'immédiateté, le factuel et la vérification. Sa mission de neutralité et son indépendance statutaire en font une référence pour le suivi des événements nationaux et internationaux. Fait notable : la marque France Info existe d'abord comme radio d'information continue lancée en 1987, avant son extension à la télévision et au numérique."
+    },
+    {
+      "source_id": "b71e6b5f-4995-43e3-990a-5674c719c737",
+      "description": "Vrai ou Fake est la rubrique de vérification des faits du service public français, hébergée par France Info et adossée à l'ensemble des rédactions de l'audiovisuel public. Elle décrypte rumeurs, intox, images sorties de leur contexte et déclarations politiques pour distinguer le vrai du faux. Le travail s'appuie sur des sources documentées, des experts et la confrontation des données disponibles. Fait notable : la marque fédère les initiatives de fact-checking de France Télévisions, Radio France et France Médias Monde sous une bannière commune."
+    },
+    {
+      "source_id": "ad73eb54-8368-4d1f-a58a-e6b2b211c981",
+      "description": "France Inter est la principale radio généraliste du service public français, éditée par Radio France et l'une des plus écoutées du pays. Sa programmation associe matinale d'information, magazines, fictions, humour et culture, avec une forte production de podcasts disponibles en réécoute. Financée par des fonds publics, elle revendique une indépendance éditoriale encadrée par son statut. Fait notable : sa matinale figure régulièrement parmi les rendez-vous d'information les plus suivis de la radio française."
+    },
+    {
+      "source_id": "8baabd4d-dd6c-48ea-bb09-c3d5373aefa5",
+      "description": "Frandroid est un média en ligne français spécialisé dans la technologie, à l'origine centré sur l'écosystème Android puis élargi aux smartphones, à l'informatique, à la mobilité électrique et aux objets connectés. Il publie actualités, tests, guides d'achat et analyses à destination d'un large public de consommateurs et de passionnés. Le site appartient au groupe Humanoid, qui édite aussi d'autres titres tech et culture numérique. Fait notable : son nom est une contraction de France et Android, héritage de sa spécialisation initiale autour du système d'exploitation de Google."
+    },
+    {
+      "source_id": "17be5094-a7e9-485d-85c0-11c90bfd56a1",
+      "description": "Heu?reka est une chaîne YouTube française de vulgarisation économique et financière créée en 2015 par Gilles Mitteau, ancien vendeur et assistant trader passé par la Société Générale, BNP Paribas et le New York Stock Exchange avant de quitter la finance. Le format, souvent un dialogue mis en scène entre deux personnages, décortique les mécanismes monétaires, le capitalisme et le rôle des médias avec un regard critique sur les modèles dominants. La chaîne rassemble plus de 400 000 abonnés et Mitteau a prolongé son travail par un livre, Tout sur l'économie ou presque, paru en 2020 et réédité en 2024."
+    },
+    {
+      "source_id": "a3a5762a-de2e-4f7f-97e8-8e470a651a78",
+      "description": "Hygiène Mentale est une chaîne YouTube francophone dédiée à l'esprit critique et à la zététique, qui enseigne la méthode scientifique, le repérage des biais cognitifs et l'analyse de la désinformation. Animée par Christophe Michel, elle propose des épisodes pédagogiques construits comme une initiation progressive à la pensée rationnelle et à l'évaluation des preuves. Ses contenus abordent des sujets pointus comme l'incertitude, les tournois de prévision ou les remises en question de notions popularisées telles que l'effet Dunning-Kruger, en privilégiant la nuance et la rigueur méthodologique."
+    },
+    {
+      "source_id": "062b6ba6-1d07-4280-8ff8-c78917e7ee8d",
+      "description": "The Kyiv Independent est un média ukrainien anglophone fondé en novembre 2021, quelques mois avant l'invasion russe de 2022, par d'anciens journalistes du Kyiv Post écartés après une tentative de reprise en main éditoriale de leur ancien titre. Centré sur l'actualité ukrainienne et d'Europe de l'Est, il couvre la guerre, la politique intérieure et les questions d'État de droit en visant un lectorat international. Son audience est passée de quelques milliers de lecteurs début 2022 à près de trois millions par mois, et il s'appuie désormais majoritairement sur les contributions de ses lecteurs après avoir reçu un financement de l'USAID en 2022 et 2023. Il a été distingué par de nombreux prix internationaux pour sa couverture de la guerre."
+    },
+    {
+      "source_id": "45d23d70-7dc5-472a-8cd0-776d4328693b",
+      "description": "L'Incorrect est un magazine mensuel français conservateur fondé en septembre 2017, vendu en kiosque et financé par abonnements, qui revendique une ligne de droite traditionnelle mêlant analyses politiques, culturelles et sociétales. Le titre a été lancé par Laurent Meeschaert, directeur de la publication, avec des journalistes comme Jacques de Guillebon, longtemps directeur de la rédaction, et Charlotte d'Ornellas. De Guillebon a quitté ses fonctions en juin 2022 sur fond de divergences autour de la stratégie d'Éric Zemmour, illustrant les tensions internes à la droite radicale française."
+    },
+    {
+      "source_id": "5dfba3fb-0c69-48be-8467-fad30e897806",
+      "description": "L'Opinion est un quotidien français en ligne fondé en 2013 par Nicolas Beytout, ancien directeur des rédactions du Figaro et des Échos, qui revendique une ligne libérale, pro-business et pro-européenne. Son actionnariat associe notamment Bernard Arnault, et le titre assume un parti pris en faveur du marché et des entreprises, avec un fort traitement de l'économie, de la dette publique et des questions internationales. Dans Facteur, la source a été retirée du flux curé en raison d'un volume de publication jugé trop important pour l'équilibre éditorial."
+    },
+    {
+      "source_id": "da7114f9-2ff9-4a3e-9c93-c707596769a9",
+      "description": "La Croix Analyses regroupe les éditoriaux, tribunes et décryptages du quotidien généraliste français La Croix, fondé en 1883 et édité par le groupe Bayard, de tradition catholique. Le titre se distingue par une réflexion éthique et sociale approfondie, abordant aussi bien les politiques publiques que les grands débats de société avec un souci de pondération et de mise en perspective. Sa couverture mêle actualité économique, sociale et culturelle, dans une approche qui privilégie le sens et le recul plutôt que l'immédiateté."
+    },
+    {
+      "source_id": "19b0b477-fb78-4c78-bdd1-7ed965f7c517",
+      "description": "La Fabrique Sociale est une chaîne YouTube francophone de vulgarisation en sciences sociales et en sociologie, qui analyse les structures sociales, les discriminations et les mobilisations collectives. Elle propose souvent des entretiens avec chercheurs, intellectuels et auteurs autour d'enjeux contemporains comme l'emprise des réseaux sociaux, l'impact des écrans ou les effets sociaux de l'intelligence artificielle. Son approche cherche à articuler théorie sociologique et débats d'actualité pour donner des clés de lecture critiques sur les transformations de la société."
+    },
+    {
+      "source_id": "d6e6be66-7aae-49aa-966c-20a71d4844a9",
+      "description": "La Science CQFD est une émission quotidienne de France Culture, radio du service public au sein de Radio France, consacrée à l'actualité et aux savoirs scientifiques. Présentée par Natacha Triou, elle invite chercheurs et experts pour décrypter avec rigueur des sujets allant de la biologie aux mathématiques en passant par la physique et l'histoire des sciences. Diffusée en podcast bien indexé et accessible, l'émission privilégie une approche pédagogique et exigeante, en confrontant les connaissances établies aux questions ouvertes de la recherche."
+    },
+    {
+      "source_id": "97eab57f-983d-4b47-a560-29debf13d2df",
+      "description": "Le Canard Enchaîné est un hebdomadaire satirique et d'investigation français fondé en 1915, dont le capital est détenu par ses salariés, gage d'une indépendance revendiquée. Le titre refuse toute publicité et tout financement extérieur, ce qui en fait une institution de la presse libre en France, célèbre pour ses révélations politiques et financières. Son site web volontairement minimaliste reflète une culture du papier, le journal misant sur l'enquête, le ton mordant et le jeu de mots plutôt que sur la présence numérique."
+    },
+    {
+      "source_id": "aa8770fd-bfb9-434b-bbe3-a24b0321f444",
+      "description": "Le Collimateur est un podcast français consacré aux questions militaires et stratégiques, lancé en janvier 2019 et produit puis animé par l'historien Alexandre Jubelin. Initialement hébergé par l'IRSEM, l'institut de recherche stratégique du ministère des Armées, il est passé chez Binge Audio en septembre 2023, en partenariat avec la plateforme Le Rubicon et l'IFRI, avec le soutien de la DGRIS. Il combine entretiens d'analyse sur la défense, récits d'opérations et chroniques d'histoire militaire, et revendiquait environ 350 000 écoutes mensuelles début 2026, témoignant d'une expertise académique forte malgré ses liens institutionnels."
+    },
+    {
+      "source_id": "d5ce3f80-a02b-4b83-9c51-fe2a3c7a1f6d",
+      "description": "Le Dessous des cartes est une émission de géopolitique produite par la chaîne franco-allemande Arte, diffusée depuis 1990 et longtemps incarnée par Jean-Christophe Victor avant d'être reprise par Émilie Aubry. Sa marque de fabrique est l'analyse des grands enjeux internationaux par la cartographie animée, rendant visibles flux, frontières et rapports de force. Le format court L'Essentiel du Dessous des cartes, diffusé sur YouTube, décline ce travail en capsules thématiques. Service audiovisuel public sans publicité, la chaîne s'appuie sur la double tutelle franco-allemande d'Arte."
+    },
+    {
+      "source_id": "ea6ed4c4-1e15-4199-85d7-976d52eea6f4",
+      "description": "Le Figaro est le plus ancien quotidien national français encore publié, fondé en 1826, propriété du groupe Dassault via la Société du Figaro. Sa ligne éditoriale est ancrée à droite, avec une couverture étendue de la politique, de l'économie, de l'international et des débats de société. Le journal édite aussi des suppléments réputés comme Le Figaro Magazine et Madame Figaro. Son site figure parmi les plus consultés de la presse française, combinant accès gratuit et offre payante par abonnement."
+    },
+    {
+      "source_id": "0318e5a5-5ef2-4d3d-8e0e-202ad0433a8a",
+      "description": "Le Grand Continent est une revue d'analyse stratégique et géopolitique à l'échelle européenne, fondée en 2019 et éditée par le Groupe d'études géopolitiques, association créée en 2017 à l'École normale supérieure de la rue d'Ulm. Elle publie de longues analyses signées par des chercheurs, diplomates et responsables politiques, traduites dans plusieurs langues du débat continental. Depuis 2022, une édition papier annuelle paraît chez Gallimard. La revue cultive une approche intellectuelle exigeante et un fort ancrage dans la recherche universitaire."
+    },
+    {
+      "source_id": "5243a419-aca5-49d2-a132-94ebd4d67ccc",
+      "description": "Le Monde est un quotidien français de référence fondé en 1944 à la demande du général de Gaulle, paraissant traditionnellement en fin d'après-midi. Son capital est détenu par un pôle d'actionnaires dont Xavier Niel, Matthieu Pigasse et Daniel Kretinsky, mais une clause protège l'indépendance de la rédaction via un droit d'agrément du directeur. Le titre est reconnu pour sa rigueur dans l'enquête et la vérification des faits. Il développe une offre numérique payante très diffusée et plusieurs déclinaisons thématiques."
+    },
+    {
+      "source_id": "e621430d-5791-4655-8b85-9f3b9422478b",
+      "description": "Les Décodeurs constituent la cellule de fact-checking et de décryptage du quotidien Le Monde, lancée en 2009 puis structurée comme rubrique permanente. L'équipe vérifie les déclarations publiques, décrypte les données chiffrées et produit des cartes et infographies pédagogiques sur l'actualité. Elle a notamment développé l'outil Decodex destiné à évaluer la fiabilité des sources en ligne. Adossée à la rédaction du Monde, la rubrique partage sa ligne et ses standards de vérification."
+    },
+    {
+      "source_id": "dc454a63-9384-417d-a216-707c2bfbbb18",
+      "description": "Le Monde diplomatique est un mensuel français fondé en 1954, consacré à l'analyse de fond en géopolitique, relations internationales et questions sociales. Bien que né dans l'orbite du quotidien Le Monde, il est éditorialement et financièrement autonome, son capital étant majoritairement contrôlé par l'association de ses salariés et celle de ses lecteurs. Sa ligne est marquée à gauche et critique des logiques de domination économique. Le titre est diffusé en de nombreuses éditions internationales à travers le monde."
+    },
+    {
+      "source_id": "cc78ee33-f922-4d98-b176-2b0bb192a23e",
+      "description": "Les Pieds sur terre est une émission documentaire de France Culture, créée en 2002 par Sonia Kronlund, diffusée et déclinée en podcast par Radio France. Sa signature est le récit à la première personne, monté sans commentaire ni voix off de journaliste, laissant les témoins raconter eux-mêmes leur expérience. Le format privilégie l'immersion dans des situations sociales concrètes et souvent méconnues. Service public, il échappe aux pressions commerciales et s'appuie sur un long travail de reportage et de montage."
+    },
+    {
+      "source_id": "be37a0fd-b8eb-4113-9432-ad894d291b3b",
+      "description": "Mediapart est un site d'information français en ligne fondé en 2008 par Edwy Plenel et d'anciens journalistes du Monde, entièrement financé par les abonnements de ses lecteurs sans publicité. Le média s'est imposé comme une référence du journalisme d'investigation, à l'origine de plusieurs grandes affaires politico-financières françaises. Sa propriété a été sanctuarisée par le Fonds pour une presse libre afin de garantir son indépendance dans la durée. Sa ligne éditoriale est engagée et orientée à gauche."
+    },
+    {
+      "source_id": "9295e831-55f4-4e66-9447-436a84be06c7",
+      "description": "Monsieur Bidouille est une chaîne YouTube française de vulgarisation technique et industrielle animée par Dimitri Ferrière. Elle explore en profondeur des sujets d'énergie, d'infrastructures, de procédés industriels et d'innovation, souvent via des visites de sites et des rencontres avec des ingénieurs. Le nucléaire, l'hydroélectricité et les technologies de production occupent une place importante dans ses vidéos. Le ton se veut pédagogique et factuel, à destination d'un public curieux des coulisses de la technique."
+    },
+    {
+      "source_id": "8900ed73-4038-49fb-847c-2078b3d42cc7",
+      "description": "Monsieur Phi est une chaîne YouTube de vulgarisation philosophique créée en 2016 par Thibaut Giraud, docteur en logique philosophique et ancien professeur de philosophie. Elle aborde aussi bien les penseurs classiques que les questions contemporaines, avec une approche d'analyse rigoureuse des arguments, des biais cognitifs et de l'éthique. La chaîne s'est récemment penchée sur l'intelligence artificielle et les modèles de langage. En 2018, le ministère de la Culture l'a citée parmi les chaînes culturelles et scientifiques utilisables en contexte éducatif."
+    },
+    {
+      "source_id": "da76f746-aed5-489f-821e-75b16d747df6",
+      "description": "Mr Mondialisation est un média citoyen indépendant français lancé en 2012, d'abord sous forme de page communautaire sur les réseaux sociaux avant de se doter d'un site éditorial. Animé par une équipe largement anonyme et financé par ses lecteurs via le don, il se consacre à l'écologie, aux alternatives sociales et à la critique du capitalisme mondialisé. Il publie enquêtes, tribunes et analyses, et a fondé l'antenne associative Extracteur pour des reportages de terrain."
+    },
+    {
+      "source_id": "99463f50-814c-40c4-bd74-d475e2652273",
+      "description": "The New Yorker est un magazine hebdomadaire américain fondé en 1925 par Harold Ross, édité aujourd'hui par le groupe Condé Nast. Réputé pour son journalisme narratif long format, ses reportages d'investigation, sa critique culturelle et ses nouvelles littéraires, il publie aussi des poèmes, des dessins de presse et ses célèbres caricatures. Son fact-checking exigeant et ses essais signés par des plumes reconnues en font une référence de la presse magazine anglophone."
+    },
+    {
+      "source_id": "c9157b18-6458-47e7-a1e7-f94cd1d9841d",
+      "description": "Next.ink, anciennement Next INpact et auparavant PC INpact, est un média français spécialisé dans l'actualité du numérique, des technologies et de leurs enjeux juridiques, fondé en 2003 par Christophe Neau. Il est reconnu pour ses analyses approfondies sur le droit du numérique, la vie privée et les politiques publiques liées au web. Depuis septembre 2023, il est adossé à la holding oui.do, liée à l'opérateur télécom moji, après des années d'édition strictement indépendante soutenue par ses abonnés."
+    },
+    {
+      "source_id": "445b1618-3e87-4d67-a646-16c6b62d703e",
+      "description": "Novethic est un média français expert de l'économie responsable, de la finance durable et de la transition écologique et sociale, créé en 2001. Il est une filiale de la Caisse des Dépôts et Consignations, ce qui lui confère un ancrage institutionnel rare dans le paysage médiatique. Outre son travail journalistique, Novethic mène des activités de recherche, de labellisation des fonds responsables et de formation des professionnels à la RSE et aux critères ESG."
+    },
+    {
+      "source_id": "6014940a-8b05-4e67-beff-43f091a5f227",
+      "description": "Numerama est un média français en ligne consacré aux technologies, à la science, à la culture numérique et à leur impact sur la société, fondé en 2001 sous le nom Ratiatum avant de prendre son nom actuel en 2008. Il appartient au groupe Humanoid, qui édite aussi Frandroid. La rédaction couvre largement l'espace, le jeu vidéo, l'intelligence artificielle, la cybersécurité et les questions de droits numériques, dans un registre accessible au grand public."
+    },
+    {
+      "source_id": "32e3231b-e0a0-4109-b235-a5e9734fee77",
+      "description": "Numerama Décryptages est la rubrique d'analyse et de fond du média tech français Numerama, édité par le groupe Humanoid. Elle approfondit les sujets de l'actualité numérique, scientifique et culturelle au-delà de la brève, avec dossiers, explications et mises en perspective. On y retrouve des décryptages sur l'espace, l'intelligence artificielle, les jeux vidéo, le cinéma et les séries, ainsi que les grandes tendances de la tech grand public."
+    },
+    {
+      "source_id": "d1f6070d-e73d-4083-97a8-d0dbb4a52342",
+      "description": "Osons Causer est une chaîne YouTube française de vulgarisation politique et économique lancée en 2015 par Ludo Torbey et son équipe. Le format mise sur des vidéos pédagogiques décryptant institutions, mouvements sociaux, fiscalité et débats démocratiques, avec un travail de sourçage assumé. Le collectif a élargi son activité avec Osons Comprendre, une plateforme de cours en ligne par abonnement, et fonctionne grâce au financement participatif de sa communauté."
+    },
+    {
+      "source_id": "39960eaf-0355-46bd-ad7a-6c096c6d119e",
+      "description": "Ouest-France est le premier quotidien de la presse écrite française en diffusion, fondé en 1944 dans la continuité de L'Ouest-Éclair. Édité par la société Ouest-France, détenue par l'association à but non lucratif Fonds pour le maintien de l'indépendance d'Ouest-France, il couvre le Grand Ouest avec un réseau dense d'éditions locales. Son traitement mêle actualité régionale de proximité, informations nationales et internationales et sport, pour un lectorat très large."
+    },
+    {
+      "source_id": "8958928e-de4d-4528-9eea-0fe67401b847",
+      "description": "Philosophie Magazine est un mensuel français lancé en avril 2006 par Fabrice Gerschel, diplômé d'HEC passé par la banque, et édité par Philo Éditions. La revue propose un pas de côté philosophique sur l'actualité, avec dossiers de fond, entretiens de penseurs contemporains et relectures des grands auteurs classiques. En 2023, Philo Éditions s'est rapprochée du magazine Sciences Humaines, formant un ensemble éditorial dédié aux idées dont Gerschel reste l'actionnaire majoritaire."
+    },
+    {
+      "source_id": "036098a3-2725-48a4-a921-7545bdec82c4",
+      "description": "Philoxime est une chaîne YouTube française de vulgarisation en philosophie morale et politique, animée par Maxime Lambrecht, docteur en philosophie et enseignant. Elle propose des vidéos de fond sur l'éthique appliquée, la justice sociale, le véganisme, l'altruisme et les fondements de la morale, en s'appuyant sur la littérature académique. Le ton est argumentatif et nuancé, cherchant à confronter les intuitions du spectateur aux travaux des philosophes contemporains."
+    },
+    {
+      "source_id": "50809fce-7f26-4ad3-90ad-92de165746bd",
+      "description": "Politico Europe est l'édition européenne du média politique américain Politico, lancée à Bruxelles en 2015 dans le cadre d'une coentreprise avec le groupe allemand Axel Springer, qui en a pris le contrôle total avant la cession de Politico à Springer en 2021. Basé au coeur du quartier européen, il couvre en continu les institutions de l'Union, le lobbying, la diplomatie et les coulisses du pouvoir à Bruxelles, Strasbourg et dans les capitales. Sa newsletter matinale Brussels Playbook est devenue une lecture quasi obligatoire pour les fonctionnaires et élus de l'UE."
+    },
+    {
+      "source_id": "b168ad4a-ef11-479e-b10d-a9da341f1519",
+      "description": "Reporterre est un quotidien en ligne français entièrement consacré à l'écologie, dirigé pendant des années par le journaliste Hervé Kempf, ancien du Monde. Le média se définit comme le quotidien de l'écologie et fonctionne sans publicité ni actionnaire, son financement reposant exclusivement sur les dons de ses lecteurs, ce qui revendique une indépendance totale. Il traite l'environnement comme un enjeu social et politique, couvrant climat, biodiversité, agriculture, luttes locales et conflits industriels comme les contentieux visant TotalEnergies."
+    },
+    {
+      "source_id": "7493233d-ffe7-4fc8-bbd6-102ccf680df1",
+      "description": "Commentaire est une revue trimestrielle de débat intellectuel fondée en 1978 par le philosophe et sociologue Raymond Aron, qui en présida le comité de rédaction. De sensibilité libérale au sens classique, elle publie de longs essais sur la politique, l'économie, la philosophie, l'histoire et les relations internationales, dans une tradition d'argumentation exigeante. Diffusée notamment via la plateforme Cairn, elle reste pilotée par un comité réunissant universitaires, hauts fonctionnaires et écrivains, gage d'indépendance vis-à-vis des modes médiatiques."
+    },
+    {
+      "source_id": "29c221eb-a832-4315-82ad-79e772ca1ab2",
+      "description": "RTL est une radio généraliste privée française, l'une des plus écoutées du pays, dont les programmes mêlent information, talk et divertissement. Longtemps propriété du groupe luxembourgeois RTL Group, la station a été rachetée et intégrée au Groupe M6 (Groupe RTL France), ce qui en fait un acteur majeur du paysage audiovisuel commercial. Son modèle dépend largement des recettes publicitaires et sa ligne éditoriale vise un large public, avec des rendez-vous d'information comme le journal de la mi-journée et les éditions horaires."
+    },
+    {
+      "source_id": "e2f0b4e9-76ad-43fe-8e0f-9594c70076c5",
+      "description": "Science & Vie est un magazine français de vulgarisation scientifique grand public, fondé en 1913 sous le nom La Science et la Vie, l'un des plus anciens titres du genre. Après être passé par Excelsior, Emap puis Mondadori France, il a été racheté en 2019 par le groupe Reworld Media. Ce changement de propriétaire a provoqué en 2021 la démission de la quasi-totalité de la rédaction, en désaccord avec les méthodes du groupe, plusieurs anciens journalistes ayant ensuite lancé le magazine concurrent Epsiloon."
+    },
+    {
+      "source_id": "52b6ac31-3fb0-44b6-9bf7-bcd22157066d",
+      "description": "ScienceEtonnante est une chaîne YouTube de vulgarisation scientifique animée par David Louapre, docteur en physique et auteur, qui a aussi exercé comme directeur scientifique dans l'industrie. Le format privilégie la science dite dure, physique, mathématiques, informatique et chimie, avec un effort pédagogique poussé qui évite la simplification excessive. La chaîne, prolongée par un blog et des ouvrages, revendique son indépendance grâce au financement participatif de sa communauté via des plateformes de dons."
+    },
+    {
+      "source_id": "0cd4319c-2322-47e9-a256-1509d6e47ed1",
+      "description": "Sismique est un podcast français créé et animé par Julien Devaureix, consacré aux grands enjeux du futur et aux transformations de nos sociétés. Sous forme d'entretiens au long cours, il donne la parole à des chercheurs, penseurs et praticiens de profils variés autour du climat, de l'énergie, de l'économie, de la technologie et des mutations sociétales. Le projet revendique son indépendance par le soutien direct de ses auditeurs, dans une démarche qui privilégie la réflexion de fond sur la transition plutôt que l'actualité immédiate."
+    },
+    {
+      "source_id": "f2a83bed-e8c9-490e-ad6d-64866cef71d3",
+      "description": "Slate FR est le pendant français du magazine en ligne américain Slate, lancé en 2009 avec notamment l'appui de Jean-Marie Colombani, ancien directeur du Monde. Le site se distingue par un journalisme d'explication et d'analyse au ton décalé, qui prend du recul sur l'actualité culturelle, scientifique, sociétale et internationale plutôt que de couvrir le breaking news. Sa rubrique Explainers prolonge cette vocation pédagogique en décortiquant des sujets complexes, des découvertes médicales aux phénomènes de société."
+    },
+    {
+      "source_id": "ffc3211a-ac85-4943-8a2a-106162d39446",
+      "description": "Socialter est un magazine bimestriel français fondé en 2013 par Olivier Cohen de Timary, d'abord né comme blog avant de devenir un titre imprimé grâce à un financement participatif. Centré sur l'écologie, la démocratie et les alternatives économiques, il a fait évoluer sa ligne vers une critique radicale du modèle dominant et l'exploration d'imaginaires alternatifs. Le média revendique une indépendance complète : plus de 90 pour cent de ses recettes proviennent des ventes, abonnements et soutiens directs de ses lecteurs."
+    },
+    {
+      "source_id": "faff0363-e0d5-47b6-a7b4-c6bd7109eeaa",
+      "description": "Stupid Economics est une chaîne de vulgarisation économique francophone qui décrypte sur un ton accessible les mécanismes financiers, les politiques monétaires et les inégalités. Le projet s'est structuré autour d'une équipe de journalistes regroupés sous une charte commune, donnant naissance à Stup Media, et aborde aussi les coulisses et le financement de l'information elle-même. Son contenu vise à rendre lisibles des notions économiques arides pour un large public, avec des séries pédagogiques sur la création monétaire et le rôle de la publicité dans les médias."
+    },
+    {
+      "source_id": "b8e4dfb0-87e5-434e-b54c-a59c49ce2fdc",
+      "description": "The Conversation est un média en ligne à but non lucratif fondé en Australie en 2011, dont l'édition française a été lancée en 2015. Sa particularité tient à son modèle éditorial: les articles sont rédigés par des chercheurs et universitaires, puis édités par des journalistes professionnels pour les rendre accessibles au grand public. Le contenu est publié sous licence Creative Commons, ce qui autorise sa republication gratuite par d'autres médias. La rédaction française s'appuie sur un réseau d'établissements partenaires comme le CNRS et de nombreuses universités."
+    },
+    {
+      "source_id": "9d93e3af-e6a5-437a-a411-d6be7b9d0412",
+      "description": "The Guardian est un quotidien britannique fondé en 1821 à Manchester sous le nom de Manchester Guardian. Il appartient au Scott Trust, une structure créée en 1936 pour garantir son indépendance éditoriale et financière sur le long terme, à l'abri d'un actionnaire privé. Le titre s'est imposé comme une référence du journalisme d'investigation, notamment avec les révélations Snowden en 2013 qui lui ont valu un prix Pulitzer. Il a fait le choix de la gratuité en ligne, financée par les dons volontaires de ses lecteurs plutôt que par un paywall strict."
+    },
+    {
+      "source_id": "ab4238b4-7279-4334-9489-fd8de5c6ca53",
+      "description": "The New York Times est un quotidien américain fondé en 1851, basé à New York et publié par l'entreprise The New York Times Company, contrôlée depuis plus d'un siècle par la famille Ochs-Sulzberger. Considéré comme l'un des journaux de référence dans le monde, il détient le record absolu de prix Pulitzer remportés par un média. Sa transformation numérique réussie en a fait un cas d'école, avec plus de dix millions d'abonnements payants cumulant presse, jeux et cuisine. Le titre est aussi connu pour ses grandes enquêtes, comme celle sur l'affaire Weinstein qui a contribué au mouvement MeToo."
+    },
+    {
+      "source_id": "343a1127-4341-43a7-88c1-d20ce1d9190f",
+      "description": "Trust My Science est un média français de vulgarisation scientifique en ligne, créé au début des années 2010. Il couvre l'actualité de la recherche dans des domaines variés tels que la physique, l'astronomie, la biologie, la médecine et les nouvelles technologies. Sa ligne éditoriale vise à rendre accessibles des découvertes scientifiques souvent issues de publications de revues spécialisées. Le site fonctionne sur un modèle web associant articles gratuits et offre premium pour soutenir la production de contenus."
+    },
+    {
+      "source_id": "03f703fb-3e6b-44d7-ad46-0b4fee77b425",
+      "description": "Usbek & Rica est un média français créé en 2010 qui se définit comme explorant le futur et les mutations de la société. Son nom est un clin d'oeil aux deux personnages persans des Lettres persanes de Montesquieu, dont le regard étranger sert de fil conducteur prospectiviste. La rédaction traite de sujets liés aux sciences, aux technologies, à l'environnement et aux transformations culturelles, avec une approche tournée vers les scénarios à venir. Au-delà de son magazine et de son site, la marque organise aussi des conférences et des événements autour de l'anticipation."
+    },
+    {
+      "source_id": "24c856bf-a1c0-45ca-9646-7e16d37166e1",
+      "description": "Valeurs Actuelles est un hebdomadaire français fondé en 1966, positionné sur une ligne éditoriale conservatrice et de droite. Le titre traite d'actualité politique, de société, d'économie et de culture, avec une attention marquée aux questions d'identité, d'immigration et de sécurité. Il appartient depuis 2015 au groupe Valmonde, contrôlé par l'homme d'affaires Iskandar Safa via Privinvest. Le magazine a connu plusieurs polémiques médiatiques retentissantes ayant donné lieu à des procédures judiciaires liées à ses unes et à certains de ses contenus."
+    }
+  ]
+}

--- a/sources/source_evaluations_llm.json
+++ b/sources/source_evaluations_llm.json
@@ -1,7 +1,7 @@
 {
   "generated_at": "2026-06-14",
-  "model": "claude-opus-4-8 (5 sous-agents WebSearch + MCP read-only), nouveau schéma",
-  "_note": "Run complet 150 cibles, NOUVEAU schéma (reliability dérivée + 4 justifs + sources_consulted). Relu/validé avant apply (bias_origin=llm). reliability_score ABSENT (dérivé). Apply gated (creds write PO). | Re-run 2026-06-14 : 9 sources captées re-générées sous rubrique « capture actionnariale » (ligne propriétaire vs pénalité indép seule).",
+  "model": "claude-opus-4-8 (5 sous-agents WebSearch + MCP read-only), nouveau schema ; +10 delta 2026-06-25 (2 agents WebSearch, pont MCP)",
+  "_note": "Run complet 150 cibles, NOUVEAU schéma (reliability dérivée + 4 justifs + sources_consulted). Relu/validé avant apply (bias_origin=llm). reliability_score ABSENT (dérivé). Apply gated (creds write PO). | Re-run 2026-06-14 : 9 sources captées re-générées sous rubrique « capture actionnariale » (ligne propriétaire vs pénalité indép seule). | Run delta 2026-06-25 : +10 sources (CyberScoop, GamesIndustry.biz, GDC Vault, GoodTech, JeuxOnLine, Les Surligneurs, Polygon, Radio Free Europe/RL, Statista, UploadVR) via build_source_eval_prompt + workflow 2 agents WebSearch ; cibles materialisees via MCP (export_source_eval_targets.py casse). 150->160. Benchmark SKIP (D2). reliability_score derive a l-apply.",
   "evaluations": [
     {
       "source_id": "82880279-c9d2-4fb8-bde2-de0595228660",
@@ -216,18 +216,21 @@
     {
       "source_id": "6e27afbc-92ec-4450-82cf-58d106e2ebe5",
       "name": "Basket USA",
-      "description": "Média français de référence sur la NBA et le basket américain, qui publie news, lives, résultats, stats et interviews. Il s'adresse aux passionnés de basket francophones. Fait moins connu : malgré son thème stocké « tech », il s'agit d'un pur média sportif, avec un fort volet interviews de joueurs français en NBA.",
+      "description": "Basket USA est un site français spécialisé dans l'actualité NBA et le basket américain, créé autour de 1998 ce qui en fait l'un des plus anciens médias NBA francophones. Il a longtemps été édité par Eureka Presse (Nantes) avant de passer sous l'éditeur North Star Network SAS, groupe basé à Levallois-Perret spécialisé dans les médias sportifs digitaux. La rédaction couvre news, transferts, résultats, statistiques, rumeurs et suit de près les joueurs français en NBA, dont une page dédiée aux stats des Frenchies. Fait moins connu : le site est régulièrement cité comme média de référence NBA en France et son fonds éditorial remonte à la fin des années 1990, bien avant la médiatisation actuelle de la ligue.",
       "bias_stance": "specialized",
-      "score_independence": 0.6,
-      "score_rigor": 0.65,
-      "score_ux": 0.6,
+      "score_independence": 0.55,
+      "score_rigor": 0.6,
+      "score_ux": 0.55,
       "confidence": 0.65,
-      "bias_rationale": "Média sport spécialisé basket, sans orientation politique.",
-      "independence_rationale": "Site sportif indépendant financé par publicité et affiliation du secteur.",
-      "rigor_rationale": "Couverture suivie et fiable de la NBA, avec interviews originales, mais editorialisée.",
-      "ux_rationale": "Site de média sport lisible, avec publicité courante.",
+      "bias_rationale": "Média thématique sport (NBA/basket US), sans ligne politique ; positionnement specialized.",
+      "independence_rationale": "Détenu par North Star Network (groupe média digital), pas un éditeur indépendant ; financement publicitaire orienté trafic, ce qui pèse modérément sur l'indépendance.",
+      "rigor_rationale": "Couverture dense et suivie (stats, transferts, live) mais ton fan/actu rapide, peu de sourcing primaire vérifiable ; rigueur moyenne.",
+      "ux_rationale": "Site fonctionnel orienté volume d'articles et publicité ; lisibilité correcte sans être premium.",
       "sources_consulted": [
-        "https://www.basketusa.com/feed/"
+        "https://www.basketusa.com/",
+        "https://www.basketusa.com/mentions-legales/",
+        "https://fr.wikipedia.org/wiki/Basket_News_America",
+        "https://www.basketusa.com/stats-francais-nba/"
       ]
     },
     {
@@ -1004,20 +1007,22 @@
     {
       "source_id": "83440dbe-f0e8-4f47-9f9d-c71ae4dd8277",
       "name": "Gamekult",
-      "description": "Média français spécialisé dans le jeu vidéo, lancé en 2000 et reconnu pour son journalisme d'enquête sur l'industrie et son modèle par abonnement (environ 12 000 abonnés). Fait moins connu : racheté par Reworld Media en 2022 après son passage chez TF1/Unify, sa rédaction historique a démissionné en bloc en dénonçant un contexte hostile à l'indépendance de la presse.",
+      "description": "Gamekult est un site français de référence sur le jeu vidéo, fondé en décembre 2000 par Kévin Kuipers et Clément Apap, longtemps réputé pour son journalisme exigeant et ses enquêtes sur l'industrie. Il est passé entre les mains de CNET puis du groupe TF1 (2015) avant d'être racheté par Reworld Media en 2022 via la cession de la division Unify. Fait moins connu mais documenté : fin 2023, la quasi-totalité de la rédaction a quitté le site, dénonçant un contexte hostile à l'indépendance de la presse, malgré un modèle d'abonnement viable d'environ 12 000 abonnés. Depuis ce départ, la qualité éditoriale historique du média est jugée fortement dégradée sous Reworld.",
       "bias_stance": "specialized",
-      "score_independence": 0.4,
-      "score_rigor": 0.6,
-      "score_ux": 0.45,
+      "score_independence": 0.3,
+      "score_rigor": 0.45,
+      "score_ux": 0.55,
       "confidence": 0.7,
-      "bias_rationale": "Média thématique jeu vidéo, sans orientation politique.",
-      "independence_rationale": "Racheté par Reworld Media en 2022, départ de la rédaction historique dénonçant l'atteinte à l'indépendance.",
-      "rigor_rationale": "Historiquement reconnu pour son journalisme d'enquête, mais qualité incertaine depuis le départ de la rédaction et la reprise Reworld.",
-      "ux_rationale": "Risque de multiplication de la publicité sous Reworld, modèle d'abonnement historique fragilisé.",
+      "bias_rationale": "Média thématique jeu vidéo, sans orientation politique ; positionnement specialized.",
+      "independence_rationale": "Propriété de Reworld Media, groupe associé à des pratiques de réduction de coûts et au contenu de marque ; départ de la rédaction historique fin 2023 affaiblit fortement l'indépendance éditoriale.",
+      "rigor_rationale": "Rigueur historiquement élevée (tests, enquêtes), mais nettement dégradée depuis le départ de la rédaction et le passage sous Reworld ; note moyenne reflétant l'incertitude post-2023.",
+      "ux_rationale": "Plateforme structurée avec offre d'abonnement et tests, mais évolution vers un contenu plus léger sous Reworld ; UX correcte.",
       "sources_consulted": [
         "https://en.wikipedia.org/wiki/Gamekult",
-        "https://www.cbnews.fr/medias/image-apres-son-rachat-reworld-media-gamekult-voit-sa-redaction-annoncer-son-depart-72796",
-        "https://snj.fr/le-snj-soutient-la-redaction-de-gamekult-face-reworld/1869"
+        "https://siecledigital.fr/2022/06/30/gamekult-les-numeriques-doctissimo-et-dautres-passent-de-tf1-a-reworld-media/",
+        "https://www.arretsurimages.net/articles/gamekult-reworld-acheve-le-site-18-mois-apres-son-rachat",
+        "https://www.actugaming.net/la-redaction-de-gamekult-annonce-quitter-le-site-533732/",
+        "https://www.rtbf.be/article/gamekult-la-fin-cinglante-du-journalisme-gaming-rigoureux-11109904"
       ]
     },
     {
@@ -2690,6 +2695,200 @@
         "https://elucid.media/elucid-c-est-quoi",
         "https://fr.wikipedia.org/wiki/Olivier_Berruyer",
         "https://force-citoyenne.fr/elucid-decryptage-dun-media-independant-et-de-son-orientation-politique/"
+      ]
+    },
+    {
+      "source_id": "289b7c6e-e096-4c2e-94cd-88912e99022d",
+      "name": "CyberScoop",
+      "description": "CyberScoop est un média en ligne américain spécialisé dans la cybersécurité, le secteur public et les menaces numériques, basé à Washington. Il est édité par Scoop News Group, groupe de presse tech B2B fondé et dirigé par Goldy Kamali, qui édite aussi FedScoop, StateScoop et EdScoop. Fait moins connu : son modèle repose largement sur l'événementiel et le sponsoring institutionnel plutôt que sur l'abonnement, ce qui le rapproche d'un média de niche orienté décideurs gouvernementaux et industriels.",
+      "bias_stance": "specialized",
+      "score_independence": 0.5,
+      "score_rigor": 0.85,
+      "score_ux": 0.8,
+      "confidence": 0.8,
+      "bias_rationale": "Couverture technique cybersécurité sans angle politique partisan, l'angle est le sujet.",
+      "independence_rationale": "Détenu par un groupe privé (Scoop News Group) au modèle événementiel/sponsoring institutionnel, indépendance moyenne.",
+      "rigor_rationale": "Media Bias/Fact Check le note factualité 'High' et il est utilisé comme référence par les fact-checkers, aucun fact-check négatif recensé.",
+      "ux_rationale": "Site clair, sans paywall agressif, lecture professionnelle propre.",
+      "sources_consulted": [
+        "https://mediabiasfactcheck.com/cyberscoop-bias/",
+        "https://cyberscoop.com/about-us/",
+        "https://scoopnewsgroup.com/ourbrands/"
+      ]
+    },
+    {
+      "source_id": "ac8a064b-0fa0-491e-bf21-4dcbbc6ddbcb",
+      "name": "GamesIndustry.biz",
+      "description": "GamesIndustry.biz est le média de référence anglophone sur le business du jeu vidéo (chiffres marché, stratégies de studios, entretiens d'exécutifs), avec plus de 130 000 utilisateurs inscrits professionnels. Le site appartient depuis mai 2024 à IGN Entertainment, division du groupe Ziff Davis, après son rachat à Gamer Network/ReedPop. Fait moins connu : ce rachat a entraîné le départ de quasiment toute l'équipe éditoriale historique en 2024, dont le managing editor Brendan Sinclair, avant une reconstitution progressive.",
+      "bias_stance": "specialized",
+      "score_independence": 0.45,
+      "score_rigor": 0.8,
+      "score_ux": 0.75,
+      "confidence": 0.75,
+      "bias_rationale": "Média trade sur l'industrie du jeu vidéo, angle économique sectoriel sans orientation politique.",
+      "independence_rationale": "Détenu par Ziff Davis (conglomérat média sans ligne partisane) via IGN, ce qui pèse sur l'indépendance sans déplacer le biais.",
+      "rigor_rationale": "Journalisme trade reconnu (analyses, données marché, interviews), réputation solide malgré l'absence de notation formelle MBFC.",
+      "ux_rationale": "Lecture professionnelle correcte, présence publicitaire et certains contenus réservés mais sans paywall lourd.",
+      "sources_consulted": [
+        "https://en.wikipedia.org/wiki/Ziff_Davis",
+        "https://esportsinsider.com/2024/05/ign-entertainment-acquires-gamer-network-websites",
+        "https://www.videogameschronicle.com/news/games-media-set-for-more-layoffs-as-ign-owned-eurogamer-cuts-editorial-staff/",
+        "https://ground.news/interest/gamesindustrybiz"
+      ]
+    },
+    {
+      "source_id": "41563601-fcd3-485a-a7b7-a2a7c53e55bc",
+      "name": "GDC Vault (Game Developers Conference)",
+      "description": "GDC Vault est l'archive vidéo officielle des conférences de la Game Developers Conference (GDC), regroupant plus de 13 000 talks, audios et présentations sur le développement de jeux (programmation, design, business, art). Il est édité par l'organisateur de la GDC, dépendant du groupe événementiel Informa. Fait moins connu : ce n'est pas un média journalistique mais un catalogue de conférences, en partie gratuit et en partie sur abonnement (environ 599 dollars par an), ce qui explique des titres de flux RSS souvent vides ou répétés (« GDC Vault »).",
+      "bias_stance": "specialized",
+      "score_independence": null,
+      "score_rigor": null,
+      "score_ux": 0.45,
+      "confidence": 0.4,
+      "bias_rationale": "Archive de conférences techniques de développement de jeux, sans ligne politique, mais ce n'est pas un média d'actualité au sens propre.",
+      "independence_rationale": "Bras éditorial de l'organisateur de la GDC (Informa) et non un média indépendant, dimension non pertinente donc non notée.",
+      "rigor_rationale": "Contenu de conférences non journalistique et non vérifiable comme de l'info, rigueur factuelle indéterminable.",
+      "ux_rationale": "Flux RSS pauvre (titres répétés et vides) et accès largement payant nuisent à l'expérience de lecture.",
+      "sources_consulted": [
+        "https://gdconf.com/gdc-vault/",
+        "https://en.wikipedia.org/wiki/GDC_Vault",
+        "https://www.gamedeveloper.com/marketing/gdc-2022-sessions-are-now-on-gdc-vault"
+      ]
+    },
+    {
+      "source_id": "9b13fb68-89fc-4ec6-a180-2a593244842a",
+      "name": "GoodTech.info",
+      "description": "GoodTech.info est un média français d'actualité tech qui a succédé en 2023 à Toolinux (lancé en 2000), centré sur le logiciel libre, l'open source, l'IA éthique et la souveraineté numérique. Il est présidé par Alexandre Zapolsky, cofondateur de l'éditeur open source Linagora, dont l'écosystème (Twake, LinShare) figure ouvertement parmi les partenaires du site. Fait moins connu : cette proximité organique avec un acteur commercial du libre donne au site une ligne militante pro open source et souveraineté, et un financement partiellement par liens d'affiliation.",
+      "bias_stance": "alternative",
+      "score_independence": 0.3,
+      "score_rigor": 0.5,
+      "score_ux": 0.55,
+      "confidence": 0.65,
+      "bias_rationale": "Ligne militante non partisane en faveur de l'open source, de l'éthique numérique et de la souveraineté, hors axe gauche-droite.",
+      "independence_rationale": "Présidé par le cofondateur de Linagora et adossé à son écosystème commercial, ce qui crée un conflit d'intérêt éditorial marqué.",
+      "rigor_rationale": "Contenu d'actualité tech parfois orienté plaidoyer et titres sensationnalistes, rigueur factuelle moyenne.",
+      "ux_rationale": "Site lisible mais financé en partie par affiliation, expérience correcte sans paywall.",
+      "sources_consulted": [
+        "https://goodtech.info/a-propos/",
+        "https://linagora.com/en/goodtechinfo-100-open-source-free-ethical-and-sovereign-information",
+        "https://goodtech.info/toolinux-devient-goodtech-info/"
+      ]
+    },
+    {
+      "source_id": "460f4601-47a8-4e66-be60-e03c6dbb150d",
+      "name": "JeuxOnLine",
+      "description": "JeuxOnLine (JOL) est un site français spécialisé dans l'actualité des jeux vidéo, des MMO(RPG) et de la culture geek, mêlant tests, dossiers, éditoriaux et une forte composante communautaire (forums, encyclopédie collaborative). Il fonctionne sur un modèle commercial hybride professionnel-communautaire, financé par la publicité et des liens d'affiliation vers des revendeurs comme Gamesplanet. Fait moins connu : il est l'un des plus anciens sites francophones dédiés aux MMORPG, avec des dossiers historiques de référence sur le genre.",
+      "bias_stance": "specialized",
+      "score_independence": 0.55,
+      "score_rigor": 0.6,
+      "score_ux": 0.5,
+      "confidence": 0.6,
+      "bias_rationale": "Site thématique jeux vidéo et MMO, l'angle est le sujet, sans orientation politique.",
+      "independence_rationale": "Site indépendant non adossé à un grand groupe média mais financé par pub et affiliation marchande.",
+      "rigor_rationale": "Tests et dossiers éditoriaux sérieux mêlés à des contenus communautaires de fiabilité variable.",
+      "ux_rationale": "Présence publicitaire et liens d'affiliation visibles qui alourdissent la lecture, sans paywall agressif.",
+      "sources_consulted": [
+        "https://www.jeuxonline.info/",
+        "https://www.jeuxonline.info/article/mmog_hist"
+      ]
+    },
+    {
+      "source_id": "d8b0ff5e-863d-4410-bd85-53a15a01b8ee",
+      "name": "Les Surligneurs",
+      "description": "Les Surligneurs sont un média associatif français de legal-checking fondé en 2017, animé par des universitaires et étudiants en droit qui vérifient la conformité juridique des propos de responsables publics de tous bords. Signataires de la charte de l'IFCN depuis 2021 et partenaires de fact-checking de Meta, ils se revendiquent non partisans. Fait moins connu, leur financement est très éclaté (Fondation Francis-Lefebvre, Commission européenne, AFP, IFCN, université Paris-Saclay), avec moins de 5 pour cent issus des dons individuels.",
+      "bias_stance": "specialized",
+      "score_independence": 0.8,
+      "score_rigor": 0.9,
+      "score_ux": 0.75,
+      "confidence": 0.85,
+      "bias_rationale": "Collectif de juristes non partisan vérifiant des propos de tous les bords politiques, l'angle est la méthode juridique et non une ligne partisane.",
+      "independence_rationale": "Association indépendante de tout parti, financée par un panel large de fondations et institutions sans actionnaire de presse dominant, mais dépendante de subventions publiques et institutionnelles.",
+      "rigor_rationale": "Signataire de la charte IFCN depuis 2021 et partenaire de vérification de Meta, méthode de legal-checking documentée et politique de correction transparente.",
+      "ux_rationale": "Site éditorial sobre, sans paywall ni publicité intrusive, lecture confortable d'articles structurés.",
+      "sources_consulted": [
+        "https://fr.wikipedia.org/wiki/Les_Surligneurs",
+        "https://lessurligneurs.eu/notre-methode/",
+        "https://lessurligneurs.eu/les-surligneurs-et-meta-sunissent-pour-verifier-les-faits-sur-facebook-et-instagram/",
+        "https://odil.org/initiative/les-surligneurs/"
+      ]
+    },
+    {
+      "source_id": "ca0a88b7-ddeb-4663-ba3f-b36afde39868",
+      "name": "Polygon",
+      "description": "Polygon est un site américain d'actualité jeu vidéo et culture pop lancé par Vox Media en 2012, longtemps réputé pour ses reportages et explications fouillés. En mai 2025 il a été vendu à Valnet, qui a licencié l'essentiel de la rédaction, dont le rédacteur en chef. Fait moins connu, Valnet est largement décrit dans la presse spécialisée comme une fabrique de contenu SEO (clickbait, rémunération au clic, mise sur liste noire de journalistes), ce qui a fait craindre une chute de la qualité éditoriale du site.",
+      "bias_stance": "specialized",
+      "score_independence": 0.35,
+      "score_rigor": 0.45,
+      "score_ux": 0.45,
+      "confidence": 0.7,
+      "bias_rationale": "Média thématique jeu vidéo et divertissement sans orientation politique, l'angle est le sujet.",
+      "independence_rationale": "Racheté en 2025 par Valnet, groupe de content-farms accusé d'imposer un modèle SEO au clic et de purger les rédactions, ce qui pèse fortement sur l'indépendance rédactionnelle.",
+      "rigor_rationale": "Rigueur historiquement bonne sous Vox Media mais dégradée après le rachat Valnet et les licenciements massifs, l'éditeur étant associé à du contenu clickbait peu vérifié.",
+      "ux_rationale": "Lisibilité jeu vidéo correcte mais site Valnet réputé pour une densité publicitaire et un SEO agressifs depuis 2025.",
+      "sources_consulted": [
+        "https://en.wikipedia.org/wiki/Polygon_(website)",
+        "https://www.axios.com/2025/05/01/vox-media-polygon-sells",
+        "https://deadline.com/2025/05/polygon-sale-valnet-vox-wga-union-response-1236384199/",
+        "https://www.andrewliptak.com/polygon-vox-media-valnet-journalism-writing/"
+      ]
+    },
+    {
+      "source_id": "5ff7a6c1-d473-49f3-b3ff-0922d14c9663",
+      "name": "Radio Free Europe / Radio Liberty (RFE/RL)",
+      "description": "Radio Free Europe Radio Liberty est un diffuseur international financé par le Congrès américain via l'US Agency for Global Media, qui couvre l'actualité dans une vingtaine de langues en Europe de l'Est, Caucase, Asie centrale et Moyen-Orient. Son indépendance éditoriale est protégée par un firewall statutaire interdisant l'ingérence des responsables gouvernementaux, et les agrégateurs de biais le classent centre et factuel. Fait moins connu, l'organisation fut financée secrètement par la CIA jusqu'en 1972 avant que le Congrès ne prenne le relais.",
+      "bias_stance": "center",
+      "score_independence": 0.45,
+      "score_rigor": 0.75,
+      "score_ux": 0.7,
+      "confidence": 0.75,
+      "bias_rationale": "Media Bias/Fact Check le classe peu biaisé et Ground News au centre, langage neutre et couverture équilibrée malgré une origine de contre-propagande.",
+      "independence_rationale": "Financement public américain via l'USAGM limite l'indépendance, atténué par un firewall légal protégeant les décisions éditoriales des journalistes.",
+      "rigor_rationale": "Reporting jugé factuel et généralement sourcé par les agrégateurs, avec critiques ponctuelles de contenus pro-gouvernementaux.",
+      "ux_rationale": "Site d'information classique sans paywall, lecture correcte mais publicité et navigation multilingue parfois denses.",
+      "sources_consulted": [
+        "https://en.wikipedia.org/wiki/Radio_Free_Europe/Radio_Liberty",
+        "https://mediabiasfactcheck.com/radio-free-europe-radio-liberty/",
+        "https://about.rferl.org/faq/how-is-rfe-rl-funded-and-managed/",
+        "https://ground.news/interest/radio-free-europe-radioliberty"
+      ]
+    },
+    {
+      "source_id": "aceb960f-3517-4ac9-af9b-52f5b9b91c15",
+      "name": "Statista",
+      "description": "Statista est un portail allemand de données et statistiques créé en 2007, qui agrège plus d'un million de statistiques issues de plus de 22 500 sources tierces et de quelques enquêtes propres. Media Bias/Fact Check le classe peu biaisé et factuellement élevé, sans orientation politique. Fait moins connu, Statista est avant tout un agrégateur de données secondaires, dont la méthodologie complète et les tailles d'échantillon sont souvent enfermées derrière un abonnement payant, ce qui complique la vérification de la source d'origine.",
+      "bias_stance": "specialized",
+      "score_independence": 0.5,
+      "score_rigor": 0.7,
+      "score_ux": 0.4,
+      "confidence": 0.75,
+      "bias_rationale": "Portail de données thématiques sans orientation politique, classé peu biaisé par Media Bias/Fact Check.",
+      "independence_rationale": "Entreprise commerciale détenue par des investisseurs (groupe média et capital privé) dont le modèle d'abonnement crée une dépendance aux clients payants, sans ligne partisane imposée.",
+      "rigor_rationale": "Données contrôlées en double regard et factuellement élevées, mais rigueur limitée par son rôle d'agrégateur de sources secondaires dont la méthodologie n'est pas toujours visible.",
+      "ux_rationale": "Paywall agressif enfermant rapports complets, exports et méthodologie derrière un abonnement, ce qui dégrade nettement l'expérience de lecture gratuite.",
+      "sources_consulted": [
+        "https://en.wikipedia.org/wiki/Statista",
+        "https://mediabiasfactcheck.com/statista/",
+        "https://www.statista.com/aboutus/trust",
+        "https://bernoff.com/blog/my-big-problem-with-statista"
+      ]
+    },
+    {
+      "source_id": "2155fdec-d9cf-44d2-8dfd-7bb3e6402e06",
+      "name": "UploadVR",
+      "description": "UploadVR est un site américain d'information spécialisé dans la réalité virtuelle, augmentée et mixte, fondé en 2014 et exploité par l'entité UVR Media. Sa rédaction se revendique indépendante pour offrir une couverture impartiale du secteur XR. Fait moins connu, l'activité de coworking d'origine d'Upload a fermé en 2018 faute de financement, mais le bras média a survécu de façon autonome et reste une référence du suivi de l'écosystème casques et jeux VR.",
+      "bias_stance": "specialized",
+      "score_independence": 0.6,
+      "score_rigor": 0.65,
+      "score_ux": 0.6,
+      "confidence": 0.6,
+      "bias_rationale": "Média thématique consacré à la VR et XR sans orientation politique, l'angle est le sujet technologique.",
+      "independence_rationale": "Site exploité par UVR Media de façon autonome, non capté par un grand groupe média, mais dépendant des annonceurs et acteurs de l'industrie qu'il couvre.",
+      "rigor_rationale": "Couverture spécialisée correcte et suivie de l'industrie XR, sans signal de sanctions ni de défaillance factuelle majeure documentée.",
+      "ux_rationale": "Site de news tech lisible avec publicité standard, expérience de lecture moyenne sans paywall agressif.",
+      "sources_consulted": [
+        "https://en.wikipedia.org/wiki/UploadVR",
+        "https://www.uploadvr.com/about-us/",
+        "https://techcrunch.com/2017/01/30/upload-brings-on-ign-co-founder-as-the-vr-tastemaker-continues-to-grow/"
       ]
     }
   ]


### PR DESCRIPTION
## Quoi

Partie A du plan « 3 points data/backend de L'Essentiel » — 1 PR code groupée (points 1 + 3).

- **Point 1 — Tournée ~8 sections thématiques.** Les suggestions « Choisie pour vous » **complètent** les favoris jusqu'à une cible additive `TOURNEE_TARGET_SECTIONS=8`, au lieu de remplir le reliquat de `FAVORITE_CAP`. Un compte à 7 favoris reçoit donc 1 suggestion, un compte à 0 favori jusqu'à 8. `TOURNEE_SUGGEST_SUBCAP` 4→8, `TOURNEE_SUGGEST_CONTENT_FLOOR` 3→2 (pool élargi les jours pauvres). Cap d'affichage mobile `kTourneeVisibleCap` 10→13 (8 thématiques + Actus + Bonnes + Grille = 11, + marge).
- **Point 3 — Mode serein recharge fiable.** `/api/essentiel` accepte `?serein=` (override explicite, fallback DB conservé). Le mobile le passe explicitement (`fetch(serein: isSerene)`) → plus de dépendance à la persistance DB au moment du refetch.

`FAVORITE_CAP` (7, input favoris) et `InterestConstants.favoriteCap` (7) restent inchangés.

## Pourquoi

- La Tournée plafonnait à ~7 thématiques (les suggestions remplissaient le reliquat de `FAVORITE_CAP` au lieu de s'ajouter) → page trop maigre. Décision PO : viser ~8 thématiques, cartes éditoriales en plus.
- Le toggle « mode serein » ne rechargeait pas l'Essentiel : `toggle()` posait l'état serein en synchrone → le listener refetchait `/essentiel` **avant** la persistance DB ; or `/essentiel` lisait le mode **depuis la DB** → ancien mode renvoyé.

## Comment ça a été vérifié

- [x] **pytest** ciblé (`test_top_themes_suggestions`, `test_top_themes_with_favorites`, `test_tournee_suggester`, `test_essentiel_endpoint`) : 65 OK. Suite complète : **1894 passed** (les 2 seuls échecs sont pré-existants et hors-scope = artefacts timezone `+02:00` local sur des fichiers non touchés, verts en CI UTC).
- [x] **flutter test** des fichiers touchés : `flux_continu_tournee_order` 18/18, `flux_continu_sources` 9/9, `manage_favorites_sheet` 11/11, `flux_continu_progressive_fanout` 6/6. (`flux_continu_provider_test` : 1 flake d'ordre **pré-existant**, vert en isolation, non lié au diff.)
- [x] **flutter analyze** : 0 issue sur les fichiers modifiés.
- [x] **/simplify** (4 agents reuse/simplification/efficiency/altitude) : RAS, hors clarification d'un commentaire sur `TOURNEE_SUGGEST_SUBCAP`.
- [ ] Playwright `/validate-feature` (toggle serein recharge Essentiel + feed ; Tournée ~8 sections) — à faire avant deploy.

## Zones à risque

- `app/routers/users.py` `_arrange_tournee` (Router) + `tournee_suggester` (pool élargi mais **nombre de requêtes DB constant**, ~16 candidats max).
- `app/routers/essentiel.py` : nouveau query param, rétro-compat préservée par le fallback DB.
- **Aucune migration Alembic**, aucun changement de schéma (1 head inchangé).

## Suite (hors PR)

Partie B — run data (point 2 : sources curées non évaluées, ex. Cerveau & Psycho, BDM) : workflow multi-agents séparé après GO, **stop avant apply prod** (gate PO).
