### PR TITLE
fix(android): retire READ_MEDIA_IMAGES/READ_MEDIA_VIDEO du flavor pla…

### DIFF
--- a/apps/mobile/android/app/src/playstore/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/playstore/AndroidManifest.xml
@@ -1,7 +1,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
-    <!-- Flavor Play Store : retire REQUEST_INSTALL_PACKAGES, injectee par open_filex (auto-update APK side-load). Bannie du Play Store, inutile ici car les MAJ passent par le Store. -->
-    <uses-permission
-        android:name="android.permission.REQUEST_INSTALL_PACKAGES"
-        tools:node="remove" />
+        xmlns:tools="http://schemas.android.com/tools">
+        <!-- Flavor Play Store : retire REQUEST_INSTALL_PACKAGES, injectee par open_filex (auto-update APK side-load). Bannie du Play Store, inutile ici car les MAJ passent par le Store. -->
+        <uses-permission
+                    android:name="android.permission.REQUEST_INSTALL_PACKAGES"
+                    tools:node="remove" />
+        <!-- Flavor Play Store : retire READ_MEDIA_IMAGES / READ_MEDIA_VIDEO (Photo & Video Permissions policy). Usage media non-core ; le selecteur systeme Android (Photo Picker) ne necessite aucune permission. -->
+        <uses-permission
+                    android:name="android.permission.READ_MEDIA_IMAGES"
+                    tools:node="remove" />
+        <uses-permission
+                    android:name="android.permission.READ_MEDIA_VIDEO"
+                    tools:node="remove" />
 </manifest>


### PR DESCRIPTION
## What
Retire les permissions READ_MEDIA_IMAGES et READ_MEDIA_VIDEO du flavor playstore via tools:node="remove" dans src/playstore/AndroidManifest.xml.

## Why
Google Play a refuse la soumission (Photo and Video Permissions policy) : ces permissions donnent un acces large a la phototheque, reserve aux apps dont c'est le coeur de metier. Facteur n'en a qu'un usage ponctuel (file-chooser webview). Elles sont injectees par une dependance transitive (probablement flutter_inappwebview / flutter_downloader), pas par notre code. Le selecteur systeme Android (Photo Picker) couvre le besoin sans permission. Meme approche que le retrait de REQUEST_INSTALL_PACKAGES (#867).

## Type
- [x] Bug fix
## Notes / suivi
- A verifier apres build : un eventuel upload de fichier dans une webview fonctionne toujours (Photo Picker, Android 13+).
- - Apres merge : rebuild "Build Android AAB (Play Store)" -> reuploader sur Closed testing -> solder la declaration "Sensitive app permissions" (none of these) -> resubmit.