### PR TITLE
fix(ios): ajoute NSLocationAlwaysAndWhenInUseUsageDescription (ITMS-9…

### DIFF
--- a/apps/mobile/ios/Runner/Info.plist
+++ b/apps/mobile/ios/Runner/Info.plist
@@ -58,6 +58,8 @@
 	</array>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Pour afficher la météo de ta ville.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Pour afficher la météo de ta ville.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Facteur n’enregistre pas de son. Cette autorisation est requise par le lecteur audio utilisé pour écouter les contenus.</string>
 	<key>ITSAppUsesNonExemptEncryption</key>


### PR DESCRIPTION
## What
Ajoute la purpose string NSLocationAlwaysAndWhenInUseUsageDescription dans apps/mobile/ios/Runner/Info.plist.

## Why
Apple a remonte l'alerte ITMS-90683 (Missing purpose string) a l'upload du build 1782312713 : la dependance geolocator reference l'API de localisation "Always", donc Apple exige cette purpose string meme si Facteur n'utilise que le "When In Use". Sans elle, risque de rejet a la soumission App Store. Texte reutilise de la chaine WhenInUse existante (usage meteo uniquement).

## Type
- [x] Bug fix
## Notes / suivi
- Alerte (pas un rejet) : n'a pas bloque TestFlight. A corriger avant soumission App Store.
- - Apres merge : nouveau build iOS Codemagic -> l'alerte disparait sur le prochain upload.