### PR TITLE
feat(couverture): polish Couverture médiatique — repères G/D, source cliquable, aperçu

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,18 @@
 {
   "unreleased": [
     {
+      "tag": "Perspectives",
+      "summary": "Couverture médiatique plus lisible : repères Gauche/Droite sous la barre, source cliquable et aperçu de l'article au toucher prolongé."
+    },
+    {
+      "tag": "Reader",
+      "summary": "La barre de biais de la Couverture médiatique passe en pleine largeur et devient interactive : touche un bord politique pour filer vers ces articles. Et à l'ouverture d'un article sur son site, le bandeau cookies n'est plus masqué."
+    },
+    {
+      "tag": "Essentiel",
+      "summary": "Ta carte du jour est plus compacte (titres resserrés) et tient mieux à l'écran, et la fin de tournée est épurée avec des idées d'activités plus inspirantes."
+    },
+    {
       "tag": "Lecture",
       "summary": "Carrousels plus nets : le bas des cartes ne se coupe plus quand leurs tailles diffèrent, et les points de défilement respirent mieux."
     },

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -279,6 +279,13 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
   // Footer slide offset: 0.0 = fully visible, 1.0 = fully hidden.
   final ValueNotifier<double> _footerOffset = ValueNotifier<double>(0.0);
+  // « Arrival gate » WebView : à l'entrée dans une WebView, le footer est caché
+  // et toute *révélation* est bloquée tant qu'on n'a pas scrollé d'au moins
+  // [_kWebViewFooterRevealThreshold] px — sinon la garde overscroll (scroll à 0)
+  // re-révèle le footer au moindre contact et masque le bandeau cookies que les
+  // sites verrouillent en bas d'écran. La garde ne concerne QUE le mode WebView.
+  bool _footerRevealLocked = false;
+  static const double _kWebViewFooterRevealThreshold = 48.0; // px
   double _footerAutoStart = 0.0;
   double _footerAutoTarget = 0.0;
   late AnimationController _footerAutoController;
@@ -322,6 +329,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
             sourceDomain: p.sourceDomain,
             biasStance: p.biasStance,
             publishedAt: p.publishedAt,
+            description: p.description,
           ),
         )
         .toList();
@@ -369,6 +377,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       _contentResolved = true;
       _isConsumed = false;
       _showWebView = true;
+      // Arrival gate : footer caché + révélation verrouillée jusqu'au 1er scroll
+      // (laisse le bandeau cookies du site visible en bas).
+      _footerOffset.value = 1.0;
+      _footerRevealLocked = true;
     } else {
       _content = widget.content;
       if (_content != null) {
@@ -673,7 +685,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     }
     if (msg.startsWith('scroll_y:')) {
       final y = double.tryParse(msg.substring(9));
-      if (y != null) _webScrollY = y;
+      if (y != null) _updateWebScrollY(y);
       return;
     }
     if (msg.startsWith('progress:')) {
@@ -896,6 +908,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       _scrollStopTimer?.cancel();
       _inactivityTimer?.cancel();
       _animateFooterTo(1.0);
+      // Arrival gate : verrouille la révélation jusqu'au 1er scroll dans le site
+      // (la garde overscroll `_webScrollY <= 0` re-révélerait sinon le footer).
+      _footerRevealLocked = true;
     }
   }
 
@@ -913,10 +928,24 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     _footerAutoController.forward(from: 0);
   }
 
+  /// Met à jour [_webScrollY] depuis la WebView (ScrollBridge ou callback
+  /// premium) et **lève l'arrival gate** dès que le scroll dépasse le seuil :
+  /// le footer peut alors réapparaître normalement au scroll vers le haut.
+  void _updateWebScrollY(double y) {
+    _webScrollY = y;
+    if (_footerRevealLocked && y >= _kWebViewFooterRevealThreshold) {
+      _footerRevealLocked = false;
+    }
+  }
+
   /// Apply a page-scroll-equivalent [delta] (positive = page going down)
   /// to the footer offset. The header is pinned and never reacts to scroll.
   void _applyChromeOffsetDelta(double delta) {
     if (_footerPermanent.value) return;
+    // Arrival gate : tant que verrouillée, on ignore les deltas de *révélation*
+    // (delta négatif = scroll vers le haut) pour ne pas découvrir le footer sur
+    // le bandeau cookies ; seuls les masquages (delta positif) passent.
+    if (_footerRevealLocked && delta < 0) return;
     final footerHeight =
         _kFooterContentHeight + MediaQuery.of(context).viewPadding.bottom;
     // Hide a touch faster than it reveals: bias downward (hide) deltas so the
@@ -970,7 +999,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   void _onGestureEnd(double velocityPxPerSec) {
     if (_content?.isVideo ?? false) return;
     if (_webScrollY <= 0) {
-      if (!_footerPermanent.value && _footerOffset.value != 0) {
+      // Arrival gate : ne pas re-révéler le footer en haut de page tant que la
+      // garde est armée (sinon masque le bandeau cookies dès le 1er contact).
+      if (!_footerRevealLocked &&
+          !_footerPermanent.value &&
+          _footerOffset.value != 0) {
         _animateFooterTo(0);
       }
       return;
@@ -982,6 +1015,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     } else if (velocityPxPerSec < -kVelocitySnapThreshold) {
       target = 0.0;
     }
+    // Arrival gate : ignore un flick de révélation (target 0.0) avant le seuil.
+    if (_footerRevealLocked && target == 0.0) return;
     if (target != null &&
         !_footerPermanent.value &&
         _footerOffset.value != target) {
@@ -1829,7 +1864,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                 if (notification is ScrollUpdateNotification) {
                   final delta = notification.scrollDelta ?? 0.0;
                   final metrics = notification.metrics;
-                  if (metrics.pixels <= 0 && !_isWebViewActive) {
+                  if (metrics.pixels <= 0 &&
+                      !_isWebViewActive &&
+                      !_footerRevealLocked) {
                     _footerOffset.value = 0.0;
                   }
 
@@ -2000,6 +2037,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       _showWebView = true;
       _ctaTapped = true;
     });
+    // Arrival gate : cache le footer + verrouille la révélation jusqu'au 1er
+    // scroll (préserve le bandeau cookies du site en bas d'écran).
+    _footerRevealLocked = true;
+    _animateFooterTo(1.0);
   }
 
   /// External-source CTA used in the footer for video/audio readers.
@@ -3531,7 +3572,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         onGestureStart: _onGestureStart,
         onGestureDelta: _onGestureDelta,
         onGestureEnd: _onGestureEnd,
-        onScrollY: (y) => _webScrollY = y,
+        onScrollY: _updateWebScrollY,
         onProgress: _applyWebReadingProgress,
         onPaywallDetected: _onPremiumPaywallDetected,
         gestureRecognizers: swipeBackCompatiblePlatformViewGestureRecognizers(),

--- a/apps/mobile/lib/features/detail/widgets/deep_recommendation_card.dart
+++ b/apps/mobile/lib/features/detail/widgets/deep_recommendation_card.dart
@@ -68,7 +68,7 @@ class DeepRecommendationCard extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      'Le pas de recul'.toUpperCase(),
+                      'Le pas de recul · Facteur'.toUpperCase(),
                       style: GoogleFonts.courierPrime(
                         fontSize: 10.5,
                         fontWeight: FontWeight.w700,

--- a/apps/mobile/lib/features/digest/widgets/divergence_inline_badge.dart
+++ b/apps/mobile/lib/features/digest/widgets/divergence_inline_badge.dart
@@ -27,16 +27,28 @@ class DivergenceInlineBadge extends StatelessWidget {
   /// (~+45 %) ; toutes les autres call-sites gardent 1.0.
   final double scale;
 
+  /// Boost **léger** du niveau `medium` (« Avis variés »), réservé au header
+  /// Couverture médiatique : label en `textSecondary` + poids w600, opacité des
+  /// dots remontée. Ni `textPrimary` ni w700 (réservés à `high`). Sans effet sur
+  /// les autres niveaux ; défaut `false` ⇒ les call-sites feed/flux inchangés.
+  final bool prominentMedium;
+
   const DivergenceInlineBadge({
     super.key,
     this.divergenceLevel,
     this.iconOnly = false,
     this.scale = 1.0,
+    this.prominentMedium = false,
   });
 
   @override
   Widget build(BuildContext context) {
-    final config = _configFor(divergenceLevel, context.facteurColors, iconOnly);
+    final config = _configFor(
+      divergenceLevel,
+      context.facteurColors,
+      iconOnly,
+      prominentMedium,
+    );
     if (config == null) return const SizedBox.shrink();
 
     final glyph = CustomPaint(
@@ -55,7 +67,7 @@ class DivergenceInlineBadge extends StatelessWidget {
           config.label,
           style: GoogleFonts.courierPrime(
             fontSize: 8 * scale,
-            fontWeight: config.bold ? FontWeight.w700 : FontWeight.w500,
+            fontWeight: config.labelWeight,
             color: config.labelColor,
             letterSpacing: 0.35 * scale,
           ),
@@ -68,6 +80,7 @@ class DivergenceInlineBadge extends StatelessWidget {
     String? level,
     FacteurColors colors,
     bool iconOnly,
+    bool prominentMedium,
   ) {
     switch (level) {
       case 'low':
@@ -80,12 +93,14 @@ class DivergenceInlineBadge extends StatelessWidget {
             _Dot(19, 6, colors.success, dotOpacity),
           ],
           labelColor: colors.textSecondary,
-          bold: false,
+          labelWeight: FontWeight.w500,
         );
       case 'medium':
-        // En iconOnly les dots portent tout le sens — on remonte l'opacité
-        // pour qu'ils restent lisibles sans le label.
-        final dotOpacity = iconOnly ? 0.85 : 0.5;
+        // Boost léger réservé au header Couverture (label visible) : dots à 0.7
+        // au lieu de 0.5, label secondary w600. En iconOnly les dots portent
+        // tout le sens — on remonte l'opacité comme avant.
+        final boosted = prominentMedium && !iconOnly;
+        final dotOpacity = iconOnly ? 0.85 : (boosted ? 0.7 : 0.5);
         return _BadgeConfig(
           label: 'AVIS VARIÉS',
           dots: [
@@ -95,8 +110,8 @@ class DivergenceInlineBadge extends StatelessWidget {
             _Dot(20, 6, colors.textTertiary, dotOpacity),
             _Dot(25, 6, colors.textTertiary, dotOpacity),
           ],
-          labelColor: colors.textTertiary,
-          bold: false,
+          labelColor: boosted ? colors.textSecondary : colors.textTertiary,
+          labelWeight: boosted ? FontWeight.w600 : FontWeight.w500,
         );
       case 'high':
         return _BadgeConfig(
@@ -108,7 +123,7 @@ class DivergenceInlineBadge extends StatelessWidget {
             _Dot(24, 6, colors.biasRight, 1.0),
           ],
           labelColor: colors.textPrimary,
-          bold: true,
+          labelWeight: FontWeight.w700,
         );
       default:
         return null;
@@ -120,12 +135,15 @@ class _BadgeConfig {
   final String label;
   final List<_Dot> dots;
   final Color labelColor;
-  final bool bold;
+
+  /// Poids du label (granulaire — remplace l'ancien `bold` binaire) : w500
+  /// (low/medium discret), w600 (medium boosté), w700 (high polarisé).
+  final FontWeight labelWeight;
   const _BadgeConfig({
     required this.label,
     required this.dots,
     required this.labelColor,
-    required this.bold,
+    required this.labelWeight,
   });
 }
 

--- a/apps/mobile/lib/features/digest/widgets/topic_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/topic_section.dart
@@ -894,6 +894,7 @@ class _TopicSectionState extends ConsumerState<TopicSection>
                   sourceDomain: p.sourceDomain,
                   biasStance: p.biasStance,
                   publishedAt: p.publishedAt,
+                  description: p.description,
                 ))
             .toList(),
         biasDistribution: response.biasDistribution,

--- a/apps/mobile/lib/features/feed/repositories/feed_repository.dart
+++ b/apps/mobile/lib/features/feed/repositories/feed_repository.dart
@@ -1189,6 +1189,10 @@ class PerspectiveData {
   final String biasStance;
   final String? publishedAt;
 
+  /// Chapô / extrait de l'article variant (servi par le back, `null` si absent).
+  /// Alimente l'aperçu au long-press de la carte de couverture.
+  final String? description;
+
   /// Spans divergents du titre variant vs. référence (colorisés par bias).
   /// Liste vide si la chaîne back n'a pas pu calculer (cluster manquant, etc.).
   final List<HighlightSpan> highlightSpans;
@@ -1209,6 +1213,7 @@ class PerspectiveData {
     required this.sourceDomain,
     required this.biasStance,
     this.publishedAt,
+    this.description,
     this.highlightSpans = const [],
     this.sharedTokens = const [],
     this.language,
@@ -1224,6 +1229,7 @@ class PerspectiveData {
       sourceDomain: (json['source_domain'] as String?) ?? '',
       biasStance: (json['bias_stance'] as String?) ?? 'unknown',
       publishedAt: json['published_at'] as String?,
+      description: json['description'] as String?,
       highlightSpans: rawHighlights == null
           ? const []
           : rawHighlights

--- a/apps/mobile/lib/features/feed/widgets/coverage_comparison_card.dart
+++ b/apps/mobile/lib/features/feed/widgets/coverage_comparison_card.dart
@@ -4,6 +4,7 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:timeago/timeago.dart' as timeago;
 
 import '../../../config/theme.dart';
+import '../../../widgets/article_preview_modal.dart';
 import '../../../widgets/design/facteur_card.dart';
 import '../../../widgets/design/facteur_image.dart';
 import 'diff_title.dart';
@@ -24,10 +25,16 @@ class CoverageComparisonCard extends StatelessWidget {
   /// le scroll au-delà (nudge CTA). `null` sur les cartes suivantes.
   final Key? firstCardKey;
 
+  /// Tap sur la zone source (pastille + nom) → ouvre la [SourceDetailModal].
+  /// `null` quand la source n'est pas suivie par l'utilisateur ⇒ la zone retombe
+  /// sur l'ouverture de l'article (pas de zone morte).
+  final VoidCallback? onSourceTap;
+
   const CoverageComparisonCard({
     super.key,
     required this.perspective,
     this.firstCardKey,
+    this.onSourceTap,
   });
 
   /// Temps relatif depuis `publishedAt` (`timeago` `fr_short`). `null` si la
@@ -51,6 +58,14 @@ class CoverageComparisonCard extends StatelessWidget {
       width: 248,
       child: FacteurCard(
         onTap: () => openPerspectiveReader(context, perspective),
+        // Long-press → aperçu flottant (titre + chapô + source) ; relâché = ferme.
+        onLongPressStart: (_) => ArticlePreviewOverlay.show(
+          context,
+          perspective.toPreviewContent(),
+        ),
+        onLongPressMoveUpdate: (d) =>
+            ArticlePreviewOverlay.updateScroll(d.localOffsetFromOrigin.dy),
+        onLongPressEnd: (_) => ArticlePreviewOverlay.dismiss(),
         backgroundColor: colors.surface,
         borderRadius: 16,
         padding: const EdgeInsets.all(15),
@@ -88,7 +103,11 @@ class CoverageComparisonCard extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 14),
-            _Footer(perspective: perspective, biasColor: biasColor),
+            _Footer(
+              perspective: perspective,
+              biasColor: biasColor,
+              onSourceTap: onSourceTap,
+            ),
           ],
         ),
       ),
@@ -100,13 +119,49 @@ class _Footer extends StatelessWidget {
   final Perspective perspective;
   final Color biasColor;
 
-  const _Footer({required this.perspective, required this.biasColor});
+  /// Tap sur la zone source → [SourceDetailModal] (cf.
+  /// [CoverageComparisonCard.onSourceTap]). `null` ⇒ zone non interactive.
+  final VoidCallback? onSourceTap;
+
+  const _Footer({
+    required this.perspective,
+    required this.biasColor,
+    this.onSourceTap,
+  });
 
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
     final timeLabel = CoverageComparisonCard.relativeTime(
       perspective.publishedAt,
+    );
+
+    // Zone source (pastille + nom) — rendue tappable quand [onSourceTap] est
+    // fourni. Le GestureDetector enfant l'emporte sur le tap de la carte pour
+    // cette zone ; absent, la zone retombe sur l'ouverture article (pas de zone
+    // morte → on ne pose pas de detector opaque sans callback).
+    final sourceGroup = Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _SourcePastille(
+          domain: perspective.sourceDomain,
+          name: perspective.sourceName,
+          colors: colors,
+        ),
+        const SizedBox(width: 7),
+        Flexible(
+          child: Text(
+            perspective.sourceName,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: GoogleFonts.dmSans(
+              fontSize: 12.5,
+              fontWeight: FontWeight.w600,
+              color: colors.textPrimary,
+            ),
+          ),
+        ),
+      ],
     );
 
     // Groupe source + biais à gauche (shrink via le nom), temps à droite.
@@ -119,23 +174,14 @@ class _Footer extends StatelessWidget {
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              _SourcePastille(
-                domain: perspective.sourceDomain,
-                name: perspective.sourceName,
-                colors: colors,
-              ),
-              const SizedBox(width: 7),
               Flexible(
-                child: Text(
-                  perspective.sourceName,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: GoogleFonts.dmSans(
-                    fontSize: 12.5,
-                    fontWeight: FontWeight.w600,
-                    color: colors.textPrimary,
-                  ),
-                ),
+                child: onSourceTap != null
+                    ? GestureDetector(
+                        behavior: HitTestBehavior.opaque,
+                        onTap: onSourceTap,
+                        child: sourceGroup,
+                      )
+                    : sourceGroup,
               ),
               const SizedBox(width: 9),
               // Chip biais (dot + libellé MAJ coloré).

--- a/apps/mobile/lib/features/feed/widgets/coverage_spectrum_bar.dart
+++ b/apps/mobile/lib/features/feed/widgets/coverage_spectrum_bar.dart
@@ -1,7 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
 import '../../../config/theme.dart';
 
-const _radius = BorderRadius.all(Radius.circular(2));
+/// Rayon des coins **internes** (entre segments) — adouci à 4 px pour une barre
+/// plus élégante. Les coins externes (1ʳᵉ/dernière stance visible) sont plus
+/// marqués ([CoverageSpectrumBar._kRadiusOuter]). Réutilisé tel quel par le
+/// shimmer pour la cohérence.
+const _radius = BorderRadius.all(Radius.circular(4));
 
 /// Spectrum bar pour le bandeau hi-fi `cm-panel-inline` de la Couverture
 /// médiatique : 5 segments distincts L/CL/C/CR/R, hauteur fixe 8 px,
@@ -18,7 +23,24 @@ class CoverageSpectrumBar extends StatelessWidget {
   /// pas rendus afin que les largeurs reflètent strictement les compteurs.
   final Map<String, int> distribution;
 
-  const CoverageSpectrumBar({super.key, required this.distribution});
+  /// Optionnel : tap sur un segment → renvoie la clé de stance (`left`…`right`).
+  /// Quand fourni, la barre devient **interactive** : la cible tactile est
+  /// élargie (~24 px de haut, padding transparent) sans grossir le trait
+  /// visuel, et un `GestureDetector` mappe la position du tap → segment.
+  final void Function(String stanceKey)? onSegmentTap;
+
+  /// Quand `true`, ancre la barre par deux libellés « Gauche » / « Droite »
+  /// posés sous le trait (permanents — pas de libellé central éphémère). Utilisé
+  /// en pied de bande de la Couverture médiatique ; défaut `false` ⇒ aucun
+  /// autre call-site impacté.
+  final bool showAnchorLabels;
+
+  const CoverageSpectrumBar({
+    super.key,
+    required this.distribution,
+    this.onSegmentTap,
+    this.showAnchorLabels = false,
+  });
 
   // Ordre canonique du spectre politique, gauche → droite.
   static const _keys = [
@@ -32,7 +54,16 @@ class CoverageSpectrumBar extends StatelessWidget {
   // Lissage de l'évolution de la barre quand `distribution` change (refetch
   // incrémental ~2.2 s) : chaque segment grandit/rétrécit au lieu de sauter.
   static const _kSegmentAnim = Duration(milliseconds: 350);
-  static const _kGap = 2.0;
+  static const _kGap = 3.0;
+  // Coins externes (bord gauche de la 1ʳᵉ stance visible, bord droit de la
+  // dernière) : plus marqués que les coins internes (`_radius` = 4) pour que la
+  // barre se lise comme une pilule arrondie aux extrémités.
+  static const _kRadiusOuter = 5.0;
+  // Trait visuel (épaissi de 8 → 11 pour la pleine largeur en pied de bande).
+  static const _kBarHeight = 11.0;
+  // Cible tactile confortable quand interactive : padding transparent autour du
+  // trait, sans l'épaissir.
+  static const _kTapTargetHeight = 24.0;
 
   @override
   Widget build(BuildContext context) {
@@ -47,9 +78,13 @@ class CoverageSpectrumBar extends StatelessWidget {
     final counts =
         List.generate(_keys.length, (i) => distribution[_keys[i]] ?? 0);
     final total = counts.fold<int>(0, (sum, c) => sum + c);
+    final interactive = onSegmentTap != null;
+    // 1ʳᵉ / dernière stance visible → coins externes plus marqués (pilule).
+    final firstVisible = counts.indexWhere((c) => c > 0);
+    final lastVisible = counts.lastIndexWhere((c) => c > 0);
 
-    return SizedBox(
-      height: 8,
+    final barArea = SizedBox(
+      height: interactive ? _kTapTargetHeight : _kBarHeight,
       // LayoutBuilder : on calcule des largeurs explicites pour pouvoir les
       // animer (les `flex` d'`Expanded` ne s'animent pas → saut visible).
       child: LayoutBuilder(
@@ -61,34 +96,104 @@ class CoverageSpectrumBar extends StatelessWidget {
           final barWidth =
               (constraints.maxWidth - totalGap).clamp(0.0, constraints.maxWidth);
 
-          return Row(
-            // stretch : sans ça, un AnimatedContainer sans enfant reçoit une
-            // contrainte cross-axis loose (0..8) → hauteur 0, invisible. cf.
-            // coverage_spectrum_visible_test.dart.
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: List.generate(_keys.length, (i) {
-              final count = counts[i];
-              final width = total > 0 ? barWidth * count / total : 0.0;
-              // Gap à droite seulement s'il reste un segment visible après.
-              final hasLaterVisible =
-                  counts.skip(i + 1).any((c) => c > 0);
-              final rightGap =
-                  count > 0 && hasLaterVisible ? _kGap : 0.0;
-              return AnimatedContainer(
-                duration: _kSegmentAnim,
-                curve: Curves.easeOutCubic,
-                width: width,
-                margin: EdgeInsets.only(right: rightGap),
-                decoration: BoxDecoration(
-                  color: segmentColors[i],
-                  borderRadius: _radius,
-                ),
-              );
-            }),
+          final bar = SizedBox(
+            height: _kBarHeight,
+            child: Row(
+              // stretch : sans ça, un AnimatedContainer sans enfant reçoit une
+              // contrainte cross-axis loose → hauteur 0, invisible. cf.
+              // coverage_spectrum_visible_test.dart.
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: List.generate(_keys.length, (i) {
+                final count = counts[i];
+                final width = total > 0 ? barWidth * count / total : 0.0;
+                // Gap à droite seulement s'il reste un segment visible après.
+                final hasLaterVisible = counts.skip(i + 1).any((c) => c > 0);
+                final rightGap = count > 0 && hasLaterVisible ? _kGap : 0.0;
+                // Coins externes (bord gauche de la 1ʳᵉ visible, bord droit de
+                // la dernière) plus marqués ; coins internes au rayon de base.
+                final borderRadius = BorderRadius.horizontal(
+                  left: Radius.circular(
+                    i == firstVisible ? _kRadiusOuter : 4,
+                  ),
+                  right: Radius.circular(
+                    i == lastVisible ? _kRadiusOuter : 4,
+                  ),
+                );
+                return AnimatedContainer(
+                  duration: _kSegmentAnim,
+                  curve: Curves.easeOutCubic,
+                  width: width,
+                  margin: EdgeInsets.only(right: rightGap),
+                  decoration: BoxDecoration(
+                    color: segmentColors[i],
+                    borderRadius: borderRadius,
+                  ),
+                );
+              }),
+            ),
+          );
+
+          if (!interactive) return bar;
+
+          // Toute la hauteur (24) capte le tap ; le trait (11) reste centré.
+          return GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTapUp: (details) {
+              final key =
+                  _stanceAt(details.localPosition.dx, counts, barWidth, total);
+              if (key != null) onSegmentTap!(key);
+            },
+            child: Center(child: bar),
           );
         },
       ),
     );
+
+    if (!showAnchorLabels) return barArea;
+
+    // Ancrage permanent « Gauche » / « Droite » sous le trait.
+    final anchorStyle = GoogleFonts.courierPrime(
+      fontSize: 8.5,
+      fontWeight: FontWeight.w600,
+      letterSpacing: 0.4,
+      color: colors.textTertiary,
+    );
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        barArea,
+        const SizedBox(height: 3),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text('Gauche', style: anchorStyle),
+            Text('Droite', style: anchorStyle),
+          ],
+        ),
+      ],
+    );
+  }
+
+  /// Trouve la clé de stance dont les bornes x contiennent [dx]. Les segments
+  /// visibles remplissent toute la largeur (gaps inclus dans le segment qui les
+  /// précède) → un tap n'importe où atteint un segment non vide. Renvoie le
+  /// dernier segment visible si [dx] déborde à droite, `null` si total nul.
+  String? _stanceAt(double dx, List<int> counts, double barWidth, int total) {
+    if (total <= 0) return null;
+    var cursor = 0.0;
+    String? lastVisible;
+    for (var i = 0; i < _keys.length; i++) {
+      final count = counts[i];
+      if (count == 0) continue;
+      final width = barWidth * count / total;
+      lastVisible = _keys[i];
+      final hasLaterVisible = counts.skip(i + 1).any((c) => c > 0);
+      final right = cursor + width + (hasLaterVisible ? _kGap : 0.0);
+      if (dx < right) return _keys[i];
+      cursor = right;
+    }
+    return lastVisible;
   }
 }
 

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -3,6 +3,7 @@ import 'dart:ui' show ImageFilter;
 
 import 'package:flutter/foundation.dart' show ValueListenable;
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show HapticFeedback;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -20,6 +21,7 @@ import '../../digest/widgets/section_divider.dart';
 import '../../sources/models/source_model.dart';
 import '../../sources/providers/sources_providers.dart';
 import '../../sources/widgets/source_detail_modal.dart';
+import '../models/content_model.dart';
 import '../providers/feed_provider.dart';
 import '../repositories/feed_repository.dart' show HighlightSpan, TokenSpan;
 import 'coverage_comparison_card.dart';
@@ -56,6 +58,44 @@ void openPerspectiveReader(BuildContext context, Perspective p) {
   context.pushNamed(RouteNames.contentExternal, extra: p);
 }
 
+/// Résout la [Source] suivie par l'utilisateur correspondant à [domain] (match
+/// par host, insensible au préfixe `www.`). Renvoie `null` si le domaine est
+/// vide ou non trouvé. Partagé par la liste du bottom sheet ET le carrousel
+/// inline (carte de couverture cliquable).
+Source? findSourceByDomain(List<Source> sources, String domain) {
+  final d = domain.toLowerCase();
+  if (d.isEmpty) return null;
+  return sources.cast<Source?>().firstWhere((s) {
+    if (s?.url == null) return false;
+    final uri = Uri.tryParse(s!.url!);
+    if (uri == null) return false;
+    final host = uri.host.toLowerCase().replaceFirst('www.', '');
+    return host == d || host == 'www.$d';
+  }, orElse: () => null);
+}
+
+/// Ouvre la [SourceDetailModal] pour [source] (suivi/trust). Partagé par la
+/// liste du bottom sheet ET le carrousel inline.
+void showSourceDetailModal(
+  BuildContext context,
+  WidgetRef ref,
+  Source source,
+) {
+  showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    builder: (_) => SourceDetailModal(
+      source: source,
+      onToggleTrust: () {
+        ref
+            .read(userSourcesProvider.notifier)
+            .toggleTrust(source.id, source.isTrusted);
+      },
+    ),
+  );
+}
+
 /// Model for a perspective from an external source
 class Perspective {
   final String title;
@@ -64,6 +104,10 @@ class Perspective {
   final String sourceDomain;
   final String biasStance;
   final String? publishedAt;
+
+  /// Chapô / extrait servi par le back (`null` si absent). Alimente l'aperçu au
+  /// long-press de la carte de couverture (cf. [toPreviewContent]).
+  final String? description;
 
   /// Tokens divergents du titre vs. référence, colorisés par bias.
   final List<HighlightSpan> highlightSpans;
@@ -82,6 +126,7 @@ class Perspective {
     required this.sourceDomain,
     required this.biasStance,
     this.publishedAt,
+    this.description,
     this.highlightSpans = const [],
     this.sharedTokens = const [],
     this.language,
@@ -99,6 +144,7 @@ class Perspective {
       sourceDomain: (json['source_domain'] as String?) ?? '',
       biasStance: (json['bias_stance'] as String?) ?? 'unknown',
       publishedAt: json['published_at'] as String?,
+      description: json['description'] as String?,
       language: json['language'] as String?,
     );
   }
@@ -158,6 +204,31 @@ class Perspective {
       default:
         return 'centre';
     }
+  }
+
+  /// Adaptateur vers un [Content] partiel pour l'aperçu au long-press
+  /// ([ArticlePreviewOverlay]). [Source] synthétique : favicon Google comme
+  /// logo, type article par défaut. `description` (chapô back) alimente le corps
+  /// de l'aperçu ; `thumbnailUrl` reste `null` (pas de vignette côté variant).
+  Content toPreviewContent() {
+    final parsedDate =
+        publishedAt != null ? DateTime.tryParse(publishedAt!) : null;
+    return Content(
+      id: url,
+      title: title,
+      url: url,
+      description: description,
+      contentType: ContentType.article,
+      publishedAt: parsedDate ?? DateTime.now(),
+      source: Source(
+        id: '',
+        name: sourceName,
+        type: SourceType.article,
+        logoUrl: sourceDomain.isNotEmpty
+            ? 'https://www.google.com/s2/favicons?domain=$sourceDomain&sz=64'
+            : null,
+      ),
+    );
   }
 }
 
@@ -650,42 +721,14 @@ class _PerspectiveCard extends ConsumerWidget {
 
   const _PerspectiveCard({required this.perspective, this.onView});
 
-  /// Find matching Source from user sources by domain
-  Source? _findSource(List<Source> sources) {
-    final domain = perspective.sourceDomain.toLowerCase();
-    if (domain.isEmpty) return null;
-    return sources.cast<Source?>().firstWhere((s) {
-      if (s?.url == null) return false;
-      final uri = Uri.tryParse(s!.url!);
-      if (uri == null) return false;
-      final host = uri.host.toLowerCase().replaceFirst('www.', '');
-      return host == domain || host == 'www.$domain';
-    }, orElse: () => null);
-  }
-
-  void _showSourceDetail(BuildContext context, WidgetRef ref, Source source) {
-    showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      backgroundColor: Colors.transparent,
-      builder: (_) => SourceDetailModal(
-        source: source,
-        onToggleTrust: () {
-          ref
-              .read(userSourcesProvider.notifier)
-              .toggleTrust(source.id, source.isTrusted);
-        },
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.facteurColors;
     final textTheme = Theme.of(context).textTheme;
     final sourcesAsync = ref.watch(userSourcesProvider);
     final matchedSource = sourcesAsync.valueOrNull != null
-        ? _findSource(sourcesAsync.valueOrNull!)
+        ? findSourceByDomain(
+            sourcesAsync.valueOrNull!, perspective.sourceDomain)
         : null;
 
     return Padding(
@@ -763,7 +806,7 @@ class _PerspectiveCard extends ConsumerWidget {
             GestureDetector(
               behavior: HitTestBehavior.opaque,
               onTap: matchedSource != null
-                  ? () => _showSourceDetail(context, ref, matchedSource)
+                  ? () => showSourceDetailModal(context, ref, matchedSource)
                   : null,
               child: Container(
                 decoration: BoxDecoration(
@@ -1490,6 +1533,16 @@ class _PerspectivesInlineSectionState
   static const double _kCarouselViewportHeight =
       _kCarouselCardHeight + 15 + 16;
 
+  // Géométrie horizontale du carrousel : largeur de carte, gap inter-cartes,
+  // padding latéral du viewport. Source unique pour le rendu ET le calcul de
+  // l'offset cible du tap-to-scroll (barre de biais interactive).
+  static const double _kCoverageCardWidth = 248;
+  static const double _kCoverageCardGap = 13;
+  static const double _kCarouselPaddingH = 18;
+
+  // Pilote le scroll du carrousel pour le tap-to-scroll de la barre de biais.
+  final ScrollController _carouselScrollController = ScrollController();
+
   @override
   void initState() {
     super.initState();
@@ -1538,7 +1591,44 @@ class _PerspectivesInlineSectionState
   void dispose() {
     _emptyDismissTimer?.cancel();
     _emptyCollapseTimer?.cancel();
+    _carouselScrollController.dispose();
     super.dispose();
+  }
+
+  /// Tap sur un segment de la barre de biais → scrolle le carrousel vers la 1ʳᵉ
+  /// carte de cette stance. Si la stance n'est pas présente dans les 8 cartes
+  /// affichées (segment hors plage), fallback sur la carte la plus proche dans
+  /// l'ordre canonique 5-stances.
+  void _onSpectrumSegmentTap(String stanceKey) {
+    if (!_carouselScrollController.hasClients) return;
+    final variants = _sortedPerspectives.take(8).toList();
+    if (variants.isEmpty) return;
+
+    var index = variants.indexWhere((p) => p.biasStance == stanceKey);
+    if (index < 0) {
+      // Fallback : carte la plus proche par distance dans l'ordre 5-stances.
+      final targetRank = _stanceRank(stanceKey);
+      var bestDist = 1 << 30;
+      var best = 0;
+      for (var i = 0; i < variants.length; i++) {
+        final d = (_stanceRank(variants[i].biasStance) - targetRank).abs();
+        if (d < bestDist) {
+          bestDist = d;
+          best = i;
+        }
+      }
+      index = best;
+    }
+
+    final maxExtent = _carouselScrollController.position.maxScrollExtent;
+    final target = ((_kCoverageCardWidth + _kCoverageCardGap) * index)
+        .clamp(0.0, maxExtent);
+    HapticFeedback.selectionClick();
+    _carouselScrollController.animateTo(
+      target,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeOutCubic,
+    );
   }
 
   void _syncEmptyDismissal() {
@@ -1569,14 +1659,28 @@ class _PerspectivesInlineSectionState
     });
   }
 
-  static const _groupOrder = ['gauche', 'centre', 'droite'];
+  // Ordre canonique 5-stances (identique à `CoverageSpectrumBar._keys`) : clé de
+  // tri des cartes ET référence de distance pour le fallback tap-to-scroll.
+  static const _stanceOrder = [
+    'left',
+    'center-left',
+    'center',
+    'center-right',
+    'right',
+  ];
+
+  static int _stanceRank(String stance) {
+    final i = _stanceOrder.indexOf(stance);
+    // Stances inconnues : reléguées en fin (et au centre pour la distance).
+    return i < 0 ? _stanceOrder.length : i;
+  }
 
   List<Perspective> get _sortedPerspectives {
     final sorted = [..._displayedPerspectives];
+    // Tri strict L → CL → C → CR → R : condition nécessaire pour que le
+    // tap-to-scroll de la barre de biais tombe sur la bonne carte.
     sorted.sort(
-      (a, b) => _groupOrder
-          .indexOf(a.biasGroup)
-          .compareTo(_groupOrder.indexOf(b.biasGroup)),
+      (a, b) => _stanceRank(a.biasStance).compareTo(_stanceRank(b.biasStance)),
     );
     return sorted;
   }
@@ -1630,9 +1734,9 @@ class _PerspectivesInlineSectionState
                         child: Column(
                           children: [
                             _buildCarousel(variants),
-                            // Libellé de polarisation déplacé SOUS le carrousel
-                            // (le header ne porte plus que le titre + la barre).
-                            _buildBandFooter(colors, textTheme),
+                            // Barre de biais pleine largeur + interactive, sous
+                            // le carrousel (le header porte titre + polarisation).
+                            _buildBandFooter(),
                           ],
                         ),
                       ),
@@ -1701,7 +1805,9 @@ class _PerspectivesInlineSectionState
     );
   }
 
-  /// Header 2 lignes : (titre + barre spectre) / (badge divergence + info).
+  /// Header : titre à gauche + badge de polarisation et bouton info à droite.
+  /// La barre de biais (interactive) est descendue en pied de bande, pleine
+  /// largeur (cf. [_buildBandFooter]).
   Widget _buildHeader(
     FacteurColors colors,
     TextTheme textTheme,
@@ -1715,8 +1821,8 @@ class _PerspectivesInlineSectionState
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           // Ligne 1 : libellé à gauche (FittedBox scaleDown absorbe les titres
-          // longs sans wrap), barre spectre (96 px) épinglée à droite et
-          // centrée verticalement sur le titre.
+          // longs sans wrap), badge de polarisation + bouton info épinglés à
+          // droite et centrés verticalement sur le titre.
           Row(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
@@ -1737,14 +1843,23 @@ class _PerspectivesInlineSectionState
               ),
               if (!isEmpty) ...[
                 const SizedBox(width: 11),
-                SizedBox(
-                  width: 96,
-                  child: isLoading
-                      ? const CoverageSpectrumBarShimmer()
-                      : CoverageSpectrumBar(
-                          distribution: widget.biasDistribution,
-                        ),
-                ),
+                // Loading : on garde le shimmer (badge + info masqués). Prêt :
+                // badge de polarisation (échelle 1.0, contre 1.45 en footer
+                // avant la refonte) + bouton info.
+                if (isLoading)
+                  const SizedBox(width: 96, child: CoverageSpectrumBarShimmer())
+                else ...[
+                  DivergenceInlineBadge(
+                    divergenceLevel: widget.divergenceLevel,
+                    scale: 1.0,
+                    prominentMedium: true,
+                  ),
+                  const SizedBox(width: 6),
+                  _HighlightInfoButton(
+                    colors: colors,
+                    onTap: () => _showHighlightInfo(context, colors, textTheme),
+                  ),
+                ],
               ],
             ],
           ),
@@ -1768,50 +1883,73 @@ class _PerspectivesInlineSectionState
     );
   }
 
-  /// Pied de bande, sous le carrousel : libellé de polarisation à gauche +
-  /// bouton info (surlignage) à droite. Rendu uniquement quand la couverture
-  /// est prête (le `if (isReady)` du parent garantit déjà la condition).
-  Widget _buildBandFooter(FacteurColors colors, TextTheme textTheme) {
+  /// Pied de bande, sous le carrousel : la barre de biais **pleine largeur** et
+  /// **interactive** (tap sur un segment → scrolle le carrousel vers le bord
+  /// politique correspondant). Rendu uniquement quand la couverture est prête
+  /// (le `if (isReady)` du parent garantit déjà la condition).
+  Widget _buildBandFooter() {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(18, 0, 10, 6),
-      child: Row(
-        children: [
-          Expanded(
-            child: DivergenceInlineBadge(
-              divergenceLevel: widget.divergenceLevel,
-              scale: 1.45,
-            ),
-          ),
-          const SizedBox(width: 8),
-          _HighlightInfoButton(
-            colors: colors,
-            onTap: () => _showHighlightInfo(context, colors, textTheme),
-          ),
-        ],
+      padding: const EdgeInsets.fromLTRB(
+        _kCarouselPaddingH,
+        0,
+        _kCarouselPaddingH,
+        6,
+      ),
+      child: CoverageSpectrumBar(
+        distribution: widget.biasDistribution,
+        onSegmentTap: _onSpectrumSegmentTap,
+        showAnchorLabels: true,
       ),
     );
+  }
+
+  /// Renvoie le callback de tap source pour [domain] : ouvre la
+  /// [SourceDetailModal] si la source est suivie, sinon `null` (la zone retombe
+  /// sur l'ouverture article — pas de zone morte).
+  VoidCallback? _sourceTapFor(
+    BuildContext context,
+    List<Source>? sources,
+    String domain,
+  ) {
+    if (sources == null) return null;
+    final matched = findSourceByDomain(sources, domain);
+    if (matched == null) return null;
+    return () => showSourceDetailModal(context, ref, matched);
   }
 
   /// Carrousel horizontal : cartes de couverture (gap 13) + carte CTA Analyse
   /// en fin de course. Viewport à hauteur fixe → cartes équi-hauteur.
   Widget _buildCarousel(List<Perspective> variants) {
+    // Sources suivies → résolution par domaine pour rendre la pastille cliquable.
+    final sources = ref.watch(userSourcesProvider).valueOrNull;
     return SizedBox(
       height: _kCarouselViewportHeight,
       child: SingleChildScrollView(
+        controller: _carouselScrollController,
         scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.fromLTRB(18, 15, 18, 16),
+        padding: const EdgeInsets.fromLTRB(
+          _kCarouselPaddingH,
+          15,
+          _kCarouselPaddingH,
+          16,
+        ),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             for (var i = 0; i < variants.length; i++) ...[
-              if (i > 0) const SizedBox(width: 13),
+              if (i > 0) const SizedBox(width: _kCoverageCardGap),
               CoverageComparisonCard(
                 key: ValueKey('coverage_${_animationGeneration}_$i'),
                 perspective: variants[i],
                 firstCardKey: i == 0 ? widget.firstCardKey : null,
+                onSourceTap: _sourceTapFor(
+                  context,
+                  sources,
+                  variants[i].sourceDomain,
+                ),
               ),
             ],
-            if (variants.isNotEmpty) const SizedBox(width: 13),
+            if (variants.isNotEmpty) const SizedBox(width: _kCoverageCardGap),
             _AnalysisCtaCard(
               onTap: widget.onOpenAnalysis,
               count: _displayedPerspectives.length,

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -26,7 +26,6 @@ import '../../custom_topics/widgets/topic_chip.dart';
 import '../../detail/content_preview_mapper.dart';
 import '../../digest/models/digest_models.dart';
 import '../../feed/models/content_model.dart';
-import '../../feed/services/read_sync_service.dart';
 import '../../feed/widgets/explore_section.dart' show ExploreDiscoverySkeleton;
 import '../../feed/widgets/feedback_inline.dart';
 import '../../lettres/widgets/lettres_notification_banner.dart';
@@ -43,7 +42,6 @@ import '../providers/flux_continu_provider.dart';
 import '../providers/personalisation_cta_provider.dart';
 import '../providers/tournee_order_prefs_provider.dart'
     show tourneeOrderPrefsProvider;
-import '../utils/closing_recap.dart';
 import '../utils/section_fit.dart' show kMinPlausibleUsableHeight;
 import '../utils/section_snap.dart';
 import '../widgets/citation_du_jour_card.dart';
@@ -1173,16 +1171,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     final notifier = ref.read(fluxContinuProvider.notifier);
     final colors = context.facteurColors;
     final impressionSlot = ref.watch(firstImpressionSlotProvider);
-    final totalArticles = state.sections.fold<int>(
-      0,
-      (sum, s) => sum + s.totalCount,
-    );
-    // Récap personnalisé de fin de tournée (articles lus par section). Null
-    // quand rien n'a été lu → la carte retombe sur « X étapes parcourues ».
-    final consumedIds = ref.watch(consumedContentIdsProvider);
-    final recapLine = formatClosingRecap(
-      buildClosingRecap(sections: state.sections, consumedIds: consumedIds),
-    );
     // Android peut fermer l'app programmatiquement ; iOS l'interdit (App
     // Store) → on y montre une phrase de clôture au lieu du bouton.
     final isAndroid = defaultTargetPlatform == TargetPlatform.android;
@@ -1262,8 +1250,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
               child: KeyedSubtree(
                 key: _closingKey,
                 child: ClosingCardV18(
-                  articleCount: totalArticles,
-                  recapLine: recapLine,
                   onContinue: () => context.go(RoutePaths.flaner),
                   onClose: isAndroid ? () => SystemNavigator.pop() : null,
                   closeHint: isAndroid

--- a/apps/mobile/lib/features/flux_continu/utils/closing_activity.dart
+++ b/apps/mobile/lib/features/flux_continu/utils/closing_activity.dart
@@ -24,25 +24,29 @@ class ClosingActivity {
 /// Activités d'intérieur — toujours éligibles (par défaut quand la météo n'est
 /// pas clémente ou inconnue).
 const List<ClosingActivity> kIndoorActivities = [
-  ClosingActivity(emoji: '📖', prompt: 'Ouvrir un bon livre ?', isOutdoor: false),
+  ClosingActivity(
+    emoji: '📖',
+    prompt: 'Ouvrir ce livre qui prend la poussière sur ton étagère ?',
+    isOutdoor: false,
+  ),
   ClosingActivity(
     emoji: '🍳',
-    prompt: 'Tester une nouvelle recette ?',
+    prompt: 'Te lancer dans une recette végé ?',
     isOutdoor: false,
   ),
   ClosingActivity(
     emoji: '☕',
-    prompt: 'Prendre un vrai temps calme ?',
+    prompt: 'T’offrir un vrai moment rien qu’à toi ?',
     isOutdoor: false,
   ),
   ClosingActivity(
     emoji: '📓',
-    prompt: 'Écrire trois lignes dans un carnet ?',
+    prompt: 'Noter ce qui t’a traversé l’esprit aujourd’hui ?',
     isOutdoor: false,
   ),
   ClosingActivity(
     emoji: '🎧',
-    prompt: 'Écouter l’album du moment en entier ?',
+    prompt: 'Écouter cet album que tu attendais depuis un moment ?',
     isOutdoor: false,
   ),
 ];
@@ -51,11 +55,19 @@ const List<ClosingActivity> kIndoorActivities = [
 const List<ClosingActivity> kOutdoorActivities = [
   ClosingActivity(
     emoji: '🌳',
-    prompt: 'Aller marcher dans un parc ?',
+    prompt: 'Aller marcher là où tu ne vas jamais ?',
     isOutdoor: true,
   ),
-  ClosingActivity(emoji: '☀️', prompt: 'Sortir prendre l’air ?', isOutdoor: true),
-  ClosingActivity(emoji: '🚲', prompt: 'Faire un tour à vélo ?', isOutdoor: true),
+  ClosingActivity(
+    emoji: '☀️',
+    prompt: 'Sortir respirer un peu d’air frais ?',
+    isOutdoor: true,
+  ),
+  ClosingActivity(
+    emoji: '🚲',
+    prompt: 'Enfourcher ton vélo sans destination précise ?',
+    isOutdoor: true,
+  ),
 ];
 
 /// Nombre de propositions affichées chaque jour sur la carte de fin.

--- a/apps/mobile/lib/features/flux_continu/widgets/closing_card_v18.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/closing_card_v18.dart
@@ -14,13 +14,10 @@ import 'tournee_cta_buttons.dart';
 /// Layout per maquette V6 :
 /// - "FIN DE TOURNÉE" stamp Courier Prime 10 w700, color/border #2E7D32,
 ///   rotation -2°.
-/// - Heading "Vous êtes à jour" Fraunces 700 24px.
-/// - Description (DM Sans 13, line-height 1.5, max-w 280, centered) — "X
-///   étape(s) parcourue(s)" or "Tournée terminée" when empty.
+/// - Heading "Tu es à jour" Fraunces 700 24px.
 /// - Primary CTA "Continuer à Flâner" (background #D35400) + ghost CTA
 ///   "Refermer pour aujourd'hui" (border 1.5px rgba(0,0,0,0.1)).
 class ClosingCardV18 extends ConsumerWidget {
-  final int articleCount;
   final VoidCallback? onContinue;
   final VoidCallback? onClose;
 
@@ -29,17 +26,11 @@ class ClosingCardV18 extends ConsumerWidget {
   /// par l'App Store). Ignorée si [onClose] est fourni (cas Android).
   final String? closeHint;
 
-  /// Récap personnalisé de ce qui a été lu (« Tu as lu sur la Tech (4)… »).
-  /// Null quand rien n'a été lu → retombe sur [_stepLabel].
-  final String? recapLine;
-
   const ClosingCardV18({
     super.key,
-    required this.articleCount,
     this.onContinue,
     this.onClose,
     this.closeHint,
-    this.recapLine,
   });
 
   @override
@@ -100,7 +91,7 @@ class ClosingCardV18 extends ConsumerWidget {
             ),
             const SizedBox(height: 12),
             Text(
-              'Vous êtes à jour',
+              'Tu es à jour',
               textAlign: TextAlign.center,
               style: GoogleFonts.fraunces(
                 fontSize: 24,
@@ -108,19 +99,6 @@ class ClosingCardV18 extends ConsumerWidget {
                 height: 1.1,
                 letterSpacing: -0.4,
                 color: colors.textPrimary,
-              ),
-            ),
-            const SizedBox(height: 8),
-            ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 280),
-              child: Text(
-                recapLine ?? _stepLabel(articleCount),
-                textAlign: TextAlign.center,
-                style: GoogleFonts.dmSans(
-                  fontSize: 13,
-                  height: 1.5,
-                  color: colors.textSecondary,
-                ),
               ),
             ),
             const SizedBox(height: 18),
@@ -159,12 +137,6 @@ class ClosingCardV18 extends ConsumerWidget {
       ),
     );
   }
-
-  String _stepLabel(int count) {
-    if (count <= 0) return 'Tournée terminée';
-    final plural = count > 1 ? 's' : '';
-    return '$count étape$plural parcourue$plural';
-  }
 }
 
 /// Bloc discret « Et si tu en profitais pour… » : trois propositions tangibles
@@ -192,38 +164,32 @@ class _ActivitySuggestions extends StatelessWidget {
           ),
         ),
         const SizedBox(height: 8),
-        Container(
-          width: double.infinity,
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-          decoration: BoxDecoration(
-            color: colors.primary.withValues(alpha: 0.05),
-            borderRadius: BorderRadius.circular(FacteurRadius.medium),
-          ),
-          child: Column(
-            children: [
-              for (final activity in activities)
-                Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 7),
-                  child: Row(
-                    children: [
-                      Text(activity.emoji, style: const TextStyle(fontSize: 17)),
-                      const SizedBox(width: 10),
-                      Expanded(
-                        child: Text(
-                          activity.prompt,
-                          style: GoogleFonts.dmSans(
-                            fontSize: 13,
-                            fontWeight: FontWeight.w500,
-                            height: 1.3,
-                            color: colors.textPrimary,
-                          ),
+        // Fond blanc (plus de container orange) : les propositions reposent
+        // directement sur la surface de la carte pour alléger la fin de tournée.
+        Column(
+          children: [
+            for (final activity in activities)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 7),
+                child: Row(
+                  children: [
+                    Text(activity.emoji, style: const TextStyle(fontSize: 17)),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Text(
+                        activity.prompt,
+                        style: GoogleFonts.dmSans(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w500,
+                          height: 1.3,
+                          color: colors.textPrimary,
                         ),
                       ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
-            ],
-          ),
+              ),
+          ],
         ),
       ],
     );

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -83,8 +83,9 @@ class EssentielHiFiCard extends ConsumerWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             _Header(accent: accent, onTapPersonalize: onTapPersonalize),
-            // Compaction : gap header→lead resserré space3→space2.
-            const SizedBox(height: FacteurSpacing.space2),
+            // Compaction « cartes ≤ écran » (passe 2, validée UX) : gap
+            // header→lead 8→6 (le fond teinté du lead rétablit la séparation).
+            const SizedBox(height: 6),
             if (lead != null)
               _LeadTile(
                 article: lead,
@@ -93,9 +94,11 @@ class EssentielHiFiCard extends ConsumerWidget {
                 onTap: () => onTapArticle(lead),
               ),
             for (final a in remaining) ...[
-              const SizedBox(height: FacteurSpacing.space2),
+              // Séparateur de tuiles medium 8→6 de part et d'autre du hairline
+              // (poste le plus rentable : ×4, hairline 0.6px conserve le « moat »).
+              const SizedBox(height: 6),
               const _Hairline(),
-              const SizedBox(height: FacteurSpacing.space2),
+              const SizedBox(height: 6),
               _MediumTile(article: a, spec: spec, onTap: () => onTapArticle(a)),
             ],
           ],
@@ -134,7 +137,7 @@ class _Header extends StatelessWidget {
                     child: Text(
                       'Ton Essentiel',
                       style: GoogleFonts.fraunces(
-                        fontSize: 18,
+                        fontSize: 15,
                         fontWeight: FontWeight.w700,
                         height: 1.15,
                         color: colors.textPrimary,
@@ -381,11 +384,21 @@ class _WeatherBadgeState extends State<_WeatherBadge>
             ),
           ),
         ),
-        Icon(
-          Icons.keyboard_arrow_down_rounded,
-          size: 16,
-          color: colors.textTertiary,
-          semanticLabel: 'Voir la météo détaillée',
+        const SizedBox(height: 2),
+        // Libellé discret souligné « Météo » (remplace l'ancien chevron) :
+        // signale qu'un tap ouvre la modal détaillée 5 jours.
+        Text(
+          'Météo',
+          style: GoogleFonts.courierPrime(
+            fontSize: 11,
+            fontWeight: FontWeight.w700,
+            height: 1.0,
+            letterSpacing: 0.6,
+            color: colors.textTertiary,
+            decoration: TextDecoration.underline,
+            decorationColor: colors.textTertiary.withValues(alpha: 0.6),
+          ),
+          semanticsLabel: 'Voir la météo détaillée',
         ),
       ],
     );
@@ -537,12 +550,9 @@ class _LeadTile extends StatelessWidget {
           child: Stack(
             children: [
               Container(
-                padding: const EdgeInsets.fromLTRB(
-                  FacteurSpacing.space3,
-                  FacteurSpacing.space3,
-                  FacteurSpacing.space3,
-                  FacteurSpacing.space3,
-                ),
+                // Compaction passe 2 (validée UX) : padding héro 12→10. Plancher
+                // dur à 10 — sous ce seuil le texte « fuit » du fond teinté.
+                padding: const EdgeInsets.all(10),
                 decoration: BoxDecoration(
                   color: accent.withValues(alpha: 0.06),
                   borderRadius: BorderRadius.circular(FacteurRadius.medium),
@@ -567,13 +577,14 @@ class _LeadTile extends StatelessWidget {
                       maxLines: 4 + spec.titleMaxLinesDelta,
                       overflow: TextOverflow.ellipsis,
                       style: GoogleFonts.fraunces(
-                        fontSize: 19 * spec.fontScale,
+                        fontSize: 16 * spec.fontScale,
                         fontWeight: FontWeight.w700,
                         height: 1.3,
                         color: colors.textPrimary,
                       ),
                     ),
-                    const SizedBox(height: FacteurSpacing.space2),
+                    // Titre→source 8→6 (le badge actu→titre reste à 8, délibéré).
+                    const SizedBox(height: 6),
                     _SourceRow(article: article, accent: chipAccent),
                   ],
                 ),
@@ -648,7 +659,7 @@ class _MediumTile extends StatelessWidget {
                       maxLines: 3 + spec.titleMaxLinesDelta,
                       overflow: TextOverflow.ellipsis,
                       style: GoogleFonts.fraunces(
-                        fontSize: 16 * spec.fontScale,
+                        fontSize: 15 * spec.fontScale,
                         fontWeight: FontWeight.w600,
                         height: 1.3,
                         color: colors.textPrimary,

--- a/apps/mobile/test/features/detail/deep_recommendation_card_test.dart
+++ b/apps/mobile/test/features/detail/deep_recommendation_card_test.dart
@@ -27,7 +27,7 @@ void main() {
       await tester.pumpWidget(host(DeepRecommendationCard(reco: reco())));
       await tester.pumpAndSettle();
 
-      expect(find.text('LE PAS DE RECUL'), findsOneWidget);
+      expect(find.text('LE PAS DE RECUL · FACTEUR'), findsOneWidget);
       expect(find.text('Le fond du dossier'), findsOneWidget);
       expect(find.text('Le Monde'), findsOneWidget);
     });

--- a/apps/mobile/test/features/digest/widgets/divergence_inline_badge_test.dart
+++ b/apps/mobile/test/features/digest/widgets/divergence_inline_badge_test.dart
@@ -44,6 +44,56 @@ void main() {
       expect(label.style?.fontWeight, FontWeight.w500);
     });
 
+    testWidgets('medium + prominentMedium → boost léger (w600, secondary)', (
+      tester,
+    ) async {
+      final colors = FacteurTheme.lightTheme.extension<FacteurColors>()!;
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: FacteurTheme.lightTheme,
+          home: const Scaffold(
+            body: Center(
+              child: DivergenceInlineBadge(
+                divergenceLevel: 'medium',
+                prominentMedium: true,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final label = tester.widget<Text>(find.text('AVIS VARIÉS'));
+      // Boost léger : w600 (ni w500 discret, ni w700 réservé à high) en
+      // text_secondary (ni tertiary discret, ni text_primary réservé à high).
+      expect(label.style?.fontWeight, FontWeight.w600);
+      expect(label.style?.color, colors.textSecondary);
+    });
+
+    testWidgets('prominentMedium sans effet sur high (reste w700/primary)', (
+      tester,
+    ) async {
+      final colors = FacteurTheme.lightTheme.extension<FacteurColors>()!;
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: FacteurTheme.lightTheme,
+          home: const Scaffold(
+            body: Center(
+              child: DivergenceInlineBadge(
+                divergenceLevel: 'high',
+                prominentMedium: true,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final label = tester.widget<Text>(find.text('POLARISÉ'));
+      expect(label.style?.fontWeight, FontWeight.w700);
+      expect(label.style?.color, colors.textPrimary);
+    });
+
     testWidgets('high → Polarisé en text_primary bold', (tester) async {
       await tester.pumpWidget(host('high'));
       await tester.pumpAndSettle();

--- a/apps/mobile/test/features/feed/widgets/coverage_spectrum_bar_test.dart
+++ b/apps/mobile/test/features/feed/widgets/coverage_spectrum_bar_test.dart
@@ -35,7 +35,7 @@ void main() {
       .toList();
 
   group('CoverageSpectrumBar', () {
-    testWidgets('hauteur fixe 8, largeur déléguée, 5 segments montés',
+    testWidgets('hauteur fixe 11, largeur déléguée, 5 segments montés',
         (tester) async {
       await tester.pumpWidget(host(const {
         'left': 1,
@@ -54,7 +54,7 @@ void main() {
             )
             .first,
       );
-      expect(sized.height, 8);
+      expect(sized.height, 11);
       // Largeur non fixée par la barre (déléguée au parent).
       expect(sized.width, isNull);
 
@@ -98,6 +98,89 @@ void main() {
       // 5 segments montés mais tous à largeur nulle (rien de visible).
       expect(widths.length, 5);
       expect(widths.every((w) => w == 0), isTrue);
+    });
+
+    testWidgets('showAnchorLabels : repères Gauche / Droite sous la barre',
+        (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        theme: FacteurTheme.lightTheme,
+        home: const Scaffold(
+          body: Center(
+            child: SizedBox(
+              width: 150,
+              child: CoverageSpectrumBar(
+                distribution: {
+                  'left': 1,
+                  'center': 1,
+                  'right': 1,
+                },
+                showAnchorLabels: true,
+              ),
+            ),
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Gauche'), findsOneWidget);
+      expect(find.text('Droite'), findsOneWidget);
+      // Permanents : présents même sans interaction.
+      // La barre conserve sa largeur pleine déléguée (150) malgré la Column.
+      expect(
+        tester.getSize(find.byType(CoverageSpectrumBar)).width,
+        closeTo(150, 0.5),
+      );
+    });
+
+    testWidgets('sans showAnchorLabels : aucun repère (défaut)',
+        (tester) async {
+      await tester.pumpWidget(host(const {
+        'left': 1,
+        'center': 1,
+        'right': 1,
+      }));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Gauche'), findsNothing);
+      expect(find.text('Droite'), findsNothing);
+    });
+
+    testWidgets('interactive : tap mappe la position x → clé de stance',
+        (tester) async {
+      final tapped = <String>[];
+      await tester.pumpWidget(MaterialApp(
+        theme: FacteurTheme.lightTheme,
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              width: 150,
+              child: CoverageSpectrumBar(
+                distribution: const {
+                  'left': 1,
+                  'center-left': 1,
+                  'center': 1,
+                  'center-right': 1,
+                  'right': 1,
+                },
+                onSegmentTap: tapped.add,
+              ),
+            ),
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      // Cible tactile élargie à 24 px de haut quand interactive.
+      expect(tester.getSize(find.byType(CoverageSpectrumBar)).height, 24);
+
+      final rect = tester.getRect(find.byType(CoverageSpectrumBar));
+      // Tap à gauche → 'left' ; tap à droite → 'right'.
+      await tester.tapAt(Offset(rect.left + 5, rect.center.dy));
+      await tester.tapAt(Offset(rect.right - 5, rect.center.dy));
+      await tester.pumpAndSettle();
+
+      expect(tapped.first, 'left');
+      expect(tapped.last, 'right');
     });
   });
 }

--- a/apps/mobile/test/features/feed/widgets/coverage_spectrum_visible_test.dart
+++ b/apps/mobile/test/features/feed/widgets/coverage_spectrum_visible_test.dart
@@ -4,7 +4,7 @@ import 'package:facteur/config/theme.dart';
 import 'package:facteur/features/feed/widgets/coverage_spectrum_bar.dart';
 
 void main() {
-  testWidgets('chaque segment a une taille non nulle (h8, largeur bornée)',
+  testWidgets('chaque segment a une taille non nulle (h11, largeur bornée)',
       (tester) async {
     await tester.pumpWidget(MaterialApp(
       theme: FacteurTheme.lightTheme,
@@ -22,7 +22,7 @@ void main() {
     await tester.pumpAndSettle();
 
     final szBox = tester.getSize(find.byType(CoverageSpectrumBar));
-    expect(szBox.height, 8);
+    expect(szBox.height, 11);
 
     final boxes = find.byType(DecoratedBox);
     final count = boxes.evaluate().length;

--- a/apps/mobile/test/features/feed/widgets/perspective_description_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspective_description_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/feed/repositories/feed_repository.dart'
+    show PerspectiveData;
+import 'package:facteur/features/feed/widgets/perspectives_bottom_sheet.dart';
+
+void main() {
+  group('Perspective.fromJson description', () {
+    test('parse le champ description quand présent', () {
+      final p = Perspective.fromJson(const {
+        'title': 'Titre',
+        'url': 'https://ex.com/a',
+        'source_name': 'Le Monde',
+        'source_domain': 'lemonde.fr',
+        'bias_stance': 'center',
+        'description': 'Un chapô explicatif.',
+      });
+      expect(p.description, 'Un chapô explicatif.');
+    });
+
+    test('description null quand absente (rétro-compat cache)', () {
+      final p = Perspective.fromJson(const {
+        'title': 'Titre',
+        'url': 'https://ex.com/a',
+        'source_name': 'Le Monde',
+        'source_domain': 'lemonde.fr',
+        'bias_stance': 'center',
+      });
+      expect(p.description, isNull);
+    });
+  });
+
+  group('PerspectiveData.fromJson description', () {
+    test('parse le champ description quand présent', () {
+      final p = PerspectiveData.fromJson(const {
+        'title': 'Titre',
+        'url': 'https://ex.com/a',
+        'source_name': 'Le Monde',
+        'source_domain': 'lemonde.fr',
+        'bias_stance': 'center',
+        'description': 'Chapô.',
+      });
+      expect(p.description, 'Chapô.');
+    });
+  });
+
+  group('Perspective.toPreviewContent', () {
+    test('mappe description, source synthétique et favicon', () {
+      final p = Perspective(
+        title: 'Titre',
+        url: 'https://ex.com/article',
+        sourceName: 'Le Monde',
+        sourceDomain: 'lemonde.fr',
+        biasStance: 'center',
+        publishedAt: '2026-06-20T10:00:00Z',
+        description: 'Un chapô.',
+      );
+      final content = p.toPreviewContent();
+
+      expect(content.title, 'Titre');
+      expect(content.url, 'https://ex.com/article');
+      expect(content.description, 'Un chapô.');
+      expect(content.source.name, 'Le Monde');
+      expect(content.source.logoUrl, contains('domain=lemonde.fr'));
+      expect(content.thumbnailUrl, isNull);
+      expect(content.publishedAt.toUtc().year, 2026);
+    });
+
+    test('logo null si domaine vide ; date repli si non parsable', () {
+      final p = Perspective(
+        title: 'Titre',
+        url: 'https://ex.com/article',
+        sourceName: 'Inconnu',
+        sourceDomain: '',
+        biasStance: 'unknown',
+        publishedAt: 'pas-une-date',
+      );
+      final content = p.toPreviewContent();
+
+      expect(content.source.logoUrl, isNull);
+      // Date non parsable → repli sur "maintenant" (pas de crash).
+      expect(content.publishedAt, isNotNull);
+    });
+  });
+}

--- a/apps/mobile/test/features/feed/widgets/perspectives_inline_intro_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspectives_inline_intro_test.dart
@@ -49,23 +49,25 @@ Future<void> _pumpInline(
 }
 
 void main() {
-  const introSnippet = "marquent l'angle éditorial";
+  // Le bouton info de l'en-tête ouvre une modal expliquant la divergence
+  // (le surlignage est désactivé → kHighlightIntroText n'est plus rendu).
+  const infoSnippet = 'Facteur mesure la divergence';
   final infoIcon = PhosphorIcons.info(PhosphorIconsStyle.regular);
 
-  testWidgets('ready : intro derrière le bouton info de l\'en-tête',
+  testWidgets('ready : explication divergence derrière le bouton info de l\'en-tête',
       (tester) async {
     await _pumpInline(tester, perspectives: [_p('A'), _p('B', bias: 'left')]);
     await tester.pump(const Duration(seconds: 1));
 
-    expect(find.textContaining(introSnippet), findsNothing);
+    expect(find.textContaining(infoSnippet), findsNothing);
 
     await tester.tap(find.byIcon(infoIcon).first);
     await tester.pumpAndSettle();
 
-    expect(find.textContaining(introSnippet), findsOneWidget);
+    expect(find.textContaining(infoSnippet), findsOneWidget);
   });
 
-  testWidgets('loading : ni bouton info ni intro', (tester) async {
+  testWidgets('loading : ni bouton info ni explication', (tester) async {
     await _pumpInline(
       tester,
       perspectives: const [],
@@ -73,7 +75,7 @@ void main() {
     );
 
     expect(find.byIcon(infoIcon), findsNothing);
-    expect(find.textContaining(introSnippet), findsNothing);
+    expect(find.textContaining(infoSnippet), findsNothing);
   });
 
   testWidgets('ready high divergence → badge POLARISÉ', (tester) async {
@@ -99,7 +101,7 @@ void main() {
     expect(find.text('TRAITEMENTS SIMILAIRES'), findsOneWidget);
   });
 
-  testWidgets('badge de la couverture utilise l’échelle agrandie 1.45',
+  testWidgets('badge de polarisation en en-tête à l’échelle 1.0',
       (tester) async {
     await _pumpInline(
       tester,
@@ -111,6 +113,6 @@ void main() {
     final badge = tester.widget<DivergenceInlineBadge>(
       find.byType(DivergenceInlineBadge),
     );
-    expect(badge.scale, 1.45);
+    expect(badge.scale, 1.0);
   });
 }

--- a/apps/mobile/test/features/feed/widgets/perspectives_inline_overflow_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspectives_inline_overflow_test.dart
@@ -76,8 +76,10 @@ void main() {
       );
       expect(titleRender.didExceedMaxLines, isFalse);
 
+      // La barre de biais est descendue en pied de bande, pleine largeur
+      // (padding latéral 18 de part et d'autre).
       final spectrumSize = tester.getSize(find.byType(CoverageSpectrumBar));
-      expect(spectrumSize.width, lessThanOrEqualTo(96));
+      expect(spectrumSize.width, closeTo(width - 36, 1.0));
     });
   }
 }

--- a/apps/mobile/test/features/flux_continu/widgets/closing_card_v18_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/closing_card_v18_test.dart
@@ -62,38 +62,23 @@ void main() {
   });
 
   group('ClosingCardV18', () {
-    testWidgets('renders the personalized recap line when provided',
+    testWidgets('renders the heading without a recap description',
         (tester) async {
       await tester.pumpWidget(_wrap(
-        const ClosingCardV18(
-          articleCount: 6,
-          recapLine: 'Tu as lu sur la Tech (4) et la Politique (2).',
-        ),
+        const ClosingCardV18(),
       ));
       await tester.pumpAndSettle();
 
-      expect(
-        find.text('Tu as lu sur la Tech (4) et la Politique (2).'),
-        findsOneWidget,
-      );
-      // Le fallback « X étapes parcourues » ne doit pas s'afficher.
+      expect(find.text('Tu es à jour'), findsOneWidget);
+      // La ligne de récap « Tu as lu… » a été retirée.
+      expect(find.textContaining('Tu as lu'), findsNothing);
       expect(find.textContaining('étape'), findsNothing);
-    });
-
-    testWidgets('falls back to step label when recapLine is null',
-        (tester) async {
-      await tester.pumpWidget(_wrap(
-        const ClosingCardV18(articleCount: 3),
-      ));
-      await tester.pumpAndSettle();
-
-      expect(find.text('3 étapes parcourues'), findsOneWidget);
     });
 
     testWidgets('always shows three activity prompts under the amorce',
         (tester) async {
       await tester.pumpWidget(_wrap(
-        const ClosingCardV18(articleCount: 0),
+        const ClosingCardV18(),
         condition: WeatherCondition.sunny,
       ));
       await tester.pumpAndSettle();
@@ -110,7 +95,7 @@ void main() {
     testWidgets('keeps prompts indoor-only when the weather is poor',
         (tester) async {
       await tester.pumpWidget(_wrap(
-        const ClosingCardV18(articleCount: 0),
+        const ClosingCardV18(),
         condition: WeatherCondition.rainy,
       ));
       await tester.pumpAndSettle();

--- a/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
@@ -357,7 +357,9 @@ void main() {
       await tester.pump();
 
       expect(find.byType(SvgPicture), findsOneWidget);
-      expect(find.text('Météo'), findsOneWidget);
+      // Mid-flip les deux faces (pastille date + badge météo) sont montées et
+      // portent chacune un libellé « Météo » → assertion précise reportée après
+      // la fin du flip (cf. plus bas).
       expect(
         find.byWidgetPredicate(
           (widget) =>
@@ -382,6 +384,10 @@ void main() {
       await tester.pump(const Duration(milliseconds: 200));
       expect(temperatures.scale.value, closeTo(1, 0.001));
       expect(find.byIcon(Icons.keyboard_return_rounded), findsNothing);
+      // Flip terminé → seul le badge météo subsiste, avec son libellé discret
+      // souligné « Météo » (remplace l'ancien chevron).
+      expect(find.text('Météo'), findsOneWidget);
+      expect(find.byIcon(Icons.keyboard_arrow_down_rounded), findsNothing);
 
       // Tap the weather badge → opens the detail sheet (5-day forecast).
       await tester.tap(find.byType(SvgPicture), warnIfMissed: false);


### PR DESCRIPTION
## PR A — « Couverture médiatique polish » (mobile)

Items 1, 2, 4, 5, 6 du plan « Couverture médiatique : retours E2E », posés sur le refactor de bande déjà présent sur la branche (barre de biais pleine largeur + interactive).

### Changements
- **Item 1 — Repères Gauche / Droite** : `CoverageSpectrumBar.showAnchorLabels` (opt-in, off par défaut → aucun autre call-site impacté). Libellés permanents `courierPrime` 8.5 px `textTertiary` sous la barre, posés en pied de bande.
- **Item 2 — Barre plus élégante** : coins **externes** (1ʳᵉ/dernière stance visible) plus marqués (rayon 5), coins internes au rayon de base 4, gap 2→3 ; shimmer aligné.
- **Item 4 — Source cliquable + aperçu** :
  - (a) tap sur la zone source (pastille + nom) → `SourceDetailModal` (helpers `findSourceByDomain` / `showSourceDetailModal` extraits et réutilisés). Source non suivie ⇒ pas de zone morte (retombe sur l'ouverture article).
  - (b) toucher prolongé → `ArticlePreviewOverlay` via `Perspective.toPreviewContent()`. Plumbing du chapô `description` (back → `PerspectiveData` → `Perspective`, 3 sites de construction).
- **Item 5 — « Avis variés » plus visible** : `DivergenceInlineBadge.prominentMedium` (w600 + `textSecondary`, dots 0.7) appliqué **uniquement** au header Couverture. `bold` binaire remplacé par `labelWeight` granulaire. Les autres call-sites (feed, flux icon-only) gardent le défaut.
- **Item 6 — Deep reco** : « Le pas de recul » → « Le pas de recul · Facteur » (point médian, pas d'em-dash).

### Tests
- Nouveaux : repères G/D (présents/absents), `prominentMedium` (w600/secondary, sans effet sur high), `Perspective.fromJson` + `PerspectiveData.fromJson` parse `description`, `toPreviewContent` (description, source synthétique, favicon, date repli).
- Recalés : libellé deep reco.
- `flutter analyze` : pas d'erreur/warning sur les fichiers touchés.

### Notes
- La branche porte aussi le WIP UI **Essentiel / closing-card** déjà en cours (mêmes fichiers de bande) — tests verts.
- Pré-existant hors scope : `perspectives_bottom_sheet_intro_test.dart` est rouge depuis le retrait du surlignage (DÉSACTIVÉ T1, déjà committé sur `main`) — non touché par cette PR.
- La **fiabilité par perspective** (item 3) fait l'objet d'une **PR B dédiée** (backend + mobile, gate PO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)