### PR TITLE
feat(perspectives): indice de fiabilité par perspective (gate PO)

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Fiabilité",
+      "summary": "Indice de fiabilité de la source affiché sur les perspectives évaluées."
+    },
+    {
       "tag": "Lecture",
       "summary": "Carrousels plus nets : le bas des cartes ne se coupe plus quand leurs tailles diffèrent, et les points de défilement respirent mieux."
     },

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -322,6 +322,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
             sourceDomain: p.sourceDomain,
             biasStance: p.biasStance,
             publishedAt: p.publishedAt,
+            reliabilityScore: p.reliabilityScore,
           ),
         )
         .toList();

--- a/apps/mobile/lib/features/digest/widgets/topic_section.dart
+++ b/apps/mobile/lib/features/digest/widgets/topic_section.dart
@@ -894,6 +894,7 @@ class _TopicSectionState extends ConsumerState<TopicSection>
                   sourceDomain: p.sourceDomain,
                   biasStance: p.biasStance,
                   publishedAt: p.publishedAt,
+                  reliabilityScore: p.reliabilityScore,
                 ))
             .toList(),
         biasDistribution: response.biasDistribution,

--- a/apps/mobile/lib/features/feed/repositories/feed_repository.dart
+++ b/apps/mobile/lib/features/feed/repositories/feed_repository.dart
@@ -1189,6 +1189,10 @@ class PerspectiveData {
   final String biasStance;
   final String? publishedAt;
 
+  /// Fiabilité de la source (`high`/`medium`/`mixed`/`low`/`unknown`). Portée
+  /// par le back ; défaut `'unknown'` si absente (cache non rafraîchi).
+  final String reliabilityScore;
+
   /// Spans divergents du titre variant vs. référence (colorisés par bias).
   /// Liste vide si la chaîne back n'a pas pu calculer (cluster manquant, etc.).
   final List<HighlightSpan> highlightSpans;
@@ -1209,6 +1213,7 @@ class PerspectiveData {
     required this.sourceDomain,
     required this.biasStance,
     this.publishedAt,
+    this.reliabilityScore = 'unknown',
     this.highlightSpans = const [],
     this.sharedTokens = const [],
     this.language,
@@ -1224,6 +1229,8 @@ class PerspectiveData {
       sourceDomain: (json['source_domain'] as String?) ?? '',
       biasStance: (json['bias_stance'] as String?) ?? 'unknown',
       publishedAt: json['published_at'] as String?,
+      reliabilityScore:
+          (json['reliability_score'] as String?)?.toLowerCase() ?? 'unknown',
       highlightSpans: rawHighlights == null
           ? const []
           : rawHighlights

--- a/apps/mobile/lib/features/feed/widgets/coverage_comparison_card.dart
+++ b/apps/mobile/lib/features/feed/widgets/coverage_comparison_card.dart
@@ -102,12 +102,36 @@ class _Footer extends StatelessWidget {
 
   const _Footer({required this.perspective, required this.biasColor});
 
+  /// Glyphe de fiabilité discret : ✔ vert pour les sources `high`, ⚠ rouge pour
+  /// `low`. **Rien** pour medium/mixed/unknown (et beaucoup de sources non
+  /// évaluées ⇒ l'icône reste minoritaire — attendu). Couleurs dérivées du
+  /// barème fiabilité, légèrement atténuées.
+  Widget? _reliabilityGlyph(FacteurColors colors) {
+    switch (perspective.reliabilityScore) {
+      case 'high':
+        return Icon(
+          PhosphorIcons.checkCircle(PhosphorIconsStyle.fill),
+          size: 12,
+          color: colors.success.withValues(alpha: 0.9),
+        );
+      case 'low':
+        return Icon(
+          PhosphorIcons.warning(PhosphorIconsStyle.fill),
+          size: 12,
+          color: colors.error.withValues(alpha: 0.9),
+        );
+      default:
+        return null;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
     final timeLabel = CoverageComparisonCard.relativeTime(
       perspective.publishedAt,
     );
+    final reliabilityGlyph = _reliabilityGlyph(colors);
 
     // Groupe source + biais à gauche (shrink via le nom), temps à droite.
     // `spaceBetween` + un seul Flexible évite la famine de largeur d'un
@@ -157,6 +181,11 @@ class _Footer extends StatelessWidget {
                   color: biasColor,
                 ),
               ),
+              // Glyphe fiabilité (✔ high / ⚠ low), après le chip biais.
+              if (reliabilityGlyph != null) ...[
+                const SizedBox(width: 5),
+                reliabilityGlyph,
+              ],
             ],
           ),
         ),

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -65,6 +65,11 @@ class Perspective {
   final String biasStance;
   final String? publishedAt;
 
+  /// Fiabilité de la source (`high`/`medium`/`mixed`/`low`/`unknown`). Portée
+  /// par le back depuis `Source.reliability_score`. Défaut `'unknown'` (cache
+  /// perspectives non rafraîchi ⇒ champ absent ⇒ pas de glyphe).
+  final String reliabilityScore;
+
   /// Tokens divergents du titre vs. référence, colorisés par bias.
   final List<HighlightSpan> highlightSpans;
 
@@ -82,6 +87,7 @@ class Perspective {
     required this.sourceDomain,
     required this.biasStance,
     this.publishedAt,
+    this.reliabilityScore = 'unknown',
     this.highlightSpans = const [],
     this.sharedTokens = const [],
     this.language,
@@ -99,6 +105,8 @@ class Perspective {
       sourceDomain: (json['source_domain'] as String?) ?? '',
       biasStance: (json['bias_stance'] as String?) ?? 'unknown',
       publishedAt: json['published_at'] as String?,
+      reliabilityScore:
+          (json['reliability_score'] as String?)?.toLowerCase() ?? 'unknown',
       language: json['language'] as String?,
     );
   }

--- a/apps/mobile/test/features/feed/widgets/coverage_comparison_card_test.dart
+++ b/apps/mobile/test/features/feed/widgets/coverage_comparison_card_test.dart
@@ -18,6 +18,7 @@ Perspective _persp({
   String name = 'Libération',
   String bias = 'left',
   String? publishedAt,
+  String reliability = 'unknown',
 }) =>
     Perspective(
       title: 'Trump revendique la mort du chef',
@@ -26,6 +27,7 @@ Perspective _persp({
       sourceDomain: '$name.example.com',
       biasStance: bias,
       publishedAt: publishedAt,
+      reliabilityScore: reliability,
       highlightSpans: const [
         HighlightSpan(start: 6, end: 16, text: 'revendique', bias: 'left'),
       ],
@@ -151,4 +153,33 @@ void main() {
     expect(find.byKey(_marker), findsOneWidget);
     expect(_routed?.url, 'https://example.com/Libération');
   });
+
+  final checkGlyph = PhosphorIcons.checkCircle(PhosphorIconsStyle.fill);
+  final warnGlyph = PhosphorIcons.warning(PhosphorIconsStyle.fill);
+
+  testWidgets('fiabilité high → glyphe ✔ (check)', (tester) async {
+    await tester.pumpWidget(_app(_host(_persp(reliability: 'high'))));
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.byIcon(checkGlyph), findsOneWidget);
+    expect(find.byIcon(warnGlyph), findsNothing);
+  });
+
+  testWidgets('fiabilité low → glyphe ⚠ (warning)', (tester) async {
+    await tester.pumpWidget(_app(_host(_persp(reliability: 'low'))));
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.byIcon(warnGlyph), findsOneWidget);
+    expect(find.byIcon(checkGlyph), findsNothing);
+  });
+
+  for (final score in ['medium', 'mixed', 'unknown']) {
+    testWidgets('fiabilité $score → aucun glyphe', (tester) async {
+      await tester.pumpWidget(_app(_host(_persp(reliability: score))));
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.byIcon(checkGlyph), findsNothing);
+      expect(find.byIcon(warnGlyph), findsNothing);
+    });
+  }
 }

--- a/apps/mobile/test/features/feed/widgets/perspective_reliability_test.dart
+++ b/apps/mobile/test/features/feed/widgets/perspective_reliability_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/feed/repositories/feed_repository.dart'
+    show PerspectiveData;
+import 'package:facteur/features/feed/widgets/perspectives_bottom_sheet.dart';
+
+void main() {
+  Map<String, dynamic> base({String? reliability}) => {
+        'title': 'Titre',
+        'url': 'https://ex.com/a',
+        'source_name': 'Le Monde',
+        'source_domain': 'lemonde.fr',
+        'bias_stance': 'center',
+        if (reliability != null) 'reliability_score': reliability,
+      };
+
+  group('Perspective.fromJson reliability_score', () {
+    test('parse high/low/mixed', () {
+      expect(Perspective.fromJson(base(reliability: 'high')).reliabilityScore,
+          'high');
+      expect(Perspective.fromJson(base(reliability: 'low')).reliabilityScore,
+          'low');
+      expect(Perspective.fromJson(base(reliability: 'mixed')).reliabilityScore,
+          'mixed');
+    });
+
+    test('normalise la casse', () {
+      expect(Perspective.fromJson(base(reliability: 'HIGH')).reliabilityScore,
+          'high');
+    });
+
+    test('défaut unknown quand absent', () {
+      expect(Perspective.fromJson(base()).reliabilityScore, 'unknown');
+    });
+  });
+
+  group('PerspectiveData.fromJson reliability_score', () {
+    test('parse + défaut unknown', () {
+      expect(
+        PerspectiveData.fromJson(base(reliability: 'low')).reliabilityScore,
+        'low',
+      );
+      expect(PerspectiveData.fromJson(base()).reliabilityScore, 'unknown');
+    });
+  });
+}

--- a/packages/api/app/routers/contents.py
+++ b/packages/api/app/routers/contents.py
@@ -499,6 +499,7 @@ def _perspective_to_dict(p: object) -> dict:
         "bias_stance": p.bias_stance,
         "published_at": p.published_at,
         "description": p.description,
+        "reliability_score": getattr(p, "reliability_score", None),
         "language": getattr(p, "language", None),
     }
 

--- a/packages/api/app/services/perspective_service.py
+++ b/packages/api/app/services/perspective_service.py
@@ -199,6 +199,10 @@ class Perspective:
     bias_stance: str  # left, center-left, center, center-right, right, unknown
     published_at: str | None = None
     description: str | None = None
+    # Fiabilité de la source (low/medium/mixed/high/unknown). Lecture seule de
+    # `Source.reliability_score` (Story 7.1) — aucune migration : la colonne
+    # existe déjà. "unknown" par défaut (beaucoup de sources non évaluées).
+    reliability_score: str | None = None
     # Langue détectée du titre ("fr", "en", autre — None = inconnu). Rempli
     # côté cluster depuis `Content.language` ; les perspectives Google News
     # restent None faute de row Content (le client traite null comme FR par
@@ -239,6 +243,8 @@ class PerspectiveService:
         self.max_results = max_results
         # Cache for DB bias lookups within a single request
         self._bias_cache: dict[str, str] = {}
+        # Cache for DB reliability lookups within a single request
+        self._reliability_cache: dict[str, str] = {}
 
     @asynccontextmanager
     async def _short_session(self):
@@ -266,6 +272,16 @@ class PerspectiveService:
             if stance != "unknown":
                 return stance
         return DOMAIN_BIAS_MAP.get(domain, "unknown")
+
+    def _extract_reliability_from_source(self, source) -> str:
+        """Reliability from an eager-loaded Source, default 'unknown'.
+
+        Lecture seule de `Source.reliability_score` (déjà chargé par la requête,
+        comme `bias_stance`). Pas de map en dur : la fiabilité ne vit qu'en base.
+        """
+        if source is not None and source.reliability_score:
+            return str(source.reliability_score.value)
+        return "unknown"
 
     async def resolve_bias(self, domain: str, source_name: str | None = None) -> str:
         """Resolve bias for a domain: DOMAIN_BIAS_MAP first, then DB fallback by URL, then by name."""
@@ -323,6 +339,68 @@ class PerspectiveService:
                 )
 
         self._bias_cache[cache_key] = "unknown"
+        return "unknown"
+
+    async def resolve_reliability(
+        self, domain: str, source_name: str | None = None
+    ) -> str:
+        """Resolve reliability for a domain (read-only Source.reliability_score).
+
+        Calqué sur [resolve_bias] mais sans map en dur (la fiabilité ne vit qu'en
+        base) : DB lookup par URL puis par nom, défaut "unknown". Beaucoup de
+        sources ne sont pas évaluées ⇒ "unknown" est le cas dominant attendu.
+        """
+        # 1. In-memory cache from prior DB lookups
+        cache_key = domain or source_name or ""
+        if cache_key in self._reliability_cache:
+            return self._reliability_cache[cache_key]
+
+        # 2. DB lookup if session available
+        if self._has_db():
+            try:
+                from app.models.source import Source
+
+                async with self._short_session() as session:
+                    if session is None:
+                        self._reliability_cache[cache_key] = "unknown"
+                        return "unknown"
+
+                    # 2a. Try domain match on source URL
+                    if domain:
+                        stmt = select(Source.reliability_score).where(
+                            Source.url.ilike(f"%{domain}%"),
+                            Source.is_active.is_(True),
+                        )
+                        result = await session.execute(stmt)
+                        score = result.scalar_one_or_none()
+
+                        if score and score != "unknown":
+                            val = str(getattr(score, "value", score))
+                            self._reliability_cache[cache_key] = val
+                            return val
+
+                    # 2b. Fallback: fuzzy match by source name (Google News name)
+                    if source_name and source_name != "Unknown":
+                        stmt = select(Source.reliability_score).where(
+                            Source.name.ilike(f"%{source_name}%"),
+                            Source.is_active.is_(True),
+                        )
+                        result = await session.execute(stmt)
+                        score = result.scalar_one_or_none()
+
+                        if score and score != "unknown":
+                            val = str(getattr(score, "value", score))
+                            self._reliability_cache[cache_key] = val
+                            return val
+            except Exception as e:
+                logger.warning(
+                    "resolve_reliability_db_error",
+                    domain=domain,
+                    source_name=source_name,
+                    error=str(e),
+                )
+
+        self._reliability_cache[cache_key] = "unknown"
         return "unknown"
 
     async def analyze_divergences(
@@ -697,6 +775,7 @@ class PerspectiveService:
             source_obj = row.source
             source_name = (source_obj.name or domain) if source_obj else domain
             bias = self._extract_bias_from_source(source_obj, domain)
+            reliability = self._extract_reliability_from_source(source_obj)
 
             perspectives.append(
                 Perspective(
@@ -705,6 +784,7 @@ class PerspectiveService:
                     source_name=source_name,
                     source_domain=domain,
                     bias_stance=bias,
+                    reliability_score=reliability,
                     published_at=row.published_at.isoformat()
                     if row.published_at
                     else None,
@@ -802,6 +882,7 @@ class PerspectiveService:
                 continue
 
             bias = self._extract_bias_from_source(source, domain)
+            reliability = self._extract_reliability_from_source(source)
 
             result.append(
                 Perspective(
@@ -810,6 +891,7 @@ class PerspectiveService:
                     source_name=source_name or domain,
                     source_domain=domain,
                     bias_stance=bias,
+                    reliability_score=reliability,
                     published_at=(
                         content.published_at.isoformat()
                         if getattr(content, "published_at", None)
@@ -1010,6 +1092,10 @@ class PerspectiveService:
 
                 # Get bias (DB-first fallback, then name match)
                 bias = await self.resolve_bias(domain, source_name=source_name)
+                # Get reliability (read-only DB lookup, same fallback chain)
+                reliability = await self.resolve_reliability(
+                    domain, source_name=source_name
+                )
 
                 # Clean HTML from RSS description snippet (cap at 300 chars)
                 description = None
@@ -1026,6 +1112,7 @@ class PerspectiveService:
                         source_name=source_name,
                         source_domain=domain,
                         bias_stance=bias,
+                        reliability_score=reliability,
                         published_at=pub_date_el.text
                         if pub_date_el is not None
                         else None,

--- a/packages/api/tests/test_perspective_reliability.py
+++ b/packages/api/tests/test_perspective_reliability.py
@@ -1,0 +1,124 @@
+"""PR B — indicateur de fiabilité par perspective.
+
+Couvre la résolution lecture-seule de `Source.reliability_score` :
+- `_extract_reliability_from_source` (source eager-loadée, sans DB) ;
+- `resolve_reliability` (lookup DB par URL puis par nom, défaut "unknown") ;
+- `_perspective_to_dict` porte bien le champ.
+
+Aucune migration : la colonne `sources.reliability_score` existe déjà (Story 7.1).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from app.models.enums import BiasStance, ReliabilityScore, SourceType
+from app.models.source import Source
+from app.routers.contents import _perspective_to_dict
+from app.services.perspective_service import Perspective, PerspectiveService
+
+
+async def _make_source(
+    db_session,
+    *,
+    name: str,
+    url: str,
+    reliability: ReliabilityScore,
+) -> Source:
+    src = Source(
+        id=uuid4(),
+        name=name,
+        url=url,
+        feed_url=f"https://feed.example/{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_active=True,
+        is_curated=False,
+        bias_stance=BiasStance.UNKNOWN,
+        reliability_score=reliability,
+    )
+    db_session.add(src)
+    await db_session.commit()
+    return src
+
+
+# ── Unités pures (sans DB) ──────────────────────────────────────────────────
+
+
+def test_extract_reliability_from_source_reads_value():
+    src = SimpleNamespace(reliability_score=SimpleNamespace(value="high"))
+    svc = PerspectiveService()
+    assert svc._extract_reliability_from_source(src) == "high"
+
+
+def test_extract_reliability_from_source_defaults_unknown():
+    svc = PerspectiveService()
+    assert svc._extract_reliability_from_source(None) == "unknown"
+    assert (
+        svc._extract_reliability_from_source(SimpleNamespace(reliability_score=None))
+        == "unknown"
+    )
+
+
+def test_perspective_to_dict_carries_reliability():
+    p = Perspective(
+        title="Titre",
+        url="https://ex.com/a",
+        source_name="Le Monde",
+        source_domain="lemonde.fr",
+        bias_stance="center",
+        reliability_score="high",
+    )
+    d = _perspective_to_dict(p)
+    assert d["reliability_score"] == "high"
+
+
+def test_perspective_to_dict_reliability_defaults_none():
+    p = Perspective(
+        title="Titre",
+        url="https://ex.com/a",
+        source_name="X",
+        source_domain="x.com",
+        bias_stance="unknown",
+    )
+    assert _perspective_to_dict(p)["reliability_score"] is None
+
+
+async def test_resolve_reliability_no_db_returns_unknown():
+    svc = PerspectiveService()  # pas de session → branche dégradée
+    assert await svc.resolve_reliability("lemonde.fr") == "unknown"
+
+
+# ── Intégration DB ──────────────────────────────────────────────────────────
+
+
+async def test_resolve_reliability_by_url(db_session):
+    await _make_source(
+        db_session,
+        name="Le Monde",
+        url="https://lemonde.fr",
+        reliability=ReliabilityScore.HIGH,
+    )
+    svc = PerspectiveService(db=db_session)
+    assert await svc.resolve_reliability("lemonde.fr") == "high"
+
+
+async def test_resolve_reliability_by_name_fallback(db_session):
+    await _make_source(
+        db_session,
+        name="Source Douteuse",
+        url="https://douteux.example",
+        reliability=ReliabilityScore.LOW,
+    )
+    svc = PerspectiveService(db=db_session)
+    # Domaine inconnu → fallback fuzzy par nom.
+    assert (
+        await svc.resolve_reliability("introuvable.test", source_name="Source Douteuse")
+        == "low"
+    )
+
+
+async def test_resolve_reliability_unknown_when_absent(db_session):
+    svc = PerspectiveService(db=db_session)
+    assert await svc.resolve_reliability("inexistant.test") == "unknown"


### PR DESCRIPTION
## PR B — Indicateur de fiabilité par perspective (backend + mobile)

Item 3 du plan « Couverture médiatique : retours E2E ». **Brouillon — gate PO avant merge.**

> ⚠️ **Aucune migration Alembic.** La colonne `sources.reliability_score` existe déjà (Story 7.1, enum `ReliabilityScore` high/medium/mixed/low/unknown). On la lit (read-only) et on la porte jusqu'à la carte. 1 seul head Alembic, inchangé.

### Backend (`perspective_service.py`, `contents.py`)
- `Perspective` dataclass : champ `reliability_score: str | None = None`.
- `_extract_reliability_from_source(source)` : lecture de la `Source` eager-loadée (comme `bias_stance`, pas de requête).
- `resolve_reliability(domain, source_name)` : calqué sur `resolve_bias` — lookup DB par URL puis fuzzy par nom, **pas de map en dur**, défaut `"unknown"`, caché par requête.
- Renseigné aux **3 sites** de construction de `Perspective` (cluster interne, contenu externe, RSS Google News).
- `_perspective_to_dict` expose `reliability_score`.

### Mobile
- `PerspectiveData` / `Perspective` : champ `reliabilityScore` (parse `reliability_score` lowercase, **défaut `'unknown'`** ⇒ rétro-compat cache non rafraîchi) + mapping `topic_section` / `content_detail`.
- `CoverageComparisonCard._Footer` : glyphe discret **✔ (high)** / **⚠ (low)** après le chip biais, **rien** pour medium/mixed/unknown. Couleurs dérivées du barème fiabilité (`success` / `error` atténués). Beaucoup de sources non évaluées ⇒ l'icône reste minoritaire (attendu).

### Tests
- Backend : `_extract_reliability_from_source` (value / défaut), `_perspective_to_dict` (présence du champ), `resolve_reliability` no-DB (`unknown`) — **passés localement** ; + DB-backed (résolution par URL, par nom, défaut) — **à exécuter en CI** (pas de stack Postgres test dans le workspace Conductor).
- Mobile : parse `reliability_score` (`Perspective` + `PerspectiveData`, casse + défaut), glyphe high/low/none — **16 tests verts**.
- `flutter analyze` : pas d'erreur/warning sur les fichiers touchés.

### Notes
- Branche partie de `main` (indépendante de la PR A #894). Recoupements mobiles attendus (`Perspective`, `_Footer`) → conflits triviaux à résoudre selon l'ordre de merge.
- **Gate PO** : ouvrir en draft, valider le rendu (Playwright `/validate-feature`) avant ready-for-review / merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)