### PR TITLE
fix(api): upsert atomique sur user_interests (race PYTHON-4P)

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,33 +1,45 @@
-## Tour guidé Facteur (coach-mark post-onboarding)
+## fix(api): upsert atomique sur user_interests (race condition Sentry PYTHON-4P)
 
-Tour guidé en 5 étapes joué **une seule fois juste après l'onboarding**, qui pilote la vraie app pour présenter ses pages principales. Il s'insère **avant** les modales post-onboarding existantes (thème puis notifications).
+### Problème
+`update_content_status` (SEEN au scroll + CONSUMED au retour WebView) déclenchait une
+re-pondération des intérêts via un **check-then-insert non atomique** (SELECT `UserInterest` ;
+si absent → `add()`). Deux requêtes concurrentes pour le même `(user_id, interest_slug)`
+voyaient toutes deux « absent » et inséraient → `IntegrityError / UniqueViolation` sur
+`user_interests_user_slug_uniq` → **500**, lecture non retenue (progression + perso intérêts).
+Sentry **PYTHON-4P** : 260 occurrences / 24h, 11 personnes.
 
-### Parcours (6 états joués, 5 puces)
-1. **1/5** — hero « L'Essentiel du jour » + onglet Essentiel (scroll top).
-2. **2/5 (a)** — scroll vers la 1ʳᵉ section de la Tournée (`ensureVisible`).
-3. **2/5 (b)** — ouverture de la vraie feuille « Mes favoris », spotlight par-dessus.
-4. **3/5** — bascule onglet Flâner, voile plein, carte centrée.
-5. **4/5** — retour accueil, spotlight de l'avatar profil (Réglages).
-6. **5/5** — même avatar (Mon courrier), bouton « Terminer ».
-7. **done** — carte « C'est parti », puis main rendue aux modales.
+### Fix
+Remplacement de tous les points d'insertion `UserInterest` par un **upsert Postgres atomique**
+(`INSERT ... ON CONFLICT (user_id, interest_slug) DO UPDATE`), pattern déjà utilisé dans le repo
+(`UserContentStatus`, `grille_seed`). La sémantique métier est préservée :
 
-### Architecture
-- **Machine à états Riverpod** (`GuidedTourController`, `keepAlive`) — survit aux changements d'onglet/feuilles, **ne touche jamais `BuildContext`**. `start(onComplete)` gate le flag « vu » (scopé user) ; `next()`/`skip()`/`finish()` → `done` + `onComplete` tiré une seule fois.
-- **Bridge racine** (`GuidedTourBridge`, monté une fois dans `MainShell`) — exécute les effets de bord (navigation, ouverture feuille, scroll) et insère l'`OverlayEntry` dans l'overlay **racine** (au-dessus de la feuille favoris qui vit en branche).
-- **Overlay** — scrim `#2C2A29` α0.72 + découpe spotlight (`Path`/`BlendMode.clear`, contour `#E8943F`), rect relu live depuis le `RenderBox` des `GlobalKey` à chaque frame (suit slide/scroll). Coach card : avatar Facteur, pastille « N/5 », titre Fraunces, corps DM Sans, 5 puces, Passer/Suivant/Terminer.
+- **`content_service._adjust_interest_weight`** (culprit) : poids `= least(weight + boost, 3.0)` ;
+  `state` non touché sur conflit (préserve FAVORITE).
+- **`content_service._adjust_subtopic_weights`** (branche intérêt) : `delta > 0` → upsert borné
+  `[0.1, 3.0]` ; `delta < 0` → UPDATE ciblé (pas d'INSERT, jamais de création au dislike).
+- **`user_interests_service.set_state`** : création implicite de thème → upsert (set `state`).
+- **`user_service`** (onboarding) : état FAVORITE précalculé avant insertion, upsert par thème.
 
-### Garde « une seule fois »
-Double verrou : démarrage seulement depuis le chemin post-onboarding (`postOnboardingFlowPendingProvider`) **et** flag persistant `nudge.guided_tour.seen.<userId>` (namespace `nudge.`, scopé user comme `NudgeStorage`).
-
-### Fichiers
-- **Nouveaux** : `lib/features/tour/` (models/tour_step, providers/guided_tour_controller, tour_anchors, tour_strings, tour_ids, widgets/guided_tour_bridge|overlay|coach_card).
-- **Édités** : `flux_continu_screen.dart` (split `_runPostOnboardingFlow` → tour puis `_runPostOnboardingModals`, listen `tourScrollTargetProvider`, ancre 1ʳᵉ section), `essentiel_hi_fi_card.dart` (ancre hero), `main_shell.dart` (montage bridge + ancre avatar), `main_bottom_nav.dart` (ancre onglet), `manage_favorites_sheet.dart` (ancre feuille + note z-order), `navigation_providers.dart` (`tourScrollTargetProvider`), `changelog.json`.
+Aucun DDL / migration (la contrainte unique existe déjà). Hors périmètre : le jumeau
+`UserSubtopic` (table `user_subtopics`). Attention, ce n'est **pas** le même bug shape :
+la contrainte unique `(user_id, topic_slug)` y a été **supprimée** (migration `4d497ce7bcc2`),
+donc son check-then-insert ne lève pas d'`UniqueViolation` — sous concurrence il insère
+des lignes dupliquées en silence (poids faussé). Le corriger proprement exigerait d'abord
+de re-créer la contrainte unique via migration → hors scope de ce hotfix de crash.
 
 ### Tests
-- `test/features/tour/guided_tour_controller_test.dart` — séquence complète, displayIndex (2/5 mutualisé), skip/finish → done + flag persisté + onComplete une fois, no-op si déjà vu.
-- `test/features/tour/guided_tour_overlay_test.dart` — coach card (titre/pastille/puces/boutons), « Terminer » en dernière étape, carte de conclusion, voile plein sans ancre.
-- `flutter analyze` : 0 nouvelle erreur. Tests des fichiers touchés (essentiel_hi_fi_card, main_bottom_nav, flux_continu) : verts.
+`tests/test_interest_weight_concurrency.py` : création → incrément (1 seule ligne), cap 3.0,
+préservation FAVORITE. Le chemin `ON CONFLICT DO UPDATE` est exactement celui qu'emprunte la
+requête perdante d'une course ; exercé ici par double-appel séquentiel (la fixture `db_session`
+mono-connexion ne permet pas une vraie concurrence 2-connexions).
 
-### Notes
-- Frontend pur, aucune migration / endpoint.
-- Reste à faire avant deploy : `/validate-feature` Playwright (handoff dans `.context/qa-handoff.md`).
+Tests exécutés en local contre `facteur_test` (Postgres 5432) : les 3 tests de régression
+passent, ainsi que la suite complète (1895 passed ; les 2 seuls échecs —
+`test_notification_preferences` et `test_sources_recent_items` — sont pré-existants sur
+`main`, sans rapport avec ce diff, vérifié en revertant les services). Tests adaptés au
+nouveau chemin upsert : `test_onboarding_sources` (l'intérêt passe par `execute` et non plus
+`db.add` ; offset des appers `execute` recalculé), `test_like_feature` (1 seul `add` + 1
+upsert intérêt). `ruff check` + `ruff format` OK sur les fichiers touchés.
+
+### Post-merge (PO)
+Vérifier que le compteur Sentry **PYTHON-4P** retombe à ~0 après déploiement.

--- a/packages/api/app/services/content_service.py
+++ b/packages/api/app/services/content_service.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from uuid import UUID
 
 import structlog
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import func
@@ -216,29 +216,30 @@ class ContentService:
             elif ratio < 0.1:
                 engagement_factor = 0.2
 
-        # 3. Update UserInterest
-        # Check if interest exists
-        stmt = select(UserInterest).where(
-            UserInterest.user_id == user_id, UserInterest.interest_slug == theme_slug
-        )
-        interest = await self.session.scalar(stmt)
-
+        # 3. Update UserInterest — upsert atomique (Postgres ON CONFLICT)
+        # SEEN (scroll) et CONSUMED (retour WebView) arrivent quasi-simultanément
+        # pour le même (user_id, theme_slug) ; un check-then-insert classique
+        # provoquait une UniqueViolation (user_interests_user_slug_uniq).
+        # NewWeight = OldWeight + (Engagement * Rate), capé à 3.0 pour éviter
+        # l'explosion. À la création : poids 1.0 + boost (découverte de thèmes
+        # via sources généralistes). On ne touche pas `state` sur conflit pour
+        # préserver un éventuel FAVORITE.
         learning_rate = 0.05
+        boost = engagement_factor * learning_rate
 
-        if interest:
-            # NewWeight = OldWeight + (Engagement * Rate)
-            # On cap le poids max à 3.0 pour éviter l'explosion
-            new_weight = interest.weight + (engagement_factor * learning_rate)
-            interest.weight = min(new_weight, 3.0)
-        else:
-            # Create new interest with base weight 1.0 + boost
-            # Cela permet de découvrir de nouveaux thèmes via sources généralistes
-            new_interest = UserInterest(
+        stmt = (
+            insert(UserInterest)
+            .values(
                 user_id=user_id,
                 interest_slug=theme_slug,
-                weight=1.0 + (engagement_factor * learning_rate),
+                weight=1.0 + boost,
             )
-            self.session.add(new_interest)
+            .on_conflict_do_update(
+                constraint="user_interests_user_slug_uniq",
+                set_={"weight": func.least(UserInterest.weight + boost, 3.0)},
+            )
+        )
+        await self.session.execute(stmt)
 
     async def _adjust_subtopic_weights(
         self, user_id: UUID, content_id: UUID, delta: float
@@ -285,25 +286,46 @@ class ContentService:
             from app.services.recommendation.scoring_config import ScoringWeights
 
             theme_slug = content.source.theme
-            stmt = select(UserInterest).where(
-                UserInterest.user_id == user_id,
-                UserInterest.interest_slug == theme_slug,
-            )
-            interest = await self.session.scalar(stmt)
             learning_rate = ScoringWeights.LIKE_INTEREST_RATE
 
-            if interest:
-                new_weight = interest.weight + (
-                    learning_rate * (1.0 if delta > 0 else -1.0)
+            if delta > 0:
+                # Like/bookmark : upsert atomique, poids borné [0.1, 3.0].
+                stmt = (
+                    insert(UserInterest)
+                    .values(
+                        user_id=user_id,
+                        interest_slug=theme_slug,
+                        weight=1.0 + learning_rate,
+                    )
+                    .on_conflict_do_update(
+                        constraint="user_interests_user_slug_uniq",
+                        set_={
+                            "weight": func.greatest(
+                                func.least(UserInterest.weight + learning_rate, 3.0),
+                                0.1,
+                            )
+                        },
+                    )
                 )
-                interest.weight = max(0.1, min(new_weight, 3.0))
-            elif delta > 0:
-                new_interest = UserInterest(
-                    user_id=user_id,
-                    interest_slug=theme_slug,
-                    weight=1.0 + learning_rate,
+                await self.session.execute(stmt)
+            else:
+                # Unlike : décrément ciblé, jamais de création de ligne (pas
+                # d'INSERT → pas de risque de conflit). No-op si l'intérêt
+                # n'existe pas.
+                stmt = (
+                    update(UserInterest)
+                    .where(
+                        UserInterest.user_id == user_id,
+                        UserInterest.interest_slug == theme_slug,
+                    )
+                    .values(
+                        weight=func.greatest(
+                            func.least(UserInterest.weight - learning_rate, 3.0),
+                            0.1,
+                        )
+                    )
                 )
-                self.session.add(new_interest)
+                await self.session.execute(stmt)
 
     async def set_like_status(
         self, user_id: UUID, content_id: UUID, is_liked: bool

--- a/packages/api/app/services/user_interests_service.py
+++ b/packages/api/app/services/user_interests_service.py
@@ -10,6 +10,7 @@ from uuid import UUID
 
 import structlog
 from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.constants import FAVORITE_CAP
@@ -156,11 +157,18 @@ class UserInterestsService:
             if row is None:
                 # Création implicite : permet à l'utilisateur d'épingler un Thème
                 # qu'il n'avait pas encore (weight neutre, state demandé).
-                row = UserInterest(
-                    user_id=user_id, interest_slug=interest_slug, state=state
+                # Upsert atomique : un double-tap concurrent ne lève plus
+                # d'IntegrityError sur user_interests_user_slug_uniq.
+                # prev_state reste None (sémantique "créé à la volée").
+                stmt = (
+                    insert(UserInterest)
+                    .values(user_id=user_id, interest_slug=interest_slug, state=state)
+                    .on_conflict_do_update(
+                        constraint="user_interests_user_slug_uniq",
+                        set_={"state": state},
+                    )
                 )
-                self.db.add(row)
-                await self.db.flush()
+                await self.db.execute(stmt)
             else:
                 prev_state = row.state
                 row.state = state

--- a/packages/api/app/services/user_service.py
+++ b/packages/api/app/services/user_service.py
@@ -200,21 +200,12 @@ class UserService:
 
         user_uuid = UUID(user_id)
 
-        # Sauvegarder les intérêts
+        # Sauvegarder les intérêts.
+        # Les 3 premiers thèmes deviennent FAVORITE (sauf si l'utilisateur a déjà
+        # des favoris). On calcule l'état AVANT insertion pour pouvoir faire un
+        # upsert atomique : une double-soumission de l'onboarding ne lève plus
+        # d'IntegrityError sur user_interests_user_slug_uniq.
         interest_count = 0
-        created_interests: dict[str, UserInterest] = {}
-        if answers.themes:
-            for interest_slug in answers.themes:
-                interest = UserInterest(
-                    id=uuid4(),
-                    user_id=user_uuid,
-                    interest_slug=interest_slug,
-                    weight=1.0,
-                )
-                self.db.add(interest)
-                created_interests[interest_slug] = interest
-                interest_count += 1
-
         favorites_seeded = 0
         if answers.themes:
             existing_favorite = await self.db.scalar(
@@ -222,11 +213,35 @@ class UserService:
                     UserFavoriteInterest.user_id == user_uuid
                 )
             )
+            favorite_slugs = (
+                set(answers.themes[:3]) if existing_favorite is None else set()
+            )
+
+            for interest_slug in answers.themes:
+                state = (
+                    InterestState.FAVORITE
+                    if interest_slug in favorite_slugs
+                    else InterestState.FOLLOWED
+                )
+                stmt = (
+                    pg_insert(UserInterest)
+                    .values(
+                        id=uuid4(),
+                        user_id=user_uuid,
+                        interest_slug=interest_slug,
+                        weight=1.0,
+                        state=state,
+                    )
+                    .on_conflict_do_update(
+                        constraint="user_interests_user_slug_uniq",
+                        set_={"weight": 1.0, "state": state},
+                    )
+                )
+                await self.db.execute(stmt)
+                interest_count += 1
+
             if existing_favorite is None:
                 for position, interest_slug in enumerate(answers.themes[:3]):
-                    interest = created_interests.get(interest_slug)
-                    if interest is not None:
-                        interest.state = InterestState.FAVORITE
                     self.db.add(
                         UserFavoriteInterest(
                             user_id=user_uuid,

--- a/packages/api/tests/test_interest_weight_concurrency.py
+++ b/packages/api/tests/test_interest_weight_concurrency.py
@@ -1,0 +1,153 @@
+"""Régression Sentry PYTHON-4P — race condition user_interests_user_slug_uniq.
+
+L'ancien code de re-pondération des intérêts faisait un check-then-insert
+(SELECT UserInterest ; si absent → add()). Sous concurrence (SEEN au scroll +
+CONSUMED au retour WebView quasi-simultanés pour le même thème), les deux
+requêtes voyaient "absent" et inséraient → IntegrityError sur
+user_interests_user_slug_uniq → 500, et le commit de lecture était perdu.
+
+Le fix remplace l'insertion par un upsert Postgres atomique
+(INSERT ... ON CONFLICT (user_id, interest_slug) DO UPDATE). La requête
+"perdante" d'une course emprunte la branche DO UPDATE — c'est exactement ce
+qu'exerce ici un second appel séquentiel sur le même (user, thème).
+
+NB : la fixture `db_session` isole chaque test dans une connexion unique +
+savepoints (cf. conftest), donc une vraie concurrence 2-connexions n'est pas
+reproductible ici ; on valide le chemin ON CONFLICT de façon déterministe.
+"""
+
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+
+from app.models.content import Content
+from app.models.enums import ContentType, InterestState
+from app.models.user import UserInterest, UserProfile
+from app.services.content_service import ContentService
+
+
+async def _make_user(db_session):
+    """Crée un UserProfile valide — la FK user_interests_user_id_fkey l'exige."""
+    user_id = uuid4()
+    db_session.add(UserProfile(user_id=user_id, display_name="Test User"))
+    await db_session.commit()
+    return user_id
+
+
+async def _make_content(db_session, source, *, duration_seconds=None):
+    content = Content(
+        id=uuid4(),
+        source_id=source.id,
+        title="Article test",
+        url=f"https://example.com/{uuid4()}",
+        guid=str(uuid4()),
+        published_at=datetime.utcnow(),
+        content_type=ContentType.ARTICLE,
+        duration_seconds=duration_seconds,
+    )
+    db_session.add(content)
+    await db_session.commit()
+    return content
+
+
+@pytest.mark.asyncio
+async def test_adjust_interest_weight_creates_then_increments(db_session, test_source):
+    """1er appel crée l'intérêt (1.0 + boost, FOLLOWED) ; 2e appel incrémente."""
+    service = ContentService(db_session)
+    user_id = await _make_user(db_session)
+    content = await _make_content(db_session, test_source)
+    content_id = content.id  # capturé avant expunge_all (évite un reload sync)
+    theme = test_source.theme  # "society"
+
+    # 1er appel : création
+    await service._adjust_interest_weight(user_id, content_id, time_spent=None)
+    await db_session.commit()
+
+    db_session.expunge_all()  # l'upsert Core bypass l'ORM → vider l'identity map
+    row = await db_session.scalar(
+        select(UserInterest).where(
+            UserInterest.user_id == user_id,
+            UserInterest.interest_slug == theme,
+        )
+    )
+    assert row is not None
+    # engagement_factor=1.0 (pas de time_spent), learning_rate=0.05
+    assert row.weight == pytest.approx(1.0 + 0.05)
+    assert row.state == InterestState.FOLLOWED
+
+    # 2e appel : branche ON CONFLICT DO UPDATE → incrément, une seule ligne
+    await service._adjust_interest_weight(user_id, content_id, time_spent=None)
+    await db_session.commit()
+
+    db_session.expunge_all()
+    rows = (
+        await db_session.scalars(
+            select(UserInterest).where(
+                UserInterest.user_id == user_id,
+                UserInterest.interest_slug == theme,
+            )
+        )
+    ).all()
+    assert len(rows) == 1, "pas de doublon : la contrainte unique tient"
+    assert rows[0].weight == pytest.approx(1.0 + 0.05 + 0.05)
+
+
+@pytest.mark.asyncio
+async def test_adjust_interest_weight_caps_at_3(db_session, test_source):
+    """Le DO UPDATE préserve le cap métier à 3.0."""
+    service = ContentService(db_session)
+    user_id = await _make_user(db_session)
+    content = await _make_content(db_session, test_source)
+    theme = test_source.theme
+
+    # Seed près du plafond.
+    db_session.add(UserInterest(user_id=user_id, interest_slug=theme, weight=2.99))
+    await db_session.commit()
+
+    # Plusieurs incréments : le poids ne dépasse jamais 3.0.
+    for _ in range(5):
+        await service._adjust_interest_weight(user_id, content.id, time_spent=None)
+    await db_session.commit()
+
+    db_session.expunge_all()
+    row = await db_session.scalar(
+        select(UserInterest).where(
+            UserInterest.user_id == user_id,
+            UserInterest.interest_slug == theme,
+        )
+    )
+    assert row.weight == pytest.approx(3.0)
+
+
+@pytest.mark.asyncio
+async def test_adjust_interest_weight_preserves_favorite_state(db_session, test_source):
+    """Sur conflit, le state (ex. FAVORITE) n'est jamais écrasé."""
+    service = ContentService(db_session)
+    user_id = await _make_user(db_session)
+    content = await _make_content(db_session, test_source)
+    theme = test_source.theme
+
+    db_session.add(
+        UserInterest(
+            user_id=user_id,
+            interest_slug=theme,
+            weight=1.5,
+            state=InterestState.FAVORITE,
+        )
+    )
+    await db_session.commit()
+
+    await service._adjust_interest_weight(user_id, content.id, time_spent=None)
+    await db_session.commit()
+
+    db_session.expunge_all()
+    row = await db_session.scalar(
+        select(UserInterest).where(
+            UserInterest.user_id == user_id,
+            UserInterest.interest_slug == theme,
+        )
+    )
+    assert row.state == InterestState.FAVORITE
+    assert row.weight == pytest.approx(1.55)

--- a/packages/api/tests/test_like_feature.py
+++ b/packages/api/tests/test_like_feature.py
@@ -185,5 +185,15 @@ async def test_like_creates_new_subtopic():
 
     await service._adjust_subtopic_weights(user_id, content_id, 0.15)
 
-    # Verify session.add was called (for new subtopic + new interest)
-    assert session.add.call_count == 2
+    # Le sous-thème est créé via add() ; l'intérêt de thème passe désormais par
+    # un upsert atomique (execute) — un seul add() (le sous-thème).
+    assert session.add.call_count == 1
+    # L'intérêt est upserté sur user_interests via execute().
+    interest_inserts = [
+        call.args[0]
+        for call in session.execute.call_args_list
+        if getattr(call.args[0], "is_insert", False)
+        and getattr(call.args[0], "table", None) is not None
+        and call.args[0].table.name == "user_interests"
+    ]
+    assert len(interest_inserts) == 1

--- a/packages/api/tests/test_onboarding_sources.py
+++ b/packages/api/tests/test_onboarding_sources.py
@@ -4,10 +4,10 @@ from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.dialects import postgresql
 
 from app.models.enums import InterestState
 from app.models.source import UserSource
-from app.models.user import UserInterest
 from app.models.user_favorites import UserFavoriteInterest
 from app.schemas.user import OnboardingAnswers
 from app.services.user_service import UserService
@@ -153,17 +153,15 @@ async def test_save_onboarding_creates_user_sources():
         nonlocal execute_call_count
         execute_call_count += 1
         # Calls order in save_onboarding:
-        # 1. delete UserPreference
-        # 2. delete UserInterest
-        # 3. delete UserSubtopic
-        # 4. pg_insert UserPersonalization (muted themes)
-        # 5. select Source.id (existing sources check)
-        # 6. select UserSource.source_id (already trusted check)
-        # 7. select UserSource (cleanup query)
+        # 1-3. delete UserPreference / UserInterest / UserSubtopic
+        # 4..4+N-1. pg_insert UserInterest (one upsert per theme, N=len(themes))
+        # 4+N. pg_insert UserPersonalization (muted themes)
+        # then: select Source.id / select UserSource.source_id / select UserSource
+        src_base = 3 + len(answers.themes) + 1
         responses_by_call = {
-            5: mock_sources_result,
-            6: mock_already_result,
-            7: mock_all_user_sources_result,
+            src_base + 1: mock_sources_result,
+            src_base + 2: mock_already_result,
+            src_base + 3: mock_all_user_sources_result,
         }
         return responses_by_call.get(execute_call_count, MagicMock())
 
@@ -228,10 +226,13 @@ async def test_save_onboarding_marks_existing_source_followed():
     async def mock_execute(stmt):
         nonlocal execute_call_count
         execute_call_count += 1
+        # Interests are upserted via execute() (one per theme) before the
+        # source selects — offset by len(themes). Cf. test above.
+        src_base = 3 + len(answers.themes) + 1
         responses_by_call = {
-            5: mock_sources_result,
-            6: mock_already_result,
-            7: mock_all_user_sources_result,
+            src_base + 1: mock_sources_result,
+            src_base + 2: mock_already_result,
+            src_base + 3: mock_all_user_sources_result,
         }
         return responses_by_call.get(execute_call_count, MagicMock())
 
@@ -274,19 +275,34 @@ async def test_save_onboarding_seeds_theme_favorites_when_empty():
 
     added_objects = [call.args[0] for call in mock_db.add.call_args_list]
     favorites = [obj for obj in added_objects if isinstance(obj, UserFavoriteInterest)]
-    interests = [obj for obj in added_objects if isinstance(obj, UserInterest)]
 
     assert [(f.interest_slug, f.position) for f in favorites] == [
         ("tech", 0),
         ("science", 1),
         ("culture", 2),
     ]
+
+    # Interests are now persisted via atomic upserts (execute), not db.add().
+    # Read the declared state back from each insert into user_interests.
+    executed = [call.args[0] for call in mock_db.execute.call_args_list]
+    interest_states = {}
+    for stmt in executed:
+        table = getattr(stmt, "table", None)
+        if not getattr(stmt, "is_insert", False) or table is None:
+            continue
+        if table.name != "user_interests":
+            continue
+        params = stmt.compile(dialect=postgresql.dialect()).params
+        interest_states[params["interest_slug"]] = params["state"]
+
     favorite_interest_states = {
-        i.interest_slug: i.state
-        for i in interests
-        if i.interest_slug in {"tech", "science", "culture"}
+        slug: state
+        for slug, state in interest_states.items()
+        if slug in {"tech", "science", "culture"}
     }
     assert set(favorite_interest_states.values()) == {InterestState.FAVORITE}
+    # Le 4e thème reste un simple suivi.
+    assert interest_states["economy"] == InterestState.FOLLOWED
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## fix(api): upsert atomique sur user_interests (race condition Sentry PYTHON-4P)

### Problème
`update_content_status` (SEEN au scroll + CONSUMED au retour WebView) déclenchait une
re-pondération des intérêts via un **check-then-insert non atomique** (SELECT `UserInterest` ;
si absent → `add()`). Deux requêtes concurrentes pour le même `(user_id, interest_slug)`
voyaient toutes deux « absent » et inséraient → `IntegrityError / UniqueViolation` sur
`user_interests_user_slug_uniq` → **500**, lecture non retenue (progression + perso intérêts).
Sentry **PYTHON-4P** : 260 occurrences / 24h, 11 personnes.

### Fix
Remplacement de tous les points d'insertion `UserInterest` par un **upsert Postgres atomique**
(`INSERT ... ON CONFLICT (user_id, interest_slug) DO UPDATE`), pattern déjà utilisé dans le repo
(`UserContentStatus`, `grille_seed`). La sémantique métier est préservée :

- **`content_service._adjust_interest_weight`** (culprit) : poids `= least(weight + boost, 3.0)` ;
  `state` non touché sur conflit (préserve FAVORITE).
- **`content_service._adjust_subtopic_weights`** (branche intérêt) : `delta > 0` → upsert borné
  `[0.1, 3.0]` ; `delta < 0` → UPDATE ciblé (pas d'INSERT, jamais de création au dislike).
- **`user_interests_service.set_state`** : création implicite de thème → upsert (set `state`).
- **`user_service`** (onboarding) : état FAVORITE précalculé avant insertion, upsert par thème.

Aucun DDL / migration (la contrainte unique existe déjà). Hors périmètre : le jumeau
`UserSubtopic` (table `user_subtopics`). Attention, ce n'est **pas** le même bug shape :
la contrainte unique `(user_id, topic_slug)` y a été **supprimée** (migration `4d497ce7bcc2`),
donc son check-then-insert ne lève pas d'`UniqueViolation` — sous concurrence il insère
des lignes dupliquées en silence (poids faussé). Le corriger proprement exigerait d'abord
de re-créer la contrainte unique via migration → hors scope de ce hotfix de crash.

### Tests
`tests/test_interest_weight_concurrency.py` : création → incrément (1 seule ligne), cap 3.0,
préservation FAVORITE. Le chemin `ON CONFLICT DO UPDATE` est exactement celui qu'emprunte la
requête perdante d'une course ; exercé ici par double-appel séquentiel (la fixture `db_session`
mono-connexion ne permet pas une vraie concurrence 2-connexions).

Tests exécutés en local contre `facteur_test` (Postgres 5432) : les 3 tests de régression
passent, ainsi que la suite complète (1895 passed ; les 2 seuls échecs —
`test_notification_preferences` et `test_sources_recent_items` — sont pré-existants sur
`main`, sans rapport avec ce diff, vérifié en revertant les services). Tests adaptés au
nouveau chemin upsert : `test_onboarding_sources` (l'intérêt passe par `execute` et non plus
`db.add` ; offset des appers `execute` recalculé), `test_like_feature` (1 seul `add` + 1
upsert intérêt). `ruff check` + `ruff format` OK sur les fichiers touchés.

### Post-merge (PO)
Vérifier que le compteur Sentry **PYTHON-4P** retombe à ~0 après déploiement.
