### PR TITLE
fix(android): retire toute la famille READ_MEDIA_* app-wide (rejet Play)

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,16 @@
          requis par l'auto-update APK side-loaded, banni du Play Store. -->
     <!-- Story 10.1 — météo géolocalisée : coarse suffit pour la météo -->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <!-- open_filex (ouverture de l'APK téléchargé) injecte la famille
+         READ_MEDIA_* dans son propre manifest. L'app n'en a besoin sur AUCUN
+         flavor : open_filex passe par un FileProvider (URI content://, sans
+         permission) et le Photo Picker Android ne requiert aucune permission.
+         Retrait app-wide — sinon Google Play rejette au titre de la Photo &
+         Video Permissions policy (READ_MEDIA_IMAGES / READ_MEDIA_VIDEO). -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" tools:node="remove" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" tools:node="remove" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" tools:node="remove" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" tools:node="remove" />
     <application
         android:label="Facteur"
         android:name="${applicationName}"

--- a/apps/mobile/android/app/src/playstore/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/playstore/AndroidManifest.xml
@@ -1,14 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools">
-        <!-- Flavor Play Store : retire REQUEST_INSTALL_PACKAGES, injectee par open_filex (auto-update APK side-load). Bannie du Play Store, inutile ici car les MAJ passent par le Store. -->
+        <!-- Flavor Play Store : retire REQUEST_INSTALL_PACKAGES (l'auto-update
+             APK side-load est banni du Store ; les MAJ passent par le Store).
+             Specifique playstore : le flavor beta l'ajoute volontairement.
+             Le retrait de la famille READ_MEDIA_* vit desormais dans
+             src/main/AndroidManifest.xml (applique a TOUS les flavors). -->
         <uses-permission
                     android:name="android.permission.REQUEST_INSTALL_PACKAGES"
-                    tools:node="remove" />
-        <!-- Flavor Play Store : retire READ_MEDIA_IMAGES / READ_MEDIA_VIDEO (Photo & Video Permissions policy). Usage media non-core ; le selecteur systeme Android (Photo Picker) ne necessite aucune permission. -->
-        <uses-permission
-                    android:name="android.permission.READ_MEDIA_IMAGES"
-                    tools:node="remove" />
-        <uses-permission
-                    android:name="android.permission.READ_MEDIA_VIDEO"
                     tools:node="remove" />
 </manifest>


### PR DESCRIPTION
Diagnostic par décompilation (aapt2) de l'APK release playstore à HEAD : la source d'injection est open_filex 4.7.0 (READ_MEDIA_IMAGES/VIDEO/AUDIO + READ_EXTERNAL_STORAGE maxSdk32). Le remove de #892 fonctionnait pour IMAGES et VIDEO mais NE couvrait pas READ_MEDIA_AUDIO, qui survivait dans le binaire ; et le retrait était limité au source set playstore.

Fix : déplace le remove dans src/main (s'applique à TOUS les flavors) et couvre les 4 clés (IMAGES, VIDEO, AUDIO, VISUAL_USER_SELECTED). Aucun flavor n'a besoin de READ_MEDIA_* : open_filex ouvre via FileProvider (URI content://, sans permission) et le Photo Picker Android ne requiert aucune permission.

Preuve aapt2 après fix : zéro READ_MEDIA_* sur playstore ET beta.
Non-régression beta : REQUEST_INSTALL_PACKAGES conservé (updater side-load).

## What

<!-- Brief description of the change -->

## Why

<!-- What problem does this solve? -->

## Type

- [ ] Feature
- [ ] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [ ] Tests pass locally (`cd packages/api && pytest -v`)
- [ ] Linting passes (`ruff check app/`)
- [ ] No new Python `List[]` imports (use `list[]`)
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)
