### PR TITLE
fix(feed): /api/feed 500 — sonde LATERAL quiet_sources (PYTHON-5N) + short session _user_context (PYTHON-37)

### DIFF
--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -9,10 +9,11 @@ from typing import Any
 from uuid import UUID
 
 import structlog
-from sqlalchemy import case, desc, func, select
+from sqlalchemy import case, desc, func, literal, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.database import SessionMaker, safe_async_session
 from app.models.content import Content, UserContentStatus
 from app.models.enums import ContentStatus, ContentType, FeedFilterMode, InterestState
 from app.models.source import Source, UserSource
@@ -184,8 +185,17 @@ from app.services.recommendation.scoring_engine import (
 
 
 class RecommendationService:
-    def __init__(self, session: AsyncSession):
+    def __init__(
+        self,
+        session: AsyncSession,
+        session_maker: "SessionMaker | None" = None,
+    ):
         self.session = session
+        # Factory de sessions courtes ad-hoc (capées par phase). Injectable
+        # pour les tests (cf. fixture `fake_session_maker`) car le pattern
+        # savepoint du `db_session` de test n'est pas visible depuis une vraie
+        # connexion pool ouverte par `safe_async_session`. Défaut = prod.
+        self._session_maker: SessionMaker = session_maker or safe_async_session
         self.user_custom_topics: list = []  # Populated by get_feed() for reuse by caller
         self.source_overflow: dict[
             UUID, int
@@ -290,12 +300,25 @@ class RecommendationService:
             DailyDigest.target_date == date_module.today(),
         )
 
-        async def _user_context_on_self():
-            # Réutilise la session injectée — pas de nouvelle connexion pool.
-            profile = await self.session.scalar(profile_stmt)
-            sources = (await self.session.execute(sources_stmt)).all()
-            subtopics = (await self.session.scalars(subtopics_stmt)).all()
-            return profile, sources, subtopics
+        async def _user_context_short():
+            # PYTHON-37 fix : ces lectures tournaient sur `self.session`
+            # (Round 4) → ouvraient sa transaction dès la phase 1, qui restait
+            # ensuite idle pendant les longs `await` (batches parallèles,
+            # scoring) jusqu'à ce que Postgres la tue
+            # (idle_in_transaction_session_timeout=10s) → IdleInTransaction
+            # → /api/feed 500. On exécute désormais ces 3 lectures dans une
+            # short session capée 8s/5s, comme _batch_personalization : la
+            # connexion n'est tenue que le temps du gather puis rendue au pool,
+            # et `self.session` n'ouvre plus sa tx ici.
+            # joinedload(interests/preferences) précharge les collections →
+            # `profile` reste exploitable après le expunge_all() du helper.
+            async with safe_async_session(
+                statement_timeout_ms=8_000, idle_in_tx_timeout_ms=5_000
+            ) as s:
+                profile = await s.scalar(profile_stmt)
+                sources = (await s.execute(sources_stmt)).all()
+                subtopics = (await s.scalars(subtopics_stmt)).all()
+                return profile, sources, subtopics
 
         async def _batch_personalization():
             async with safe_async_session(
@@ -307,14 +330,18 @@ class RecommendationService:
                 muted_entities = await _load_muted_entities_safe(s, user_id)
                 return pz, digest, muted_entities
 
-        # gather() préserve le parallélisme : self.session et la short
-        # session de _batch_personalization sont des sessions distinctes,
-        # aucun risque de "concurrent operations on same session".
+        # gather() préserve le parallélisme : _user_context_short et
+        # _batch_personalization ouvrent chacune leur propre short session
+        # (sessions distinctes), aucun risque de "concurrent operations on
+        # same session". Tradeoff PYTHON-37 : 2 connexions courtes
+        # concurrentes pendant la fenêtre du gather, toutes deux rendues au
+        # pool ensuite (vs. self.session qui gardait sa tx ouverte tout le
+        # pipeline). La pression pool résiduelle est traitée séparément.
         (
             (user_profile, followed_sources_rows, subtopics_rows),
             (personalization, digest_row, muted_entities),
         ) = await asyncio.gather(
-            _user_context_on_self(),
+            _user_context_short(),
             _batch_personalization(),
         )
 
@@ -777,6 +804,16 @@ class RecommendationService:
                     for row in rows
                 }
 
+        # Hardening résiduel PYTHON-37 (non activé pour l'instant) : `self.session`
+        # a ouvert sa tx au phase 2 (`_get_candidates`) et la garde idle pendant
+        # ce gather où seules les short sessions font des I/O. Si Postgres tue à
+        # nouveau cette tx (idle_in_transaction_session_timeout=10s) sur une
+        # nouvelle ligne après le fix _user_context_short, insérer ici :
+        #     await self.session.rollback()
+        #     await apply_session_timeouts(self.session)
+        # (libère la tx idle puis re-pose les SET LOCAL sur la prochaine tx).
+        # Laissé en commentaire tant que PYTHON-37 ne réapparaît pas — un
+        # rollback() systématique a un coût et n'est pas justifié sans signal.
         (
             (source_affinity_scores, user_custom_topics),
             impression_data,
@@ -1633,50 +1670,75 @@ class RecommendationService:
                 thirty_days_ago = now - datetime.timedelta(days=30)
                 sixty_days_ago = now - datetime.timedelta(days=60)
 
-                quiet_source_ids = (
-                    (
-                        await self.session.execute(
-                            select(UserSource.source_id)
-                            .join(Source, Source.id == UserSource.source_id)
-                            .outerjoin(
-                                Content,
-                                (Content.source_id == UserSource.source_id)
-                                & (Content.published_at >= thirty_days_ago),
-                            )
-                            .where(
-                                UserSource.user_id == user_id,
-                                UserSource.state.in_(FOLLOWED_SOURCE_STATES),
-                                Source.is_active == True,  # noqa: E712
-                            )
-                            .group_by(UserSource.source_id)
-                            .having(func.count(Content.id) < QUIET_SOURCE_MAX_RECENT)
-                        )
-                    )
-                    .scalars()
-                    .all()
-                )
-
+                # PYTHON-5N fix : l'ancien agrégat `outerjoin(Content) + GROUP BY
+                # + HAVING count() < 3` matérialisait TOUTES les lignes 30j par
+                # source juste pour les compter (1721ms / 5775 lignes sur un user
+                # à 62 sources) → dérapait vers le statement_timeout 30s → 500.
+                # On sonde désormais via LATERAL ... LIMIT 3 (court-circuit dès la
+                # 3ᵉ ligne par source, Index-Only Scan → 198ms / ~186 lignes), sur
+                # une short session capée 8s/5s plutôt que `self.session` (cap 30s).
+                # Tout le bloc est gardé par un try/except : le carrousel est
+                # optionnel, donc un QueryCanceled / erreur DB le SKIP au lieu de
+                # remonter en 500.
                 quiet_articles: list[Content] = []
-                if quiet_source_ids:
-                    latest_per_source = (
-                        select(Content)
-                        .options(selectinload(Content.source))
+                quiet_source_ids: list[UUID] = []
+                try:
+                    probe = (
+                        select(Content.id)
                         .where(
-                            Content.source_id.in_(quiet_source_ids),
-                            Content.published_at >= sixty_days_ago,
-                            Content.id.notin_(promoted_ids | consumed_ids),
+                            Content.source_id == UserSource.source_id,
+                            Content.published_at >= thirty_days_ago,
                         )
-                        .distinct(Content.source_id)
-                        .order_by(
-                            Content.source_id,
-                            Content.published_at.desc(),
+                        .limit(QUIET_SOURCE_MAX_RECENT)
+                        .lateral()
+                    )
+                    quiet_ids_stmt = (
+                        select(UserSource.source_id)
+                        .select_from(UserSource)
+                        .join(Source, Source.id == UserSource.source_id)
+                        .join(probe, literal(True))
+                        .where(
+                            UserSource.user_id == user_id,
+                            UserSource.state.in_(FOLLOWED_SOURCE_STATES),
+                            Source.is_active.is_(True),
                         )
+                        .group_by(UserSource.source_id)
+                        .having(func.count() < QUIET_SOURCE_MAX_RECENT)
                     )
-                    quiet_articles = list(
-                        (await self.session.scalars(latest_per_source)).all()
-                    )
+                    async with self._session_maker(
+                        statement_timeout_ms=8_000, idle_in_tx_timeout_ms=5_000
+                    ) as quiet_s:
+                        quiet_source_ids = list(
+                            (await quiet_s.scalars(quiet_ids_stmt)).all()
+                        )
+                        if quiet_source_ids:
+                            latest_per_source = (
+                                select(Content)
+                                .options(selectinload(Content.source))
+                                .where(
+                                    Content.source_id.in_(quiet_source_ids),
+                                    Content.published_at >= sixty_days_ago,
+                                    Content.id.notin_(promoted_ids | consumed_ids),
+                                )
+                                .distinct(Content.source_id)
+                                .order_by(
+                                    Content.source_id,
+                                    Content.published_at.desc(),
+                                )
+                            )
+                            quiet_articles = list(
+                                (await quiet_s.scalars(latest_per_source)).all()
+                            )
                     quiet_articles.sort(key=lambda c: c.published_at, reverse=True)
                     quiet_articles = quiet_articles[:MAX_CAROUSEL_ITEMS]
+                except Exception as exc:
+                    logger.warning(
+                        "carousel_quiet_sources_skipped",
+                        error=str(exc),
+                        exc_type=type(exc).__name__,
+                    )
+                    quiet_articles = []
+                    quiet_source_ids = []
 
                 logger.info(
                     "carousel_quiet_sources_query",

--- a/packages/api/tests/conftest.py
+++ b/packages/api/tests/conftest.py
@@ -126,7 +126,10 @@ def fake_session_maker(db_session):
     """
 
     @asynccontextmanager
-    async def _maker():
+    async def _maker(**_kwargs):
+        # Accepte (et ignore) les kwargs de cap (statement_timeout_ms,
+        # idle_in_tx_timeout_ms) pour matcher la signature de
+        # `safe_async_session` — cf. SessionMaker = Callable[..., ...].
         yield db_session
 
     return _maker

--- a/packages/api/tests/test_feed_carousels.py
+++ b/packages/api/tests/test_feed_carousels.py
@@ -554,10 +554,12 @@ class TestBuildCarouselsCommunity:
         async def mock_execute(stmt):
             nonlocal call_count
             call_count += 1
-            # 1: consumed_ids, 2: new_source, 3: quiet_sources → empty
-            if call_count <= 3:
+            # 1: consumed_ids, 2: new_source → empty. quiet_sources tourne
+            # désormais sur une short session dédiée (PYTHON-5N), plus sur
+            # self.session.execute → la requête community est l'appel #3.
+            if call_count <= 2:
                 return _mock_execute_result([])
-            # 4: community query
+            # 3: community query
             return _mock_execute_result(community_rows)
 
         service.session.execute = AsyncMock(side_effect=mock_execute)
@@ -594,10 +596,12 @@ class TestBuildCarouselsCommunity:
         async def mock_execute(stmt):
             nonlocal call_count
             call_count += 1
-            # 1: consumed_ids, 2: new_source, 3: quiet_sources → empty
-            if call_count <= 3:
+            # 1: consumed_ids, 2: new_source → empty. quiet_sources tourne
+            # désormais sur une short session dédiée (PYTHON-5N), plus sur
+            # self.session.execute → la requête community est l'appel #3.
+            if call_count <= 2:
                 return _mock_execute_result([])
-            # 4: community
+            # 3: community
             return _mock_execute_result(community_rows)
 
         service.session.execute = AsyncMock(side_effect=mock_execute)

--- a/packages/api/tests/test_feed_carousels_quiet_sources.py
+++ b/packages/api/tests/test_feed_carousels_quiet_sources.py
@@ -70,8 +70,11 @@ async def _seed_quiet_source(
     return source, content
 
 
-async def _build(db_session, user_id):
-    service = RecommendationService(db_session)
+async def _build(db_session, session_maker, user_id):
+    # session_maker = fake_session_maker → la sonde quiet_sources (short
+    # session capée en prod) tourne sur la db_session de test (le pattern
+    # savepoint n'est pas visible d'une vraie connexion pool).
+    service = RecommendationService(db_session, session_maker=session_maker)
     service.entity_overflow = []
     service.keyword_overflow = []
     _, carousels = await service._build_carousels([], {}, user_id=user_id)
@@ -83,14 +86,14 @@ def _quiet(carousels):
 
 
 @pytest.mark.asyncio
-async def test_quiet_sources_carousel_basic(db_session):
+async def test_quiet_sources_carousel_basic(db_session, fake_session_maker):
     user_id = uuid4()
     src_a, content_a = await _seed_quiet_source(db_session, "Rare A", user_id)
     src_b, content_b = await _seed_quiet_source(
         db_session, "Rare B", user_id, article_days_ago=10
     )
 
-    carousels = await _build(db_session, user_id)
+    carousels = await _build(db_session, fake_session_maker, user_id)
     quiet = _quiet(carousels)
     assert len(quiet) == 1
     c = quiet[0]
@@ -106,7 +109,7 @@ async def test_quiet_sources_carousel_basic(db_session):
 
 
 @pytest.mark.asyncio
-async def test_high_volume_source_excluded(db_session):
+async def test_high_volume_source_excluded(db_session, fake_session_maker):
     user_id = uuid4()
     await _seed_quiet_source(db_session, "Rare A", user_id)
     await _seed_quiet_source(db_session, "Rare B", user_id)
@@ -121,7 +124,7 @@ async def test_high_volume_source_excluded(db_session):
         db_session.add(_make_content(busy, d))
     await db_session.commit()
 
-    carousels = await _build(db_session, user_id)
+    carousels = await _build(db_session, fake_session_maker, user_id)
     quiet = _quiet(carousels)
     assert len(quiet) == 1
     sources_in_carousel = {i.source_id for i in quiet[0]["items"]}
@@ -129,7 +132,7 @@ async def test_high_volume_source_excluded(db_session):
 
 
 @pytest.mark.asyncio
-async def test_consumed_article_excluded(db_session):
+async def test_consumed_article_excluded(db_session, fake_session_maker):
     user_id = uuid4()
     await _seed_quiet_source(db_session, "Rare A", user_id)
     await _seed_quiet_source(db_session, "Rare B", user_id)
@@ -143,14 +146,14 @@ async def test_consumed_article_excluded(db_session):
     )
     await db_session.commit()
 
-    carousels = await _build(db_session, user_id)
+    carousels = await _build(db_session, fake_session_maker, user_id)
     quiet = _quiet(carousels)
     assert len(quiet) == 1
     assert consumed_content.id not in {i.id for i in quiet[0]["items"]}
 
 
 @pytest.mark.asyncio
-async def test_all_consumed_no_carousel(db_session):
+async def test_all_consumed_no_carousel(db_session, fake_session_maker):
     user_id = uuid4()
     for name in ("Rare A", "Rare B"):
         _, content = await _seed_quiet_source(db_session, name, user_id)
@@ -163,12 +166,12 @@ async def test_all_consumed_no_carousel(db_session):
         )
     await db_session.commit()
 
-    carousels = await _build(db_session, user_id)
+    carousels = await _build(db_session, fake_session_maker, user_id)
     assert _quiet(carousels) == []
 
 
 @pytest.mark.asyncio
-async def test_old_article_beyond_60_days_excluded(db_session):
+async def test_old_article_beyond_60_days_excluded(db_session, fake_session_maker):
     user_id = uuid4()
     await _seed_quiet_source(db_session, "Rare A", user_id)
     await _seed_quiet_source(db_session, "Rare B", user_id)
@@ -176,23 +179,23 @@ async def test_old_article_beyond_60_days_excluded(db_session):
         db_session, "Rare Old", user_id, article_days_ago=75
     )
 
-    carousels = await _build(db_session, user_id)
+    carousels = await _build(db_session, fake_session_maker, user_id)
     quiet = _quiet(carousels)
     assert len(quiet) == 1
     assert content_old.id not in {i.id for i in quiet[0]["items"]}
 
 
 @pytest.mark.asyncio
-async def test_below_min_display_items_no_carousel(db_session):
+async def test_below_min_display_items_no_carousel(db_session, fake_session_maker):
     user_id = uuid4()
     await _seed_quiet_source(db_session, "Lonely Rare", user_id)
 
-    carousels = await _build(db_session, user_id)
+    carousels = await _build(db_session, fake_session_maker, user_id)
     assert _quiet(carousels) == []
 
 
 @pytest.mark.asyncio
-async def test_unfollowed_and_inactive_sources_excluded(db_session):
+async def test_unfollowed_and_inactive_sources_excluded(db_session, fake_session_maker):
     user_id = uuid4()
     await _seed_quiet_source(db_session, "Rare A", user_id)
     await _seed_quiet_source(db_session, "Rare B", user_id)
@@ -203,7 +206,7 @@ async def test_unfollowed_and_inactive_sources_excluded(db_session):
         db_session, "Inactive", user_id, is_active=False
     )
 
-    carousels = await _build(db_session, user_id)
+    carousels = await _build(db_session, fake_session_maker, user_id)
     quiet = _quiet(carousels)
     assert len(quiet) == 1
     ids = {i.id for i in quiet[0]["items"]}
@@ -212,7 +215,7 @@ async def test_unfollowed_and_inactive_sources_excluded(db_session):
 
 
 @pytest.mark.asyncio
-async def test_one_item_per_source_latest_only(db_session):
+async def test_one_item_per_source_latest_only(db_session, fake_session_maker):
     user_id = uuid4()
     src_a, latest_a = await _seed_quiet_source(db_session, "Rare A", user_id)
     older_a = _make_content(src_a, 20, title="Rare A older")
@@ -220,7 +223,7 @@ async def test_one_item_per_source_latest_only(db_session):
     await _seed_quiet_source(db_session, "Rare B", user_id)
     await db_session.commit()
 
-    carousels = await _build(db_session, user_id)
+    carousels = await _build(db_session, fake_session_maker, user_id)
     quiet = _quiet(carousels)
     assert len(quiet) == 1
     items_from_a = [i for i in quiet[0]["items"] if i.source_id == src_a.id]
@@ -229,34 +232,32 @@ async def test_one_item_per_source_latest_only(db_session):
 
 
 @pytest.mark.asyncio
-async def test_promoted_items_removed_from_main_feed(db_session):
+async def test_promoted_items_removed_from_main_feed(db_session, fake_session_maker):
     user_id = uuid4()
     _, content_a = await _seed_quiet_source(db_session, "Rare A", user_id)
     await _seed_quiet_source(db_session, "Rare B", user_id)
 
-    service = RecommendationService(db_session)
+    service = RecommendationService(db_session, session_maker=fake_session_maker)
     service.entity_overflow = []
     service.keyword_overflow = []
-    result, carousels = await service._build_carousels(
-        [content_a], {}, user_id=user_id
-    )
+    result, carousels = await service._build_carousels([content_a], {}, user_id=user_id)
     assert len(_quiet(carousels)) == 1
     assert content_a.id not in {a.id for a in result}
 
 
 @pytest.mark.asyncio
-async def test_deep_carousel_not_emitted(db_session):
+async def test_deep_carousel_not_emitted(db_session, fake_session_maker):
     """PO decision: the deep carousel is disabled (flag DEEP_CAROUSEL_ENABLED)."""
     from app.services import recommendation_service as rs
 
     assert rs.DEEP_CAROUSEL_ENABLED is False
     user_id = uuid4()
-    carousels = await _build(db_session, user_id)
+    carousels = await _build(db_session, fake_session_maker, user_id)
     assert not any(c["carousel_type"] == "deep" for c in carousels)
 
 
 @pytest.mark.asyncio
-async def test_saved_carousel_most_recently_saved_first(db_session):
+async def test_saved_carousel_most_recently_saved_first(db_session, fake_session_maker):
     user_id = uuid4()
     source = _make_source("Saved Source")
     db_session.add(source)
@@ -274,7 +275,7 @@ async def test_saved_carousel_most_recently_saved_first(db_session):
         )
     await db_session.commit()
 
-    carousels = await _build(db_session, user_id)
+    carousels = await _build(db_session, fake_session_maker, user_id)
     saved = [c for c in carousels if c["carousel_type"] == "saved"]
     assert len(saved) == 1
     # contents[0] saved most recently (saved_at = now) → first


### PR DESCRIPTION
## Quoi
Fix des 500 sur `/api/feed/`, deux causes traitées dans `recommendation_service.py` :

- **PYTHON-5N** — le carrousel « sources discrètes » faisait un agrégat `outerjoin(Content) + GROUP BY + HAVING count() < 3` qui matérialisait toutes les lignes 30j par source juste pour les compter (~1721ms / 5775 lignes sur un user à 62 sources) → dérapage vers le `statement_timeout` 30s → 500. Réécrit en sonde **`LATERAL ... LIMIT 3`** (court-circuit dès la 3ᵉ ligne, Index-Only Scan, ~198ms) sur une short session capée 8s/5s, tout le bloc gardé par `try/except` : le carrousel est optionnel → un timeout/erreur DB le **skip** au lieu de remonter en 500.
- **PYTHON-37** — `_user_context_on_self` lisait sur `self.session` → ouvrait sa transaction dès la phase 1, qui restait *idle in transaction* pendant les longs `await` (batches, scoring) → tuée par `idle_in_transaction_session_timeout=10s` → 500. Déplacé sur une short session capée (`_user_context_short`), comme `_batch_personalization` ; `self.session` n'ouvre plus sa tx ici.

## Pourquoi
Les deux signatures Sentry (PYTHON-5N timeout, PYTHON-37 idle-in-tx) faisaient remonter des 500 sur le feed des users à beaucoup de sources. Fix purement additif, **aucune migration** (l'index requis existe déjà).

## Comment ça a été vérifié
- [x] `pytest` suite complète — **1895 passed, 18 skipped, 2 xfailed, 0 failed** (DB test locale 54322)
- [x] Cible : `test_feed_carousels_quiet_sources.py` (11) + `test_feed_carousels.py` (30) verts
- [x] `alembic heads` — exactement 1 head (`sec02_new_public_rls`), aucune migration ajoutée
- [x] Smoke `uvicorn` + `curl /api/feed/` : sans auth → **403**, mauvais token → **401** (plus de 500)
- [x] `/simplify` passé — findings = design intentionnel, aucune modif requise

## Zones à risque
- `RecommendationService` (chemin chaud `/api/feed/`). DB Supabase **partagée staging/prod** → fix additif, pas de DDL, `try/except` sur le carrousel optionnel garantit l'innocuité.
- Hardening résiduel PYTHON-37 (rollback + re-pose des SET LOCAL sur `self.session` tenue idle pendant le gather) laissé **en commentaire**, non activé tant que le signal ne réapparaît pas.
- `_session_maker` injecté pour les tests (le pattern savepoint du `db_session` de test n'est pas visible d'une vraie connexion pool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)