### PR TITLE
feat(updates): version gate iOS (App Store) + In-App Updates Android (Play)

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,45 +1,46 @@
-## fix(api): upsert atomique sur user_interests (race condition Sentry PYTHON-4P)
+## feat(android): In-App Updates Play Store (flavor playstore) + gate par flavor
 
-### Problème
-`update_content_status` (SEEN au scroll + CONSUMED au retour WebView) déclenchait une
-re-pondération des intérêts via un **check-then-insert non atomique** (SELECT `UserInterest` ;
-si absent → `add()`). Deux requêtes concurrentes pour le même `(user_id, interest_slug)`
-voyaient toutes deux « absent » et inséraient → `IntegrityError / UniqueViolation` sur
-`user_interests_user_slug_uniq` → **500**, lecture non retenue (progression + perso intérêts).
-Sentry **PYTHON-4P** : 260 occurrences / 24h, 11 personnes.
+### Pourquoi
+Sur le flavor `playstore` (`facteur.app`), Google interdit l'auto-update par APK : la
+permission `REQUEST_INSTALL_PACKAGES` a été retirée (#892) et l'updater maison est inopérant.
+Un user Play Store n'avait donc **aucun** signal natif « mise à jour disponible ». Cette PR
+ajoute les **Google Play In-App Updates** sur le chemin playstore, en laissant le chemin
+`beta` (side-load APK) strictement inchangé.
 
-### Fix
-Remplacement de tous les points d'insertion `UserInterest` par un **upsert Postgres atomique**
-(`INSERT ... ON CONFLICT (user_id, interest_slug) DO UPDATE`), pattern déjà utilisé dans le repo
-(`UserContentStatus`, `grille_seed`). La sémantique métier est préservée :
+### Ce que fait la PR
+- **Dépendance** : ajoute `in_app_update: ^4.2.3` (résolu 4.2.5 ; Android-only).
+- **Point de décision unique** : `PlayStoreUpdateService.checkAndStart()`
+  (`lib/features/app_update/services/playstore_update_service.dart`). Routage piloté par le
+  flavor via `AppUpdateConstants.isPlayStoreBuild` (no-op total sur beta/dev). Garde
+  `kIsWeb`/`Platform.isAndroid`, anti-ré-entrance `_inFlight`, fail-silently.
+  - `updatePriority >= 4` + `immediateUpdateAllowed` → `performImmediateUpdate()` (bloquant).
+  - sinon `flexibleUpdateAllowed` → `startFlexibleUpdate()` + `completeFlexibleUpdate()`.
+- **Lifecycle** (`lib/app.dart`) : appel au **cold-start** (post-frame de `initState`) et au
+  **retour foreground** (`didChangeAppLifecycleState` → `resumed`). Réutilise l'observer
+  existant, aucun nouvel observer.
+- **Doc** : `docs/maintenance/maintenance-playstore-in-app-updates.md` (routage par flavor +
+  procédure Play Console `updatePriority` + constat Mission B).
+- **Changelog** : entrée `unreleased` « Mise à jour ».
 
-- **`content_service._adjust_interest_weight`** (culprit) : poids `= least(weight + boost, 3.0)` ;
-  `state` non touché sur conflit (préserve FAVORITE).
-- **`content_service._adjust_subtopic_weights`** (branche intérêt) : `delta > 0` → upsert borné
-  `[0.1, 3.0]` ; `delta < 0` → UPDATE ciblé (pas d'INSERT, jamais de création au dislike).
-- **`user_interests_service.set_state`** : création implicite de thème → upsert (set `state`).
-- **`user_service`** (onboarding) : état FAVORITE précalculé avant insertion, upsert par thème.
+### Décisions
+- immediate vs flexible piloté par **Play Console `updatePriority`** (reco Google, 0 backend).
+  `app_config` (Supabase) ne porte pas de min-version Android → aucun champ ajouté.
+- `flutter_downloader`/`open_filex` **conservés** (partagés avec beta). Sur playstore leur
+  chemin n'est plus atteint ; `READ_MEDIA_*` déjà strippé app-wide dans `src/main` (Mission B).
 
-Aucun DDL / migration (la contrainte unique existe déjà). Hors périmètre : le jumeau
-`UserSubtopic` (table `user_subtopics`). Attention, ce n'est **pas** le même bug shape :
-la contrainte unique `(user_id, topic_slug)` y a été **supprimée** (migration `4d497ce7bcc2`),
-donc son check-then-insert ne lève pas d'`UniqueViolation` — sous concurrence il insère
-des lignes dupliquées en silence (poids faussé). Le corriger proprement exigerait d'abord
-de re-créer la contrainte unique via migration → hors scope de ce hotfix de crash.
+### Vérifs locales
+- `flutter pub get` OK ; `flutter analyze` (fichiers touchés) : 0 issue.
+- `flutter test test/features/app_update` : 8/8 ✅.
+- Plugin natif enregistré (GeneratedPluginRegistrant régénéré).
+- Manifests playstore (retrait `REQUEST_INSTALL_PACKAGES`) / beta (ajout) inchangés.
 
-### Tests
-`tests/test_interest_weight_concurrency.py` : création → incrément (1 seule ligne), cap 3.0,
-préservation FAVORITE. Le chemin `ON CONFLICT DO UPDATE` est exactement celui qu'emprunte la
-requête perdante d'une course ; exercé ici par double-appel séquentiel (la fixture `db_session`
-mono-connexion ne permet pas une vraie concurrence 2-connexions).
+### À faire côté PO (device réel)
+- Track de test Play : publier une version supérieure → vérifier l'invite native (immediate
+  si `updatePriority >= 4`, sinon flexible). Décompiler le build playstore → aucun chemin
+  d'install APK atteignable.
+- Build `beta` side-load → flux APK identique à avant.
 
-Tests exécutés en local contre `facteur_test` (Postgres 5432) : les 3 tests de régression
-passent, ainsi que la suite complète (1895 passed ; les 2 seuls échecs —
-`test_notification_preferences` et `test_sources_recent_items` — sont pré-existants sur
-`main`, sans rapport avec ce diff, vérifié en revertant les services). Tests adaptés au
-nouveau chemin upsert : `test_onboarding_sources` (l'intérêt passe par `execute` et non plus
-`db.add` ; offset des appers `execute` recalculé), `test_like_feature` (1 seul `add` + 1
-upsert intérêt). `ruff check` + `ruff format` OK sur les fichiers touchés.
+### Hors scope
+iOS (gate iOS séparé existant), champ min-version backend, retrait de dépendances.
 
-### Post-merge (PO)
-Vérifier que le compteur Sentry **PYTHON-4P** retombe à ~0 après déploiement.
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/apps/mobile/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
+++ b/apps/mobile/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
@@ -76,6 +76,11 @@ public final class GeneratedPluginRegistrant {
       Log.e(TAG, "Error registering plugin home_widget, es.antonborri.home_widget.HomeWidgetPlugin", e);
     }
     try {
+      flutterEngine.getPlugins().add(new de.ffuf.in_app_update.InAppUpdatePlugin());
+    } catch (Exception e) {
+      Log.e(TAG, "Error registering plugin in_app_update, de.ffuf.in_app_update.InAppUpdatePlugin", e);
+    }
+    try {
       flutterEngine.getPlugins().add(new com.github.dart_lang.jni.JniPlugin());
     } catch (Exception e) {
       Log.e(TAG, "Error registering plugin jni, com.github.dart_lang.jni.JniPlugin", e);

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -2,6 +2,10 @@
   "unreleased": [
     {
       "tag": "Mise à jour",
+      "summary": "Sur Android, les mises à jour passent désormais par une invite native du Play Store, plus fiable, avec téléchargement en arrière-plan."
+    },
+    {
+      "tag": "Mise à jour",
       "summary": "Facteur te prévient quand une nouvelle version est disponible sur l'App Store, et t'invite à mettre à jour."
     },
     {

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,8 +1,14 @@
 {
   "unreleased": [
     {
+      "tag": "Mise à jour",
+      "summary": "Facteur te prévient quand une nouvelle version est disponible sur l'App Store, et t'invite à mettre à jour."
+    },
+    {
       "tag": "Tournée",
       "summary": "Ta Tournée du jour propose plus de sujets, choisis pour toi par le Facteur."
+    },
+    {
       "tag": "Perspectives",
       "summary": "Couverture médiatique plus lisible : repères Gauche/Droite sous la barre, source cliquable et aperçu de l'article au toucher prolongé."
     },

--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -15,6 +15,7 @@ import 'features/feed/services/read_sync_service.dart';
 import 'features/flux_continu/providers/flux_continu_preload_provider.dart';
 import 'features/flux_continu/services/tournee_progress_service.dart';
 import 'features/my_interests/services/interests_sync_service.dart';
+import 'features/app_update/services/playstore_update_service.dart';
 import 'features/onboarding/providers/onboarding_sync_provider.dart';
 import 'features/settings/providers/theme_provider.dart';
 
@@ -53,6 +54,8 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
       _flushFluxScrollMetricIfAny();
       _startAnalyticsSessionIfNeeded();
       unawaited(ref.read(readSyncServiceProvider).flushCurrentUser());
+      // playstore : invite native Play « MàJ disponible » (no-op sur beta/dev).
+      unawaited(ref.read(playStoreUpdateServiceProvider).checkAndStart());
     });
     // Story 23.2 PR-4 : si un endpoint retiré répond 410, afficher un
     // snackbar global "Mise à jour requise". Le ApiClient intercepte tous
@@ -95,6 +98,9 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
       _flushFluxScrollMetricIfAny();
       _startAnalyticsSessionIfNeeded();
       unawaited(ref.read(readSyncServiceProvider).flushCurrentUser());
+      // playstore : re-check au retour foreground (no-op sur beta/dev ; garde
+      // anti-ré-entrance interne au service).
+      unawaited(ref.read(playStoreUpdateServiceProvider).checkAndStart());
       if (_wasBackgrounded) {
         _wasBackgrounded = false;
         final elapsed = _backgroundedAt != null

--- a/apps/mobile/lib/core/version/semver.dart
+++ b/apps/mobile/lib/core/version/semver.dart
@@ -1,0 +1,46 @@
+/// Comparaison sémantique de versions `X.Y.Z` (numérique par composant).
+///
+/// Contrairement à une comparaison lexicographique (`"1.10.0" < "1.9.0"` en
+/// texte), on compare composant par composant en entier : `1.10.0 > 1.9.0`.
+///
+/// Tolérances :
+/// - suffixe de build (`1.2.0+8`) et pré-release (`1.2.0-rc1`) ignorés ;
+/// - composants manquants traités comme `0` (`1.2` == `1.2.0`) ;
+/// - composants en trop ignorés au-delà des trois premiers.
+///
+/// Renvoie `null` si l'une des deux entrées n'est pas parsable (le caller
+/// décide alors de fail-open). Sinon `-1` (a < b), `0` (a == b), `1` (a > b).
+int? compareSemver(String a, String b) {
+  final pa = _parse(a);
+  final pb = _parse(b);
+  if (pa == null || pb == null) return null;
+
+  for (var i = 0; i < 3; i++) {
+    if (pa[i] != pb[i]) return pa[i] < pb[i] ? -1 : 1;
+  }
+  return 0;
+}
+
+/// Parse `X.Y.Z` (avec `X` et `Y` optionnels) en `[major, minor, patch]`.
+/// Coupe tout suffixe `+build` ou `-prerelease` avant le parsing.
+/// Renvoie `null` si un composant n'est pas un entier.
+List<int>? _parse(String raw) {
+  final trimmed = raw.trim();
+  if (trimmed.isEmpty) return null;
+
+  // Retire suffixes build (`+...`) et pré-release (`-...`).
+  var core = trimmed;
+  final plus = core.indexOf('+');
+  if (plus != -1) core = core.substring(0, plus);
+  final dash = core.indexOf('-');
+  if (dash != -1) core = core.substring(0, dash);
+
+  final parts = core.split('.');
+  final out = <int>[0, 0, 0];
+  for (var i = 0; i < parts.length && i < 3; i++) {
+    final v = int.tryParse(parts[i].trim());
+    if (v == null || v < 0) return null;
+    out[i] = v;
+  }
+  return out;
+}

--- a/apps/mobile/lib/features/app_update/providers/ios_update_gate_provider.dart
+++ b/apps/mobile/lib/features/app_update/providers/ios_update_gate_provider.dart
@@ -1,0 +1,117 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../../../core/api/providers.dart';
+import '../../../core/version/semver.dart';
+
+/// Niveau d'incitation à la mise à jour iOS, résolu à partir de la version
+/// installée et des deux seuils distants ([app_config]).
+enum IosUpdateLevel {
+  /// À jour (ou indéterminé / fail-open) : rien à afficher.
+  none,
+
+  /// `installée < ios_latest_version` : bannière incitative non bloquante.
+  banner,
+
+  /// `installée < ios_min_supported_version` : gate bloquant.
+  gate,
+}
+
+/// Résultat du contrôle de version iOS : niveau + fiche App Store à ouvrir.
+@immutable
+class IosUpdateStatus {
+  const IosUpdateStatus({required this.level, this.appStoreUrl});
+
+  final IosUpdateLevel level;
+  final String? appStoreUrl;
+
+  static const none = IosUpdateStatus(level: IosUpdateLevel.none);
+}
+
+const String _kLatestKey = 'ios_latest_version';
+const String _kMinSupportedKey = 'ios_min_supported_version';
+const String _kAppStoreUrlKey = 'ios_app_store_url';
+
+/// Logique pure de résolution du niveau (testable sans `Platform` ni réseau).
+///
+/// Priorité au gate. Toute valeur manquante ou non parsable rend le seuil
+/// concerné inopérant (fail-open) :
+/// - `installed < min`            → [IosUpdateLevel.gate]
+/// - sinon `installed < latest`   → [IosUpdateLevel.banner]
+/// - sinon                        → [IosUpdateLevel.none]
+IosUpdateLevel resolveIosUpdateLevel({
+  required String installed,
+  String? latest,
+  String? minSupported,
+}) {
+  if (minSupported != null) {
+    final cmp = compareSemver(installed, minSupported);
+    if (cmp != null && cmp < 0) return IosUpdateLevel.gate;
+  }
+  if (latest != null) {
+    final cmp = compareSemver(installed, latest);
+    if (cmp != null && cmp < 0) return IosUpdateLevel.banner;
+  }
+  return IosUpdateLevel.none;
+}
+
+/// Lit une clé `app_config` (jsonb string) ; `null` si absente/non-string.
+Future<String?> _readConfigString(SupabaseClient client, String key) async {
+  final row = await client
+      .from('app_config')
+      .select('value')
+      .eq('key', key)
+      .maybeSingle();
+  final value = row?['value'];
+  return value is String ? value : null;
+}
+
+/// Contrôle de version iOS : compare la version installée aux deux seuils
+/// distants servis par `app_config` (même pattern que [nudgesEnabledProvider]).
+///
+/// **iOS uniquement** : web et Android renvoient toujours [IosUpdateStatus.none]
+/// (Android a son propre flow de self-update via `appUpdateProvider`).
+///
+/// **Fail-open** : toute erreur (réseau, table/clé absente, RLS, valeur
+/// malformée) résout en [IosUpdateLevel.none] — jamais de gate accidentel.
+final iosUpdateStatusProvider = FutureProvider<IosUpdateStatus>((ref) async {
+  if (kIsWeb || !Platform.isIOS) return IosUpdateStatus.none;
+
+  try {
+    final info = await PackageInfo.fromPlatform();
+    final installed = info.version;
+    if (installed.isEmpty) return IosUpdateStatus.none;
+
+    final client = ref.watch(supabaseClientProvider);
+    final latest = await _readConfigString(client, _kLatestKey);
+    final minSupported = await _readConfigString(client, _kMinSupportedKey);
+    final appStoreUrl = await _readConfigString(client, _kAppStoreUrlKey);
+
+    final level = resolveIosUpdateLevel(
+      installed: installed,
+      latest: latest,
+      minSupported: minSupported,
+    );
+
+    // Sans fiche App Store on ne peut rien proposer : reste neutre.
+    if (level == IosUpdateLevel.none || appStoreUrl == null) {
+      return IosUpdateStatus.none;
+    }
+    return IosUpdateStatus(level: level, appStoreUrl: appStoreUrl);
+  } on PostgrestException catch (e) {
+    debugPrint('iosUpdateStatusProvider Postgrest: ${e.message}');
+    return IosUpdateStatus.none;
+  } catch (e) {
+    debugPrint('iosUpdateStatusProvider failure: $e');
+    return IosUpdateStatus.none;
+  }
+});
+
+/// Masquage de la bannière pour la session courante (le `×`). Non persistant :
+/// la bannière revient au prochain lancement tant que la version reste en deçà
+/// de `ios_latest_version`. Sans effet sur le gate (non masquable).
+final iosBannerDismissedProvider = StateProvider<bool>((ref) => false);

--- a/apps/mobile/lib/features/app_update/services/playstore_update_service.dart
+++ b/apps/mobile/lib/features/app_update/services/playstore_update_service.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:in_app_update/in_app_update.dart';
+
+import '../../../config/constants.dart';
+
+/// Point de décision UNIQUE des mises à jour pour le flavor **playstore**.
+///
+/// Google interdit à une app du Play Store de se mettre à jour en
+/// téléchargeant/installant un APK : sur ce flavor, l'updater APK maison
+/// (`flutter_downloader` + `open_filex`) est déjà neutralisé
+/// (cf. `appUpdateProvider`, gaté par `AppUpdateConstants.isPlayStoreBuild`).
+/// Ce service le remplace par les **Google Play In-App Updates** (invite native).
+///
+/// Sur les flavors beta/dev, [checkAndStart] est un **no-op total** : le chemin
+/// APK maison reste seul actif, inchangé.
+class PlayStoreUpdateService {
+  PlayStoreUpdateService();
+
+  /// Priorité (Play Console, 0-5) à partir de laquelle on force une MàJ
+  /// bloquante (immediate). Fixée par release dans la Play Console. En-dessous
+  /// du seuil → MàJ flexible (téléchargement en fond, non bloquant).
+  static const int kImmediateUpdatePriority = 4;
+
+  /// Anti-ré-entrance : le check est déclenché au cold-start ET au retour
+  /// foreground ; on évite de relancer un flux pendant qu'un autre est en cours.
+  bool _inFlight = false;
+
+  /// Vérifie la disponibilité d'une MàJ Play et déclenche le flux adéquat.
+  ///
+  /// Ne lève jamais : un check d'update ne doit jamais bloquer ni casser l'app.
+  Future<void> checkAndStart() async {
+    // Routage piloté par le flavor, pas par une condition runtime fragile.
+    if (kIsWeb || !Platform.isAndroid) return;
+    if (!AppUpdateConstants.isPlayStoreBuild) return;
+    if (_inFlight) return;
+
+    _inFlight = true;
+    try {
+      final info = await InAppUpdate.checkForUpdate();
+      if (info.updateAvailability != UpdateAvailability.updateAvailable) {
+        return;
+      }
+
+      final priority = info.updatePriority;
+      if (info.immediateUpdateAllowed && priority >= kImmediateUpdatePriority) {
+        // MàJ critique : flux bloquant plein écran géré par le Play Store.
+        await InAppUpdate.performImmediateUpdate();
+      } else if (info.flexibleUpdateAllowed) {
+        // MàJ standard : téléchargement en fond puis install à la complétion.
+        await InAppUpdate.startFlexibleUpdate();
+        await InAppUpdate.completeFlexibleUpdate();
+      }
+    } catch (e) {
+      // Fail silently — comme appUpdateProvider, le check ne doit jamais
+      // bloquer l'app (ex. user qui refuse l'immediate update → exception).
+      // ignore: avoid_print
+      print('PlayStoreUpdate: check failed: $e');
+    } finally {
+      _inFlight = false;
+    }
+  }
+}
+
+/// Service singleton de MàJ Play Store (no-op hors flavor playstore).
+final playStoreUpdateServiceProvider = Provider<PlayStoreUpdateService>(
+  (ref) => PlayStoreUpdateService(),
+);

--- a/apps/mobile/lib/features/app_update/widgets/ios_update_banner.dart
+++ b/apps/mobile/lib/features/app_update/widgets/ios_update_banner.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../../config/theme.dart';
+import '../providers/ios_update_gate_provider.dart';
+
+/// Bandeau discret « nouvelle version dispo » (iOS), affiché tant que la version
+/// installée est en deçà de `ios_latest_version` et que le gate n'est pas actif.
+/// Tap → ouvre la fiche App Store. `×` → masque pour la session.
+///
+/// Calqué sur `ChangelogBanner` (Material 10% primary, icône, texte, `×`).
+class IosUpdateBanner extends ConsumerWidget {
+  const IosUpdateBanner({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final status = ref.watch(iosUpdateStatusProvider).valueOrNull;
+    final dismissed = ref.watch(iosBannerDismissedProvider);
+
+    if (dismissed ||
+        status == null ||
+        status.level != IosUpdateLevel.banner ||
+        status.appStoreUrl == null) {
+      return const SizedBox.shrink();
+    }
+
+    final colors = context.facteurColors;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+      child: Material(
+        color: colors.primary.withValues(alpha: 0.10),
+        borderRadius: BorderRadius.circular(10),
+        child: InkWell(
+          onTap: () => _openAppStore(status.appStoreUrl!),
+          borderRadius: BorderRadius.circular(10),
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(12, 8, 4, 8),
+            child: Row(
+              children: [
+                Icon(
+                  PhosphorIcons.arrowCircleUp(PhosphorIconsStyle.fill),
+                  size: 16,
+                  color: colors.primary,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Nouvelle version disponible. Touchez pour mettre à jour.',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: colors.textPrimary,
+                          fontWeight: FontWeight.w600,
+                        ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                IconButton(
+                  onPressed: () =>
+                      ref.read(iosBannerDismissedProvider.notifier).state = true,
+                  icon: Icon(
+                    PhosphorIcons.x(),
+                    size: 16,
+                    color: colors.textTertiary,
+                  ),
+                  padding: const EdgeInsets.all(6),
+                  constraints: const BoxConstraints(),
+                  tooltip: 'Ignorer',
+                  splashRadius: 16,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+Future<void> _openAppStore(String url) async {
+  final uri = Uri.parse(url);
+  if (await canLaunchUrl(uri)) {
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+}

--- a/apps/mobile/lib/features/app_update/widgets/ios_update_gate.dart
+++ b/apps/mobile/lib/features/app_update/widgets/ios_update_gate.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../../config/theme.dart';
+import '../providers/ios_update_gate_provider.dart';
+
+/// Gate bloquant « Mise à jour requise » (iOS) : recouvre toute l'app quand la
+/// version installée est en deçà de `ios_min_supported_version`. Aucune sortie
+/// (`PopScope(canPop: false)`, pas de bouton fermer) ; le seul CTA ouvre la
+/// fiche App Store.
+///
+/// Monté en haut du `Stack` racine du shell : renvoie [SizedBox.shrink] tant
+/// que le gate n'est pas requis, donc transparent au cas nominal.
+class IosUpdateGate extends ConsumerWidget {
+  const IosUpdateGate({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final status = ref.watch(iosUpdateStatusProvider).valueOrNull;
+
+    if (status == null ||
+        status.level != IosUpdateLevel.gate ||
+        status.appStoreUrl == null) {
+      return const SizedBox.shrink();
+    }
+
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+
+    return PopScope(
+      canPop: false,
+      child: Material(
+        color: colors.backgroundPrimary,
+        child: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 32),
+            child: Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    PhosphorIcons.arrowCircleUp(PhosphorIconsStyle.fill),
+                    size: 56,
+                    color: colors.primary,
+                  ),
+                  const SizedBox(height: 24),
+                  Text(
+                    'Mise à jour requise',
+                    textAlign: TextAlign.center,
+                    style: textTheme.titleLarge?.copyWith(
+                      color: colors.textPrimary,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    'Cette version de Facteur n\'est plus prise en charge. '
+                    'Mettez à jour depuis l\'App Store pour continuer.',
+                    textAlign: TextAlign.center,
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: colors.textSecondary,
+                      height: 1.4,
+                    ),
+                  ),
+                  const SizedBox(height: 32),
+                  SizedBox(
+                    width: double.infinity,
+                    child: FilledButton(
+                      onPressed: () => _openAppStore(status.appStoreUrl!),
+                      style: FilledButton.styleFrom(
+                        backgroundColor: colors.primary,
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                      child: const Text(
+                        'Mettre à jour',
+                        style: TextStyle(
+                          fontWeight: FontWeight.w700,
+                          fontSize: 16,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+Future<void> _openAppStore(String url) async {
+  final uri = Uri.parse(url);
+  if (await canLaunchUrl(uri)) {
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+}

--- a/apps/mobile/lib/shared/widgets/navigation/main_shell.dart
+++ b/apps/mobile/lib/shared/widgets/navigation/main_shell.dart
@@ -6,6 +6,8 @@ import '../../../config/routes.dart';
 import '../../../config/theme.dart';
 import '../../../core/providers/navigation_providers.dart';
 import '../../../features/app_update/providers/app_update_provider.dart';
+import '../../../features/app_update/widgets/ios_update_banner.dart';
+import '../../../features/app_update/widgets/ios_update_gate.dart';
 import '../../../features/feed/widgets/profile_avatar_button.dart';
 import '../../../features/gamification/widgets/streak_indicator.dart';
 import '../../../features/tour/tour_anchors.dart';
@@ -35,6 +37,9 @@ class MainShell extends StatelessWidget {
         children: [
           navigationShell,
           const GuidedTourBridge(),
+          // Gate bloquant « Mise à jour requise » (iOS) : transparent au cas
+          // nominal, recouvre tout quand la version est sous le seuil minimal.
+          const IosUpdateGate(),
         ],
       ),
     );
@@ -106,6 +111,9 @@ class MainTabPageScaffold extends ConsumerWidget {
           // (étapes 4/5 y naviguent) — clé unique malgré les deux branches
           // montées simultanément.
           _SharedTopHeader(attachTourAvatarKey: currentIndex == 0),
+          // Bannière incitative « nouvelle version dispo » (iOS) : non bloquante,
+          // app-wide sur les deux onglets. SizedBox.shrink au cas nominal.
+          const IosUpdateBanner(),
           Expanded(child: child),
         ],
       ),

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -872,6 +872,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.7.2"
+  in_app_update:
+    dependency: "direct main"
+    description:
+      name: in_app_update
+      sha256: "9924a3efe592e1c0ec89dda3683b3cfec3d4cd02d908e6de00c24b759038ddb1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.5"
   intl:
     dependency: "direct main"
     description:

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -88,12 +88,16 @@ dependencies:
   # Spotlight coachmark (Story 16.1 Welcome Tour v2)
   tutorial_coach_mark: ^1.2.12
 
-  # Auto Update (Android APK)
+  # Auto Update (Android APK — flavor beta side-load uniquement)
   package_info_plus: ^8.0.0
   path_provider: ^2.1.2
   open_filex: ^4.5.0
   flutter_downloader: ^1.11.8
   flutter_inappwebview: ^6.1.5
+
+  # Google Play In-App Updates (flavor playstore uniquement — invite native).
+  # Android-only ; lève PlatformException ailleurs → gate par Platform.isAndroid.
+  in_app_update: ^4.2.3
 
   # PWA install prompt detection (Story web.1 — iOS Safari add-to-home)
   web: ^1.1.0

--- a/apps/mobile/test/core/version/semver_test.dart
+++ b/apps/mobile/test/core/version/semver_test.dart
@@ -1,0 +1,39 @@
+import 'package:facteur/core/version/semver.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('compareSemver', () {
+    test('compare numériquement (pas lexicographiquement)', () {
+      expect(compareSemver('1.10.0', '1.9.0'), 1);
+      expect(compareSemver('1.9.0', '1.10.0'), -1);
+      expect(compareSemver('2.0.0', '1.99.99'), 1);
+    });
+
+    test('égalité', () {
+      expect(compareSemver('1.2.3', '1.2.3'), 0);
+    });
+
+    test('composants manquants traités comme 0', () {
+      expect(compareSemver('1.2', '1.2.0'), 0);
+      expect(compareSemver('1', '1.0.0'), 0);
+      expect(compareSemver('1.2', '1.2.1'), -1);
+    });
+
+    test('suffixe build (+) ignoré', () {
+      expect(compareSemver('1.2.0+8', '1.2.0+99'), 0);
+      expect(compareSemver('1.2.0+8', '1.2.0'), 0);
+      expect(compareSemver('1.3.0+1', '1.2.0+999'), 1);
+    });
+
+    test('suffixe pré-release (-) ignoré', () {
+      expect(compareSemver('1.2.0-rc1', '1.2.0'), 0);
+    });
+
+    test('entrée malformée renvoie null', () {
+      expect(compareSemver('abc', '1.0.0'), isNull);
+      expect(compareSemver('1.0.0', ''), isNull);
+      expect(compareSemver('1.x.0', '1.0.0'), isNull);
+      expect(compareSemver('  ', '1.0.0'), isNull);
+    });
+  });
+}

--- a/apps/mobile/test/features/app_update/ios_update_gate_provider_test.dart
+++ b/apps/mobile/test/features/app_update/ios_update_gate_provider_test.dart
@@ -1,0 +1,92 @@
+import 'package:facteur/features/app_update/providers/ios_update_gate_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('resolveIosUpdateLevel', () {
+    test('installée < min → gate (prioritaire sur banner)', () {
+      expect(
+        resolveIosUpdateLevel(
+          installed: '1.0.0',
+          latest: '1.3.0',
+          minSupported: '1.1.0',
+        ),
+        IosUpdateLevel.gate,
+      );
+    });
+
+    test('min ≤ installée < latest → banner', () {
+      expect(
+        resolveIosUpdateLevel(
+          installed: '1.1.0',
+          latest: '1.3.0',
+          minSupported: '1.1.0',
+        ),
+        IosUpdateLevel.banner,
+      );
+    });
+
+    test('installée ≥ latest → none', () {
+      expect(
+        resolveIosUpdateLevel(
+          installed: '1.3.0',
+          latest: '1.3.0',
+          minSupported: '1.1.0',
+        ),
+        IosUpdateLevel.none,
+      );
+      expect(
+        resolveIosUpdateLevel(
+          installed: '2.0.0',
+          latest: '1.3.0',
+          minSupported: '1.1.0',
+        ),
+        IosUpdateLevel.none,
+      );
+    });
+
+    test('comparaison numérique (1.10.0 ≥ 1.9.0 → none)', () {
+      expect(
+        resolveIosUpdateLevel(installed: '1.10.0', latest: '1.9.0'),
+        IosUpdateLevel.none,
+      );
+    });
+
+    group('fail-open', () {
+      test('seuils absents → none', () {
+        expect(
+          resolveIosUpdateLevel(installed: '1.0.0'),
+          IosUpdateLevel.none,
+        );
+      });
+
+      test('latest malformé → pas de banner', () {
+        expect(
+          resolveIosUpdateLevel(installed: '1.0.0', latest: 'abc'),
+          IosUpdateLevel.none,
+        );
+      });
+
+      test('min malformé → pas de gate (mais banner si latest valide)', () {
+        expect(
+          resolveIosUpdateLevel(
+            installed: '1.0.0',
+            latest: '1.3.0',
+            minSupported: 'xx',
+          ),
+          IosUpdateLevel.banner,
+        );
+      });
+
+      test('installée malformée → none', () {
+        expect(
+          resolveIosUpdateLevel(
+            installed: '',
+            latest: '1.3.0',
+            minSupported: '1.1.0',
+          ),
+          IosUpdateLevel.none,
+        );
+      });
+    });
+  });
+}

--- a/apps/mobile/test/features/app_update/playstore_update_service_test.dart
+++ b/apps/mobile/test/features/app_update/playstore_update_service_test.dart
@@ -1,0 +1,40 @@
+import 'package:facteur/features/app_update/services/playstore_update_service.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// La suite tourne sur l'hôte (non-Android) sans `--dart-define=PLAYSTORE_BUILD`,
+/// donc `checkAndStart()` court-circuite AVANT tout appel au canal natif
+/// `in_app_update` (qui lèverait un MissingPluginException). On valide ici la
+/// propriété de sûreté cœur du service : ne jamais lever, ne jamais bloquer.
+/// Le routage immediate/flexible dépend du canal natif Play et se teste sur un
+/// track de test Play Console (cf. maintenance-playstore-in-app-updates.md).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('PlayStoreUpdateService.checkAndStart', () {
+    test('no-op silencieux hors flavor playstore (jamais d\'exception)', () async {
+      final service = PlayStoreUpdateService();
+      // Hôte non-Android + isPlayStoreBuild=false → retour anticipé, pas de
+      // MissingPluginException remontée.
+      await expectLater(service.checkAndStart(), completes);
+    });
+
+    test('appels répétés restent inoffensifs (garde anti-ré-entrance)', () async {
+      final service = PlayStoreUpdateService();
+      // Simule cold-start + retour foreground enchaînés.
+      await expectLater(
+        Future.wait([service.checkAndStart(), service.checkAndStart()]),
+        completes,
+      );
+    });
+
+    test('provider expose un singleton stable', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final a = container.read(playStoreUpdateServiceProvider);
+      final b = container.read(playStoreUpdateServiceProvider);
+      expect(identical(a, b), isTrue);
+    });
+  });
+}

--- a/docs/maintenance/maintenance-playstore-in-app-updates.md
+++ b/docs/maintenance/maintenance-playstore-in-app-updates.md
@@ -1,0 +1,68 @@
+# Maintenance — Mises à jour par flavor (Play In-App Updates + APK maison)
+
+> Mission A-Android. Branche le comportement d'update **par flavor** côté Dart et intègre
+> les **Google Play In-App Updates** sur le flavor `playstore`.
+
+## Routage par flavor
+
+Le routage est piloté par le flavor (`AppUpdateConstants.isPlayStoreBuild`, injecté via
+`--dart-define=PLAYSTORE_BUILD=true` par le build AAB), **pas** par une condition runtime
+fragile.
+
+| Flavor       | applicationId                   | Mécanisme d'update                                            |
+|--------------|---------------------------------|--------------------------------------------------------------|
+| `beta`       | `com.example.facteur.staging`   | Updater **APK maison** (`flutter_downloader` + `open_filex`), permission `REQUEST_INSTALL_PACKAGES` (`src/beta/AndroidManifest.xml`). Inchangé. |
+| `playstore`  | `facteur.app`                   | **Google Play In-App Updates** (`in_app_update`) — invite native. Aucun chemin APK atteint. |
+
+### Chemin `playstore`
+- `PlayStoreUpdateService.checkAndStart()`
+  (`lib/features/app_update/services/playstore_update_service.dart`) est le **point de
+  décision unique**. Appelé depuis `lib/app.dart` :
+  - au **cold-start** (post-frame callback de `initState`) ;
+  - au **retour foreground** (`didChangeAppLifecycleState` → `resumed`).
+- Garde stricte en tête : no-op si `kIsWeb`, non-Android, ou non-`isPlayStoreBuild`. Garde
+  anti-ré-entrance (`_inFlight`) car le check est déclenché deux fois.
+- `InAppUpdate.checkForUpdate()` → si MàJ dispo :
+  - `updatePriority >= 4` **et** `immediateUpdateAllowed` → `performImmediateUpdate()`
+    (flux **bloquant** plein écran géré par le Store) ;
+  - sinon `flexibleUpdateAllowed` → `startFlexibleUpdate()` puis `completeFlexibleUpdate()`
+    (téléchargement **en fond**, install à la complétion).
+- Fail silently : un check d'update ne doit jamais bloquer/casser l'app (ex. user qui
+  refuse l'immediate update).
+
+### Chemin `beta`
+Strictement inchangé. Le provider `appUpdateProvider`
+(`lib/features/app_update/providers/app_update_provider.dart`) gate déjà les builds
+playstore (`if (AppUpdateConstants.isPlayStoreBuild) return null;`) → le bouton maison ne
+s'affiche que sur beta. `PlayStoreUpdateService` est un no-op hors playstore.
+
+## Play Console — fixer immediate vs flexible
+
+Pas de source de vérité backend/Supabase (`app_config` ne porte que `nudges_enabled`).
+La distinction immediate/flexible est pilotée par **`updatePriority`** (0-5), fixée
+**par release dans la Play Console** :
+- `>= 4` → MàJ **bloquante** (immediate) — réservé aux correctifs critiques ;
+- `< 4` → MàJ **flexible** (par défaut), non bloquante.
+
+Le seuil est la constante `PlayStoreUpdateService.kImmediateUpdatePriority` (= 4).
+
+## Lien Mission B — permissions / dépendances
+
+Sur `playstore`, le chemin APK (`flutter_downloader` / `open_filex`) n'est **plus atteint**
+(gaté par `isPlayStoreBuild` dans `appUpdateProvider` + `PlayStoreUpdateService` no-op).
+
+**Aucun retrait de dépendance nécessaire ni souhaité** :
+- `flutter_downloader` et `open_filex` restent au `pubspec.yaml` car **partagés avec le
+  flavor beta** (side-load APK, seul moyen hors store).
+- Les permissions `READ_MEDIA_*` qu'`open_filex` injecte sont déjà **neutralisées app-wide**
+  dans `src/main/AndroidManifest.xml` (`tools:node="remove"`, cf. #892 / Mission B). Elles
+  ne réapparaissent donc pas sur le build playstore.
+- `in_app_update` n'exige **aucune** permission ni `REQUEST_INSTALL_PACKAGES` (l'install
+  passe par le Play Store) → rien à ajouter dans `src/playstore/AndroidManifest.xml`.
+
+## Vérification
+
+- **playstore** (track de test Play) : publier une version supérieure → invite native
+  apparaît. `updatePriority >= 4` → flux immediate bloquant ; sinon flexible (download fond
+  + invite d'install). Décompiler → aucun chemin d'install APK atteignable.
+- **beta** (side-load) : flux APK maison identique à avant.

--- a/docs/stories/core/10.1.ios-version-gate.md
+++ b/docs/stories/core/10.1.ios-version-gate.md
@@ -1,0 +1,73 @@
+# Story 10.1 — iOS : version check (bannière + gate) → App Store
+
+**Type** : Feature
+**Statut** : Implémenté (PR vers `main`), en attente merge + seed `app_config` (PO).
+
+## Contexte
+
+Sur iOS il n'y a pas de self-update (pas de side-load APK comme sur Android) : l'App Store
+met à jour automatiquement. On ne peut donc qu'inciter (bannière non bloquante) ou forcer
+(écran bloquant) l'utilisateur à aller mettre à jour via la fiche App Store.
+
+Le flow d'update existant (`lib/features/app_update/`) est Android-only (download APK depuis
+`/app/update` + install via `flutter_downloader`/`open_filex`, gardé par `!Platform.isAndroid`).
+iOS n'avait aucun contrôle de version. Cette story comble ce manque, iOS-only.
+
+## Source de vérité : Supabase `app_config`
+
+Réutilise la table `public.app_config` (`key text`, `value jsonb`) et le pattern de lecture
+client direct fail-open de `lib/core/nudges/nudges_enabled_provider.dart`. Aucun endpoint
+backend, aucune migration Alembic (c'est de la donnée).
+
+Trois clés (renseignées par le PO) :
+
+| key | exemple value | rôle |
+|-----|---------------|------|
+| `ios_latest_version` | `"1.3.0"` | installée `<` → bannière incitative |
+| `ios_min_supported_version` | `"1.1.0"` | installée `<` → gate bloquant |
+| `ios_app_store_url` | `"https://apps.apple.com/app/idXXXXXXXX"` | cible du CTA |
+
+Fail-open : clé absente / malformée / erreur réseau / RLS / pas d'URL ⇒ aucun affichage.
+Jamais de gate accidentel.
+
+## Implémentation
+
+- `lib/core/version/semver.dart` — `compareSemver(a, b)` numérique par composant
+  (`1.10.0 > 1.9.0`), tolère `+build`/`-prerelease`, `null` si non parsable.
+- `lib/features/app_update/providers/ios_update_gate_provider.dart` :
+  - `resolveIosUpdateLevel(...)` — logique pure testable (priorité gate).
+  - `iosUpdateStatusProvider` — `FutureProvider<IosUpdateStatus>`, gardé iOS-only
+    (`kIsWeb || !Platform.isIOS → none`), lit version installée (`PackageInfo`) + 3 clés
+    Supabase, fail-open.
+  - `iosBannerDismissedProvider` — masquage bannière pour la session (non persistant).
+- `lib/features/app_update/widgets/ios_update_banner.dart` — bandeau calqué sur
+  `ChangelogBanner`, CTA `launchUrl(externalApplication)`, `×` masque.
+- `lib/features/app_update/widgets/ios_update_gate.dart` — écran plein `PopScope(canPop:false)`,
+  CTA unique → App Store.
+- `lib/shared/widgets/navigation/main_shell.dart` — 2 injections : bannière dans le `Column`
+  de `MainTabPageScaffold` (entre header et contenu) ; gate en haut du `Stack` racine de
+  `MainShell` (au-dessus de `navigationShell` + `GuidedTourBridge`).
+
+## Critères d'acceptation
+
+- [x] installée `< ios_latest_version` → bannière non bloquante, CTA App Store.
+- [x] installée `< ios_min_supported_version` → gate bloquant, sortie impossible, CTA App Store.
+- [x] à jour → aucun affichage.
+- [x] iOS-only (Android garde son self-update APK ; web rien).
+- [x] fail-open sur erreur / valeurs absentes.
+
+## Tests
+
+- `test/core/version/semver_test.dart` (6 cas).
+- `test/features/app_update/ios_update_gate_provider_test.dart` (résolution + fail-open).
+- `flutter analyze` propre.
+
+## Vérification device (PO)
+
+Sur build TestFlight : seed `ios_latest_version` > installée → bannière + CTA ouvre la fiche ;
+puis seed `ios_min_supported_version` > installée → gate bloquant + CTA. Screenshots.
+
+## Stop conditions
+
+- Dev : prépare la PR vers `main`. Ne touche pas aux secrets / compte Apple / valeurs Supabase.
+- PO (Laurin) : merge `main`, seed des 3 clés `app_config`, build/submit TestFlight → App Store.


### PR DESCRIPTION
## Contexte

Sur iOS il n'y a **pas de self-update** (pas de side-load APK comme sur Android) : l'App Store met à jour automatiquement. Le flow d'update existant (`lib/features/app_update/`) est **Android-only**. Cette PR ajoute un contrôle de version **iOS-only** qui compare la version installée à deux seuils distants et affiche :

- une **bannière incitative** non bloquante (`installée < ios_latest_version`) ;
- un **gate bloquant** (`installée < ios_min_supported_version`) ;

dans les deux cas le CTA ouvre la fiche App Store (bundle `app.facteur`).

## Source de vérité : Supabase `app_config`

Réutilise la table `app_config` (`key`/`value` jsonb) et le pattern fail-open de `nudgesEnabledProvider` (lecture client direct). **Aucun endpoint backend, aucune migration Alembic** (c'est de la donnée). Le **PO** renseigne 3 clés :

| key | exemple | rôle |
|-----|---------|------|
| `ios_latest_version` | `"1.3.0"` | → bannière |
| `ios_min_supported_version` | `"1.1.0"` | → gate |
| `ios_app_store_url` | `"https://apps.apple.com/app/idXXXXXXXX"` | cible CTA |

**Fail-open** : clé absente / malformée / erreur réseau / RLS / pas d'URL ⇒ aucun affichage. Jamais de gate accidentel.

## Changements

- `lib/core/version/semver.dart` — `compareSemver` numérique par composant (`1.10.0 > 1.9.0`), tolère `+build`/`-prerelease`.
- `lib/features/app_update/providers/ios_update_gate_provider.dart` — `resolveIosUpdateLevel` (pur, testable) + `iosUpdateStatusProvider` (iOS-only, gardé `kIsWeb || !Platform.isIOS`).
- `widgets/ios_update_banner.dart` (calqué `ChangelogBanner`) + `widgets/ios_update_gate.dart` (`PopScope(canPop:false)`), CTA `url_launcher`.
- `main_shell.dart` — bannière app-wide dans le `Column` + gate en overlay racine du `Stack`.
- **Fix** : `changelog.json` malformé (entrée Tournée #891 fusionnée dans Perspectives, JSON invalide sur `main`).

## Tests

- `test/core/version/semver_test.dart` + `test/features/app_update/ios_update_gate_provider_test.dart` → **14/14 pass**.
- `flutter analyze` propre sur les fichiers touchés.

## Vérification device (PO)

Sur build TestFlight : seed `ios_latest_version` > installée → bannière + CTA ouvre la fiche ; puis seed `ios_min_supported_version` > installée → gate bloquant + CTA. Screenshots.

## Stop conditions

- Dev : prépare cette PR. Ne touche pas aux secrets / compte Apple / valeurs Supabase.
- PO (Laurin) : merge `main`, seed des 3 clés `app_config`, build/submit TestFlight → App Store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)