### PR TITLE
fix(widget): bouton refresh + re-amorçage à l'ouverture + cold-open deep link fiable

### DIFF
--- a/apps/mobile/android/app/src/main/kotlin/com/example/facteur/FacteurWidget.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/example/facteur/FacteurWidget.kt
@@ -104,6 +104,23 @@ abstract class FacteurWidget : AppWidgetProvider() {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
         views.setOnClickPendingIntent(R.id.widget_masthead, openPending)
+
+        // Refresh button: wakes the app and forces a Flux refresh via the
+        // `refresh=1` query param (DeepLinkService → feedProvider.refresh).
+        // Distinct requestCode + data so it never collides with the masthead
+        // open intent above.
+        val refreshIntent = Intent(context, MainActivity::class.java).apply {
+            action = Intent.ACTION_VIEW
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            data = Uri.parse("io.supabase.facteur://feed?refresh=1")
+        }
+        val refreshPending = PendingIntent.getActivity(
+            context,
+            appWidgetId * 10 + 3,
+            refreshIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        views.setOnClickPendingIntent(R.id.masthead_refresh, refreshPending)
     }
 
     private fun bindArticleList(

--- a/apps/mobile/android/app/src/main/kotlin/com/example/facteur/FacteurWidgetService.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/example/facteur/FacteurWidgetService.kt
@@ -79,25 +79,28 @@ private class FacteurRemoteViewsFactory(
         }
         val rv = RemoteViews(context.packageName, rowLayoutId)
 
-        // Topic line: Essentiel keeps the rank prefix ("1 — Climat") as a
-        // positional cue inside the daily 5; Flux drops it to feel like a
-        // continuous scroll.
-        val topicSegment = article.topicLabel.ifBlank { "Actu" }
-        val topicLine = if (article.sourceKind == WidgetRendering.SOURCE_KIND_ESSENTIEL) {
-            "${article.rank} — $topicSegment"
+        val isEssentiel = article.sourceKind == WidgetRendering.SOURCE_KIND_ESSENTIEL
+
+        // En-tête (rang + thème + badge « À la Une ») : visible uniquement en
+        // Essentiel, comme repère positionnel dans les 5 du jour. En Flux il est
+        // masqué — le thème migre en pied (« source • thème ») pour donner une
+        // sensation de flux continu.
+        if (isEssentiel) {
+            val topicSegment = article.topicLabel.ifBlank { "Actu" }
+            rv.setViewVisibility(R.id.row_header, View.VISIBLE)
+            rv.setTextViewText(R.id.row_topic, "${article.rank} — $topicSegment")
+            rv.setViewVisibility(
+                R.id.row_a_la_une,
+                if (article.isMain) View.VISIBLE else View.GONE,
+            )
         } else {
-            topicSegment
+            rv.setViewVisibility(R.id.row_header, View.GONE)
         }
-        rv.setTextViewText(R.id.row_topic, topicLine)
-        rv.setViewVisibility(
-            R.id.row_a_la_une,
-            if (article.isMain) View.VISIBLE else View.GONE,
-        )
         rv.setTextViewText(R.id.row_title, article.title)
 
         // Thumbnails: only Essentiel articles carry one (Flux is image-less
         // to keep the merged payload under the Binder ceiling at MAX_ROWS=80).
-        if (article.sourceKind == WidgetRendering.SOURCE_KIND_ESSENTIEL) {
+        if (isEssentiel) {
             val thumb = WidgetRendering.loadBitmap(context, article.thumbnailPath, 72)?.let {
                 WidgetRendering.roundCorners(context, it, 8f)
             }
@@ -118,7 +121,14 @@ private class FacteurRemoteViewsFactory(
         } else {
             rv.setViewVisibility(R.id.row_source_logo, View.GONE)
         }
-        rv.setTextViewText(R.id.row_source_name, article.sourceName)
+        // Pied de row : Essentiel = source seule (le thème est déjà dans
+        // l'en-tête) ; Flux = « source • thème » (séparateur U+2022, pas d'em-dash).
+        val sourceLine = if (!isEssentiel && article.topicLabel.isNotBlank()) {
+            "${article.sourceName} • ${article.topicLabel}"
+        } else {
+            article.sourceName
+        }
+        rv.setTextViewText(R.id.row_source_name, sourceLine)
 
         if (article.perspectiveCount > 0) {
             rv.setTextViewText(R.id.row_perspective, "+${article.perspectiveCount}")

--- a/apps/mobile/android/app/src/main/res/drawable/ic_widget_refresh.xml
+++ b/apps/mobile/android/app/src/main/res/drawable/ic_widget_refresh.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Bouton refresh du widget — trait fin (feather "refresh-cw"). La teinte est
+     appliquée par l'ImageView hôte (android:tint) selon le thème Clair/Sombre. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="18dp"
+    android:height="18dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M23,4 L23,10 L17,10" />
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M1,20 L1,14 L7,14" />
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M3.51,9 a9,9 0 0 1 14.85,-3.36 L23,10 M1,14 l4.64,4.36 A9,9 0 0 0 20.49,15" />
+</vector>

--- a/apps/mobile/android/app/src/main/res/layout/facteur_widget_dark.xml
+++ b/apps/mobile/android/app/src/main/res/layout/facteur_widget_dark.xml
@@ -53,6 +53,18 @@
             android:letterSpacing="0.06"
             android:textColor="@color/facteur_text_tertiary_dark"
             android:maxLines="1" />
+
+        <!-- Bouton refresh : réveille l'app et force un refresh du flux Flâner
+             (qui re-pousse le widget). -->
+        <ImageView
+            android:id="@+id/masthead_refresh"
+            android:layout_width="18dp"
+            android:layout_height="18dp"
+            android:layout_marginStart="10dp"
+            android:src="@drawable/ic_widget_refresh"
+            android:tint="@color/facteur_text_tertiary_dark"
+            android:scaleType="fitCenter"
+            android:contentDescription="Rafraîchir" />
     </LinearLayout>
 
     <ListView

--- a/apps/mobile/android/app/src/main/res/layout/facteur_widget_light.xml
+++ b/apps/mobile/android/app/src/main/res/layout/facteur_widget_light.xml
@@ -55,6 +55,18 @@
             android:letterSpacing="0.06"
             android:textColor="@color/facteur_text_tertiary_light"
             android:maxLines="1" />
+
+        <!-- Bouton refresh : réveille l'app et force un refresh du flux Flâner
+             (qui re-pousse le widget). -->
+        <ImageView
+            android:id="@+id/masthead_refresh"
+            android:layout_width="18dp"
+            android:layout_height="18dp"
+            android:layout_marginStart="10dp"
+            android:src="@drawable/ic_widget_refresh"
+            android:tint="@color/facteur_text_tertiary_light"
+            android:scaleType="fitCenter"
+            android:contentDescription="Rafraîchir" />
     </LinearLayout>
 
     <!-- Liste scrollable — bound to FacteurWidgetService via setRemoteAdapter. -->

--- a/apps/mobile/android/app/src/main/res/layout/widget_article_row_dark.xml
+++ b/apps/mobile/android/app/src/main/res/layout/widget_article_row_dark.xml
@@ -10,7 +10,9 @@
     android:paddingStart="0dp"
     android:paddingEnd="0dp">
 
+    <!-- Header line. Masqué en Flux (le thème migre en pied « source • thème »). -->
     <LinearLayout
+        android:id="@+id/row_header"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"

--- a/apps/mobile/android/app/src/main/res/layout/widget_article_row_light.xml
+++ b/apps/mobile/android/app/src/main/res/layout/widget_article_row_light.xml
@@ -10,8 +10,10 @@
     android:paddingStart="0dp"
     android:paddingEnd="0dp">
 
-    <!-- Header line: "1 — International" + (optional) À la Une badge -->
+    <!-- Header line: "1 — International" + (optional) À la Une badge.
+         Masqué en Flux (le thème migre en pied « source • thème »). -->
     <LinearLayout
+        android:id="@+id/row_header"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Widget",
+      "summary": "Le widget se rafraîchit à nouveau, avec un bouton pour forcer la mise à jour."
+    },
+    {
       "tag": "Perspectives",
       "summary": "Couverture médiatique plus lisible : repères Gauche/Droite sous la barre, source cliquable et aperçu de l'article au toucher prolongé."
     },

--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -53,6 +53,7 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
       _flushFluxScrollMetricIfAny();
       _startAnalyticsSessionIfNeeded();
       unawaited(ref.read(readSyncServiceProvider).flushCurrentUser());
+      _ensureWidgetFresh();
     });
     // Story 23.2 PR-4 : si un endpoint retiré répond 410, afficher un
     // snackbar global "Mise à jour requise". Le ApiClient intercepte tous
@@ -102,7 +103,13 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
             : null;
         final router = ref.read(routerProvider);
         final currentPath = router.routeInformationProvider.value.uri.path;
-        if (ref.read(authStateProvider).isAuthenticated &&
+        final isAuthenticated = ref.read(authStateProvider).isAuthenticated;
+        // Re-amorce le widget à chaque reprise, quel que soit l'onglet courant
+        // (re-push immédiat + refresh réseau si le flux est périmé) — sans ça,
+        // le widget gèle tant que l'utilisateur n'ouvre pas explicitement
+        // Flâner.
+        _ensureWidgetFresh(stale: shouldRefreshFlanerOnForeground(elapsed));
+        if (isAuthenticated &&
             currentPath == RoutePaths.fluxContinu &&
             ref
                 .read(tourneeProgressServiceProvider)
@@ -110,13 +117,16 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
           router.go(RoutePaths.flaner);
           return;
         }
-        if (ref.read(authStateProvider).isAuthenticated &&
-            currentPath == RoutePaths.flaner &&
-            shouldRefreshFlanerOnForeground(elapsed)) {
-          ref.read(feedProvider.notifier).refresh();
-        }
       }
     }
+  }
+
+  /// Re-pushe le flux courant vers le widget (best-effort, silencieux si pas
+  /// authentifié ou flux pas encore chargé). [stale] force en plus un refresh
+  /// réseau (retour de premier plan après un long passage en arrière-plan).
+  void _ensureWidgetFresh({bool stale = false}) {
+    if (!ref.read(authStateProvider).isAuthenticated) return;
+    unawaited(ref.read(feedProvider.notifier).ensureWidgetFresh(stale: stale));
   }
 
   Future<void> _flushFluxScrollMetricIfAny() async {
@@ -162,7 +172,13 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
 
     // Bind the DeepLinkService once the router is built. Idempotent.
     final analytics = ref.read(analyticsServiceProvider);
-    DeepLinkService.instance.bind(router: router, analytics: analytics);
+    DeepLinkService.instance.bind(
+      router: router,
+      analytics: analytics,
+      // Widget refresh button → réveille l'app, force un refresh Flâner (qui
+      // re-pushe le widget via le chemin existant).
+      onRefreshRequested: () => ref.read(feedProvider.notifier).refresh(),
+    );
 
     if (!_deepLinksStarted) {
       _deepLinksStarted = true;

--- a/apps/mobile/lib/config/routes.dart
+++ b/apps/mobile/lib/config/routes.dart
@@ -173,6 +173,10 @@ final routerProvider = Provider<GoRouter>((ref) {
       // both ultimately call router.go on the same in-app path.
       if (state.uri.scheme == 'io.supabase.facteur') {
         final action = DeepLinkService.parse(state.uri);
+        // GoRouter received the deep link directly (some launchers deliver it
+        // as the initial route). Consume any seeded pending URI so the
+        // post-auth `flushPendingIfReady` doesn't replay it and double-navigate.
+        DeepLinkService.instance.clearPending();
         return action.route ?? RoutePaths.fluxContinu;
       }
 
@@ -241,9 +245,18 @@ final routerProvider = Provider<GoRouter>((ref) {
 
       // 3. Les utilisateurs confirmés ne doivent pas être sur login, confirmation ou splash
       if (isOnLoginPage || isOnEmailConfirmation || isOnSplash) {
-        return authState.needsOnboarding
-            ? RoutePaths.onboarding
-            : postAuthHomePath();
+        if (authState.needsOnboarding) {
+          return RoutePaths.onboarding;
+        }
+        // Deep link de cold-start (widget) : il est la source de vérité de
+        // l'atterrissage. On le consomme ici pour éviter la course avec
+        // `flushPendingIfReady` (qui redeviendrait no-op après clearPending).
+        final pending = DeepLinkService.instance.pendingRoute();
+        if (pending != null) {
+          DeepLinkService.instance.clearPending();
+          return pending;
+        }
+        return postAuthHomePath();
       }
 
       // 4. Onboarding : forcer si nécessaire

--- a/apps/mobile/lib/core/services/deep_link_service.dart
+++ b/apps/mobile/lib/core/services/deep_link_service.dart
@@ -63,6 +63,11 @@ class DeepLinkService {
   /// Replayed once both conditions are met via [flushPendingIfReady].
   Uri? _pending;
 
+  /// `true` once a cold-start link has been seeded via [seedPending] (from
+  /// `main.dart`). Lets [start] skip its own `getInitialLink` so the link isn't
+  /// handled twice (which would double-navigate after the redirect consumed it).
+  bool _initialLinkSeeded = false;
+
   /// Reference to the current [GoRouter]. Set via [bind] from `app.dart`.
   GoRouter? _router;
 
@@ -70,11 +75,23 @@ class DeepLinkService {
   /// from `app.dart` via a Riverpod listener on `authStateProvider`.
   bool _authenticated = false;
 
+  /// Callback invoked when a widget tap explicitly requests a feed refresh
+  /// (`io.supabase.facteur://feed?refresh=1`, fired by the widget's refresh
+  /// button). Wired from `app.dart` to `feedProvider.refresh()`.
+  VoidCallback? _onRefreshRequested;
+
   /// Bind the service to the running router and analytics. Idempotent.
-  void bind({required GoRouter router, AnalyticsService? analytics}) {
+  void bind({
+    required GoRouter router,
+    AnalyticsService? analytics,
+    VoidCallback? onRefreshRequested,
+  }) {
     _router = router;
     if (analytics != null) {
       _analytics = analytics;
+    }
+    if (onRefreshRequested != null) {
+      _onRefreshRequested = onRefreshRequested;
     }
   }
 
@@ -92,14 +109,17 @@ class DeepLinkService {
   Future<void> start() async {
     if (_sub != null) return;
 
-    // 1. Cold start: check the URI that launched the app.
-    try {
-      final initial = await _appLinks.getInitialLink();
-      if (initial != null) {
-        _handle(initial);
+    // 1. Cold start: check the URI that launched the app — unless main.dart
+    // already seeded it via [seedPending] (then the redirect owns it).
+    if (!_initialLinkSeeded) {
+      try {
+        final initial = await _appLinks.getInitialLink();
+        if (initial != null) {
+          _handle(initial);
+        }
+      } catch (e) {
+        debugPrint('DeepLinkService: getInitialLink failed: $e');
       }
-    } catch (e) {
-      debugPrint('DeepLinkService: getInitialLink failed: $e');
     }
 
     // 2. Hot stream: subsequent URIs while the app is alive.
@@ -147,6 +167,45 @@ class DeepLinkService {
     _route(pending);
   }
 
+  /// Seed a pending URI without going through the auth gate. Used at boot from
+  /// `main.dart` (`AppLinks().getInitialLink()`) so the cold-start deep link is
+  /// known *before* the first GoRouter redirect resolves — making the deep link
+  /// the single source of truth for the post-auth landing route instead of
+  /// racing [flushPendingIfReady] against `postAuthHomePath()`.
+  void seedPending(Uri uri) {
+    if (uri.scheme != 'io.supabase.facteur') return;
+    _pending = uri;
+    _initialLinkSeeded = true;
+  }
+
+  /// Resolve the in-app route for the currently pending URI **without
+  /// consuming it**, or `null` when nothing navigable is pending. Called by the
+  /// router `redirect` to land cold-opens on their deep-linked destination.
+  String? pendingRoute() {
+    final pending = _pending;
+    if (pending == null) return null;
+    final action = parse(pending);
+    switch (action.target) {
+      case WidgetDeepLinkTarget.article:
+      case WidgetDeepLinkTarget.digest:
+      case WidgetDeepLinkTarget.feed:
+      case WidgetDeepLinkTarget.veille:
+      case WidgetDeepLinkTarget.grille:
+        return action.route;
+      case WidgetDeepLinkTarget.authCallback:
+      case WidgetDeepLinkTarget.ignored:
+      case WidgetDeepLinkTarget.unhandled:
+        return null;
+    }
+  }
+
+  /// Clear the pending URI. Called by the redirect once it has consumed the
+  /// pending route via [pendingRoute] so [flushPendingIfReady] becomes a no-op
+  /// (no double navigation on cold-open).
+  void clearPending() {
+    _pending = null;
+  }
+
   void _route(Uri uri) {
     final router = _router;
     if (router == null) {
@@ -177,6 +236,11 @@ class DeepLinkService {
       case WidgetDeepLinkTarget.feed:
         _analytics?.trackWidgetAppOpened(target: 'feed');
         router.go(action.route!);
+        // Widget refresh button: after landing on Flâner, force a feed refresh
+        // (which re-pushes the widget through the existing path).
+        if (action.refresh) {
+          _onRefreshRequested?.call();
+        }
         return;
       case WidgetDeepLinkTarget.veille:
         _analytics?.trackWidgetAppOpened(target: 'veille');
@@ -285,10 +349,12 @@ class DeepLinkService {
         }
       }
       // FeedScreen historique — on route vers Flâner, désormais page feed
-      // autonome.
-      return const WidgetDeepLinkAction(
+      // autonome. `refresh=1` (bouton refresh du widget) garde la route Flâner
+      // mais signale qu'un rafraîchissement du flux doit suivre.
+      return WidgetDeepLinkAction(
         target: WidgetDeepLinkTarget.feed,
         route: RoutePaths.flaner,
+        refresh: uri.queryParameters['refresh'] == '1',
       );
     }
 
@@ -318,6 +384,8 @@ class DeepLinkService {
     _sub = null;
     _router = null;
     _pending = null;
+    _onRefreshRequested = null;
+    _initialLinkSeeded = false;
   }
 }
 
@@ -340,6 +408,10 @@ class WidgetDeepLinkAction {
   final String? topicId;
   final String? authType;
 
+  /// `true` when the link carries `refresh=1` (widget refresh button) — the
+  /// router lands on Flâner and the service then triggers a feed refresh.
+  final bool refresh;
+
   const WidgetDeepLinkAction({
     required this.target,
     this.route,
@@ -347,5 +419,6 @@ class WidgetDeepLinkAction {
     this.position,
     this.topicId,
     this.authType,
+    this.refresh = false,
   });
 }

--- a/apps/mobile/lib/features/feed/providers/feed_provider.dart
+++ b/apps/mobile/lib/features/feed/providers/feed_provider.dart
@@ -395,6 +395,27 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     });
   }
 
+  /// Re-amorce le widget home-screen à chaque ouverture/reprise de l'app :
+  ///
+  ///  - (a) re-pushe **immédiatement** le flux Flâner courant vers le widget
+  ///    via [_scheduleWidgetPush] — répare un widget fraîchement épinglé ou un
+  ///    payload vidé même si le contenu n'a pas changé ;
+  ///  - (b) déclenche un [refresh] réseau quand [stale] (typiquement quand
+  ///    l'app revient au premier plan après [flanerForegroundRefreshThreshold])
+  ///    pour que le widget reçoive du contenu réellement frais.
+  ///
+  /// Le garde de signature de [_scheduleWidgetPush] évite tout churn de
+  /// SharedPreferences si le contenu est identique.
+  Future<void> ensureWidgetFresh({bool stale = false}) async {
+    final items = state.value?.items ?? const <Content>[];
+    if (items.isNotEmpty) {
+      _scheduleWidgetPush(items);
+    }
+    if (stale) {
+      await refresh();
+    }
+  }
+
   /// Push the current default feed to the home-screen widget. No-op when a
   /// filter/theme/source/etc. is active — only the canonical, unfiltered Flux
   /// is mirrored to the widget. Debounced + signature-guarded so optimistic

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io' show Platform;
+import 'package:app_links/app_links.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -18,6 +19,7 @@ import 'app.dart';
 import 'config/constants.dart';
 import 'core/auth/supabase_storage.dart';
 import 'core/api/notification_preferences_api_service.dart';
+import 'core/services/deep_link_service.dart';
 import 'core/services/posthog_service.dart';
 import 'core/services/push_notification_service.dart';
 import 'core/services/server_push_service.dart';
@@ -217,6 +219,25 @@ Future<void> _bootstrap() async {
         break;
     }
   });
+
+  // Résout le deep link de cold-start AVANT la 1ère redirection du router pour
+  // qu'il soit la source de vérité de l'atterrissage post-auth (sinon course
+  // entre `flushPendingIfReady` → article et le redirect → Flâner, cf.
+  // bug widget cold-open). Best-effort, borné à ~300ms — un échec/timeout
+  // laisse simplement DeepLinkService.start() retomber sur getInitialLink.
+  if (!kIsWeb && Platform.isAndroid) {
+    try {
+      final initialUri = await AppLinks().getInitialLink().timeout(
+            const Duration(milliseconds: 300),
+            onTimeout: () => null,
+          );
+      if (initialUri != null) {
+        DeepLinkService.instance.seedPending(initialUri);
+      }
+    } catch (e) {
+      debugPrint('Main: getInitialLink seed failed (non-critical): $e');
+    }
+  }
 
   debugPrint('[PERF] boot.pre_runapp_ms=${bootSw.elapsedMilliseconds}');
 

--- a/apps/mobile/test/core/services/deep_link_service_test.dart
+++ b/apps/mobile/test/core/services/deep_link_service_test.dart
@@ -158,5 +158,68 @@ void main() {
       expect(action.target, WidgetDeepLinkTarget.article);
       expect(action.position, isNull);
     });
+
+    test('feed?refresh=1 → flâner + refresh flag (bouton refresh widget)', () {
+      final action = DeepLinkService.parse(
+        Uri.parse('io.supabase.facteur://feed?refresh=1'),
+      );
+      expect(action.target, WidgetDeepLinkTarget.feed);
+      expect(action.route, '/flaner');
+      expect(action.refresh, isTrue);
+    });
+
+    test('feed sans refresh → flag refresh false', () {
+      final action = DeepLinkService.parse(
+        Uri.parse('io.supabase.facteur://feed'),
+      );
+      expect(action.target, WidgetDeepLinkTarget.feed);
+      expect(action.refresh, isFalse);
+    });
+  });
+
+  group('DeepLinkService pending (cold-start seed)', () {
+    tearDown(DeepLinkService.resetForTest);
+
+    test('seedPending + pendingRoute resolves the route without consuming', () {
+      final service = DeepLinkService.forTest();
+      DeepLinkService.setInstanceForTest(service);
+
+      service.seedPending(
+        Uri.parse('io.supabase.facteur://feed/content/abc-123'),
+      );
+
+      // Resolves but does not consume — repeatable.
+      expect(service.pendingRoute(), '/flaner/content/abc-123');
+      expect(service.pendingRoute(), '/flaner/content/abc-123');
+    });
+
+    test('clearPending makes pendingRoute null', () {
+      final service = DeepLinkService.forTest();
+      DeepLinkService.setInstanceForTest(service);
+
+      service.seedPending(Uri.parse('io.supabase.facteur://digest/xyz'));
+      expect(service.pendingRoute(), '/flux-continu/content/xyz');
+
+      service.clearPending();
+      expect(service.pendingRoute(), isNull);
+    });
+
+    test('seedPending ignores foreign schemes', () {
+      final service = DeepLinkService.forTest();
+      DeepLinkService.setInstanceForTest(service);
+
+      service.seedPending(Uri.parse('https://facteur.app/digest'));
+      expect(service.pendingRoute(), isNull);
+    });
+
+    test('pendingRoute is null for non-navigable (auth callback) links', () {
+      final service = DeepLinkService.forTest();
+      DeepLinkService.setInstanceForTest(service);
+
+      service.seedPending(
+        Uri.parse('io.supabase.facteur://login-callback#access_token=xyz'),
+      );
+      expect(service.pendingRoute(), isNull);
+    });
   });
 }


### PR DESCRIPTION
## Quoi
Répare le widget home-screen Android et fiabilise l'atterrissage des cold-opens depuis le widget. Trois volets :
1. **Bouton refresh** dans le widget (nouveau drawable `ic_widget_refresh`, layouts clair/sombre) câblé au deep link `io.supabase.facteur://feed?refresh=1` → réveille l'app et force un refresh Flâner (qui re-pousse le widget).
2. **Re-amorçage du widget à chaque ouverture/reprise** (`FeedNotifier.ensureWidgetFresh`) : re-push immédiat du flux courant (répare un widget fraîchement épinglé / payload vidé) + refresh réseau si périmé. Plus besoin d'ouvrir Flâner pour dégeler le widget.
3. **Cold-open deep link = source de vérité** de la route post-auth : `main.dart` seed le lien initial (borné 300 ms, Android only) avant la 1ère redirection ; le router consomme `pendingRoute()`/`clearPending()` pour éviter la double navigation contre `flushPendingIfReady`.
4. Bonus rendu des rows : Flux masque l'en-tête (rang/badge) et déplace le thème en pied « source • thème » (séparateur U+2022, pas d'em-dash) ; Essentiel inchangé.

## Pourquoi
Le widget gelait tant que l'utilisateur n'ouvrait pas explicitement Flâner, et un tap sur le widget au cold-start atterrissait sur Flâner au lieu de l'article (course `flushPendingIfReady` → article vs redirect → Flâner). Mobile-only, aucun changement backend / aucune migration Alembic.

## Comment ça a été vérifié
- [x] pytest : **N/A** (mobile-only, rien backend)
- [x] `flutter test test/core/services/deep_link_service_test.dart` : 23/23 (dont 6 nouveaux cas : flag refresh, seed/pending/clear)
- [x] `flutter test` (suite complète) : +1307 / -22 — les 22 échecs sont **pré-existants** (Hive/Supabase non init, cf. infra de test), aucun dans les fichiers touchés
- [x] `flutter analyze` (fichiers touchés) : aucun nouveau warning
- [x] **Smoke APK** : `flutter build apk --debug --flavor beta` → `✓ Built app-beta-debug.apk` (compile les nouvelles réfs Kotlin `R.id.masthead_refresh`, `R.id.row_header` + drawable `ic_widget_refresh` ; CI ne build pas l'APK en PR)
- [x] `/simplify` passé (consolidation du garde auth de `_ensureWidgetFresh`)

## Zones à risque
- **Router redirect** (`config/routes.dart`) : nouvel ordre onboarding → pending → `postAuthHomePath()` ; `clearPending()` est le garde anti-double-navigation (ne pas le retirer).
- **DeepLinkService** (`core/services/deep_link_service.dart`) : cold-start seed (`seedPending` + flag `_initialLinkSeeded`) vs `flushPendingIfReady` ; `start()` saute `getInitialLink` si seedé pour éviter le double-handling.
