### PR TITLE
perf(scaling): mesure tokens Mistral + fix burst éditorial 429 (LR-1 PR 1)

### DIFF
--- a/docs/maintenance/maintenance-mistral-cost-lr1-pr1.md
+++ b/docs/maintenance/maintenance-mistral-cost-lr1-pr1.md
@@ -1,0 +1,116 @@
+# Maintenance — LR-1 / PR 1 : mesurer le € Mistral + fixer le burst éditorial
+
+> Phase 3 / Launch Readiness. Première des 4 PR du plan LR-1 (cf.
+> `.context/attachments/.../plan.md`). **Zéro impact produit.**
+> Cible `main`. Conclure avec `/go`.
+
+## Objectif
+
+1. **Capture des tokens** : transformer le compteur d'appels (`api_usage_events`)
+   en vrai modèle €/token. Les réponses Mistral renvoient déjà
+   `usage.{prompt_tokens, completion_tokens}` ; on les persiste pour pouvoir
+   faire un `GROUP BY model` → € réel par modèle / call_site, sans dépendre du
+   dashboard Mistral.
+2. **Fix du burst éditorial (les 28 % de 429)** : l'`EditorialLLMClient` est
+   appelé via des `asyncio.gather` non bornés (curation + deep_matcher +
+   perspective, tous `mistral-large-latest`). On ajoute un token-bucket /minute
+   + une `Semaphore` de concurrence **partagés au niveau module** (chokepoint
+   unique), gatés sur le modèle large, + un retry/backoff sur `chat_text` (qui
+   n'en avait aucun).
+
+## Vérité terrain (constatée dans le code)
+
+- 1 seul head Alembic : `au01_api_usage_events` (le « 2 heads » du plan était la
+  situation pré-merge `origin/main`, désormais résolue). La migration tokens
+  s'enchaîne proprement → `au02`.
+- `EditorialLLMClient` est instancié **par appelant** (pipeline, perspective,
+  veille x2, bias, smart_search) → le limiteur DOIT être un singleton module
+  (sinon il ne borne pas l'agrégat). Les appels bursty sont tous `large`.
+- Capture tokens nécessaire seulement sur les 2 sites à client propre
+  (`classification_service`, `good_news_classifier`) + le chokepoint éditorial
+  (`chat_json`/`chat_text`). `smart_search` (Mistral) passe déjà par `chat_json`
+  → couvert ; son chemin Brave n'a pas de tokens.
+
+## Tâches
+
+### Capture tokens
+- [ ] `models/api_usage_event.py` : `prompt_tokens` / `completion_tokens` (int, nullable).
+- [ ] Migration `au02_api_usage_tokens` (additive, down_revision `au01`, 1 head).
+- [ ] `usage_recorder.py` : params tokens sur `record_api_call` + champs sur
+      `_ApiCallTracker` + propagation dans le `finally` de `track_api_call`.
+- [ ] `classification_service._call_mistral` : pose les tokens sur le tracker.
+- [ ] `good_news_classifier._call` : idem.
+- [ ] `editorial/llm_client.chat_json` + `chat_text` : idem.
+
+### Fix burst éditorial
+- [ ] `config.py` : `mistral_large_rpm` (def. 60), `mistral_large_concurrency`
+      (def. 4), `mistral_rate_limit_enabled` (def. True, kill-switch).
+- [ ] `editorial/rate_limiter.py` (nouveau) : `_MistralRateLimiter` token-bucket
+      + semaphore, loop-safe (recrée sem/lock au changement de loop), horloge
+      injectable (fake clock pour tests).
+- [ ] `editorial/llm_client.py` : singleton limiteur module + `_is_large_model`
+      + `_do_post` (slot limiteur autour du POST, large only) ; ajout
+      retry/backoff à `chat_text`.
+
+### Tests
+- [ ] `tests/test_usage_recorder.py` : enregistrement des tokens.
+- [ ] `tests/editorial/test_rate_limiter.py` : token-bucket (fake clock) +
+      cap de concurrence.
+- [ ] `tests/editorial/test_llm_client.py` : retry `chat_text`, limiteur
+      large-only, capture tokens.
+- [ ] `tests/conftest.py` : fixture autouse reset du limiteur (bucket plein /test).
+- [ ] Capture tokens côté classification / good_news.
+
+### Verify
+- [ ] `pytest -v` vert. Alembic 1 head, `upgrade head` + `downgrade` sur DB vide.
+- [ ] `/go` (VERIFY → simplify → PR `--base main`).
+
+## Acceptance
+
+- Chaque ligne Mistral porte des compteurs de tokens → `GROUP BY model` donne
+  un €/jour.
+- Le limiteur borne le burst large (test fake-clock) ; `chat_text` retente sur
+  429/5xx. Pas de changement de schéma/comportement pour les modèles non-large.
+- Reversible : `mistral_rate_limit_enabled=False` désactive le throttle,
+  `usage_tracking_enabled=False` coupe l'instrumentation, sans redéploiement de
+  schéma.
+
+## Pas de changelog
+
+PR backend-only, aucun écran impacté → pas d'entrée `changelog.json`.
+
+---
+
+## Statut : implémenté + testé (prêt pour `/go`)
+
+Toutes les tâches ci-dessus sont faites. Fichiers livrés :
+- `app/config.py` (3 settings), `app/services/editorial/rate_limiter.py` (nouveau),
+  `app/models/api_usage_event.py` (2 colonnes), `alembic/versions/au02_api_usage_tokens.py`
+  (nouveau), `app/services/observability/usage_recorder.py`,
+  `app/services/ml/classification_service.py`, `app/services/ml/good_news_classifier.py`,
+  `app/services/editorial/llm_client.py`.
+- Tests : `tests/editorial/test_rate_limiter.py` (nouveau), `tests/test_usage_recorder.py`,
+  `tests/editorial/test_llm_client.py`, `tests/ml/test_classification_service.py`,
+  `tests/ml/test_good_news_classifier.py`, `tests/conftest.py` (fixture reset limiteur).
+
+### Vérif réalisée
+- pytest ciblé vert (pyenv) : limiteur (fake-clock), recorder, llm_client (retry
+  chat_text + gating large-only + tokens), call-sites classif/good_news ; +
+  consommateurs (perspective/veille/bias). Collection pleine suite = 1650, 0 erreur.
+- Alembic : 1 head (`au02`) ; SQL up/down rendu offline (ADD/DROP 2 colonnes).
+- `ruff check app/` clean ; mes fichiers `ruff format` OK.
+
+### Caveats env (non bloquants, CI-vert)
+1. **DB locale** : conteneur test 54322 partagé avec un autre workspace Conductor
+   (creds inconnues, `make db-reset` interdit) → les tests DB et l'upgrade DB-vide
+   tournent en **CI** (`alembic-smoke` + pytest backend), pas en local.
+2. **Hook stop-verify** : appelle `.venv/bin/pytest` (absent en Conductor) →
+   faux négatif connu ; vérif réelle faite via pyenv pytest.
+3. **Cycle d'import pré-existant** `editorial.pipeline ↔ llm_bias` (ordre-sensible,
+   via `editorial/__init__`) — hors scope, mon ajout (`llm_client → rate_limiter`)
+   est un leaf hors du cycle ; collection pleine suite OK.
+4. **Drift ruff non épinglé** : `main.py` / `digest_generation_job.py`
+   (non touchés) flaggés `would reformat` — issue connue, hors scope.
+
+### Reste
+`/go` (VERIFY → simplify → PR `--base main`, body = `.context/pr-handoff.md`).

--- a/docs/scaling/phase-2-structural-handoff.md
+++ b/docs/scaling/phase-2-structural-handoff.md
@@ -1,0 +1,94 @@
+# Hand-off — Phase 2 : premières actions structurelles de scalabilité
+
+> **À copier comme prompt de lancement d'un agent dédié.** Auto-portant : tout le contexte nécessaire est ici ou lié.
+> **Prérequis lecture** : [`scaling-investigation-200-users.md`](scaling-investigation-200-users.md) (briefs WP-A→E), [`baseline-2026-06-04.md`](baseline-2026-06-04.md) (chiffres), [`../maintenance/maintenance-observabilite-scaling.md`](../maintenance/maintenance-observabilite-scaling.md) (phase A = instrumentation).
+
+---
+
+## 0. Mission
+
+Mettre en place les **premières actions structurelles à impact** pour rendre la scalabilité de l'app **robuste** vers 200 users (et avec de la marge au-delà). Pas une refonte : **2 à 3 PRs fondatrices, data-gated, sûres et réversibles**, qui suppriment les fragilités identifiées et posent les fondations de capacité. Tu mesures d'abord, tu remédies ensuite, tu re-mesures.
+
+**Cadre mental (ne pas l'oublier)** : la phase 1 a montré qu'à 200 users *mécaniquement presque rien ne casse* — la marge est large (digest ~20 s sur une fenêtre de 45 min, `user_content_status` négligeable, pool jamais saturé en conditions normales). Donc « robuste » ici = **enlever les signaux de fragilité** (idle-in-transaction en prod, process unique, coût Mistral non gouverné, fenêtre RSS au bord) et **établir la fondation capacité**, pas sur-ingénierer pour 10k. Right-size chaque action à l'évidence.
+
+---
+
+## 1. État au démarrage
+
+**Phase 1 (cadrage)** : livrée — baseline réel + 5 work-packages auto-portants. Rappels des **corrections de cadrage** mesurées (lire le §0 du baseline) : 89 users (pas 50) · **278 sources actives** (pas 50, RSS déjà à 5,5×) · `user_content_status` = `O(interactions)` ~3,3k lignes (table « explosive » inexistante) · **serene ~50 %** (pas 10 %) → `mistral-large` sur ~moitié du FR · caps Mistral/Brave **en mémoire, veille seule** → classif+éditorial non gouvernés · digest **~20 s/89 users** (pas le hot spot) · vrai vecteur disque = **`daily_digest` TOAST 126 MB** · signal pool prod = **`IdleInTransactionSessionTimeout`** + N+1 (Sentry projet `python`).
+
+**Phase A (instrumentation, WP-E)** : code écrit et vérifié en local (table `api_usage_events`, recorder best-effort sur les 6 call sites Mistral/Brave, résumé run digest, sonde pool périodique + métrique idle-tx). Migration `au01_api_usage_events` (down_revision `gr02_grille_featured_article`).
+
+> ⚠️ **PRÉCONDITION BLOQUANTE** : à l'écriture de ce hand-off, **`api_usage_events` n'existe PAS dans la base prod** (`ykuadtelnzavrqzbfdve`) → la PR phase A **n'est pas encore mergée/déployée** sur l'env qui sert cette base. **Sans elle, pas de données live pour gouverner WP-A/WP-D.** Donc :
+
+---
+
+## 2. Étape 0 — Faire atterrir la donnée (gate de tout le reste)
+
+1. **Merger + déployer phase A** (PR « Observabilité scaling ») sur l'env cible. Attention au split env (`main` = staging continu, `production` = branche hebdo — cf. mémoire env split) : l'instrumentation doit tourner là où tu veux mesurer. Vérifie que `alembic upgrade head` au boot Railway crée bien `api_usage_events` (le `Dockerfile` rejoue la chaîne).
+2. **Laisser collecter** (≥ 48 h idéalement, dont ≥ 1 cycle digest + ≥ 1 weekend si possible) avant de décider.
+3. **Vérifier le flux** : `SELECT provider, model, count(*) FROM api_usage_events GROUP BY 1,2;` doit renvoyer des lignes (Mistral 4 call_sites système + veille, Brave). Confirme aussi que `digest_run_summary` apparaît dans les logs et que la sonde pool émet.
+
+> Si pour une raison X phase A ne peut pas être déployée maintenant, tu **retombes sur le baseline read-only** (2026-06-04) + une nouvelle passe `execute_sql` ; mais alors WP-D (coût Mistral réel) reste estimé, pas mesuré — signale-le explicitement.
+
+---
+
+## 3. Étape 1 — Confirmer les goulots structurels avec la donnée
+
+Avant toute remédiation, **chiffre** les 3 hypothèses structurelles avec les sources désormais disponibles. Ne code rien tant que le goulot n'est pas confirmé.
+
+| Hypothèse structurelle | Évidence à produire | Sources |
+|------------------------|---------------------|---------|
+| **G1 — Connexions DB fragiles** : pool 20 + pooler 60, contention cron↔API, idle-in-tx | Pic `checked_out`/`overflow` (sonde pool phase A) pendant 07:30–08:15 vs reste de journée ; fréquence/volume `IdleInTransactionSessionTimeout` + sessions tuées par le sweeper ; N+1 chauds | sonde pool (logs/Sentry), Sentry projet `python`, `pg_stat_activity` |
+| **G2 — Process unique sature** : API + APScheduler + worker classif dans 1 `uvicorn` | Corrélation latence API ↔ fenêtres cron/worker (CPU/pool) ; durée run digest vs charge ; les 2 runs à ~46 min du baseline | Railway métriques, `digest_run_summary`, `digest_generation_state` |
+| **G3 — Coût Mistral non gouverné** : classif+éditorial hors cap, serene ~50 % | `api_usage_events` : appels/jour par provider/model/call_site → projeter ×2,25 (200 users) + croissance contenu ; mois où ça croise le plan tarifaire | `api_usage_events` (phase A) |
+
+Annexe rapide (déjà connue, à re-confirmer) : **G4 RSS** 278 sources vs fenêtre 30 min (worst case ~28 min) ; **G5 stockage** `daily_digest` TOAST `O(users×jours)`, `classification_queue` 26 MB d'index, index mort `ix_user_content_status_exclusion`.
+
+---
+
+## 4. Étape 2 — Slate structurel priorisé (livrer 2-3 PRs fondatrices)
+
+Chaque PR = brief autonome. **Ordre recommandé** (mais ré-arbitre selon ce que la donnée montre — la plus forte évidence passe devant). Préférence PO : **PRs cohérentes peu nombreuses**, réutiliser l'existant.
+
+### PR-S1 — Robustesse des connexions DB *(fondation #1, dépend de G1)*
+- **But** : garantir que le pool ne s'épuise jamais sous charge cron+API à 200, et éliminer les idle-in-transaction.
+- **Actions candidates** (choisir selon évidence, du moins au plus risqué) : (a) **corriger la cause racine des idle-in-tx** (sessions long-vécues / commit manquant sur un chemin worker — le sweeper n'est qu'un pansement) ; (b) right-size `pool_size`/`max_overflow` (`database.py:45-50`) avec marge mesurée ; (c) évaluer le **mode pooler Supabase transaction (PgBouncer)** pour les chemins background afin de ne pas concurrencer le pool requête ; (d) traiter les N+1 chauds.
+- **Impact** : élevé, fondamental (toute montée en charge dépend du pool). **Risque** : zone Infra/DB → lire les safety guardrails, tester `/api/health/pool` avant/après, rollback = revert config (pas de DDL si possible).
+- **Acceptation** : zéro `IdleInTransactionSessionTimeout` sur 48 h post-deploy ; pic `usage_pct` pool < seuil d'alerte pendant le cron ; marge connexions chiffrée à 200/1k.
+
+### PR-S2 — Découpler le worker/scheduler du process API *(fondation #2, dépend de G2)*
+- **But** : sortir APScheduler + worker classification du `uvicorn` qui sert les requêtes (`Procfile` = 1 process aujourd'hui) → supprime la contention CPU/pool requête↔background et permet un scaling indépendant.
+- **Actions candidates** : séparer en un **second service Railway** (ou un process worker dédié) ; commencer minimal (déplacer d'abord le worker classification, le plus gourmand `O(articles)`), garder le scheduler digest là où la fenêtre est sûre. Attention idempotence (un seul scheduler actif — pas de double-cron).
+- **Impact** : élevé structurellement. **Risque** : Infra (Railway topology, cf. mémoire `project_railway_topology`), déploiement, double-exécution cron. Staging d'abord.
+- **Acceptation** : background et API sur des process distincts ; aucune double-génération digest ; latence API décorrélée des fenêtres cron/worker.
+
+### PR-S3 — Gouvernance coût/quota Mistral *(fort impact, dépend de G3 + phase A)*
+- **But** : empêcher que ×2,25 users (+ croissance contenu, serene ~50 %) ne fasse exploser silencieusement le coût/quota Mistral (classif+éditorial aujourd'hui **non plafonnés**).
+- **Actions candidates** : budget mensuel **persistant** (dérivé de `api_usage_events`, pas un compteur mémoire) + **backpressure** gracieux (dégrader pass 2 good_news avant pass 1, ou throttler) quand on approche le plan ; remplacer les globals `_brave/_mistral_calls_month` (`smart_source_search.py:40-41`) par la source persistée — c'était **explicitement reporté** par la PR phase A.
+- **Impact** : élevé sur la robustesse *coût*. **Risque** : changement de comportement (dégradation) → gate par flag, mesurer l'impact qualité.
+- **Acceptation** : conso projetée à 200 chiffrée ; backpressure testé ; plus aucun chemin Mistral non compté.
+
+### Fast-follows (si la donnée les priorise, sinon phase 3)
+- **G4 RSS headroom** : mesurer la latence réelle/feed ; ajuster `Semaphore(5)`/intervalle/timeout (`sync_service.py`) ou sharder ; health par feed.
+- **G5 maîtrise stockage** : trim/compression du jsonb `daily_digest.items` ou raccourcir la rétention refs 90 j ; purge `classification_queue` (lignes `completed`) ; **DROP `ix_user_content_status_exclusion`** (le planner ne l'utilise pas — cf. EXPLAIN baseline §3). Migrations additives/non destructives, 1 head, testées DB vide.
+
+---
+
+## 5. Contraintes non négociables (CLAUDE.md)
+- PR **toujours `--base main`** (staging déprécié, hook bloquant). Une story/maintenance doc par PR avant de coder ; **STOP pour GO** sur le plan.
+- **Alembic** = seule source du schéma : `--autogenerate`, exactement **1 head**, test `upgrade`+`downgrade` sur **DB vide** (le `Dockerfile` rejoue la chaîne au boot → migration cassée = déploiement planté). Zéro SQL manuel Supabase.
+- Zones **Auth/Router/DB/Infra** → lire les safety guardrails **avant** modif. PR-S1/S2 touchent DB/Infra : prudence maximale, staging d'abord, rollback prêt.
+- Python 3.12, types natifs (`list[]`/`X | None`), pas d'em-dash dans la copy user-facing.
+- Conclure chaque PR par **`/go`** (VERIFY → simplify → PR vers `main`, STOP à « PR #XX prête »). Pas de `--no-verify`, pas de force-push sur main.
+- **Une seule action structurelle par PR**, mesurée isolément ; re-mesurer après deploy avant d'enchaîner la suivante.
+
+## 6. Definition of done (phase 2)
+- [ ] Phase A déployée, `api_usage_events` alimentée, données minées (§2-3).
+- [ ] G1/G2/G3 confirmés ou infirmés avec chiffres (pas d'action sur une hypothèse non confirmée).
+- [ ] 2-3 PRs structurelles livrées, chacune data-gated, sûre, réversible, re-mesurée post-deploy.
+- [ ] Baseline mis à jour (`baseline-<date>.md`) montrant la tendance avant/après.
+- [ ] Restitution PO : ce qui a été rendu robuste, marge gagnée à 200/1k, et ce qui reste pour phase 3.
+
+## 7. Références
+Baseline · Master investigation (WP-A→E) · Maintenance observabilité (phase A) · Mémoires : env split staging/prod, Railway topology, backend test DB local, CI backend-only.

--- a/docs/scaling/phase-3-launch-readiness-handoff.md
+++ b/docs/scaling/phase-3-launch-readiness-handoff.md
@@ -1,0 +1,110 @@
+# Hand-off — Phase 3 : Launch readiness (release stores ~J-14)
+
+> **À copier comme prompt de lancement d'un agent dédié.** Auto-portant.
+> **Prérequis lecture** : [`scaling-investigation-200-users.md`](scaling-investigation-200-users.md), [`baseline-2026-06-04.md`](baseline-2026-06-04.md), [`phase-2-structural-handoff.md`](phase-2-structural-handoff.md), [`../maintenance/maintenance-observabilite-scaling.md`](../maintenance/maintenance-observabilite-scaling.md).
+
+---
+
+## 0. Mission
+
+L'app **sort sur les stores dans ~2 semaines**. Objectif : garantir que **tout fonctionne parfaitement le jour J et les jours suivants**, sous la vague d'utilisateurs du lancement, **sans faire exploser les coûts (Mistral en premier lieu)**.
+
+Ce n'est plus de l'investigation ni du structurel : c'est de la **préparation opérationnelle de lancement** (load validation, plafonds de coût, runbook, kill-switches, game-day). Programme **time-boxé J-14 → J-0 → J+7**. Tu valides par la mesure et la répétition, pas par l'extrapolation.
+
+---
+
+## 1. État au démarrage (mesuré le 2026-06-26)
+
+Phases 1 (cadrage), A (instrumentation) et 2 (structurel : robustesse pool, découplage worker, gouvernance coût Mistral) **livrées et en prod depuis ~2 semaines**. Données live disponibles dans `api_usage_events`.
+
+- **107 users** actifs (89 il y a 3 semaines) · **309 sources actives** (278) · **~2 400 articles/jour**.
+- `api_usage_events` alimentée (13 j de données réelles) → la gouvernance coût est mesurable.
+
+---
+
+## 2. ⭐ La vérité coût Mistral (donnée réelle — à mettre au centre)
+
+> **Mesure 13 jours (2026-06-13 → 06-26), 107 users.** Le coût Mistral est **`O(contenu)`, PAS `O(users)`.**
+
+| call_site | modèle | ~appels/jour | couplage |
+|-----------|--------|-------------:|----------|
+| `classification_pass1` | mistral-small | **~2 250** | `O(articles)` |
+| `good_news_pass2` | **mistral-large** | **~315** | `O(articles serene)` (~50 % du FR) |
+| `editorial` | mistral-large | ~71 | `O(1)/jour` (global) |
+| `editorial` | mistral-small | ~58 | `O(1)/jour` |
+| `editorial` | mistral-medium | ~37 (arrêté après 06-21) | `O(1)/jour` |
+| `veille_suggester` | mistral-medium | ~0–4 | `O(actions user)` |
+| `smart_search_brave` (Brave) | — | ~1 | `O(actions user)` |
+
+**Total ≈ 2 637 appels/jour (~79 000/mois), dont ~372 large/jour.**
+
+**Conséquences directes pour le lancement (à exploiter dans le plan) :**
+1. **Une vague d'users ne fait PAS exploser le coût Mistral.** Sur la fenêtre, users **+20 % (89→107)** mais Mistral **plat** (~2 637/j) → le coût suit le **volume de contenu**, pas le nombre d'users. Les call_sites couplés aux users (`veille`, `smart_search`) sont **négligeables** (~1–4/jour).
+2. **Le vrai levier coût au lancement = croissance contenu/sources** (si les nouveaux users ajoutent des sources → plus d'articles → plus de classif) **+ le pass `good_news` large** (~50 % du FR). C'est là qu'il faut un plafond et un frein.
+3. **Gaspillage identifié** : `editorial` mistral-**large** a **28 % d'erreurs (267/942)** → coût brûlé + qualité digest dégradée. À corriger avant J.
+4. **Trou de données** : `api_usage_events` compte les **appels**, pas les **tokens** → le **coût € exact** nécessite le dashboard de facturation Mistral. Le croiser est un prérequis du modèle de coût (LR-1).
+5. **Brave** : ~1 appel/jour, marge totale, non sujet.
+
+---
+
+## 3. Work-packages launch readiness
+
+> Préférence PO : **PRs cohérentes peu nombreuses**, réutiliser l'existant (instrumentation phase A, sonde pool, kill-switch `usage_tracking_enabled`). Chaque WP = brief autonome. `/go` pour conclure toute PR, `--base main`.
+
+### LR-1 — Plafond de coût & protection anti-emballement (Mistral) *(priorité #1, c'est l'angoisse PO)*
+- **But** : rendre **impossible** un dépassement de budget Mistral au lancement, avec **dégradation gracieuse** plutôt que panne ou facture.
+- **Actions** : (a) **vérifier que la gouvernance coût de phase 2 (PR-S3) plafonne réellement** classif+éditorial (pas seulement la veille) ; (b) **plafond mensuel € dur** dérivé de `api_usage_events` × tarif Mistral (croiser le dashboard facturation pour le €/appel par modèle) ; (c) **awareness du rate-limit *par minute*** Mistral, pas que mensuel (un burst de classif peut throttler) ; (d) **ordre de dégradation** défini et testé : couper `good_news_pass2` (large) puis `editorial` **avant** `classification_pass1` ; **ne JAMAIS** faire échouer l'onboarding ni la génération digest ; (e) **corriger les 28 % d'erreurs `editorial`-large** (retries/backoff/timeout) ; (f) **frein sur l'onboarding de sources user** pour borner la croissance contenu (le vrai levier coût).
+- **Acceptation** : simuler l'atteinte du cap → l'app **dégrade, ne casse pas** ; coût projeté du mois de lancement < budget PO ; erreurs editorial < 5 %.
+
+### LR-2 — Validation de charge (valider, ne plus extrapoler)
+- **But** : prouver que les correctifs structurels de phase 2 (pool, découplage worker) **tiennent réellement** la concurrence du lancement — phase 1 n'a fait qu'extrapoler.
+- **Actions** : test de charge synthétique sur **staging** (= `main`, cf. env split) aux concurrences cibles J-day, sur les **vrais hot paths du lancement** : (1) **flood onboarding** (signup → 1er digest → smart-source-search) ; (2) **cold-open** de l'app (cf. correctif +10 s déjà livré — vérifier qu'il tient sous charge) ; (3) **tempête de refresh JWT** ; (4) `feed`/`digest`/`perspectives` en concurrence ; (5) **cron digest** pendant un pic de trafic API (contention pool).
+- **Acceptation** : latence pNN < cible à Nx concurrence ; **pool jamais saturé**, **zéro `IdleInTransactionSessionTimeout`** sous charge ; le cron digest ne dégrade pas l'API.
+
+### LR-3 — Pré-provisionnement quotas & capacité externe
+- **But** : aucune limite externe atteinte par surprise le jour J.
+- **Actions** : confirmer/relever avant J-0 — **plan Mistral** (quota mensuel **+ rate/min**), **pooler Supabase** (limite connexions, mode transaction), **Railway** (taille instance, scaling du/des service(s) après découplage worker, cf. topologie prod = service WEB `facteur-production`), **quota d'events Sentry/PostHog** (la vague va multiplier les events → risque de drop/coût), **token GitHub backend** (l'`/app/update` renvoie 502 si le token est expiré → MAJ Android invisibles : **rotation avant lancement**).
+- **Acceptation** : chaque dépendance externe a une marge chiffrée > pic projeté ; secrets/quotas validés par healthcheck.
+
+### LR-4 — Runbook jour J & war-room
+- **But** : exécution sereine le jour J avec leviers prêts.
+- **Actions** : (a) **dashboards à surveiller** : coût/volume Mistral (`api_usage_events`), pool `usage_pct`, couverture digest (`digest_run_summary`), taux d'erreur (Sentry), DAU/onboarding (PostHog) ; (b) **inventaire des kill-switches** et leur effet : `usage_tracking_enabled`, fallback Mistral smart-search, throttle classification, désactivation editorial, nudges (`app_config.nudges_enabled`) ; (c) **leviers de rollback** (revert config sans redeploy schéma, `alembic downgrade`, weekly-release prod) ; (d) **gate Go/No-Go** (§5) ; (e) **coordination client/stores** : version gate (`app_config` iOS + In-App Updates Android), timing de publication store, capacité à pousser un kill-switch **sans** release binaire.
+- **Acceptation** : runbook 1 page, chaque alerte → action + owner ; tous les kill-switches testés en staging.
+
+### LR-5 — Modes de défaillance & game-day
+- **But** : connaître et répéter le comportement sous panne **avant** le jour J.
+- **Actions** : **répétition game-day en staging** des scénarios : Mistral rate-limited / cap budget atteint en plein lancement ; pool DB saturé ; un feed RSS qui flood ; pic d'onboarding x10. Vérifier : onboarding **ne hard-fail jamais** ; digest **génère sans editorial LLM** (fallback scoring) ; messages user gracieux (pas d'em-dash dans la copy user-facing).
+- **Acceptation** : chaque scénario a un comportement observé documenté + dégradation gracieuse confirmée.
+
+### LR-6 — Veille J+1 → J+7 (charge soutenue, pas que le pic)
+- **But** : tenir dans la durée, pas seulement au pic d'install.
+- **Actions** : suivre la **vague de rétention** (digest quotidien à user-count croissant), la **tendance coût** Mistral (croît-elle avec le contenu ?), la **croissance stockage** (`daily_digest` TOAST `O(users×jours)`), le **backlog** `classification_queue`. Mettre à jour `baseline-<date>.md` (avant/après lancement).
+- **Acceptation** : aucune dérive non détectée sur 7 j ; coût et latence dans les cibles.
+
+---
+
+## 4. Timeline indicative
+
+| Fenêtre | Focus |
+|---------|-------|
+| **J-14 → J-9** | LR-1 (plafond coût + fix editorial 28 %), LR-3 (quotas externes) |
+| **J-9 → J-5** | LR-2 (load test staging), LR-5 (game-day) |
+| **J-5 → J-2** | LR-4 (runbook + kill-switches testés), gel des changements risqués |
+| **J-2 → J-0** | Gate Go/No-Go, rotation secrets, version gate prêt |
+| **J-0 → J+7** | War-room puis LR-6 (veille soutenue) |
+
+## 5. Gate Go / No-Go (jour J)
+- [ ] Plafond coût Mistral **dur + dégradation gracieuse** prouvés (LR-1) ; erreurs editorial < 5 %.
+- [ ] Load test passé aux concurrences cibles ; pool stable, zéro idle-in-tx (LR-2).
+- [ ] Quotas externes (Mistral rate/min + mensuel, Supabase, Railway, Sentry/PostHog, token GitHub) avec marge (LR-3).
+- [ ] Runbook + kill-switches testés ; rollback prêt ; version gate opérationnel (LR-4).
+- [ ] Game-day rejoué : onboarding/digest dégradent sans casser (LR-5).
+- [ ] Baseline pré-lancement figée pour comparaison.
+
+## 6. Contraintes (CLAUDE.md) & philosophie
+- **`--base main`** toujours, Alembic 1-head + test DB vide, safety guardrails (DB/Infra). `/go` pour conclure.
+- **Réversibilité d'abord** : tout levier de lancement doit s'activer **sans redeploy binaire** (kill-switch config / `app_config`), car un binaire store met des jours à se propager.
+- **Right-size** : viser la robustesse au pic de lancement réaliste, pas 10k. Mesurer, ne pas deviner.
+
+## 7. Références & mémoires utiles
+Baseline · Master investigation · Phase 2 structurel · Mémoires : cold-open +10 s, token GitHub MAJ Android (502), version gate iOS/Android, Railway topology (prod = WEB `facteur-production`), env split staging/prod, digest quasi-global cluster-gated, CI backend-only, test DB local, pas d'em-dash copy user.

--- a/packages/api/alembic/versions/au02_api_usage_tokens.py
+++ b/packages/api/alembic/versions/au02_api_usage_tokens.py
@@ -1,0 +1,38 @@
+"""api_usage_events — capture des tokens prompt/completion (LR-1 PR 1)
+
+Migration **additive** : ajoute `prompt_tokens` et `completion_tokens` (int,
+nullable) à `api_usage_events`. Les réponses Mistral renvoient déjà
+`usage.{prompt_tokens, completion_tokens}` ; les persister transforme le
+compteur d'appels en modèle €/token (un `GROUP BY model` donne le € réel par
+modèle / call_site). Nullable car Brave n'a pas de tokens et un appel échoué
+avant réponse n'en a pas non plus. Non destructif, rollback trivial.
+
+Head précédent : sec02_new_public_rls (head courant de main). Après : 1 seul
+head (au02). `api_usage_events` a été introduite par au01, mais on chaîne sur le
+head courant pour ne pas créer un 2e head (au01 a déjà des descendants).
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "au02_api_usage_tokens"
+down_revision: str | None = "sec02_new_public_rls"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "api_usage_events",
+        sa.Column("prompt_tokens", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "api_usage_events",
+        sa.Column("completion_tokens", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("api_usage_events", "completion_tokens")
+    op.drop_column("api_usage_events", "prompt_tokens")

--- a/packages/api/app/config.py
+++ b/packages/api/app/config.py
@@ -146,6 +146,16 @@ class Settings(BaseSettings):
     # lus depuis api_usage_events (persistant). TTL du cache du COUNT mensuel.
     cost_budget_cache_ttl_s: int = 120
 
+    # Mistral rate limiting (LR-1 PR 1) — borne le burst éditorial qui causait
+    # ~28 % de 429 (curation + deep_matcher + perspective fan-out non bornés sur
+    # le modèle large). Token-bucket /minute + cap de concurrence, partagés au
+    # niveau process, appliqués aux seuls appels `large`. Les défauts sont
+    # conservateurs (à affiner via LR-3 selon le plan Mistral) et configurables
+    # sans redéploiement de code.
+    mistral_rate_limit_enabled: bool = True  # kill-switch throttle large
+    mistral_large_rpm: int = 60  # requêtes large/minute (token-bucket)
+    mistral_large_concurrency: int = 4  # appels large simultanés (semaphore)
+
     # GitHub (app update feature)
     github_token: str = ""
     github_repo: str = "boujonlaurin-dotcom/facteur"

--- a/packages/api/app/models/api_usage_event.py
+++ b/packages/api/app/models/api_usage_event.py
@@ -26,6 +26,9 @@ class ApiUsageEvent(Base):
     `user_id` null = appel système (classification / éditorial / digest).
     `model` null = provider sans notion de modèle (Brave).
     `status` ∈ {ok, error, rate_limited}.
+    `prompt_tokens` / `completion_tokens` null = provider sans usage tokens
+    (Brave) ou appel échoué avant réponse — sinon issus de `usage` Mistral
+    (LR-1 PR 1 : permet un `GROUP BY model` qui donne le € réel par modèle).
     """
 
     __tablename__ = "api_usage_events"
@@ -39,6 +42,8 @@ class ApiUsageEvent(Base):
     user_id: Mapped[UUID | None] = mapped_column(PGUUID(as_uuid=True), nullable=True)
     status: Mapped[str] = mapped_column(String(16), nullable=False, default="ok")
     latency_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    prompt_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    completion_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=datetime.utcnow, nullable=False
     )

--- a/packages/api/app/services/editorial/llm_client.py
+++ b/packages/api/app/services/editorial/llm_client.py
@@ -14,11 +14,15 @@ import structlog
 
 from app.config import get_settings
 from app.services.editorial.rate_limiter import _MistralRateLimiter
-from app.services.observability.usage_recorder import track_api_call
+from app.services.observability.usage_recorder import _ApiCallTracker, track_api_call
 
 logger = structlog.get_logger()
 
 MISTRAL_API_URL = "https://api.mistral.ai/v1/chat/completions"
+
+# Politique de retry partagée par chat_json / chat_text (LR-1 PR 1).
+_MISTRAL_RETRYABLE_STATUSES = (429, 500, 502, 503)
+_MISTRAL_MAX_RETRIES = 2
 
 
 # Limiteur partagé au niveau process (LR-1 PR 1). `EditorialLLMClient` étant
@@ -46,7 +50,15 @@ def _reset_large_limiter() -> None:
 
 
 def _is_large_model(model: str | None) -> bool:
-    """True pour les modèles `large` (les seuls bursty / rate-limited)."""
+    """True pour les modèles Mistral `large` (`mistral-large-*`).
+
+    Le throttle ne cible que les appels `large` passant par `EditorialLLMClient`
+    (curation + deep + perspective) : c'est la source dominante et *mesurée* des
+    429 (cf. docstring du module rate_limiter). `good_news_classifier` appelle
+    aussi un modèle `large`, mais via son propre client et en un seul appel
+    batché par lot (burst négligeable) — hors scope de ce throttle pour LR-1
+    PR 1 ; il pourra rejoindre un limiteur partagé en LR-3/PR 4.
+    """
     return bool(model and "large" in model.lower())
 
 
@@ -96,6 +108,77 @@ class EditorialLLMClient:
                 return await client.post(MISTRAL_API_URL, json=payload)
         return await client.post(MISTRAL_API_URL, json=payload)
 
+    async def _post_with_retry(
+        self,
+        payload: dict,
+        model: str,
+        tracker: _ApiCallTracker,
+        *,
+        event_prefix: str,
+        unexpected_event: str,
+    ) -> tuple[httpx.Response, int] | None:
+        """POST + retry/backoff partagé par chat_json et chat_text (LR-1 PR 1).
+
+        Renvoie `(réponse, n° de tentative)` au premier HTTP 2xx, ou `None` quand
+        les retries sont épuisés / erreur non-retryable / timeout / exception
+        inattendue. Pose `tracker.status = "rate_limited"` sur 429. Le parsing de
+        la réponse, la capture des tokens, le log de succès et `status = "ok"`
+        restent côté appelant : les deux méthodes ont des formes de réponse
+        différentes, et un 200 au corps illisible doit rester un échec (le statut
+        ne passe `ok` qu'après un parse réussi).
+
+        Retryable : 429/500/502/503 + timeout, backoff 3s puis 6s. Les noms
+        d'évènements de log diffèrent entre les deux méthodes (clés
+        d'observabilité existantes) et sont donc paramétrés.
+        """
+        for attempt in range(_MISTRAL_MAX_RETRIES + 1):
+            try:
+                response = await self._do_post(payload, model)
+                response.raise_for_status()
+                return response, attempt
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 429:
+                    tracker.status = "rate_limited"
+                if (
+                    e.response.status_code in _MISTRAL_RETRYABLE_STATUSES
+                    and attempt < _MISTRAL_MAX_RETRIES
+                ):
+                    wait = 3 * (attempt + 1)  # 3s, 6s
+                    logger.warning(
+                        f"editorial_llm.{event_prefix}retrying",
+                        attempt=attempt + 1,
+                        wait_s=wait,
+                        status_code=e.response.status_code,
+                    )
+                    await asyncio.sleep(wait)
+                    continue
+                logger.error(
+                    "editorial_llm.http_error",
+                    status_code=e.response.status_code,
+                    body=e.response.text[:500],
+                    attempts_exhausted=attempt + 1,
+                )
+                return None
+            except httpx.TimeoutException:
+                if attempt < _MISTRAL_MAX_RETRIES:
+                    wait = 3 * (attempt + 1)
+                    logger.warning(
+                        f"editorial_llm.{event_prefix}timeout_retrying",
+                        attempt=attempt + 1,
+                        wait_s=wait,
+                    )
+                    await asyncio.sleep(wait)
+                    continue
+                logger.error(
+                    f"editorial_llm.{event_prefix}timeout_exhausted",
+                    attempts_exhausted=attempt + 1,
+                )
+                return None
+            except Exception as e:
+                logger.error(unexpected_event, error=str(e))
+                return None
+        return None
+
     async def chat_json(
         self,
         system: str,
@@ -130,93 +213,57 @@ class EditorialLLMClient:
             ],
         }
 
-        _RETRYABLE_STATUSES = (429, 500, 502, 503)
-        max_retries = 2
-
         async with track_api_call("mistral", call_site, model=model) as _call:
-            for attempt in range(max_retries + 1):
-                try:
-                    response = await self._do_post(payload, model)
-                    response.raise_for_status()
+            result = await self._post_with_retry(
+                payload,
+                model,
+                _call,
+                event_prefix="",
+                unexpected_event="editorial_llm.unexpected_error",
+            )
+            if result is None:
+                return None
+            response, attempt = result
 
-                    data = response.json()
-                    usage = data.get("usage") or {}
-                    _call.prompt_tokens = usage.get("prompt_tokens")
-                    _call.completion_tokens = usage.get("completion_tokens")
-                    text = data["choices"][0]["message"]["content"]
+            try:
+                data = response.json()
+                usage = data.get("usage") or {}
+                _call.prompt_tokens = usage.get("prompt_tokens")
+                _call.completion_tokens = usage.get("completion_tokens")
+                text = data["choices"][0]["message"]["content"]
 
-                    # Strip markdown code fences if present
+                # Strip markdown code fences if present
+                text = text.strip()
+                if text.startswith("```"):
+                    lines = text.split("\n")
+                    text = "\n".join(
+                        lines[1:-1] if lines[-1].strip() == "```" else lines[1:]
+                    )
                     text = text.strip()
-                    if text.startswith("```"):
-                        lines = text.split("\n")
-                        text = "\n".join(
-                            lines[1:-1] if lines[-1].strip() == "```" else lines[1:]
-                        )
-                        text = text.strip()
 
-                    parsed = json.loads(text)
+                parsed = json.loads(text)
 
-                    logger.info(
-                        "editorial_llm.success",
-                        model=model,
-                        attempt=attempt + 1,
-                        prompt_tokens=usage.get("prompt_tokens"),
-                        completion_tokens=usage.get("completion_tokens"),
-                    )
-                    _call.status = "ok"
-                    return parsed
+                logger.info(
+                    "editorial_llm.success",
+                    model=model,
+                    attempt=attempt + 1,
+                    prompt_tokens=usage.get("prompt_tokens"),
+                    completion_tokens=usage.get("completion_tokens"),
+                )
+                _call.status = "ok"
+                return parsed
 
-                except httpx.HTTPStatusError as e:
-                    if e.response.status_code == 429:
-                        _call.status = "rate_limited"
-                    if (
-                        e.response.status_code in _RETRYABLE_STATUSES
-                        and attempt < max_retries
-                    ):
-                        wait = 3 * (attempt + 1)  # 3s, 6s
-                        logger.warning(
-                            "editorial_llm.retrying",
-                            attempt=attempt + 1,
-                            wait_s=wait,
-                            status_code=e.response.status_code,
-                        )
-                        await asyncio.sleep(wait)
-                        continue
-                    logger.error(
-                        "editorial_llm.http_error",
-                        status_code=e.response.status_code,
-                        body=e.response.text[:500],
-                        attempts_exhausted=attempt + 1,
-                    )
-                    return None
-                except httpx.TimeoutException:
-                    if attempt < max_retries:
-                        wait = 3 * (attempt + 1)
-                        logger.warning(
-                            "editorial_llm.timeout_retrying",
-                            attempt=attempt + 1,
-                            wait_s=wait,
-                        )
-                        await asyncio.sleep(wait)
-                        continue
-                    logger.error(
-                        "editorial_llm.timeout_exhausted",
-                        attempts_exhausted=attempt + 1,
-                    )
-                    return None
-                except json.JSONDecodeError as e:
-                    # No retry for parse errors — LLM returned bad JSON
-                    logger.error(
-                        "editorial_llm.json_parse_error",
-                        error=str(e),
-                        raw_text=text[:500] if "text" in dir() else "no_text",
-                    )
-                    return None
-                except Exception as e:
-                    logger.error("editorial_llm.unexpected_error", error=str(e))
-                    return None
-
-            return None
+            except json.JSONDecodeError as e:
+                # No retry for parse errors — LLM returned bad JSON
+                logger.error(
+                    "editorial_llm.json_parse_error",
+                    error=str(e),
+                    raw_text=text[:500] if "text" in dir() else "no_text",
+                )
+                return None
+            except Exception as e:
+                logger.error("editorial_llm.unexpected_error", error=str(e))
+                return None
 
     async def chat_text(
         self,
@@ -247,74 +294,38 @@ class EditorialLLMClient:
             ],
         }
 
-        _RETRYABLE_STATUSES = (429, 500, 502, 503)
-        max_retries = 2
-
         async with track_api_call("mistral", call_site, model=model) as _call:
-            for attempt in range(max_retries + 1):
-                try:
-                    response = await self._do_post(payload, model)
-                    response.raise_for_status()
+            result = await self._post_with_retry(
+                payload,
+                model,
+                _call,
+                event_prefix="chat_text_",
+                unexpected_event="editorial_llm.chat_text_error",
+            )
+            if result is None:
+                return None
+            response, attempt = result
 
-                    data = response.json()
-                    usage = data.get("usage") or {}
-                    _call.prompt_tokens = usage.get("prompt_tokens")
-                    _call.completion_tokens = usage.get("completion_tokens")
-                    text = data["choices"][0]["message"]["content"].strip()
+            try:
+                data = response.json()
+                usage = data.get("usage") or {}
+                _call.prompt_tokens = usage.get("prompt_tokens")
+                _call.completion_tokens = usage.get("completion_tokens")
+                text = data["choices"][0]["message"]["content"].strip()
 
-                    logger.info(
-                        "editorial_llm.chat_text_success",
-                        model=model,
-                        attempt=attempt + 1,
-                        prompt_tokens=usage.get("prompt_tokens"),
-                        completion_tokens=usage.get("completion_tokens"),
-                    )
-                    _call.status = "ok"
-                    return text
+                logger.info(
+                    "editorial_llm.chat_text_success",
+                    model=model,
+                    attempt=attempt + 1,
+                    prompt_tokens=usage.get("prompt_tokens"),
+                    completion_tokens=usage.get("completion_tokens"),
+                )
+                _call.status = "ok"
+                return text
 
-                except httpx.HTTPStatusError as e:
-                    if e.response.status_code == 429:
-                        _call.status = "rate_limited"
-                    if (
-                        e.response.status_code in _RETRYABLE_STATUSES
-                        and attempt < max_retries
-                    ):
-                        wait = 3 * (attempt + 1)  # 3s, 6s
-                        logger.warning(
-                            "editorial_llm.chat_text_retrying",
-                            attempt=attempt + 1,
-                            wait_s=wait,
-                            status_code=e.response.status_code,
-                        )
-                        await asyncio.sleep(wait)
-                        continue
-                    logger.error(
-                        "editorial_llm.http_error",
-                        status_code=e.response.status_code,
-                        body=e.response.text[:500],
-                        attempts_exhausted=attempt + 1,
-                    )
-                    return None
-                except httpx.TimeoutException:
-                    if attempt < max_retries:
-                        wait = 3 * (attempt + 1)
-                        logger.warning(
-                            "editorial_llm.chat_text_timeout_retrying",
-                            attempt=attempt + 1,
-                            wait_s=wait,
-                        )
-                        await asyncio.sleep(wait)
-                        continue
-                    logger.error(
-                        "editorial_llm.chat_text_timeout_exhausted",
-                        attempts_exhausted=attempt + 1,
-                    )
-                    return None
-                except Exception as e:
-                    logger.error("editorial_llm.chat_text_error", error=str(e))
-                    return None
-
-            return None
+            except Exception as e:
+                logger.error("editorial_llm.chat_text_error", error=str(e))
+                return None
 
     async def close(self) -> None:
         """Close the underlying httpx client."""

--- a/packages/api/app/services/editorial/llm_client.py
+++ b/packages/api/app/services/editorial/llm_client.py
@@ -13,11 +13,41 @@ import httpx
 import structlog
 
 from app.config import get_settings
+from app.services.editorial.rate_limiter import _MistralRateLimiter
 from app.services.observability.usage_recorder import track_api_call
 
 logger = structlog.get_logger()
 
 MISTRAL_API_URL = "https://api.mistral.ai/v1/chat/completions"
+
+
+# Limiteur partagé au niveau process (LR-1 PR 1). `EditorialLLMClient` étant
+# instancié par appelant, un limiteur par instance ne bornerait pas l'agrégat
+# du burst quotidien — il doit être un singleton module. Construit paresseusement
+# pour lire les settings courants (et être recréable en test via _reset).
+_large_limiter: _MistralRateLimiter | None = None
+
+
+def _get_large_limiter() -> _MistralRateLimiter:
+    global _large_limiter
+    if _large_limiter is None:
+        settings = get_settings()
+        _large_limiter = _MistralRateLimiter(
+            rpm=settings.mistral_large_rpm,
+            concurrency=settings.mistral_large_concurrency,
+        )
+    return _large_limiter
+
+
+def _reset_large_limiter() -> None:
+    """Réinitialise le singleton (hook de test : bucket plein à chaque cas)."""
+    global _large_limiter
+    _large_limiter = None
+
+
+def _is_large_model(model: str | None) -> bool:
+    """True pour les modèles `large` (les seuls bursty / rate-limited)."""
+    return bool(model and "large" in model.lower())
 
 
 class EditorialLLMClient:
@@ -50,6 +80,22 @@ class EditorialLLMClient:
             )
         return self._client
 
+    async def _do_post(self, payload: dict, model: str) -> httpx.Response:
+        """POST Mistral, chokepoint unique du throttle large (LR-1 PR 1).
+
+        Les appels `large` (curation/deep/perspective, source du burst 429) sont
+        bornés par le limiteur partagé (token-bucket /minute + cap de
+        concurrence) ; les modèles non-large passent directement. Chaque
+        tentative (y compris un retry) repasse par le limiteur, donc les retries
+        respectent aussi le débit au lieu de re-burster.
+        """
+        client = self._get_client()
+        settings = get_settings()
+        if settings.mistral_rate_limit_enabled and _is_large_model(model):
+            async with _get_large_limiter().slot():
+                return await client.post(MISTRAL_API_URL, json=payload)
+        return await client.post(MISTRAL_API_URL, json=payload)
+
     async def chat_json(
         self,
         system: str,
@@ -73,7 +119,6 @@ class EditorialLLMClient:
             logger.warning("editorial_llm.not_ready")
             return None
 
-        client = self._get_client()
         payload = {
             "model": model,
             "temperature": temperature,
@@ -91,10 +136,13 @@ class EditorialLLMClient:
         async with track_api_call("mistral", call_site, model=model) as _call:
             for attempt in range(max_retries + 1):
                 try:
-                    response = await client.post(MISTRAL_API_URL, json=payload)
+                    response = await self._do_post(payload, model)
                     response.raise_for_status()
 
                     data = response.json()
+                    usage = data.get("usage") or {}
+                    _call.prompt_tokens = usage.get("prompt_tokens")
+                    _call.completion_tokens = usage.get("completion_tokens")
                     text = data["choices"][0]["message"]["content"]
 
                     # Strip markdown code fences if present
@@ -112,10 +160,8 @@ class EditorialLLMClient:
                         "editorial_llm.success",
                         model=model,
                         attempt=attempt + 1,
-                        prompt_tokens=data.get("usage", {}).get("prompt_tokens"),
-                        completion_tokens=data.get("usage", {}).get(
-                            "completion_tokens"
-                        ),
+                        prompt_tokens=usage.get("prompt_tokens"),
+                        completion_tokens=usage.get("completion_tokens"),
                     )
                     _call.status = "ok"
                     return parsed
@@ -191,7 +237,6 @@ class EditorialLLMClient:
             logger.warning("editorial_llm.not_ready")
             return None
 
-        client = self._get_client()
         payload = {
             "model": model,
             "temperature": temperature,
@@ -202,35 +247,74 @@ class EditorialLLMClient:
             ],
         }
 
+        _RETRYABLE_STATUSES = (429, 500, 502, 503)
+        max_retries = 2
+
         async with track_api_call("mistral", call_site, model=model) as _call:
-            try:
-                response = await client.post(MISTRAL_API_URL, json=payload)
-                response.raise_for_status()
+            for attempt in range(max_retries + 1):
+                try:
+                    response = await self._do_post(payload, model)
+                    response.raise_for_status()
 
-                data = response.json()
-                text = data["choices"][0]["message"]["content"].strip()
+                    data = response.json()
+                    usage = data.get("usage") or {}
+                    _call.prompt_tokens = usage.get("prompt_tokens")
+                    _call.completion_tokens = usage.get("completion_tokens")
+                    text = data["choices"][0]["message"]["content"].strip()
 
-                logger.info(
-                    "editorial_llm.chat_text_success",
-                    model=model,
-                    prompt_tokens=data.get("usage", {}).get("prompt_tokens"),
-                    completion_tokens=data.get("usage", {}).get("completion_tokens"),
-                )
-                _call.status = "ok"
-                return text
+                    logger.info(
+                        "editorial_llm.chat_text_success",
+                        model=model,
+                        attempt=attempt + 1,
+                        prompt_tokens=usage.get("prompt_tokens"),
+                        completion_tokens=usage.get("completion_tokens"),
+                    )
+                    _call.status = "ok"
+                    return text
 
-            except httpx.HTTPStatusError as e:
-                if e.response.status_code == 429:
-                    _call.status = "rate_limited"
-                logger.error(
-                    "editorial_llm.http_error",
-                    status_code=e.response.status_code,
-                    body=e.response.text[:500],
-                )
-                return None
-            except Exception as e:
-                logger.error("editorial_llm.chat_text_error", error=str(e))
-                return None
+                except httpx.HTTPStatusError as e:
+                    if e.response.status_code == 429:
+                        _call.status = "rate_limited"
+                    if (
+                        e.response.status_code in _RETRYABLE_STATUSES
+                        and attempt < max_retries
+                    ):
+                        wait = 3 * (attempt + 1)  # 3s, 6s
+                        logger.warning(
+                            "editorial_llm.chat_text_retrying",
+                            attempt=attempt + 1,
+                            wait_s=wait,
+                            status_code=e.response.status_code,
+                        )
+                        await asyncio.sleep(wait)
+                        continue
+                    logger.error(
+                        "editorial_llm.http_error",
+                        status_code=e.response.status_code,
+                        body=e.response.text[:500],
+                        attempts_exhausted=attempt + 1,
+                    )
+                    return None
+                except httpx.TimeoutException:
+                    if attempt < max_retries:
+                        wait = 3 * (attempt + 1)
+                        logger.warning(
+                            "editorial_llm.chat_text_timeout_retrying",
+                            attempt=attempt + 1,
+                            wait_s=wait,
+                        )
+                        await asyncio.sleep(wait)
+                        continue
+                    logger.error(
+                        "editorial_llm.chat_text_timeout_exhausted",
+                        attempts_exhausted=attempt + 1,
+                    )
+                    return None
+                except Exception as e:
+                    logger.error("editorial_llm.chat_text_error", error=str(e))
+                    return None
+
+            return None
 
     async def close(self) -> None:
         """Close the underlying httpx client."""

--- a/packages/api/app/services/editorial/rate_limiter.py
+++ b/packages/api/app/services/editorial/rate_limiter.py
@@ -1,0 +1,107 @@
+"""Limiteur de débit partagé pour les appels Mistral `large` (LR-1 PR 1).
+
+Le pipeline éditorial éclate des `asyncio.gather` non bornés (curation +
+deep_matcher + perspective) sur le modèle `mistral-large-latest` via un
+`EditorialLLMClient` à usage unique. Ce burst quotidien provoquait ~28 % de
+429 (201 appels rate-limited / 14 j, spécifiques à l'éditorial).
+
+`_MistralRateLimiter` borne ce burst sur **deux axes** :
+- **token-bucket /minute** (`rpm`) : lisse le débit de départ des requêtes ;
+- **semaphore** (`concurrency`) : borne le nombre d'appels HTTP simultanés.
+
+Conçu comme **singleton module** (cf. `llm_client._get_large_limiter`) parce
+que `EditorialLLMClient` est instancié par appelant : un limiteur par instance
+ne bornerait pas l'agrégat. Comme l'objet vit au niveau module, il survit aux
+changements de boucle d'événements (tests pytest-asyncio function-scoped) : la
+`Semaphore` et le `Lock` sont (re)créés à la volée quand la boucle courante
+change (`_ensure_loop_state`). L'horloge est injectable pour tester le pacing
+avec une horloge factice sans `sleep` réel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
+
+
+class _MistralRateLimiter:
+    """Token-bucket /minute + cap de concurrence, loop-safe.
+
+    `time_func` / `sleep_func` sont injectables (défaut `time.monotonic` /
+    `asyncio.sleep`) pour piloter le pacing avec une horloge factice en test.
+    """
+
+    def __init__(
+        self,
+        *,
+        rpm: int,
+        concurrency: int,
+        time_func: Callable[[], float] = time.monotonic,
+        sleep_func: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    ) -> None:
+        self._rpm = max(1, rpm)
+        self._concurrency = max(1, concurrency)
+        self._time = time_func
+        self._sleep = sleep_func
+        # Bucket démarre plein : le premier appel ne paie aucune attente.
+        self._tokens = float(self._rpm)
+        self._last_refill = self._time()
+        # (Re)créés par boucle d'événements (cf. _ensure_loop_state).
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._sem: asyncio.Semaphore | None = None
+        self._lock: asyncio.Lock | None = None
+
+    @property
+    def _refill_per_sec(self) -> float:
+        return self._rpm / 60.0
+
+    def _ensure_loop_state(self) -> None:
+        """Recrée semaphore/lock si la boucle courante a changé.
+
+        `asyncio.Semaphore`/`Lock` se lient à la boucle où ils sont utilisés
+        en premier et lèvent s'ils sont réutilisés depuis une autre boucle.
+        En prod la boucle est unique (aucun coût) ; en test chaque cas a sa
+        propre boucle, d'où la recréation paresseuse. Le bucket (compteurs
+        temporels) est, lui, agnostique à la boucle et conservé tel quel.
+        """
+        loop = asyncio.get_running_loop()
+        if self._loop is not loop or self._sem is None or self._lock is None:
+            self._loop = loop
+            self._sem = asyncio.Semaphore(self._concurrency)
+            self._lock = asyncio.Lock()
+
+    async def _consume_token(self) -> None:
+        """Attend qu'un jeton soit disponible puis le consomme.
+
+        Sérialisé par `self._lock` : la section critique contient un `await`
+        (sleep), donc sans verrou des coroutines concurrentes corrompraient le
+        compteur. Verrou tenu pendant le sleep ⇒ octroi strictement cadencé
+        (pacing FIFO), ce qui est précisément le throttle voulu.
+        """
+        assert self._lock is not None  # posé par _ensure_loop_state
+        async with self._lock:
+            while True:
+                now = self._time()
+                elapsed = now - self._last_refill
+                if elapsed > 0:
+                    self._tokens = min(
+                        float(self._rpm),
+                        self._tokens + elapsed * self._refill_per_sec,
+                    )
+                    self._last_refill = now
+                if self._tokens >= 1.0:
+                    self._tokens -= 1.0
+                    return
+                deficit = 1.0 - self._tokens
+                await self._sleep(deficit / self._refill_per_sec)
+
+    @asynccontextmanager
+    async def slot(self) -> AsyncIterator[None]:
+        """Acquiert un jeton (rpm) puis un slot de concurrence le temps du POST."""
+        self._ensure_loop_state()
+        await self._consume_token()
+        assert self._sem is not None  # posé par _ensure_loop_state
+        async with self._sem:
+            yield

--- a/packages/api/app/services/ml/classification_service.py
+++ b/packages/api/app/services/ml/classification_service.py
@@ -397,6 +397,8 @@ class ClassificationService:
                     usage = data.get("usage", {})
                     max_tokens = payload.get("max_tokens")
                     completion_tokens = usage.get("completion_tokens")
+                    _call.prompt_tokens = usage.get("prompt_tokens")
+                    _call.completion_tokens = completion_tokens
                     log.info(
                         "classification.api_usage",
                         model=payload.get("model"),

--- a/packages/api/app/services/ml/good_news_classifier.py
+++ b/packages/api/app/services/ml/good_news_classifier.py
@@ -160,8 +160,12 @@ class GoodNewsClassifier:
                 try:
                     response = await client.post(MISTRAL_API_URL, json=payload)
                     response.raise_for_status()
+                    data = response.json()
+                    usage = data.get("usage") or {}
+                    _call.prompt_tokens = usage.get("prompt_tokens")
+                    _call.completion_tokens = usage.get("completion_tokens")
                     _call.status = "ok"
-                    return response.json()
+                    return data
                 except httpx.HTTPStatusError as e:
                     status = e.response.status_code
                     if status == 429 and attempt < max_retries - 1:

--- a/packages/api/app/services/observability/usage_recorder.py
+++ b/packages/api/app/services/observability/usage_recorder.py
@@ -51,8 +51,14 @@ async def record_api_call(
     user_id: UUID | str | None = None,
     status: str = "ok",
     latency_ms: int | None = None,
+    prompt_tokens: int | None = None,
+    completion_tokens: int | None = None,
 ) -> None:
     """Persiste un appel API externe dans `api_usage_events`.
+
+    `prompt_tokens` / `completion_tokens` proviennent de `usage` Mistral quand
+    disponible (None pour Brave ou un appel échoué avant réponse) — ils donnent
+    le € réel par modèle via un `GROUP BY model` (LR-1 PR 1).
 
     Best-effort : ne lève jamais, ne bloque jamais la transaction métier
     (session courte dédiée). Désactivable d'un coup via le kill-switch
@@ -83,6 +89,8 @@ async def record_api_call(
                     user_id=uid,
                     status=status if status in _VALID_STATUSES else "ok",
                     latency_ms=latency_ms,
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
                 )
             )
             await session.commit()
@@ -96,16 +104,20 @@ async def record_api_call(
 
 
 class _ApiCallTracker:
-    """Statut mutable d'un appel suivi par `track_api_call`.
+    """État mutable d'un appel suivi par `track_api_call`.
 
     Défaut `error` : si le bloc sort sans avoir posé de statut (exception,
-    timeout, `return` précoce), l'appel est compté comme échoué.
+    timeout, `return` précoce), l'appel est compté comme échoué. Le bloc pose
+    aussi `prompt_tokens` / `completion_tokens` depuis `usage` Mistral quand la
+    réponse arrive ; ils restent None sinon (Brave, échec, provider sans usage).
     """
 
-    __slots__ = ("status",)
+    __slots__ = ("status", "prompt_tokens", "completion_tokens")
 
     def __init__(self) -> None:
         self.status = "error"
+        self.prompt_tokens: int | None = None
+        self.completion_tokens: int | None = None
 
 
 @asynccontextmanager
@@ -137,4 +149,6 @@ async def track_api_call(
             user_id=user_id,
             status=tracker.status,
             latency_ms=int((time.monotonic() - t0) * 1000),
+            prompt_tokens=tracker.prompt_tokens,
+            completion_tokens=tracker.completion_tokens,
         )

--- a/packages/api/app/services/user_interests_service.py
+++ b/packages/api/app/services/user_interests_service.py
@@ -458,9 +458,7 @@ class UserSourcesStateService:
         await self._sync_favorite_source(
             user_id=user_id, source_id=source_id, state=state, position=position
         )
-        await self._sync_muted_source(
-            user_id=user_id, source_id=source_id, state=state
-        )
+        await self._sync_muted_source(user_id=user_id, source_id=source_id, state=state)
         await self.db.commit()
         return prev_state
 

--- a/packages/api/tests/conftest.py
+++ b/packages/api/tests/conftest.py
@@ -51,6 +51,21 @@ def _reset_feed_cache():
     FEED_CACHE.reset_stats()
 
 
+@pytest.fixture(autouse=True)
+def _reset_mistral_rate_limiter():
+    # The editorial Mistral rate limiter is a module-level singleton (LR-1
+    # PR 1) bound to the running event loop. pytest-asyncio gives each test a
+    # fresh loop, and the token bucket persists across tests — resetting it
+    # gives every test a full bucket on its own loop, so the throttle never
+    # injects real sleeps into unit tests (the limiter's own pacing is tested
+    # directly with a fake clock in tests/editorial/test_rate_limiter.py).
+    from app.services.editorial.llm_client import _reset_large_limiter
+
+    _reset_large_limiter()
+    yield
+    _reset_large_limiter()
+
+
 @pytest.fixture(scope="session")
 def create_tables():
     """Create all database tables from model definitions (once per session).

--- a/packages/api/tests/editorial/test_llm_client.py
+++ b/packages/api/tests/editorial/test_llm_client.py
@@ -1,12 +1,39 @@
 """Tests for EditorialLLMClient (Mistral API wrapper)."""
 
 import json
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
 from app.services.editorial.llm_client import EditorialLLMClient
+
+
+def _error_response(status_code: int) -> MagicMock:
+    """Mock httpx.Response whose raise_for_status raises HTTPStatusError."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.text = f"error {status_code}"
+    resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        f"{status_code}", request=MagicMock(), response=resp
+    )
+    return resp
+
+
+class _SpyLimiter:
+    """Stand-in for the shared limiter: counts how often `slot()` is entered."""
+
+    def __init__(self) -> None:
+        self.slot_calls = 0
+
+    def slot(self):
+        self.slot_calls += 1
+        return self._cm()
+
+    @asynccontextmanager
+    async def _cm(self):
+        yield
 
 
 def _mock_settings(api_key: str = "test-key"):
@@ -31,12 +58,18 @@ def _make_response(content: str, status_code: int = 200) -> MagicMock:
 
 class TestIsReady:
     def test_ready_with_api_key(self):
-        with patch("app.services.editorial.llm_client.get_settings", return_value=_mock_settings("sk-123")):
+        with patch(
+            "app.services.editorial.llm_client.get_settings",
+            return_value=_mock_settings("sk-123"),
+        ):
             client = EditorialLLMClient()
         assert client.is_ready is True
 
     def test_not_ready_without_api_key(self):
-        with patch("app.services.editorial.llm_client.get_settings", return_value=_mock_settings("")):
+        with patch(
+            "app.services.editorial.llm_client.get_settings",
+            return_value=_mock_settings(""),
+        ):
             client = EditorialLLMClient()
         assert client.is_ready is False
 
@@ -44,7 +77,10 @@ class TestIsReady:
 class TestChatJson:
     @pytest.fixture
     def client(self):
-        with patch("app.services.editorial.llm_client.get_settings", return_value=_mock_settings("sk-test")):
+        with patch(
+            "app.services.editorial.llm_client.get_settings",
+            return_value=_mock_settings("sk-test"),
+        ):
             c = EditorialLLMClient()
         return c
 
@@ -103,7 +139,10 @@ class TestChatJson:
 
     @pytest.mark.asyncio
     async def test_not_ready_returns_none(self):
-        with patch("app.services.editorial.llm_client.get_settings", return_value=_mock_settings("")):
+        with patch(
+            "app.services.editorial.llm_client.get_settings",
+            return_value=_mock_settings(""),
+        ):
             client = EditorialLLMClient()
 
         result = await client.chat_json(system="sys", user_message="msg")
@@ -116,3 +155,155 @@ class TestChatJson:
         await client.close()
         mock_http.aclose.assert_awaited_once()
         assert client._client is None
+
+
+def _ready_client() -> EditorialLLMClient:
+    with patch(
+        "app.services.editorial.llm_client.get_settings",
+        return_value=_mock_settings("sk-test"),
+    ):
+        return EditorialLLMClient()
+
+
+class TestChatText:
+    @pytest.fixture
+    def client(self):
+        return _ready_client()
+
+    @pytest.mark.asyncio
+    async def test_returns_text_on_success(self, client):
+        resp = _make_response("Bonjour le monde")
+        mock_http = AsyncMock()
+        mock_http.post = AsyncMock(return_value=resp)
+        client._client = mock_http
+
+        result = await client.chat_text(system="sys", user_message="msg")
+        assert result == "Bonjour le monde"
+        mock_http.post.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_retries_on_429_then_succeeds(self, client):
+        ok = _make_response("rétabli")
+        mock_http = AsyncMock()
+        mock_http.post = AsyncMock(side_effect=[_error_response(429), ok])
+        client._client = mock_http
+
+        with patch(
+            "app.services.editorial.llm_client.asyncio.sleep", new_callable=AsyncMock
+        ):
+            result = await client.chat_text(system="sys", user_message="msg")
+
+        assert result == "rétabli"
+        assert mock_http.post.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_returns_none_after_exhausting_retries(self, client):
+        mock_http = AsyncMock()
+        mock_http.post = AsyncMock(return_value=_error_response(503))
+        client._client = mock_http
+
+        with patch(
+            "app.services.editorial.llm_client.asyncio.sleep", new_callable=AsyncMock
+        ):
+            result = await client.chat_text(system="sys", user_message="msg")
+
+        assert result is None
+        assert mock_http.post.await_count == 3  # initial + 2 retries
+
+
+class TestTokenCapture:
+    @pytest.fixture
+    def client(self):
+        return _ready_client()
+
+    @pytest.mark.asyncio
+    async def test_chat_json_records_tokens(self, client):
+        resp = _make_response(json.dumps({"ok": True}))
+        mock_http = AsyncMock()
+        mock_http.post = AsyncMock(return_value=resp)
+        client._client = mock_http
+
+        with patch(
+            "app.services.observability.usage_recorder.record_api_call",
+            new_callable=AsyncMock,
+        ) as rec:
+            await client.chat_json(system="sys", user_message="msg")
+
+        kwargs = rec.await_args.kwargs
+        assert kwargs["prompt_tokens"] == 100
+        assert kwargs["completion_tokens"] == 50
+
+    @pytest.mark.asyncio
+    async def test_chat_text_records_tokens(self, client):
+        resp = _make_response("texte")
+        mock_http = AsyncMock()
+        mock_http.post = AsyncMock(return_value=resp)
+        client._client = mock_http
+
+        with patch(
+            "app.services.observability.usage_recorder.record_api_call",
+            new_callable=AsyncMock,
+        ) as rec:
+            await client.chat_text(system="sys", user_message="msg")
+
+        kwargs = rec.await_args.kwargs
+        assert kwargs["prompt_tokens"] == 100
+        assert kwargs["completion_tokens"] == 50
+
+
+class TestRateLimiterGating:
+    @pytest.fixture
+    def client(self):
+        return _ready_client()
+
+    @pytest.mark.asyncio
+    async def test_large_model_goes_through_limiter(self, client):
+        spy = _SpyLimiter()
+        mock_http = AsyncMock()
+        mock_http.post = AsyncMock(return_value=_make_response(json.dumps({})))
+        client._client = mock_http
+
+        with patch(
+            "app.services.editorial.llm_client._get_large_limiter", return_value=spy
+        ):
+            await client.chat_json(
+                system="s", user_message="m", model="mistral-large-latest"
+            )
+        assert spy.slot_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_small_model_bypasses_limiter(self, client):
+        spy = _SpyLimiter()
+        mock_http = AsyncMock()
+        mock_http.post = AsyncMock(return_value=_make_response(json.dumps({})))
+        client._client = mock_http
+
+        with patch(
+            "app.services.editorial.llm_client._get_large_limiter", return_value=spy
+        ):
+            await client.chat_json(
+                system="s", user_message="m", model="mistral-small-latest"
+            )
+        assert spy.slot_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_kill_switch_bypasses_limiter(self, client):
+        spy = _SpyLimiter()
+        mock_http = AsyncMock()
+        mock_http.post = AsyncMock(return_value=_make_response(json.dumps({})))
+        client._client = mock_http
+
+        disabled = _mock_settings("sk-test")
+        disabled.mistral_rate_limit_enabled = False
+        with (
+            patch(
+                "app.services.editorial.llm_client._get_large_limiter", return_value=spy
+            ),
+            patch(
+                "app.services.editorial.llm_client.get_settings", return_value=disabled
+            ),
+        ):
+            await client.chat_json(
+                system="s", user_message="m", model="mistral-large-latest"
+            )
+        assert spy.slot_calls == 0

--- a/packages/api/tests/editorial/test_rate_limiter.py
+++ b/packages/api/tests/editorial/test_rate_limiter.py
@@ -1,0 +1,125 @@
+"""Tests du `_MistralRateLimiter` (LR-1 PR 1).
+
+Le pacing token-bucket est piloté par une **horloge factice** (aucun sleep
+réel) : on vérifie que le bucket démarre plein, draine sans attente, puis
+cadence à `rpm` une fois vide, et qu'il se recharge avec le temps. La
+concurrence est vérifiée avec de vraies primitives asyncio.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.services.editorial.rate_limiter import _MistralRateLimiter
+
+
+class FakeClock:
+    """Horloge monotone factice : `sleep` avance le temps sans attente réelle."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.sleeps: list[float] = []
+
+    def time(self) -> float:
+        return self.now
+
+    async def sleep(self, delay: float) -> None:
+        self.sleeps.append(delay)
+        self.now += delay
+
+
+def _limiter(clock: FakeClock, *, rpm: int, concurrency: int) -> _MistralRateLimiter:
+    return _MistralRateLimiter(
+        rpm=rpm,
+        concurrency=concurrency,
+        time_func=clock.time,
+        sleep_func=clock.sleep,
+    )
+
+
+@pytest.mark.asyncio
+async def test_first_call_never_waits():
+    """Bucket plein au démarrage ⇒ le premier appel ne paie aucune attente."""
+    clock = FakeClock()
+    limiter = _limiter(clock, rpm=1, concurrency=1)
+    async with limiter.slot():
+        pass
+    assert clock.sleeps == []
+
+
+@pytest.mark.asyncio
+async def test_full_bucket_drains_without_waiting():
+    """Drainer exactement `rpm` jetons à t=0 ne déclenche aucun sleep."""
+    clock = FakeClock()
+    limiter = _limiter(clock, rpm=60, concurrency=10)
+    for _ in range(60):
+        async with limiter.slot():
+            pass
+    assert clock.sleeps == []
+    assert clock.now == 0.0
+
+
+@pytest.mark.asyncio
+async def test_paces_at_rpm_once_bucket_empty():
+    """Une fois le bucket vide, chaque appel attend un intervalle de recharge."""
+    clock = FakeClock()
+    limiter = _limiter(clock, rpm=60, concurrency=10)  # 60 rpm -> 1 jeton/s
+    for _ in range(60):
+        async with limiter.slot():
+            pass
+    for _ in range(3):
+        async with limiter.slot():
+            pass
+    assert clock.sleeps == [1.0, 1.0, 1.0]
+    assert clock.now == 3.0
+
+
+@pytest.mark.asyncio
+async def test_tokens_refill_over_time():
+    """Le temps écoulé recharge le bucket (jusqu'au plafond `rpm`)."""
+    clock = FakeClock()
+    limiter = _limiter(clock, rpm=60, concurrency=10)
+    for _ in range(60):
+        async with limiter.slot():
+            pass
+    # 10 s s'écoulent -> 10 jetons rechargés -> 10 appels sans attente.
+    clock.now += 10.0
+    for _ in range(10):
+        async with limiter.slot():
+            pass
+    assert clock.sleeps == []
+    # Le 11e appel retrouve un bucket vide et doit attendre.
+    async with limiter.slot():
+        pass
+    assert clock.sleeps == [1.0]
+
+
+@pytest.mark.asyncio
+async def test_concurrency_cap_limits_in_flight():
+    """La semaphore borne le nombre d'appels simultanés à `concurrency`."""
+    clock = FakeClock()
+    limiter = _limiter(clock, rpm=100000, concurrency=2)  # rpm hors-jeu ici
+    in_flight = 0
+    peak = 0
+    gate = asyncio.Event()
+
+    async def worker() -> None:
+        nonlocal in_flight, peak
+        async with limiter.slot():
+            in_flight += 1
+            peak = max(peak, in_flight)
+            await gate.wait()
+            in_flight -= 1
+
+    tasks = [asyncio.create_task(worker()) for _ in range(5)]
+    # Laisse l'ordonnanceur tourner : seuls `concurrency` workers franchissent
+    # la semaphore, les autres restent bloqués sur l'acquire.
+    for _ in range(20):
+        await asyncio.sleep(0)
+    assert in_flight == 2
+    assert peak == 2
+    gate.set()
+    await asyncio.gather(*tasks)
+    assert peak == 2

--- a/packages/api/tests/ml/test_classification_service.py
+++ b/packages/api/tests/ml/test_classification_service.py
@@ -365,6 +365,31 @@ class TestCallMistral:
         assert result["choices"][0]["message"]["content"] == '{"topics": ["sport"]}'
 
     @pytest.mark.asyncio
+    async def test_records_token_usage(self):
+        """Les tokens de `usage` Mistral sont propagés à api_usage_events (LR-1)."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "{}"}}],
+            "usage": {"prompt_tokens": 1900, "completion_tokens": 42},
+        }
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        self.service._client = mock_client
+
+        with patch(
+            "app.services.observability.usage_recorder.record_api_call",
+            new_callable=AsyncMock,
+        ) as rec:
+            await self.service._call_mistral({"model": "test", "max_tokens": 100})
+
+        rec.assert_awaited_once()
+        kwargs = rec.await_args.kwargs
+        assert kwargs["prompt_tokens"] == 1900
+        assert kwargs["completion_tokens"] == 42
+        assert kwargs["status"] == "ok"
+
+    @pytest.mark.asyncio
     async def test_retries_on_429(self):
         """429 responses trigger exponential backoff retries."""
         error_response = MagicMock()
@@ -444,7 +469,11 @@ class TestResponseFormatInPayloads:
             resp.raise_for_status = MagicMock()
             resp.json.return_value = {
                 "choices": [
-                    {"message": {"content": '{"topics": ["sport"], "serene": true, "is_ad": false}'}}
+                    {
+                        "message": {
+                            "content": '{"topics": ["sport"], "serene": true, "is_ad": false}'
+                        }
+                    }
                 ],
                 "usage": {},
             }
@@ -469,7 +498,11 @@ class TestResponseFormatInPayloads:
             resp.raise_for_status = MagicMock()
             resp.json.return_value = {
                 "choices": [
-                    {"message": {"content": '[{"topics": ["sport"], "serene": true, "is_ad": false}]'}}
+                    {
+                        "message": {
+                            "content": '[{"topics": ["sport"], "serene": true, "is_ad": false}]'
+                        }
+                    }
                 ],
                 "usage": {},
             }

--- a/packages/api/tests/ml/test_good_news_classifier.py
+++ b/packages/api/tests/ml/test_good_news_classifier.py
@@ -6,6 +6,8 @@ forme du payload.
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
 from app.services.ml.good_news_classifier import (
@@ -50,8 +52,16 @@ class TestBuildUserPrompt:
     def test_includes_indices_and_titles(self) -> None:
         prompt = _build_user_prompt(
             [
-                {"title": "Article un", "description": "desc 1", "source_name": "Le Monde"},
-                {"title": "Article deux", "description": "desc 2", "source_name": "Reporterre"},
+                {
+                    "title": "Article un",
+                    "description": "desc 1",
+                    "source_name": "Le Monde",
+                },
+                {
+                    "title": "Article deux",
+                    "description": "desc 2",
+                    "source_name": "Reporterre",
+                },
             ]
         )
         assert "Article un" in prompt
@@ -86,7 +96,9 @@ class TestClassifierBatch:
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_unready_returns_none_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_unready_returns_none_list(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         classifier = GoodNewsClassifier()
         classifier._ready = False
         items = [{"title": "a"}, {"title": "b"}]
@@ -134,3 +146,34 @@ class TestClassifierBatch:
             [{"title": "A"}, {"title": "B"}, {"title": "C"}]
         )
         assert result == [None, None, None]
+
+
+class TestCallTokenCapture:
+    @pytest.mark.asyncio
+    async def test_call_records_token_usage(self) -> None:
+        """`_call` propage les tokens de `usage` Mistral à api_usage_events (LR-1)."""
+        classifier = GoodNewsClassifier()
+        classifier._ready = True
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "[]"}}],
+            "usage": {"prompt_tokens": 800, "completion_tokens": 16},
+        }
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        classifier._client = mock_client
+
+        with patch(
+            "app.services.observability.usage_recorder.record_api_call",
+            new_callable=AsyncMock,
+        ) as rec:
+            data = await classifier._call({"model": "mistral-large-latest"})
+
+        assert data is not None
+        rec.assert_awaited_once()
+        kwargs = rec.await_args.kwargs
+        assert kwargs["prompt_tokens"] == 800
+        assert kwargs["completion_tokens"] == 16
+        assert kwargs["status"] == "ok"

--- a/packages/api/tests/test_usage_recorder.py
+++ b/packages/api/tests/test_usage_recorder.py
@@ -15,7 +15,7 @@ from uuid import uuid4
 import pytest
 
 from app.services.observability import usage_recorder
-from app.services.observability.usage_recorder import record_api_call
+from app.services.observability.usage_recorder import record_api_call, track_api_call
 
 
 def _make_session_maker(commit_side_effect=None):
@@ -50,7 +50,7 @@ async def test_record_disabled_does_nothing():
         patch.object(
             usage_recorder,
             "safe_async_session",
-            side_effect=lambda *a, **k: fake_sm(),
+            side_effect=lambda *_a, **_k: fake_sm(),
         ),
     ):
         await record_api_call(
@@ -70,7 +70,7 @@ async def test_record_inserts_event_when_enabled():
         patch.object(
             usage_recorder,
             "safe_async_session",
-            side_effect=lambda *a, **k: fake_sm(),
+            side_effect=lambda *_a, **_k: fake_sm(),
         ),
     ):
         await record_api_call(
@@ -100,7 +100,7 @@ async def test_record_never_raises_on_db_error():
         patch.object(
             usage_recorder,
             "safe_async_session",
-            side_effect=lambda *a, **k: fake_sm(),
+            side_effect=lambda *_a, **_k: fake_sm(),
         ),
         patch.object(usage_recorder, "logger") as mock_logger,
     ):
@@ -119,7 +119,7 @@ async def test_record_warns_on_unknown_call_site_but_still_inserts():
         patch.object(
             usage_recorder,
             "safe_async_session",
-            side_effect=lambda *a, **k: fake_sm(),
+            side_effect=lambda *_a, **_k: fake_sm(),
         ),
         patch.object(usage_recorder, "logger") as mock_logger,
     ):
@@ -141,7 +141,7 @@ async def test_record_coerces_string_user_id():
         patch.object(
             usage_recorder,
             "safe_async_session",
-            side_effect=lambda *a, **k: fake_sm(),
+            side_effect=lambda *_a, **_k: fake_sm(),
         ),
     ):
         await record_api_call("mistral", "editorial", user_id=str(uid))
@@ -159,10 +159,73 @@ async def test_record_bad_string_user_id_falls_back_to_none():
         patch.object(
             usage_recorder,
             "safe_async_session",
-            side_effect=lambda *a, **k: fake_sm(),
+            side_effect=lambda *_a, **_k: fake_sm(),
         ),
     ):
         await record_api_call("mistral", "editorial", user_id="not-a-uuid")
 
     event = mock_session.add.call_args.args[0]
     assert event.user_id is None
+
+
+@pytest.mark.asyncio
+async def test_record_persists_token_counts():
+    """prompt_tokens / completion_tokens sont portés sur l'ApiUsageEvent (LR-1)."""
+    fake_sm, mock_session = _make_session_maker()
+    with (
+        patch.object(usage_recorder, "get_settings", return_value=_settings()),
+        patch.object(
+            usage_recorder,
+            "safe_async_session",
+            side_effect=lambda *_a, **_k: fake_sm(),
+        ),
+    ):
+        await record_api_call(
+            "mistral",
+            "good_news_pass2",
+            model="mistral-large-latest",
+            prompt_tokens=1900,
+            completion_tokens=42,
+        )
+
+    event = mock_session.add.call_args.args[0]
+    assert event.prompt_tokens == 1900
+    assert event.completion_tokens == 42
+
+
+@pytest.mark.asyncio
+async def test_track_api_call_propagates_tracker_tokens():
+    """Le context manager remonte les tokens posés sur le tracker au recorder."""
+    with patch.object(
+        usage_recorder, "record_api_call", new_callable=AsyncMock
+    ) as mock_record:
+        async with track_api_call(
+            "mistral", "classification_pass1", model="mistral-small-latest"
+        ) as call:
+            call.prompt_tokens = 1234
+            call.completion_tokens = 56
+            call.status = "ok"
+
+    mock_record.assert_awaited_once()
+    kwargs = mock_record.await_args.kwargs
+    assert kwargs["prompt_tokens"] == 1234
+    assert kwargs["completion_tokens"] == 56
+    assert kwargs["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_track_api_call_tokens_default_none_on_failure():
+    """Sans pose de tokens (échec avant réponse), ils restent None et le statut error."""
+    with (
+        patch.object(
+            usage_recorder, "record_api_call", new_callable=AsyncMock
+        ) as mock_record,
+        pytest.raises(RuntimeError),
+    ):
+        async with track_api_call("mistral", "editorial"):
+            raise RuntimeError("boom before response")
+
+    kwargs = mock_record.await_args.kwargs
+    assert kwargs["prompt_tokens"] is None
+    assert kwargs["completion_tokens"] is None
+    assert kwargs["status"] == "error"


### PR DESCRIPTION
Première des 4 PR du plan Phase 3 / LR-1 (réduire le coût Mistral avant le
lancement). **Backend-only, zéro impact produit.** Cible `main`.

## Pourquoi

- Le compteur `api_usage_events` compte les *appels*, pas les *tokens* → le €
  réel par modèle est inconnu. On le mesure avant d'optimiser (PR 2/3).
- Le pipeline éditorial éclate des `asyncio.gather` non bornés sur
  `mistral-large-latest` (curation + deep_matcher + perspective) → ~28 % de 429
  (201 appels rate-limited / 14 j, spécifiques à l'éditorial). `chat_text`
  n'avait aucun retry.

## Ce que fait la PR

### 1. Capture des tokens (ferme le trou de données)
- `api_usage_events` : 2 colonnes nullables `prompt_tokens` / `completion_tokens`
  (migration additive `au02_api_usage_tokens`).
- `usage_recorder` : `record_api_call` accepte les tokens ; `_ApiCallTracker` les
  porte ; `track_api_call` les propage dans son `finally`.
- Sites posant les tokens depuis `usage` Mistral : `classification_service`,
  `good_news_classifier`, `editorial/llm_client` (`chat_json` + `chat_text`).
  `smart_search` (Mistral) passe déjà par `chat_json` → couvert ; son chemin
  Brave n'a pas de tokens.
- → un `GROUP BY model` sur `api_usage_events` donne le €/jour réel.

### 2. Fix du burst éditorial (les 28 % de 429)
- `editorial/rate_limiter.py` (nouveau) : `_MistralRateLimiter` = token-bucket
  /minute + semaphore de concurrence, **partagé au niveau process** (singleton
  module, car `EditorialLLMClient` est instancié par appelant), loop-safe
  (recrée sem/lock au changement de boucle), horloge injectable.
- `llm_client._do_post` : chokepoint unique ; applique le limiteur aux **seuls**
  appels `large` (les cheap small/medium passent directement). Retries inclus
  dans le throttle (pas de re-burst).
- `chat_text` : ajout retry/backoff (429/5xx + timeout), comme `chat_json`.
- `config.py` : `mistral_rate_limit_enabled` (kill-switch), `mistral_large_rpm`
  (60), `mistral_large_concurrency` (4) — défauts conservateurs, à affiner via
  LR-3 (plan Mistral), configurables sans redéploiement.

## Réversibilité
- `mistral_rate_limit_enabled=False` → throttle off.
- `usage_tracking_enabled=False` → instrumentation off (existant).
- Migration purement additive (rollback = `drop_column`).

## Migration / Alembic (important)
- `au02_api_usage_tokens` est **chaînée sur le head courant de `main`,
  `sec02_new_public_rls`** (et non sur `au01` : `au01` a déjà des descendants via
  `mg01`, chaîner dessus aurait créé 2 heads et cassé le boot Railway).
  `alembic heads` local = **exactement 1 head (`au02`)** ; chaîne
  `… → sec02_new_public_rls → au02`.
- Additive : `ADD COLUMN prompt_tokens / completion_tokens` (nullable), downgrade
  = `drop_column`. L'upgrade/downgrade sur DB vide tourne en CI (`alembic-smoke`)
  — le conteneur test local (54322) est partagé avec d'autres workspaces
  Conductor (`make db-reset` interdit ici).

## Vérification
- `pytest` ciblé vert (pyenv, pas de `.venv` en Conductor) — **86 tests** :
  - `tests/editorial/test_rate_limiter.py` (token-bucket fake-clock + cap concurrence)
  - `tests/test_usage_recorder.py` (persistance tokens + propagation tracker)
  - `tests/editorial/test_llm_client.py` (retry `chat_text`, gating large-only, capture tokens)
  - `tests/ml/test_classification_service.py` + `test_good_news_classifier.py` (capture tokens)
- Collection pleine suite : **1953 tests, 0 erreur d'import** (le cycle latent
  pipeline↔llm_bias ne casse pas la collection).
- Suite complète locale : 1541 passed ; les ~392 `ERROR` restants sont
  uniformément `psycopg.OperationalError: password authentication failed` sur le
  conteneur test partagé (54322) dont les creds ont été tournées par un workspace
  parallèle en cours de run — environnemental, hors de ce diff (les tests
  concernés sont des tests DB de modules non touchés ; mes tests sont mockés).
  La vraie barrière DB = CI.
- `ruff check app/` + `ruff format --check app/` : **clean**.

## Nettoyage inclus (commits séparés)
- `refactor(editorial)` : le retry de `chat_text` dupliquait à l'identique celui
  de `chat_json` ; factorisé dans un helper unique `_post_with_retry` (comportement
  inchangé, clés de log d'observabilité préservées). Issu de la passe `/simplify`.
- `chore(lint)` : reformatage no-op (1 ligne) de `user_interests_service.py` pour
  ruff 0.15.14 (épinglé en #877) — drift pré-existant qui rendait le job `lint`
  rouge sur `main` (#899 a été mergé avec `lint=fail`). Rend le job `lint` vert.

## Notes (hors scope)
- `good_news_classifier` appelle aussi un modèle `large`, mais via son propre
  client et en **un seul appel batché par lot** (burst négligeable, déjà un retry
  429) → volontairement hors du throttle pour cette PR. Candidat à un limiteur
  partagé en LR-3 / PR 4. Le docstring de `_is_large_model` le documente.
- Cycle d'import latent `editorial.pipeline ↔ llm_bias_annotation_service`
  (pré-existant) : la suite complète collecte OK.

## Suite (non incluse)
PR 2 (batching classif + prompt cache + trim éditorial), PR 3 (downgrades
modèle eval-gated), PR 4 (governor € + cap sources + kill-switches). PR 2/3
priorisées par 2-3 j de données tokens après merge.

## Pas de changelog
Backend-only, aucun écran impacté.
