### PR TITLE
perf(scaling): S1 — capacité & robustesse couche connexion DB (sérialisation jobs + anti-double-digest + retry reads)

### DIFF
--- a/docs/maintenance/maintenance-saturation-pool-db-nocturne.md
+++ b/docs/maintenance/maintenance-saturation-pool-db-nocturne.md
@@ -54,9 +54,97 @@ contribution aux timeouts feed).
   plus du warning structlog (la métrique `db_idle_in_transaction_swept{count}`
   always-on reste émise à chaque passage).
 
+## S1 — Sérialisation jobs + garde anti-double-digest + couverture retry (suite, cette PR)
+
+> Suite directe des axes A-D ci-dessus. Même racine (fenêtre pool partagée
+> matinale), nouveaux gaps structurels : jobs sans `max_instances`, triple
+> appelant non coordonné de `run_digest_generation`, session batch idle-in-tx
+> sur le **chemin succès**, et couverture retry insuffisante sur 2 reads chauds.
+
+### S1-A — sérialiser tous les jobs récurrents (`scheduler.py`)
+`max_instances=1` (+ `coalesce=True`) sur **tous** les `add_job` : `rss_sync`,
+`daily_digest`, `subtopic_weight_decay`, `digest_watchdog`, `storage_cleanup`,
+`purge_deleted_users`, `recompute_source_language`, `cost_budget_projection`,
+`zombie_session_sweeper`, `pool_health_probe` (`daily_essentiel_push_dispatch`
+les avait déjà). Un run qui déborde sur le tick suivant ne lance jamais un 2e run
+concurrent. **Défensif/documentaire** : APScheduler met déjà `max_instances=1`
+par défaut → le vrai correctif anti-double-digest est S1-B.
+
+### S1-B — garde anti-double-digest (réutilise `generation_state`, in-process)
+`run_digest_generation` a **TROIS** appelants non coordonnés :
+- cron `daily_digest` 07h30 (`scheduler.py`),
+- watchdog 08h15 — **appel direct** (`scheduler.py`),
+- **startup catchup** Railway boot 07h30-10h00 — **appel direct** (`main.py`),
+  gardé seulement par son propre `_STARTUP_CATCHUP_LOCK`, indépendant de
+  `generation_state`.
+
+`max_instances=1` ne voit **que** le cron. Si le digest 07h30 tourne encore, un
+2e digest complet démarre → 2 × `Semaphore(5)` = 10 slots pool d'un coup.
+
+- **Garde IN-FUNCTION (load-bearing)** dans `run_digest_generation` : si
+  `is_generation_running()` est déjà `True` **à l'entrée**, retourne
+  `{"skipped": True, "reason": "already_running", "stats": job.stats}`.
+  **Placée AVANT `mark_generation_started()`** (qui met `_is_running=True` et
+  reset `_started_at` inconditionnellement). Ferme les 3 appelants d'un coup.
+- **Garde call-site** dans `_digest_watchdog` : skip + log
+  `digest_watchdog_skipped_generation_in_progress` si `is_generation_running()`
+  avant l'appel (évite même d'ouvrir une session).
+- **Safety-timeout (600s)** de `generation_state` : un run > 10 min repasse
+  `is_generation_running()` à `False` (auto-reset) → échappatoire voulue (un run
+  aussi long est pathologique). Ne **pas** augmenter `_SAFETY_TIMEOUT` ; le
+  watchdog ne doit **jamais** override la garde.
+
+### S1-C — libérer la tx batch avant le LLM (`digest_generation_job.py`)
+Sur le **chemin succès**, la lecture *trending* laissait la tx de la session
+batch ouverte (`idle in transaction`) pendant les 3-5 min de pré-calcul éditorial
+LLM (les `rollback()` existants des axes A étaient dans les `except` seulement).
+Ajout, **après** le bloc trending et **avant** le pré-calcul :
+`await session.rollback()` + `await apply_session_timeouts(session)` (sous
+`contextlib.suppress`). Sûr : le contexte trending vit dans un local Python
+(`global_trending_context`, dataclass d'UUIDs), `state_mark_pending` est déjà
+commité, le pré-calcul re-requête tout sur une tx fraîche. La pipeline
+éditoriale elle-même reste saine (sessions courtes via `session_maker`).
+
+### S1-D — étendre `retry_db_op` à 2 reads chauds (cold-open)
+Helper `app/utils/db_retry.py` réutilisé sur 2 endpoints en lecture pure (zéro
+commit, replay sûr) :
+- `collections.list_collections` (`routers/collections.py`),
+- `feed.get_tab_counts` (`routers/feed.py`) — phase de requêtes (multi-await)
+  enveloppée dans une factory `_load_counts()` passée à `retry_db_op`.
+
+**Exclus (justifiés)** : `feed.get_personalized_feed` (déjà cache + single-flight,
+replay coûteux), `contents.get_perspectives` (cache + HTTP externe + background
+tasks), `letters.get_user_letters` (**write path** : commit). Les retries
+write-path sont **différés** (dépendent de S3 — idempotence upsert).
+
 ## Hors périmètre
 PG advisory lock entre jobs de nuit (option robuste si le décalage horaire ne
 suffit pas), right-size du pool, dashboards Sentry/PostHog.
+
+### Externaliser le scheduler dans un worker Railway séparé (vrai fix long terme)
+C'est la bascule structurelle qui résout la cause racine (API + APScheduler +
+worker classification **dans le même process** = `Procfile` 1 `uvicorn`, cf.
+`docs/scaling/scaling-investigation-200-users.md` §2 « plafonds infra »). Différé
+**hors de cette PR** car non trivial :
+
+- **Coordination cross-process requise.** `generation_state` (la garde S1-B) est
+  **in-memory, per-process** : sorti dans un service séparé, le worker scheduler
+  et le service web API ne partagent plus le flag → la garde anti-double-digest
+  ne tient plus. Il faut un verrou partagé : **PG advisory lock**
+  (`pg_try_advisory_lock`, déjà cité « Hors périmètre » plus haut) ou **Redis**.
+- **Budget connexions (le chiffrage qui compte).** Le pooler Supabase plafonne à
+  **60 connexions partagées** entre staging (`main`) et prod (`production`).
+  Aujourd'hui chaque backend = 1 pool `pool_size=10 + max_overflow=10 = 20` ⇒
+  2 × 20 = **40/60** au pic. Un worker scheduler séparé = **un nouveau pool** par
+  environnement ⇒ 2 backends web (2 × 20) **+** 2 workers scheduler ⇒ il faut
+  **right-sizer** : le worker n'a pas besoin de 20 conns (digest borné à
+  `concurrency_limit=5` + marge jobs mono-connexion ⇒ ~`pool_size=6`), sinon on
+  crève les 60. Prérequis = la sonde pool (axe D) pour mesurer la marge réelle
+  avant de figer les tailles.
+- **Coût Railway.** +1 service par environnement (worker scheduler), soit
+  l'équivalent d'un petit conteneur uvicorn supplémentaire ×2 (staging + prod).
+  Décision infra séparée (cf. `docs/maintenance/maintenance-scaling-db-robustness.md`,
+  « découplage worker (S2) »).
 
 ## Tests
 - `tests/test_pool_observability.py` : warn seulement si soutenu (2 sondes), reset
@@ -68,7 +156,33 @@ suffit pas), right-size du pool, dashboards Sentry/PostHog.
 - Pas de migration Alembic (aucun DDL ; l'index `ix_user_content_status_content_id`
   existe déjà).
 
+### Tests S1 (cette PR)
+- `tests/workers/test_scheduler.py` : **chaque** job a `max_instances == 1`
+  (+ `coalesce` là où ajouté) ; watchdog skip `run_digest_generation` si
+  `is_generation_running()` est `True` (coverage < 90 %), l'appelle une fois si
+  `False`.
+- `tests/test_digest_generation_job.py` : `is_generation_running() → True` ⇒
+  `run_digest_generation` retourne `{"skipped": True, ...}`, `mark_generation_started`
+  **non** appelé, aucune `safe_async_session` ouverte ; `→ False` ⇒ procède.
+  + safety-timeout `generation_state` (monkeypatch `time.monotonic`). S1-C : sur
+  chemin succès, `session.rollback`/`apply_session_timeouts` appelés avant la
+  boucle de pré-calcul.
+- Endpoints reads (S1-D, modèle `tests/test_sources_resilience.py`) : mock
+  `service.list_collections` `side_effect=[OperationalError, payload]` ⇒ 2 awaits
+  + retour OK (idem `feed.get_tab_counts`). Le helper `retry_db_op` est déjà
+  couvert unitairement par `TestRetryDbOp` — pas de duplication.
+- Pas de migration Alembic (config/Python pur ; `generation_state` est in-memory ;
+  1 head inchangé).
+
 ## Acceptation post-deploy (lecture seule prod)
 Sur la fenêtre 07h00-08h30 : alerte *warn* dès pression soutenue ≥70 %, *page* si
 ≥90 % ; `zombie_session_sweeper_killed` remonté en Sentry s'il survient ; absence
 de nouveaux 5G/4X.
+
+### Acceptation S1 (lecture seule prod, post-deploy)
+Sur la fenêtre 07h00-08h30 : **plus de pic pool x2** lié à un double digest
+concurrent ; en cas d'overlap évité, logs `digest_generation_already_running_skipped`
+(garde in-function) et/ou `digest_watchdog_skipped_generation_in_progress` (garde
+watchdog) visibles ; pas de hausse des 500 sur `/api/collections/` ni
+`/api/feed/tab-counts` lors des hoquets de pool (retry transparent). Pas de
+load-test local de la fenêtre nocturne (couverte par unit tests).

--- a/packages/api/app/jobs/digest_generation_job.py
+++ b/packages/api/app/jobs/digest_generation_job.py
@@ -241,6 +241,19 @@ class DigestGenerationJob:
                     await session.rollback()
                     await apply_session_timeouts(session)
 
+            # Axe C — libérer la tx batch AVANT le pré-calcul éditorial (3-5 min
+            # de LLM). Sur le chemin succès, la lecture trending ci-dessus laisse
+            # la tx de la session batch ouverte ; sans ce rollback elle reste
+            # `idle in transaction` pendant tout le LLM → monopolise un slot pool
+            # (PYTHON-5M) et risque le timeout `idle_in_tx=60s`. Sûr : le contexte
+            # trending vit dans un local Python (`global_trending_context`,
+            # dataclass d'UUIDs), `state_mark_pending` est déjà commité, et le
+            # pré-calcul re-requête tout sur une tx fraîche. On re-pousse les
+            # `SET LOCAL` timeouts sur la prochaine tx.
+            with contextlib.suppress(Exception):
+                await session.rollback()
+                await apply_session_timeouts(session)
+
             # 1.6 Pre-compute editorial global context ONCE for the batch,
             # for BOTH variants (pour_vous + serein). Previously only
             # pour_vous was pre-computed, forcing each serene user to do
@@ -1118,6 +1131,7 @@ async def run_digest_generation(
         >>> result = await run_digest_generation(target_date=date(2024, 1, 15))
     """
     from app.services.generation_state import (
+        is_generation_running,
         mark_generation_finished,
         mark_generation_started,
     )
@@ -1125,6 +1139,20 @@ async def run_digest_generation(
     job = DigestGenerationJob(
         batch_size=batch_size, concurrency_limit=concurrency_limit
     )
+
+    # Garde anti-double-digest (Axe B, load-bearing). `run_digest_generation`
+    # a TROIS appelants non coordonnés : le cron 07h30 (scheduler), le watchdog
+    # 08h15 (appel direct), et le startup catchup Railway (appel direct, gardé
+    # par son propre _STARTUP_CATCHUP_LOCK seulement). `max_instances=1` ne voit
+    # que le cron. Si un digest tourne déjà, un 2e run complet = 2 × Semaphore(5)
+    # = 10 slots pool d'un coup → saturation (PYTHON-5M). On skip AVANT
+    # `mark_generation_started()` (qui met _is_running=True et reset _started_at
+    # inconditionnellement, écrasant le timestamp du run en cours). Le
+    # safety-timeout (600s) de generation_state reste l'échappatoire si un run
+    # se bloque > 10 min.
+    if is_generation_running():
+        logger.info("digest_generation_already_running_skipped")
+        return {"skipped": True, "reason": "already_running", "stats": job.stats}
 
     mark_generation_started()
 

--- a/packages/api/app/routers/collections.py
+++ b/packages/api/app/routers/collections.py
@@ -15,6 +15,7 @@ from app.schemas.collection import (
     SavedSummaryResponse,
 )
 from app.services.collection_service import CollectionService
+from app.utils.db_retry import retry_db_op
 
 router = APIRouter()
 
@@ -27,7 +28,14 @@ async def list_collections(
     """Liste les collections de l'utilisateur avec métadonnées."""
     service = CollectionService(db)
     user_uuid = UUID(current_user_id)
-    return await service.list_collections(user_uuid)
+    # Read pur (zéro commit), appelé au chargement (cold-open) → replay sûr.
+    # Absorbe les erreurs transitoires de pool (PYTHON-4/14/26/27) au lieu de
+    # 500 l'utilisateur sur un hoquet de connexion. Cf. db_retry.retry_db_op.
+    return await retry_db_op(
+        lambda: service.list_collections(user_uuid),
+        session=db,
+        op_name="collections.list",
+    )
 
 
 @router.post(

--- a/packages/api/app/routers/feed.py
+++ b/packages/api/app/routers/feed.py
@@ -34,6 +34,7 @@ from app.schemas.feed import (
 from app.services.feed_cache import FEED_CACHE
 from app.services.recommendation.french_stopwords import FRENCH_STOP_WORDS
 from app.services.recommendation_service import RecommendationService
+from app.utils.db_retry import retry_db_op
 
 logger = structlog.get_logger()
 
@@ -647,97 +648,104 @@ async def get_tab_counts(
     user_uuid = UUID(current_user_id)
     cutoff = datetime.now(UTC) - timedelta(hours=48)
 
-    followed_stmt = select(UserSource.source_id).where(
-        UserSource.user_id == user_uuid,
-        UserSource.state.in_((InterestState.FOLLOWED, InterestState.FAVORITE)),
-    )
-    favorites_stmt = select(UserTopicProfile).where(
-        UserTopicProfile.user_id == user_uuid,
-        UserTopicProfile.priority_multiplier == 2.0,
-    )
+    async def _load_counts() -> TabCountsResponse:
+        # Read pur multi-await (badges au chargement, cold-open) → replay sûr.
+        # Toute la phase de requêtes est enveloppée dans `retry_db_op` pour
+        # qu'un hoquet de pool transitoire (PYTHON-4/14/26/27) rejoue après
+        # rollback au lieu de 500 l'utilisateur. Aucun commit ici.
+        followed_stmt = select(UserSource.source_id).where(
+            UserSource.user_id == user_uuid,
+            UserSource.state.in_((InterestState.FOLLOWED, InterestState.FAVORITE)),
+        )
+        favorites_stmt = select(UserTopicProfile).where(
+            UserTopicProfile.user_id == user_uuid,
+            UserTopicProfile.priority_multiplier == 2.0,
+        )
 
-    followed_result = await db.execute(followed_stmt)
-    followed_source_ids = {row[0] for row in followed_result.all()}
-    favorite_profiles = list((await db.scalars(favorites_stmt)).all())
+        followed_result = await db.execute(followed_stmt)
+        followed_source_ids = {row[0] for row in followed_result.all()}
+        favorite_profiles = list((await db.scalars(favorites_stmt)).all())
 
-    if not followed_source_ids:
-        return TabCountsResponse(total=0)
+        if not followed_source_ids:
+            return TabCountsResponse(total=0)
 
-    # 2. Extract favorite slugs/names to count
-    fav_topic_slugs: set[str] = set()
-    fav_entity_names: set[str] = set()
-    for prof in favorite_profiles:
-        if prof.entity_type is not None:
-            if prof.canonical_name:
-                fav_entity_names.add(prof.canonical_name.lower())
-        else:
-            if prof.slug_parent:
-                fav_topic_slugs.add(prof.slug_parent)
+        # 2. Extract favorite slugs/names to count
+        fav_topic_slugs: set[str] = set()
+        fav_entity_names: set[str] = set()
+        for prof in favorite_profiles:
+            if prof.entity_type is not None:
+                if prof.canonical_name:
+                    fav_entity_names.add(prof.canonical_name.lower())
+            else:
+                if prof.slug_parent:
+                    fav_topic_slugs.add(prof.slug_parent)
 
-    # 3. Lightweight query: only columns needed for counting
-    exclude_stmt = exists().where(
-        UserContentStatus.content_id == Content.id,
-        UserContentStatus.user_id == user_uuid,
-        or_(
-            UserContentStatus.is_hidden,
-            UserContentStatus.status.in_(["seen", "consumed"]),
-        ),
-    )
+        # 3. Lightweight query: only columns needed for counting
+        exclude_stmt = exists().where(
+            UserContentStatus.content_id == Content.id,
+            UserContentStatus.user_id == user_uuid,
+            or_(
+                UserContentStatus.is_hidden,
+                UserContentStatus.status.in_(["seen", "consumed"]),
+            ),
+        )
 
-    stmt = select(Content.id, Content.topics, Content.entities).where(
-        Content.source_id.in_(list(followed_source_ids)),
-        Content.published_at >= cutoff,
-        ~exclude_stmt,
-    )
-    rows = (await db.execute(stmt)).all()
+        stmt = select(Content.id, Content.topics, Content.entities).where(
+            Content.source_id.in_(list(followed_source_ids)),
+            Content.published_at >= cutoff,
+            ~exclude_stmt,
+        )
+        rows = (await db.execute(stmt)).all()
 
-    # 4. Count in Python (single pass over lightweight rows)
-    total = len(rows)
-    topic_counts: dict[str, int] = {}
-    entity_counts: dict[str, int] = {}
-    theme_counts: dict[str, int] = {}
+        # 4. Count in Python (single pass over lightweight rows)
+        total = len(rows)
+        topic_counts: dict[str, int] = {}
+        entity_counts: dict[str, int] = {}
+        theme_counts: dict[str, int] = {}
 
-    for row in rows:
-        topics = row.topics or []
-        entities_raw = row.entities or []
+        for row in rows:
+            topics = row.topics or []
+            entities_raw = row.entities or []
 
-        for slug in fav_topic_slugs:
-            if slug in topics:
-                topic_counts[slug] = topic_counts.get(slug, 0) + 1
+            for slug in fav_topic_slugs:
+                if slug in topics:
+                    topic_counts[slug] = topic_counts.get(slug, 0) + 1
 
-        if fav_entity_names and entities_raw:
-            for raw_entity in entities_raw:
-                try:
-                    parsed = _json.loads(raw_entity)
-                    name = parsed.get("name", "").lower()
-                except (ValueError, AttributeError):
-                    name = raw_entity.lower()
-                if name in fav_entity_names:
-                    entity_counts[name] = entity_counts.get(name, 0) + 1
+            if fav_entity_names and entities_raw:
+                for raw_entity in entities_raw:
+                    try:
+                        parsed = _json.loads(raw_entity)
+                        name = parsed.get("name", "").lower()
+                    except (ValueError, AttributeError):
+                        name = raw_entity.lower()
+                    if name in fav_entity_names:
+                        entity_counts[name] = entity_counts.get(name, 0) + 1
 
-        # Theme: count each article once per theme (not per topic)
-        seen_themes: set[str] = set()
-        for topic_slug in topics:
-            theme_slug = TOPIC_TO_THEME.get(topic_slug)
-            if theme_slug and theme_slug not in seen_themes:
-                seen_themes.add(theme_slug)
-                theme_counts[theme_slug] = theme_counts.get(theme_slug, 0) + 1
+            # Theme: count each article once per theme (not per topic)
+            seen_themes: set[str] = set()
+            for topic_slug in topics:
+                theme_slug = TOPIC_TO_THEME.get(topic_slug)
+                if theme_slug and theme_slug not in seen_themes:
+                    seen_themes.add(theme_slug)
+                    theme_counts[theme_slug] = theme_counts.get(theme_slug, 0) + 1
 
-    logger.info(
-        "tab_counts_served",
-        user_id=current_user_id,
-        total=total,
-        topic_count=len(topic_counts),
-        entity_count=len(entity_counts),
-        theme_count=len(theme_counts),
-    )
+        logger.info(
+            "tab_counts_served",
+            user_id=current_user_id,
+            total=total,
+            topic_count=len(topic_counts),
+            entity_count=len(entity_counts),
+            theme_count=len(theme_counts),
+        )
 
-    return TabCountsResponse(
-        total=total,
-        topics=topic_counts,
-        entities=entity_counts,
-        themes=theme_counts,
-    )
+        return TabCountsResponse(
+            total=total,
+            topics=topic_counts,
+            entities=entity_counts,
+            themes=theme_counts,
+        )
+
+    return await retry_db_op(_load_counts, session=db, op_name="feed.tab_counts")
 
 
 @router.get("/trending-topics", response_model=list[TrendingTopicResponse])

--- a/packages/api/app/workers/scheduler.py
+++ b/packages/api/app/workers/scheduler.py
@@ -130,6 +130,22 @@ async def _digest_watchdog() -> None:
                 )
 
                 if coverage < 0.90:
+                    # Garde call-site (Axe B) : si un digest tourne déjà
+                    # (cron 07h30 encore en cours, ou startup catchup), ne pas
+                    # lancer un 2e run complet → éviterait le pic pool x2
+                    # (2 × Semaphore(5)). La garde in-function de
+                    # `run_digest_generation` bloque aussi, mais on skip ici
+                    # pour ne pas même payer l'ouverture de session.
+                    from app.services.generation_state import is_generation_running
+
+                    if is_generation_running():
+                        logger.info(
+                            "digest_watchdog_skipped_generation_in_progress",
+                            coverage_pct=round(coverage * 100, 1),
+                            missing=expected_pairs - pair_count,
+                        )
+                        return
+
                     logger.warning(
                         "digest_watchdog_low_coverage_triggering_generation",
                         coverage_pct=round(coverage * 100, 1),
@@ -304,18 +320,32 @@ async def _pool_health_probe() -> None:
 
 
 def start_scheduler() -> None:
-    """Démarre le scheduler."""
+    """Démarre le scheduler.
+
+    Discipline de sérialisation (incident PYTHON-5M, fenêtre pool partagée) :
+    **chaque** `add_job` porte `max_instances=1` (+ `coalesce=True`) pour qu'un
+    run qui déborde sur le tick suivant ne lance jamais un 2e run concurrent
+    consommant le pool en double. APScheduler met déjà `max_instances=1` par
+    défaut → c'est défensif/documentaire ; le vrai correctif anti-double-digest
+    (3 appelants non coordonnés : cron, watchdog, startup catchup) est la garde
+    in-function `is_generation_running()` dans `run_digest_generation`, que
+    `max_instances` ne peut pas couvrir (il ne voit que le cron).
+    """
     global scheduler
 
     scheduler = AsyncIOScheduler()
 
-    # Job de synchronisation RSS (Intervalle)
+    # Job de synchronisation RSS (Intervalle).
+    # max_instances=1 + coalesce=True : voir la discipline de sérialisation
+    # documentée dans la docstring de start_scheduler (appliquée à tous les jobs).
     scheduler.add_job(
         sync_all_sources,
         trigger=IntervalTrigger(minutes=settings.rss_sync_interval_minutes),
         id="rss_sync",
         name="RSS Feed Synchronization",
         replace_existing=True,
+        coalesce=True,
+        max_instances=1,
     )
 
     # Job Digest Quotidien (07h30 Paris — voir DIGEST_CRON_HOUR_PARIS pour le
@@ -334,6 +364,7 @@ def start_scheduler() -> None:
         replace_existing=True,
         misfire_grace_time=14400,
         coalesce=True,
+        max_instances=1,
     )
 
     # Daily learned-subtopic decay (07h20 Paris) so digest scoring at 07h30
@@ -350,6 +381,7 @@ def start_scheduler() -> None:
         replace_existing=True,
         misfire_grace_time=14400,
         coalesce=True,
+        max_instances=1,
     )
 
     # Watchdog 08h15 — vérifie la couverture et relance si < 90%.
@@ -363,6 +395,7 @@ def start_scheduler() -> None:
         replace_existing=True,
         misfire_grace_time=14400,
         coalesce=True,
+        max_instances=1,
     )
 
     # Job Storage Cleanup Quotidien (3h00 Paris - heure creuse)
@@ -372,6 +405,8 @@ def start_scheduler() -> None:
         id="storage_cleanup",
         name="Storage Cleanup",
         replace_existing=True,
+        coalesce=True,
+        max_instances=1,
     )
 
     # Hard-delete soft-deleted user accounts older than 30 days (4h00 Paris,
@@ -382,6 +417,8 @@ def start_scheduler() -> None:
         id="purge_deleted_users",
         name="Purge soft-deleted users (>30d)",
         replace_existing=True,
+        coalesce=True,
+        max_instances=1,
     )
 
     # Recalcul `sources.language` à partir des Content des 30 derniers jours
@@ -392,6 +429,8 @@ def start_scheduler() -> None:
         id="recompute_source_language",
         name="Recompute Source.language (majoritaire 30j)",
         replace_existing=True,
+        coalesce=True,
+        max_instances=1,
     )
 
     # Projection budget coût API externes (évidence G3 scaling) : conso du mois
@@ -403,6 +442,8 @@ def start_scheduler() -> None:
         id="cost_budget_projection",
         name="Cost budget projection (api_usage_events)",
         replace_existing=True,
+        coalesce=True,
+        max_instances=1,
     )
 
     # Zombie session sweeper — kill Supavisor sessions stuck in
@@ -414,6 +455,8 @@ def start_scheduler() -> None:
         id="zombie_session_sweeper",
         name="Zombie session sweeper (idle in tx > 5min)",
         replace_existing=True,
+        coalesce=True,
+        max_instances=1,
     )
 
     # Sonde pool DB active (5 min) — rend la pression pool visible dans
@@ -424,6 +467,8 @@ def start_scheduler() -> None:
         id="pool_health_probe",
         name="DB pool health probe (5min)",
         replace_existing=True,
+        coalesce=True,
+        max_instances=1,
     )
 
     scheduler.add_job(

--- a/packages/api/tests/test_digest_generation_job.py
+++ b/packages/api/tests/test_digest_generation_job.py
@@ -502,3 +502,170 @@ class TestBatchFollowedSourceIds:
         compiled = str(stmt.compile(compile_kwargs={"literal_binds": True})).lower()
         assert "state in" in compiled
         assert "'followed'" in compiled and "'favorite'" in compiled
+
+
+class TestAntiDoubleDigestGuard:
+    """S1-B in-function guard: run_digest_generation must short-circuit when a
+    generation is already running, closing all 3 uncoordinated callers (cron,
+    watchdog, startup catchup)."""
+
+    @pytest.mark.asyncio
+    async def test_skips_when_generation_already_running(self):
+        import app.jobs.digest_generation_job as job_mod
+        from app.jobs.digest_generation_job import run_digest_generation
+
+        with (
+            patch(
+                "app.services.generation_state.is_generation_running",
+                return_value=True,
+            ),
+            patch(
+                "app.services.generation_state.mark_generation_started",
+            ) as mock_start,
+            patch.object(job_mod, "safe_async_session") as mock_safe_session,
+        ):
+            result = await run_digest_generation(target_date=datetime.date.today())
+
+        assert result["skipped"] is True
+        assert result["reason"] == "already_running"
+        assert "stats" in result
+        # Guard runs BEFORE mark_generation_started (which would clobber the
+        # in-flight run's _started_at) and before opening any session.
+        mock_start.assert_not_called()
+        mock_safe_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_proceeds_when_not_running(self):
+        from contextlib import asynccontextmanager
+
+        import app.jobs.digest_generation_job as job_mod
+        from app.jobs.digest_generation_job import run_digest_generation
+
+        mock_session = AsyncMock()
+
+        @asynccontextmanager
+        async def fake_sm():
+            yield mock_session
+
+        sentinel = {"success": True, "stats": {}}
+        mock_job = MagicMock()
+        mock_job.run = AsyncMock(return_value=sentinel)
+
+        with (
+            patch(
+                "app.services.generation_state.is_generation_running",
+                return_value=False,
+            ),
+            patch(
+                "app.services.generation_state.mark_generation_started",
+            ) as mock_start,
+            patch(
+                "app.services.generation_state.mark_generation_finished",
+            ) as mock_finish,
+            patch.object(job_mod, "DigestGenerationJob", return_value=mock_job),
+            patch.object(job_mod, "safe_async_session", side_effect=lambda: fake_sm()),
+        ):
+            result = await run_digest_generation(target_date=datetime.date.today())
+
+        assert result is sentinel
+        mock_start.assert_called_once()
+        mock_finish.assert_called_once()
+        mock_job.run.assert_awaited_once()
+        mock_session.commit.assert_awaited_once()
+
+
+class TestGenerationStateSafetyTimeout:
+    """generation_state auto-resets the running flag after _SAFETY_TIMEOUT so a
+    crashed-but-not-finished run can't block on-demand generation forever."""
+
+    def test_is_generation_running_auto_resets_after_timeout(self, monkeypatch):
+        import app.services.generation_state as gs
+
+        try:
+            monkeypatch.setattr(gs.time, "monotonic", lambda: 1000.0)
+            gs.mark_generation_started()
+            assert gs.is_generation_running() is True
+
+            # Still inside the safety window.
+            monkeypatch.setattr(
+                gs.time, "monotonic", lambda: 1000.0 + gs._SAFETY_TIMEOUT - 1
+            )
+            assert gs.is_generation_running() is True
+
+            # Past the safety window → auto-reset to False.
+            monkeypatch.setattr(
+                gs.time, "monotonic", lambda: 1000.0 + gs._SAFETY_TIMEOUT + 1
+            )
+            assert gs.is_generation_running() is False
+        finally:
+            gs.mark_generation_finished()
+
+
+class TestAxeCBatchTxRelease:
+    """S1-C: on the SUCCESS path, run() rolls back + re-applies session timeouts
+    after the trending read and before the editorial LLM precompute, so the
+    batch session is not left idle-in-transaction during the 3-5 min of LLM."""
+
+    @pytest.mark.asyncio
+    async def test_rollback_and_timeouts_before_editorial_precompute(
+        self, mock_session
+    ):
+        from contextlib import asynccontextmanager
+
+        import app.jobs.digest_generation_job as job_mod
+        from app.jobs.digest_generation_job import (
+            DigestGenerationJob,
+            GlobalTrendingContext,
+        )
+
+        job = DigestGenerationJob(batch_size=10)
+        # Empty user list keeps the editorial precompute body + per-user batch
+        # loop out of the way, isolating the trending → precompute boundary.
+        job._get_active_users = AsyncMock(return_value=[])
+        job._prune_old_highlights = AsyncMock()
+        job._match_grille_featured_article = AsyncMock()
+
+        fake_ctx = GlobalTrendingContext(
+            trending_content_ids=set(),
+            une_content_ids=set(),
+            computed_at=datetime.datetime.now(datetime.UTC),
+        )
+
+        # Coverage read in finalize() opens its own short session.
+        cov_session = AsyncMock()
+        cov_session.scalar = AsyncMock(return_value=0)
+
+        @asynccontextmanager
+        async def fake_cov_sm():
+            yield cov_session
+
+        mock_session.rollback = AsyncMock()
+
+        with (
+            patch.object(job_mod, "DigestSelector") as mock_sel_cls,
+            patch.object(
+                job_mod, "apply_session_timeouts", new_callable=AsyncMock
+            ) as mock_apply,
+            patch(
+                "app.services.editorial.pipeline.EditorialPipelineService"
+            ) as mock_pipe_cls,
+            patch.object(
+                job_mod, "safe_async_session", side_effect=lambda: fake_cov_sm()
+            ),
+        ):
+            mock_sel = MagicMock()
+            mock_sel._build_global_trending_context = AsyncMock(return_value=fake_ctx)
+            mock_sel_cls.return_value = mock_sel
+            # llm not ready → editorial precompute body skipped (no except path).
+            mock_pipe = MagicMock()
+            mock_pipe.llm.is_ready = False
+            mock_pipe_cls.return_value = mock_pipe
+
+            await job.run(mock_session, datetime.date.today())
+
+        # On the success path the trending/editorial except blocks never fire,
+        # so the single rollback + apply_session_timeouts pair IS the Axe C
+        # release between trending and the LLM precompute.
+        mock_session.rollback.assert_awaited_once()
+        mock_apply.assert_awaited_once()
+        assert mock_apply.await_args.args[0] is mock_session

--- a/packages/api/tests/test_read_endpoints_retry.py
+++ b/packages/api/tests/test_read_endpoints_retry.py
@@ -1,0 +1,90 @@
+"""S1-D resilience tests for the two read-only endpoints wrapped with
+``retry_db_op`` (cold-open hot reads): ``collections.list_collections`` and
+``feed.get_tab_counts``.
+
+Model: ``tests/test_sources_resilience.py``. We assert the endpoint replays a
+single transient pool error and returns OK — the helper ``retry_db_op`` itself
+is already unit-covered by ``TestRetryDbOp`` there, so we do not duplicate it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import OperationalError
+
+
+def _op_error(msg: str = "pool gone") -> OperationalError:
+    return OperationalError("SELECT 1", {}, Exception(msg))
+
+
+class TestListCollectionsRetry:
+    @pytest.mark.asyncio
+    async def test_retries_transient_then_succeeds(self):
+        from app.routers import collections as col_mod
+
+        mock_session = MagicMock()
+        mock_session.rollback = AsyncMock()
+
+        payload = [{"id": uuid4(), "name": "Lecture"}]
+        service = MagicMock()
+        service.list_collections = AsyncMock(side_effect=[_op_error(), payload])
+
+        with patch.object(col_mod, "CollectionService", return_value=service):
+            result = await col_mod.list_collections(
+                db=mock_session, current_user_id=str(uuid4())
+            )
+
+        assert result == payload
+        # First await raises, second succeeds → 2 awaits, 1 rollback.
+        assert service.list_collections.await_count == 2
+        assert mock_session.rollback.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_succeeds_on_first_try_no_rollback(self):
+        from app.routers import collections as col_mod
+
+        mock_session = MagicMock()
+        mock_session.rollback = AsyncMock()
+
+        payload = [{"id": uuid4(), "name": "Lecture"}]
+        service = MagicMock()
+        service.list_collections = AsyncMock(return_value=payload)
+
+        with patch.object(col_mod, "CollectionService", return_value=service):
+            result = await col_mod.list_collections(
+                db=mock_session, current_user_id=str(uuid4())
+            )
+
+        assert result == payload
+        service.list_collections.assert_awaited_once()
+        mock_session.rollback.assert_not_called()
+
+
+class TestTabCountsRetry:
+    @pytest.mark.asyncio
+    async def test_retries_transient_then_succeeds(self):
+        from app.routers import feed as feed_mod
+        from app.schemas.feed import TabCountsResponse
+
+        # On the recovering attempt, return no followed sources so _load_counts
+        # early-returns total=0 (keeps the retry assertion focused).
+        empty_result = MagicMock()
+        empty_result.all = Mock(return_value=[])
+        empty_scalars = MagicMock()
+        empty_scalars.all = Mock(return_value=[])
+
+        mock_db = MagicMock()
+        mock_db.rollback = AsyncMock()
+        mock_db.execute = AsyncMock(side_effect=[_op_error(), empty_result])
+        mock_db.scalars = AsyncMock(return_value=empty_scalars)
+
+        result = await feed_mod.get_tab_counts(db=mock_db, current_user_id=str(uuid4()))
+
+        assert isinstance(result, TabCountsResponse)
+        assert result.total == 0
+        # 1st attempt raises on execute, 2nd attempt executes the followed query.
+        assert mock_db.execute.await_count == 2
+        assert mock_db.rollback.await_count == 1

--- a/packages/api/tests/workers/test_scheduler.py
+++ b/packages/api/tests/workers/test_scheduler.py
@@ -295,9 +295,7 @@ class TestDigestJobConfiguration:
             # les poids que le scoring du digest consomme). Garde-fou contre une
             # régression du décalage horaire (06h50 < 07h30, cf. PYTHON-5M : le
             # decall évite le chevauchement avec la fenêtre de pression pool).
-            decay_minutes = (
-                SUBTOPIC_DECAY_HOUR_PARIS * 60 + SUBTOPIC_DECAY_MINUTE_PARIS
-            )
+            decay_minutes = SUBTOPIC_DECAY_HOUR_PARIS * 60 + SUBTOPIC_DECAY_MINUTE_PARIS
             digest_minutes = DIGEST_CRON_HOUR_PARIS * 60 + DIGEST_CRON_MINUTE_PARIS
             assert decay_minutes < digest_minutes
 
@@ -477,4 +475,130 @@ class TestDigestWatchdogCoverage:
         ):
             await _digest_watchdog()
 
+        # No users → early return, no generation attempted.
         mock_run.assert_not_awaited()
+
+
+def _capture_all_jobs() -> dict:
+    """Run start_scheduler() with a mocked APScheduler and capture every
+    add_job(**kwargs) keyed by job id."""
+    captured: dict = {}
+
+    def capture_add_job(*args, **kwargs):
+        job_id = kwargs.get("id")
+        if job_id:
+            captured[job_id] = kwargs
+
+    with patch("app.workers.scheduler.AsyncIOScheduler") as mock_scheduler_class:
+        mock_scheduler = Mock()
+        mock_scheduler_class.return_value = mock_scheduler
+        mock_scheduler.add_job = capture_add_job
+        start_scheduler()
+
+    return captured
+
+
+class TestJobSerialization:
+    """S1-A: every recurring job must be serialized (max_instances=1 +
+    coalesce=True) so a run that overruns its interval never spawns a
+    concurrent second run competing for the shared DB pool (PYTHON-5M)."""
+
+    def test_every_job_has_max_instances_one(self):
+        captured = _capture_all_jobs()
+        assert captured, "no jobs captured — start_scheduler registered nothing"
+        for job_id, kwargs in captured.items():
+            assert kwargs.get("max_instances") == 1, (
+                f"job {job_id} must set max_instances=1, "
+                f"got {kwargs.get('max_instances')!r}"
+            )
+
+    def test_every_job_has_coalesce_true(self):
+        captured = _capture_all_jobs()
+        for job_id, kwargs in captured.items():
+            assert kwargs.get("coalesce") is True, (
+                f"job {job_id} must set coalesce=True, got {kwargs.get('coalesce')!r}"
+            )
+
+    def test_expected_jobs_present(self):
+        """Guard: the serialization tests are vacuous if no jobs registered.
+        Pin the known recurring jobs so a future rename surfaces here."""
+        captured = _capture_all_jobs()
+        for job_id in (
+            "rss_sync",
+            "daily_digest",
+            "subtopic_weight_decay",
+            "digest_watchdog",
+            "storage_cleanup",
+            "purge_deleted_users",
+            "recompute_source_language",
+            "cost_budget_projection",
+            "zombie_session_sweeper",
+            "pool_health_probe",
+            "daily_essentiel_push_dispatch",
+        ):
+            assert job_id in captured, f"{job_id} not registered"
+
+
+class TestDigestWatchdogConcurrencyGuard:
+    """S1-B call-site guard: the watchdog must NOT launch a 2nd digest when a
+    generation is already running, even if coverage < 90 %."""
+
+    @pytest.mark.asyncio
+    async def test_watchdog_skips_when_generation_running(self):
+        from contextlib import asynccontextmanager
+
+        mock_session = AsyncMock()
+        # 10 users, 15 pairs = 75 % < 90 % → would normally trigger a rerun.
+        mock_session.scalar = AsyncMock(side_effect=[10, 15])
+
+        @asynccontextmanager
+        async def fake_sm():
+            yield mock_session
+
+        with (
+            patch(
+                "app.database.safe_async_session",
+                side_effect=lambda: fake_sm(),
+            ),
+            patch(
+                "app.services.generation_state.is_generation_running",
+                return_value=True,
+            ),
+            patch(
+                "app.workers.scheduler.run_digest_generation",
+                new_callable=AsyncMock,
+            ) as mock_run,
+        ):
+            await _digest_watchdog()
+
+        # Already running → skip despite low coverage.
+        mock_run.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_watchdog_triggers_when_not_running_and_low_coverage(self):
+        from contextlib import asynccontextmanager
+
+        mock_session = AsyncMock()
+        mock_session.scalar = AsyncMock(side_effect=[10, 15])  # 75 %
+
+        @asynccontextmanager
+        async def fake_sm():
+            yield mock_session
+
+        with (
+            patch(
+                "app.database.safe_async_session",
+                side_effect=lambda: fake_sm(),
+            ),
+            patch(
+                "app.services.generation_state.is_generation_running",
+                return_value=False,
+            ),
+            patch(
+                "app.workers.scheduler.run_digest_generation",
+                new_callable=AsyncMock,
+            ) as mock_run,
+        ):
+            await _digest_watchdog()
+
+        mock_run.assert_awaited_once()


### PR DESCRIPTION
## perf(scaling): S1 — capacité & robustesse de la couche connexion DB (sérialisation jobs + anti-double-digest + retry reads)

### Pourquoi
Le pool app est plafonné à 20 conns sur les **60 partagées** Supabase entre staging (`main`)
et prod (`production`). Sous charge matinale, des gaps structurels saturent le pool
(PYTHON-5M) et cascadent (idle-in-tx, PendingRollback). Cette PR ferme 4 gaps **sans
migration** (Python/config pur), dans la lignée directe des correctifs #900/#905.

### Ce que fait la PR (axes)
- **A — Sérialisation jobs** (`workers/scheduler.py`) : `max_instances=1` (+ `coalesce=True`)
  sur **tous** les `add_job`. Défensif/documentaire (APScheduler met déjà `max_instances=1`
  par défaut) ; le vrai correctif anti-double-digest est l'axe B.
- **B — Garde anti-double-digest** (load-bearing) :
  - **in-function** dans `run_digest_generation` : si `is_generation_running()` est déjà
    `True` à l'entrée → return `{"skipped": True, "reason": "already_running", "stats": …}`,
    **avant** `mark_generation_started()`. Ferme les **3 appelants non coordonnés** d'un coup
    (cron 07h30, watchdog 08h15 appel direct, startup catchup Railway appel direct) que
    `max_instances` ne voit pas → évite 2× `Semaphore(5)` = 10 slots pool d'un coup.
  - **call-site** dans `_digest_watchdog` : skip + log
    `digest_watchdog_skipped_generation_in_progress` si une génération tourne déjà.
  - Safety-timeout 600s de `generation_state` inchangé (échappatoire si un run se bloque).
- **C — Libérer la tx batch avant le LLM** (`jobs/digest_generation_job.py`) : `rollback()` +
  `apply_session_timeouts()` après la lecture *trending* et **avant** le pré-calcul éditorial,
  pour que la session batch ne reste pas `idle in transaction` pendant les 3-5 min de LLM
  (sur le **chemin succès** ; les `except` axe-A ne couvraient que les échecs).
- **D — Étendre `retry_db_op` à 2 reads chauds** (cold-open, zéro commit → replay sûr) :
  `collections.list_collections` et `feed.get_tab_counts` (phase requêtes enveloppée dans une
  factory `_load_counts()`). Réutilise le helper existant `app/utils/db_retry.py`.
- **E — Doc** : extension de `docs/maintenance/maintenance-saturation-pool-db-nocturne.md`
  (axes S1 + tests + chiffrage de l'externalisation scheduler, gardée **hors périmètre**).

### Réutilisation (rien réinventé)
`generation_state` (garde), `retry_db_op` (resilience reads), `safe_async_session` /
`apply_session_timeouts` (sessions). Aucun nouveau système.

### Vérifs locales
- `pytest tests/workers/test_scheduler.py tests/test_digest_generation_job.py
  tests/test_read_endpoints_retry.py` → **vert** (43 + endpoints).
- Suite complète `pytest` → voir CI.
- `ruff check` + `ruff format --check` (0.15.14) sur les fichiers touchés → clean.
- Alembic : **1 head** (`au02_api_usage_tokens`), aucune nouvelle révision.
- Smoke import/wiring : 11 jobs tous `max_instances=1`, les 2 endpoints wrappés,
  `run_digest_generation` référence `is_generation_running`.

### Déféré (hors PR)
Externalisation scheduler → worker Railway séparé (long terme : coordination cross-process
Redis/advisory-lock car `generation_state` est in-process ; right-size pool sous les 60
partagées). Retries write-path (après S3). Sémaphore global DB cross-jobs (inutile).
Augmenter le pool (exclu : 60 partagé 2 backends).

### À valider côté PO (lecture seule prod, post-deploy)
Fenêtre 07h00-08h30 : plus de pic pool x2 lié à un double digest ; logs
`digest_generation_already_running_skipped` / `digest_watchdog_skipped_generation_in_progress`
visibles si un overlap est évité ; pas de hausse des 500 sur `/api/collections/` ni
`/api/feed/tab-counts`. **Pas de merge sans ta validation.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
