### PR TITLE
feat: app update modal + topic chip in digest cards + badge spacing (#333)

### DIFF
--- a/apps/mobile/lib/config/theme.dart
+++ b/apps/mobile/lib/config/theme.dart
@@ -455,9 +455,19 @@ class FacteurTheme {
         foregroundColor: colors.textPrimary,
         elevation: 0,
         centerTitle: false,
-        systemOverlayStyle: brightness == Brightness.dark
-            ? SystemUiOverlayStyle.light
-            : SystemUiOverlayStyle.dark,
+        // Barres système transparentes (edge-to-edge). On n'utilise pas
+        // SystemUiOverlayStyle.light/.dark car elles forcent une
+        // systemNavigationBarColor noire, repeignant la barre à chaque écran.
+        systemOverlayStyle: SystemUiOverlayStyle(
+          statusBarColor: Colors.transparent,
+          statusBarIconBrightness:
+              brightness == Brightness.dark ? Brightness.light : Brightness.dark,
+          statusBarBrightness: brightness,
+          systemNavigationBarColor: Colors.transparent,
+          systemNavigationBarContrastEnforced: false,
+          systemNavigationBarIconBrightness:
+              brightness == Brightness.dark ? Brightness.light : Brightness.dark,
+        ),
         titleTextStyle: FacteurTypography.displaySmall(colors.textPrimary),
       ),
 

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -60,11 +60,20 @@ Future<void> _bootstrap() async {
   timeago.setLocaleMessages('fr', fr_messages.FrMessages());
   timeago.setLocaleMessages('fr_short', FrCompactMessages());
 
+  // Edge-to-edge : le contenu de l'app dessine derrière les barres système
+  // (status bar + barre de navigation), permettant des barres transparentes
+  // façon LinkedIn plutôt que le fond noir système par défaut.
+  await SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+
   SystemChrome.setSystemUIOverlayStyle(
     const SystemUiOverlayStyle(
       statusBarColor: Colors.transparent,
       statusBarIconBrightness: Brightness.light,
       statusBarBrightness: Brightness.dark,
+      systemNavigationBarColor: Colors.transparent,
+      // Désactive le scrim/contraste auto qui réintroduit un fond opaque
+      systemNavigationBarContrastEnforced: false,
+      systemNavigationBarIconBrightness: Brightness.light,
     ),
   );
 

--- a/docs/maintenance/maintenance-android-footer-transparency.md
+++ b/docs/maintenance/maintenance-android-footer-transparency.md
@@ -1,0 +1,40 @@
+# Maintenance — Barre de navigation Android transparente
+
+## Contexte
+
+Sur Android, la barre de navigation système (« footer » : boutons retour/accueil/récents
+ou la pilule gestuelle) s'affichait en **noir opaque**, créant une rupture visuelle avec
+le fond de l'app. Objectif : la rendre **transparente** (rendu edge-to-edge, façon
+LinkedIn), pour que le contenu / la barre de navigation de l'app apparaisse derrière.
+
+## Diagnostic
+
+Deux causes :
+
+1. `apps/mobile/lib/main.dart` — l'`SystemUiOverlayStyle` global ne définissait jamais
+   `systemNavigationBarColor`, laissant la valeur système par défaut (noir).
+2. `apps/mobile/lib/config/theme.dart` — `AppBarTheme.systemOverlayStyle` utilisait
+   `SystemUiOverlayStyle.light` / `.dark`, dont la `systemNavigationBarColor` est **noire**.
+   Chaque écran muni d'une `AppBar` repeignait donc la barre en noir.
+
+## Changements
+
+- **`main.dart`** :
+  - Activation du mode `SystemUiMode.edgeToEdge` (le contenu dessine derrière les barres système).
+  - `systemNavigationBarColor: Colors.transparent`
+  - `systemNavigationBarContrastEnforced: false` (désactive le scrim auto d'Android qui
+    réintroduit un fond opaque).
+  - `systemNavigationBarIconBrightness` ajouté pour la lisibilité des icônes système.
+- **`theme.dart`** : remplacement de `SystemUiOverlayStyle.light/.dark` par un style custom
+  transparent, avec la luminosité d'icônes (status bar + nav bar) adaptée au thème
+  (clair / sombre).
+
+Aucun changement Android natif requis : `_BottomNavBar` (shell_scaffold.dart) enveloppe déjà
+sa `SafeArea` dans un `Container` coloré (`backgroundPrimary`), dont le fond peint
+naturellement derrière la barre système désormais transparente.
+
+## Vérification
+
+- `flutter analyze` (lib/main.dart, lib/config/theme.dart)
+- Test visuel sur device/émulateur Android : barre de navigation transparente sur les
+  écrans avec et sans `AppBar`, en thèmes clair et sombre, contenu non masqué (SafeArea).


### PR DESCRIPTION
- Show update modal on digest launch when an update is available
- Replace onNotInterested with topicChipWidget in topic section cards
- Increase badge bottom padding (6→14px) in carousels and topic sections
- Add badge height constant for accurate card height computation
- Bump transitive dependency versions in pubspec.lock

Co-authored-by: Laurin Boujon <laurinboujon@mbp-de-laurin.home>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>