### PR TITLE
feat: app update modal + topic chip in digest cards + badge spacing (#333)

### DIFF
--- a/apps/mobile/lib/config/constants.dart
+++ b/apps/mobile/lib/config/constants.dart
@@ -331,6 +331,11 @@ class ExternalLinks {
   /// Lien d'invitation au groupe WhatsApp "Facteur - Retours & idées"
   static const String whatsappGroupUrl =
       'https://chat.whatsapp.com/Fq4oKgSDEgc9AmAyZR9uhJ?mode=gi_t';
+
+  /// URL Calendly pour prendre un call qualitatif avec l'équipe (Epic 13).
+  /// TODO(laurin): remplacer par le vrai lien Calendly avant le merge.
+  static const String calendlyUrl =
+      'https://calendly.com/laurin-facteur/feedback';
 }
 
 /// Liens légaux et support — pages statiques servies par le landing facteur.app.

--- a/apps/mobile/lib/features/feedback/models/feedback_models.dart
+++ b/apps/mobile/lib/features/feedback/models/feedback_models.dart
@@ -1,0 +1,32 @@
+/// Modèles du système de feedback utilisateur (Epic 13).
+library;
+
+/// Statut de l'invitation au call qualitatif renvoyé par l'API.
+class FeedbackInviteStatus {
+  /// La modal doit-elle s'afficher ?
+  final bool shouldShow;
+
+  /// Segment d'activité ("returning" | "low_active" | "active") ou null.
+  final String? segment;
+
+  /// Raison du non-affichage (debug / analytics) ou null.
+  final String? reason;
+
+  const FeedbackInviteStatus({
+    required this.shouldShow,
+    this.segment,
+    this.reason,
+  });
+
+  /// Valeur sûre par défaut : ne rien afficher.
+  factory FeedbackInviteStatus.hidden() =>
+      const FeedbackInviteStatus(shouldShow: false);
+
+  factory FeedbackInviteStatus.fromJson(Map<String, dynamic> json) {
+    return FeedbackInviteStatus(
+      shouldShow: json['should_show'] as bool? ?? false,
+      segment: json['segment'] as String?,
+      reason: json['reason'] as String?,
+    );
+  }
+}

--- a/apps/mobile/lib/features/feedback/providers/feedback_providers.dart
+++ b/apps/mobile/lib/features/feedback/providers/feedback_providers.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/api/api_provider.dart';
+import '../models/feedback_models.dart';
+import '../repositories/feedback_repository.dart';
+
+/// Provider du repository de feedback (Epic 13).
+final feedbackRepositoryProvider = Provider<FeedbackRepository>((ref) {
+  final apiClient = ref.watch(apiClientProvider);
+  return FeedbackRepository(apiClient);
+});
+
+/// Statut de l'invitation au call (gating segmenté côté backend).
+///
+/// Lu par la carte de fin de tournée pour décider si le CTA d'invitation
+/// au call doit s'afficher. Renvoie `hidden()` en cas d'erreur (jamais d'appel
+/// imposé).
+final inviteStatusProvider = FutureProvider<FeedbackInviteStatus>((ref) async {
+  return ref.read(feedbackRepositoryProvider).getInviteStatus();
+});

--- a/apps/mobile/lib/features/feedback/repositories/feedback_repository.dart
+++ b/apps/mobile/lib/features/feedback/repositories/feedback_repository.dart
@@ -1,0 +1,69 @@
+import '../../../core/api/api_client.dart';
+import '../models/feedback_models.dart';
+
+/// Repository pour le système de feedback utilisateur (Epic 13).
+///
+/// Toutes les méthodes "best-effort" échouent silencieusement : le feedback
+/// ne doit jamais casser le flux du moment de fermeture.
+class FeedbackRepository {
+  final ApiClient _apiClient;
+
+  FeedbackRepository(this._apiClient);
+
+  /// Enregistre le micro-feedback emoji du jour ("low" | "ok" | "high").
+  Future<void> submitSentiment(String sentiment, {DateTime? date}) async {
+    try {
+      await _apiClient.dio.post<dynamic>(
+        'feedback/sentiment',
+        data: {
+          'sentiment': sentiment,
+          if (date != null)
+            'digest_date': date.toIso8601String().split('T').first,
+        },
+      );
+    } catch (e) {
+      // ignore: avoid_print
+      print('FeedbackRepository: submitSentiment failed: $e');
+    }
+  }
+
+  /// Récupère le statut de l'invitation au call.
+  /// Renvoie `hidden()` en cas d'erreur (on ne dérange jamais par défaut).
+  Future<FeedbackInviteStatus> getInviteStatus() async {
+    try {
+      final response = await _apiClient.dio.get<dynamic>('feedback/invite');
+      if (response.statusCode == 200 && response.data != null) {
+        return FeedbackInviteStatus.fromJson(
+          response.data as Map<String, dynamic>,
+        );
+      }
+    } catch (e) {
+      // ignore: avoid_print
+      print('FeedbackRepository: getInviteStatus failed: $e');
+    }
+    return FeedbackInviteStatus.hidden();
+  }
+
+  /// Marque la modal comme affichée (incrémente le compteur côté backend).
+  Future<void> markInviteShown() async {
+    try {
+      await _apiClient.dio.post<dynamic>('feedback/invite/shown');
+    } catch (e) {
+      // ignore: avoid_print
+      print('FeedbackRepository: markInviteShown failed: $e');
+    }
+  }
+
+  /// Enregistre l'action de l'utilisateur ("accepted" | "declined").
+  Future<void> submitInviteAction(String action) async {
+    try {
+      await _apiClient.dio.post<dynamic>(
+        'feedback/invite/action',
+        data: {'action': action},
+      );
+    } catch (e) {
+      // ignore: avoid_print
+      print('FeedbackRepository: submitInviteAction failed: $e');
+    }
+  }
+}

--- a/apps/mobile/lib/features/feedback/widgets/call_invite_sheet.dart
+++ b/apps/mobile/lib/features/feedback/widgets/call_invite_sheet.dart
@@ -1,0 +1,179 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../../config/constants.dart';
+import '../../../config/theme.dart';
+import '../providers/feedback_providers.dart';
+
+/// Copy de la modal, adaptée au segment d'activité.
+({String title, String body}) _copyForSegment(String? segment) {
+  switch (segment) {
+    case 'returning':
+      return (
+        title: 'Content de te revoir 👋',
+        body:
+            "Salut, c'est Laurin. Ça fait un moment qu'on s'était pas croisés — "
+            "j'aimerais beaucoup comprendre ce qui t'a éloigné, et ce qui te "
+            "ramène. Ton retour pèse directement sur ce que je code ensuite.",
+      );
+    case 'low_active':
+      return (
+        title: 'On prend 15 min ? 👋',
+        body:
+            "Salut, c'est Laurin. Je vois que tu passes de temps en temps — "
+            "j'aimerais comprendre ce qui te retient de revenir plus souvent. "
+            "Ton avis a un impact direct sur la suite de Facteur.",
+      );
+    case 'active':
+    default:
+      return (
+        title: 'Merci d\'être là 🙏',
+        body:
+            "Salut, c'est Laurin. Tu lis Facteur régulièrement, et ça compte "
+            "énormément. J'aimerais t'entendre : ce qui marche, ce qu'on peut "
+            "améliorer. 15 min en visio, à l'horaire qui t'arrange.",
+      );
+  }
+}
+
+/// Modal d'invitation à un call qualitatif avec l'équipe (Epic 13).
+///
+/// Affichée 1x (gating segmenté côté backend) au moment de fermeture.
+/// Trois sorties : prendre un call, signaler un point précis (les deux
+/// ouvrent Calendly en v1), ou reporter ("Pas maintenant" → snooze backend).
+class CallInviteSheet extends ConsumerWidget {
+  final String? segment;
+
+  const CallInviteSheet({super.key, this.segment});
+
+  /// Affiche la modal en bottom sheet.
+  static Future<void> show(BuildContext context, {String? segment}) {
+    return showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (_) => CallInviteSheet(segment: segment),
+    );
+  }
+
+  Future<void> _accept(BuildContext context, WidgetRef ref) async {
+    await ref.read(feedbackRepositoryProvider).submitInviteAction('accepted');
+    final uri = Uri.parse(ExternalLinks.calendlyUrl);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+    if (context.mounted) Navigator.pop(context);
+  }
+
+  Future<void> _decline(BuildContext context, WidgetRef ref) async {
+    await ref.read(feedbackRepositoryProvider).submitInviteAction('declined');
+    if (context.mounted) Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+    final copy = _copyForSegment(segment);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: colors.surface,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      padding: const EdgeInsets.fromLTRB(24, 12, 24, 32),
+      child: SingleChildScrollView(
+        child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Drag handle
+          Center(
+            child: Container(
+              width: 36,
+              height: 4,
+              decoration: BoxDecoration(
+                color: colors.textTertiary.withValues(alpha: 0.3),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          const SizedBox(height: 20),
+
+          // Avatar (placeholder — TODO(laurin): remplacer par une vraie photo)
+          Center(
+            child: CircleAvatar(
+              radius: 36,
+              backgroundColor: colors.primary.withValues(alpha: 0.12),
+              child: const Text(
+                '👋',
+                style: TextStyle(fontSize: 34),
+              ),
+            ),
+          ),
+          const SizedBox(height: FacteurSpacing.space4),
+
+          Text(
+            copy.title,
+            style: textTheme.titleLarge?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: colors.textPrimary,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: FacteurSpacing.space3),
+
+          Text(
+            copy.body,
+            style: textTheme.bodyMedium?.copyWith(color: colors.textSecondary),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: FacteurSpacing.space6),
+
+          // Primary : prendre un call
+          ElevatedButton(
+            onPressed: () => _accept(context, ref),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: colors.primary,
+              foregroundColor: Colors.white,
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(FacteurRadius.medium),
+              ),
+            ),
+            child: const Text('15 min, je suis curieux'),
+          ),
+          const SizedBox(height: FacteurSpacing.space3),
+
+          // Secondary : un point précis
+          OutlinedButton(
+            onPressed: () => _accept(context, ref),
+            style: OutlinedButton.styleFrom(
+              foregroundColor: colors.primary,
+              side: BorderSide(color: colors.primary.withValues(alpha: 0.4)),
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(FacteurRadius.medium),
+              ),
+            ),
+            child: const Text('J\'ai un truc précis à te dire'),
+          ),
+          const SizedBox(height: FacteurSpacing.space2),
+
+          // Sortie douce
+          TextButton(
+            onPressed: () => _decline(context, ref),
+            child: Text(
+              'Pas maintenant',
+              style: textTheme.bodyMedium?.copyWith(
+                color: colors.textTertiary,
+              ),
+            ),
+          ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/feedback/widgets/feedback_closing_card.dart
+++ b/apps/mobile/lib/features/feedback/widgets/feedback_closing_card.dart
@@ -1,0 +1,163 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../../config/theme.dart';
+import '../providers/feedback_providers.dart';
+import 'call_invite_sheet.dart';
+import 'sentiment_picker.dart';
+
+/// Carte de fin de Tournée du jour dédiée au feedback (Epic 13).
+///
+/// Insérée juste après la carte « Fin de tournée » sur la page l'Essentiel.
+/// - Toujours : micro-feedback emoji (😴/🙂/🔥).
+/// - Si l'utilisateur est éligible (gating segmenté côté backend) : un CTA
+///   discret pour prendre un call qualitatif avec Laurin (ouvre CallInviteSheet).
+class FeedbackClosingCard extends ConsumerStatefulWidget {
+  /// Date de la tournée notée (par défaut : aujourd'hui côté backend).
+  final DateTime? digestDate;
+
+  const FeedbackClosingCard({super.key, this.digestDate});
+
+  @override
+  ConsumerState<FeedbackClosingCard> createState() =>
+      _FeedbackClosingCardState();
+}
+
+class _FeedbackClosingCardState extends ConsumerState<FeedbackClosingCard> {
+  bool _shownMarked = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final invite = ref.watch(inviteStatusProvider).valueOrNull;
+    final showCall = invite?.shouldShow ?? false;
+
+    // Marque l'invitation comme affichée une seule fois (source de vérité
+    // backend pour le cap d'affichages et le snooze).
+    if (showCall && !_shownMarked) {
+      _shownMarked = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        ref.read(feedbackRepositoryProvider).markInviteShown();
+      });
+    }
+
+    return Container(
+      margin: const EdgeInsets.fromLTRB(18, 8, 18, 8),
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        color: colors.surface,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.06),
+            blurRadius: 4,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(22, 20, 22, 22),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Tampon « TON AVIS COMPTE » dans l'esprit des cartes de tournée.
+            Transform.rotate(
+              angle: -2 * math.pi / 180,
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                decoration: BoxDecoration(
+                  border: Border.all(color: colors.primary, width: 1.5),
+                ),
+                child: Text(
+                  'TON AVIS COMPTE',
+                  style: GoogleFonts.courierPrime(
+                    fontSize: 10,
+                    fontWeight: FontWeight.w700,
+                    color: colors.primary,
+                    letterSpacing: 2.0,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 6),
+
+            // Micro-feedback emoji (toujours présent).
+            SentimentPicker(digestDate: widget.digestDate),
+
+            // Invitation au call (conditionnelle, gated backend).
+            if (showCall) ...[
+              const SizedBox(height: 18),
+              Divider(
+                height: 1,
+                color: colors.textTertiary.withValues(alpha: 0.15),
+              ),
+              const SizedBox(height: 16),
+              _CallInviteTeaser(
+                onTap: () =>
+                    CallInviteSheet.show(context, segment: invite?.segment),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Bloc compact qui amorce l'invitation au call : avatar + une phrase + CTA.
+/// Le détail (copy segmentée + 3 sorties) vit dans [CallInviteSheet].
+class _CallInviteTeaser extends StatelessWidget {
+  final VoidCallback onTap;
+
+  const _CallInviteTeaser({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+
+    return Column(
+      children: [
+        Row(
+          children: [
+            CircleAvatar(
+              radius: 22,
+              backgroundColor: colors.primary.withValues(alpha: 0.12),
+              child: const Text('👋', style: TextStyle(fontSize: 20)),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                'Laurin (qui construit Facteur) aimerait t’entendre 15 min.',
+                style: GoogleFonts.dmSans(
+                  fontSize: 13,
+                  height: 1.35,
+                  fontWeight: FontWeight.w500,
+                  color: colors.textPrimary,
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 14),
+        SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            onPressed: onTap,
+            style: ElevatedButton.styleFrom(
+              backgroundColor: colors.primary,
+              foregroundColor: Colors.white,
+              padding: const EdgeInsets.symmetric(vertical: 14),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(FacteurRadius.medium),
+              ),
+            ),
+            child: const Text('Discuter avec Laurin'),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/mobile/lib/features/feedback/widgets/sentiment_picker.dart
+++ b/apps/mobile/lib/features/feedback/widgets/sentiment_picker.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../config/theme.dart';
+import '../providers/feedback_providers.dart';
+
+/// Micro-feedback emoji affiché en fin de Tournée du jour (Epic 13).
+///
+/// 3 niveaux : 😴 ("low"), 🙂 ("ok"), 🔥 ("high"). Un tap, optionnel, non
+/// bloquant. Intégré dans la carte de fin de tournée (`FeedbackClosingCard`).
+class SentimentPicker extends ConsumerStatefulWidget {
+  /// Date du digest noté (par défaut : aujourd'hui côté backend).
+  final DateTime? digestDate;
+
+  const SentimentPicker({super.key, this.digestDate});
+
+  @override
+  ConsumerState<SentimentPicker> createState() => _SentimentPickerState();
+}
+
+class _SentimentPickerState extends ConsumerState<SentimentPicker> {
+  String? _selected;
+
+  static const List<({String value, String emoji, String label})> _options = [
+    (value: 'low', emoji: '😴', label: 'Bof'),
+    (value: 'ok', emoji: '🙂', label: 'Sympa'),
+    (value: 'high', emoji: '🔥', label: 'Top'),
+  ];
+
+  Future<void> _onTap(String value) async {
+    if (_selected != null) return;
+    setState(() => _selected = value);
+    await ref
+        .read(feedbackRepositoryProvider)
+        .submitSentiment(value, date: widget.digestDate);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+
+    if (_selected != null) {
+      return Padding(
+        padding: const EdgeInsets.only(top: FacteurSpacing.space3),
+        child: Text(
+          'Merci pour ton retour 🙏',
+          style: textTheme.bodyMedium?.copyWith(
+            color: colors.textSecondary,
+            fontWeight: FontWeight.w500,
+          ),
+          textAlign: TextAlign.center,
+        ),
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.only(top: FacteurSpacing.space3),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            'Ta tournée du jour, c\'était comment ?',
+            style: textTheme.bodySmall?.copyWith(
+              color: colors.textSecondary,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: FacteurSpacing.space2),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              for (final option in _options)
+                _EmojiButton(
+                  emoji: option.emoji,
+                  label: option.label,
+                  onTap: () => _onTap(option.value),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmojiButton extends StatelessWidget {
+  final String emoji;
+  final String label;
+  final VoidCallback onTap;
+
+  const _EmojiButton({
+    required this.emoji,
+    required this.label,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 10),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(16),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(emoji, style: const TextStyle(fontSize: 30)),
+              const SizedBox(height: 4),
+              Text(
+                label,
+                style: textTheme.labelSmall?.copyWith(
+                  color: colors.textTertiary,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -28,6 +28,7 @@ import '../../digest/models/digest_models.dart';
 import '../../feed/models/content_model.dart';
 import '../../feed/widgets/explore_section.dart' show ExploreDiscoverySkeleton;
 import '../../feed/widgets/feedback_inline.dart';
+import '../../feedback/widgets/feedback_closing_card.dart';
 import '../../lettres/widgets/lettres_notification_banner.dart';
 import '../../notifications/widgets/notification_activation_modal.dart';
 import '../../notifications/widgets/notification_renudge_banner.dart';
@@ -1258,6 +1259,9 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
                 ),
               ),
             ),
+            // Carte feedback de fin de tournée (Epic 13) — micro-feedback emoji
+            // + invitation au call qualitatif (gating segmenté côté backend).
+            const SliverToBoxAdapter(child: FeedbackClosingCard()),
             const SliverToBoxAdapter(child: SizedBox(height: 92)),
           ],
         ),

--- a/apps/mobile/test/features/feedback/widgets/call_invite_sheet_test.dart
+++ b/apps/mobile/test/features/feedback/widgets/call_invite_sheet_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:facteur/features/feedback/providers/feedback_providers.dart';
+import 'package:facteur/features/feedback/repositories/feedback_repository.dart';
+import 'package:facteur/features/feedback/widgets/call_invite_sheet.dart';
+
+class MockFeedbackRepository extends Mock implements FeedbackRepository {}
+
+void main() {
+  late MockFeedbackRepository mockRepo;
+
+  setUp(() {
+    mockRepo = MockFeedbackRepository();
+    when(() => mockRepo.submitInviteAction(any())).thenAnswer((_) async {});
+  });
+
+  // Bouton lanceur pour disposer d'un Navigator capable de "pop".
+  Widget createLauncher(String? segment) {
+    return ProviderScope(
+      overrides: [
+        feedbackRepositoryProvider.overrideWithValue(mockRepo),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: ElevatedButton(
+                onPressed: () =>
+                    CallInviteSheet.show(context, segment: segment),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> openSheet(WidgetTester tester, String? segment) async {
+    await tester.pumpWidget(createLauncher(segment));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  group('CallInviteSheet', () {
+    testWidgets('shows the active-segment copy and three options',
+        (tester) async {
+      await openSheet(tester, 'active');
+
+      expect(find.textContaining('Merci d\'être là'), findsOneWidget);
+      expect(find.text('15 min, je suis curieux'), findsOneWidget);
+      expect(find.text('J\'ai un truc précis à te dire'), findsOneWidget);
+      expect(find.text('Pas maintenant'), findsOneWidget);
+    });
+
+    testWidgets('shows returning-segment copy', (tester) async {
+      await openSheet(tester, 'returning');
+      expect(find.textContaining('Content de te revoir'), findsOneWidget);
+    });
+
+    testWidgets('shows low_active-segment copy', (tester) async {
+      await openSheet(tester, 'low_active');
+      expect(find.textContaining('On prend 15 min'), findsOneWidget);
+    });
+
+    testWidgets('"Pas maintenant" records declined and closes the sheet',
+        (tester) async {
+      await openSheet(tester, 'active');
+
+      await tester.tap(find.text('Pas maintenant'));
+      await tester.pumpAndSettle();
+
+      verify(() => mockRepo.submitInviteAction('declined')).called(1);
+      expect(find.text('Pas maintenant'), findsNothing);
+    });
+  });
+}

--- a/apps/mobile/test/features/feedback/widgets/feedback_closing_card_test.dart
+++ b/apps/mobile/test/features/feedback/widgets/feedback_closing_card_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:facteur/features/feedback/models/feedback_models.dart';
+import 'package:facteur/features/feedback/providers/feedback_providers.dart';
+import 'package:facteur/features/feedback/repositories/feedback_repository.dart';
+import 'package:facteur/features/feedback/widgets/feedback_closing_card.dart';
+
+class MockFeedbackRepository extends Mock implements FeedbackRepository {}
+
+void main() {
+  late MockFeedbackRepository mockRepo;
+
+  setUpAll(() => registerFallbackValue(DateTime(2024, 1, 1)));
+
+  setUp(() {
+    mockRepo = MockFeedbackRepository();
+    when(() => mockRepo.markInviteShown()).thenAnswer((_) async {});
+    when(() => mockRepo.submitSentiment(any(), date: any(named: 'date')))
+        .thenAnswer((_) async {});
+  });
+
+  Widget createWidget(FeedbackInviteStatus status) {
+    return ProviderScope(
+      overrides: [
+        feedbackRepositoryProvider.overrideWithValue(mockRepo),
+        inviteStatusProvider.overrideWith((ref) async => status),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(child: FeedbackClosingCard()),
+        ),
+      ),
+    );
+  }
+
+  group('FeedbackClosingCard', () {
+    testWidgets('always shows the emoji micro-feedback', (tester) async {
+      await tester.pumpWidget(
+        createWidget(const FeedbackInviteStatus(shouldShow: false)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('TON AVIS'), findsOneWidget);
+      expect(find.text('🔥'), findsOneWidget);
+    });
+
+    testWidgets('hides the call CTA when not eligible', (tester) async {
+      await tester.pumpWidget(
+        createWidget(const FeedbackInviteStatus(shouldShow: false)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Discuter avec Laurin'), findsNothing);
+      verifyNever(() => mockRepo.markInviteShown());
+    });
+
+    testWidgets('shows the call CTA and marks shown when eligible',
+        (tester) async {
+      await tester.pumpWidget(
+        createWidget(
+          const FeedbackInviteStatus(shouldShow: true, segment: 'active'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Discuter avec Laurin'), findsOneWidget);
+      verify(() => mockRepo.markInviteShown()).called(1);
+    });
+  });
+}

--- a/apps/mobile/test/features/feedback/widgets/sentiment_picker_test.dart
+++ b/apps/mobile/test/features/feedback/widgets/sentiment_picker_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:facteur/features/feedback/providers/feedback_providers.dart';
+import 'package:facteur/features/feedback/repositories/feedback_repository.dart';
+import 'package:facteur/features/feedback/widgets/sentiment_picker.dart';
+
+class MockFeedbackRepository extends Mock implements FeedbackRepository {}
+
+void main() {
+  late MockFeedbackRepository mockRepo;
+
+  setUpAll(() {
+    registerFallbackValue(DateTime(2024, 1, 1));
+  });
+
+  setUp(() {
+    mockRepo = MockFeedbackRepository();
+    when(() => mockRepo.submitSentiment(any(), date: any(named: 'date')))
+        .thenAnswer((_) async {});
+  });
+
+  Widget createWidget() {
+    return ProviderScope(
+      overrides: [
+        feedbackRepositoryProvider.overrideWithValue(mockRepo),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(
+          body: Center(child: SentimentPicker()),
+        ),
+      ),
+    );
+  }
+
+  group('SentimentPicker', () {
+    testWidgets('renders the question and three emojis', (tester) async {
+      await tester.pumpWidget(createWidget());
+
+      expect(find.textContaining('c\'était comment'), findsOneWidget);
+      expect(find.text('😴'), findsOneWidget);
+      expect(find.text('🙂'), findsOneWidget);
+      expect(find.text('🔥'), findsOneWidget);
+    });
+
+    testWidgets('tapping an emoji submits sentiment and shows thanks',
+        (tester) async {
+      await tester.pumpWidget(createWidget());
+
+      await tester.tap(find.text('🔥'));
+      await tester.pump();
+
+      verify(() => mockRepo.submitSentiment('high', date: any(named: 'date')))
+          .called(1);
+      expect(find.textContaining('Merci'), findsOneWidget);
+      // Emojis are gone after selection
+      expect(find.text('🔥'), findsNothing);
+    });
+
+    testWidgets('only submits once even on repeated taps', (tester) async {
+      await tester.pumpWidget(createWidget());
+
+      await tester.tap(find.text('🙂'));
+      await tester.pump();
+      // After first tap the picker is replaced by the thanks message, so a
+      // second tap on the (now absent) emoji is a no-op.
+      verify(() => mockRepo.submitSentiment('ok', date: any(named: 'date')))
+          .called(1);
+    });
+  });
+}

--- a/docs/qa/scripts/verify_feedback.sh
+++ b/docs/qa/scripts/verify_feedback.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Vérification du système de feedback utilisateur (Epic 13, story 13.1).
+# - Lance les tests unitaires du router feedback (segmentation, gating, snooze).
+# - Vérifie qu'il reste exactement 1 head Alembic.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+API_DIR="$PROJECT_ROOT/packages/api"
+
+cd "$API_DIR"
+
+echo "=== 1. Tests unitaires feedback (segmentation + gating + snooze) ==="
+pytest tests/test_feedback_router.py -v
+
+echo ""
+echo "=== 2. Un seul head Alembic ? ==="
+HEADS=$(alembic heads 2>/dev/null | grep -c "(head)")
+echo "Nombre de heads: $HEADS"
+if [ "$HEADS" != "1" ]; then
+  echo "❌ Attendu 1 head, trouvé $HEADS"
+  exit 1
+fi
+echo "✅ 1 head"
+
+echo ""
+echo "=== 3. Endpoints exposés ? ==="
+grep -q "feedback.router" app/main.py && echo "✅ router feedback enregistré" \
+  || { echo "❌ router feedback non enregistré dans main.py"; exit 1; }
+
+echo ""
+echo "✅ Vérification feedback OK"

--- a/docs/stories/core/13.1.feedback-system.md
+++ b/docs/stories/core/13.1.feedback-system.md
@@ -1,0 +1,207 @@
+# Story 13.1 — Système de feedback utilisateur (micro-feedback + invitation call)
+
+> **Type** : Feature
+> **Statut** : ✅ IMPLÉMENTÉ — tests backend verts, mobile à valider en CI (pas de SDK Flutter dans l'env)
+> **Branche** : `claude/user-feedback-system-6hrqr6`
+> **Épic** : 13 — Voix de l'utilisateur
+
+---
+
+## 1. Contexte & objectif
+
+On veut **structurellement** récolter du feedback utilisateur :
+- **En volume / quantitatif** : capter le ressenti de tous les lecteurs, sans friction.
+- **En profondeur / qualitatif** : parler en visio avec les utilisateurs engagés (call Calendly avec Laurin).
+
+Le **moment de fermeture** (`ClosureScreen`, fin du digest quotidien) est le point d'ancrage : moment calme, à forte charge émotionnelle, où l'utilisateur vient de *terminer* son rituel. On y greffe les deux étages.
+
+### Décisions actées (brainstorm)
+- **Scope v1 = B** : micro-feedback emojis **+** modal d'invitation call.
+- **RDV = lien Calendly externe** (pas de webhook en v1), URL en **placeholder** à remplacer avant merge.
+- **Logique de déclenchement = backend** (robuste, pilotable, analysable), pas SharedPreferences seul.
+- **Le micro-feedback emojis REMPLACE** le CTA Notion existant du `ClosureScreen`.
+- **Gating segmenté** par niveau d'activité (cf. §2) — on cible aussi les utilisateurs qui décrochent.
+
+### Non-objectifs v1
+- Pas de webhook Calendly / mesure de conversion booking (v2).
+- Pas de question ouverte conditionnelle ni de canal asynchrone permanent (v2/v3).
+- Pas de WebView Calendly embarquée (on ouvre le navigateur externe).
+
+---
+
+## 2. Règles produit
+
+### Micro-feedback emojis (chaque fermeture)
+- 3 emojis sur le `ClosureScreen` : 😴 (mou) · 🙂 (correct) · 🔥 (top).
+- 1 tap, optionnel, non bloquant. Remplace/complète le CTA Notion existant (ligne 287-329).
+- Une réponse par `(user_id, digest_date)` — upsert (l'utilisateur peut changer d'avis).
+- Feedback visuel léger après tap (« Merci 🙏 »), pas de modal intrusive.
+
+### Modal d'invitation au call (1x, gated, segmenté)
+
+Le seuil de déclenchement **dépend du segment d'activité**, calculé depuis `digest_completions` (1 ligne/jour complété). On cible aussi bien les utilisateurs engagés que ceux qui décrochent.
+
+| Segment | Définition | Seuil call | Intention |
+|---|---|---|---|
+| **`returning`** (dormant/de retour) | a déjà ≥1 digest, **revient après ≥10 j d'absence** (gap avant la complétion du jour) | **1** | « ce qui t'a éloigné / ramené » |
+| **`low_active`** (peu actif) | **≥2** digests **étalés sur ≥7 j**, et NON `returning` | **2** | « ce qui te retient de revenir + souvent » |
+| **`active`** (actif) | **≥4** digests | **4** | « ce qui marche / à améliorer » |
+
+Conditions communes (toutes vraies) :
+1. **Segment éligible** atteint (table ci-dessus).
+2. **Jamais terminal** : pas d'invite `accepted`, ni `declined` après 2ᵉ affichage.
+3. **Snooze respecté** : « Pas maintenant » → pas de relance avant +21 j (1 relance max, ensuite plus jamais).
+
+Constantes (ajustables, dans le router) :
+`RETURNING_GAP_DAYS = 10`, `LOWACTIVE_MIN = 2`, `LOWACTIVE_SPREAD_DAYS = 7`, `ACTIVE_MIN = 4`, `SNOOZE_DAYS = 21`, `MAX_SHOWS = 2`.
+
+Le `segment` est persisté sur `feedback_invites` → texte de la modal adapté par segment + analyse.
+
+> **Limite assumée v1** : `returning` ne se déclenche que si l'utilisateur **rouvre** un digest (trigger in-app). Les vrais churners qui ne reviennent jamais nécessitent push/email → candidat v2.
+
+Contenu de la modal (humain / attrayant) :
+- Photo + 1ʳᵉ personne : « Salut, c'est Laurin 👋 ».
+- Reconnaissance : « Ça fait X jours que tu lis ton digest — merci, vraiment. »
+- Valeur d'échange : accès roadmap / influence directe v2 (pas de récompense monétaire).
+- 3 sorties :
+  - **« 15 min, je suis curieux »** → ouvre Calendly (lien externe).
+  - **« J'ai un truc précis à te dire »** → ouvre aussi Calendly (v1 ; champ texte direct en v2).
+  - **« Pas maintenant »** → snooze 21j, fermeture sans culpabilité.
+
+---
+
+## 3. Architecture technique
+
+### 3.1 Backend (`packages/api`)
+
+**Nouveau modèle** `app/models/user_feedback.py` (style calqué sur `digest_completion.py`) :
+
+```python
+class DigestSentiment(Base):
+    __tablename__ = "digest_sentiments"
+    __table_args__ = (
+        UniqueConstraint("user_id", "digest_date", name="uq_digest_sentiments_user_date"),
+        Index("ix_digest_sentiments_user_id", "user_id"),
+    )
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    digest_date: Mapped[date] = mapped_column(Date, nullable=False)
+    sentiment: Mapped[str] = mapped_column(String, nullable=False)  # "low" | "ok" | "high"
+    created_at / updated_at
+
+class FeedbackInvite(Base):
+    __tablename__ = "feedback_invites"
+    __table_args__ = (UniqueConstraint("user_id", name="uq_feedback_invites_user"),)
+    id: Mapped[UUID] = ...
+    user_id: Mapped[UUID] = mapped_column(unique=True, nullable=False)
+    status: Mapped[str]  # "snoozed" | "accepted" | "declined"
+    shown_count: Mapped[int] = mapped_column(default=0, server_default="0")
+    last_shown_at: Mapped[datetime | None]
+    snoozed_until: Mapped[datetime | None]
+    created_at / updated_at
+```
+
+**Schemas** `app/schemas/feedback.py` (natif `list[]` / `X | None`) :
+- `SentimentRequest { sentiment: str (pattern ^(low|ok|high)$), digest_date: str | None }`
+- `FeedbackInviteStatus { should_show: bool, reason: str | None }`
+- `InviteActionRequest { action: str (pattern ^(accepted|declined)$) }`
+
+**Router** `app/routers/feedback.py` (préfixe `/api/feedback`, `Depends(get_current_user_id)`) :
+- `POST /sentiment` → upsert `digest_sentiments`.
+- `GET /invite` → calcule `should_show` (requête `digest_completions` : count distinct + écart min/max date ≥ 7j ; vérifie `feedback_invites`). N'incrémente PAS ici.
+- `POST /invite/shown` → incrémente `shown_count`, set `last_shown_at` (appelé quand la modal s'affiche).
+- `POST /invite/action` → enregistre `accepted` (terminal) ou `declined` (→ `snoozed`, `snoozed_until = now + 21j`, terminal après 2ᵉ affichage).
+
+**Enregistrement dans** `main.py` : `app.include_router(feedback.router, prefix="/api/feedback", tags=["Feedback"])`.
+
+**Migration Alembic** : `alembic revision -m "add_feedback_tables"` → crée `digest_sentiments` + `feedback_invites`. Brancher sur le head réel (`alembic heads`), 1 seul head (hook `post-edit-alembic-heads.sh`). **Exécution SQL via Supabase SQL Editor** (jamais sur Railway, cf. CLAUDE.md) — le SQL sera fourni dans la PR.
+
+### 3.2 Mobile (`apps/mobile`)
+
+**Config** `lib/config/constants.dart` → `ExternalLinks.calendlyUrl`.
+
+**Repository** `lib/features/feedback/repositories/feedback_repository.dart` (Dio via `apiClient`) :
+- `submitSentiment(sentiment, date)`
+- `getInviteStatus() → FeedbackInviteStatus`
+- `markInviteShown()` / `submitInviteAction(action)`
+
+**Providers Riverpod** (`@Riverpod`) : `feedbackRepository`, `inviteStatus`.
+
+**Widgets** :
+- `lib/features/feedback/widgets/sentiment_picker.dart` — 3 emojis, intégré dans `ClosureScreen` (remplace le pill Notion ligne 287-329).
+- `lib/features/feedback/widgets/call_invite_sheet.dart` — `showModalBottomSheet` (pattern `source_adjust_sheet.dart`), photo + texte + 3 boutons, ouvre `calendlyUrl` via `url_launcher` (déjà dépendance).
+
+**Intégration : carte de fin de Tournée du jour** (page *l'Essentiel* = `FluxContinuScreen`, `lib/features/flux_continu/screens/flux_continu_screen.dart`) :
+- Nouvelle `FeedbackClosingCard` insérée comme `SliverToBoxAdapter` **juste après** `ClosingCardV18` (« Fin de tournée »), avant le spacing final.
+- La carte affiche **toujours** le micro-feedback emoji (`SentimentPicker`).
+- Si `inviteStatusProvider` (→ `GET /api/feedback/invite`) renvoie `should_show`, la carte affiche **en plus** un teaser + CTA « Discuter avec Laurin » qui ouvre `CallInviteSheet` (copy segmentée). `markInviteShown()` est appelé une fois (post-frame) ; le backend reste source de vérité pour le cap d'affichages et le snooze.
+- ⚠️ L'ancien `ClosureScreen` n'existe plus sur `main` (le moment de fermeture est devenu `ClosingCardV18` dans le flux Essentiel) — l'intégration initiale sur `ClosureScreen` (faite sur base `staging`) a été abandonnée lors du rebase sur `main`.
+
+---
+
+## 4. Plan de tâches
+
+### Backend
+- [x] `app/models/user_feedback.py` (2 modèles) + export `models/__init__.py`
+- [x] `app/schemas/feedback.py`
+- [x] `app/routers/feedback.py` (4 endpoints) + include dans `main.py`
+- [x] Migration Alembic `ufb01_create_feedback_tables` (1 head) + SQL Supabase dans le docstring
+- [x] Tests `tests/test_feedback_router.py` (segmentation, gating should_show vrai/faux, snooze, action terminale) — 20/20 verts
+
+### Mobile
+- [x] `ExternalLinks.calendlyUrl` (placeholder)
+- [x] `feedback_repository.dart` + `feedback_models.dart`
+- [x] `feedback_providers.dart`
+- [x] `sentiment_picker.dart` (micro-feedback emoji)
+- [x] `call_invite_sheet.dart` (copy segmentée, 3 sorties)
+- [x] `feedback_closing_card.dart` + insertion dans `FluxContinuScreen` (fin de Tournée)
+- [x] `inviteStatusProvider` (gating lu côté carte)
+- [x] Tests widget (`sentiment_picker_test`, `call_invite_sheet_test`, `feedback_closing_card_test`)
+
+### Validation
+- [x] Tests backend feedback : 20/20 verts (408 passants au global ; les 12 échecs `test_topic_selector` + 28 erreurs DB sont **pré-existants**, hors scope)
+- [ ] `flutter test` + `flutter analyze` — **à exécuter en CI** (SDK Flutter absent de l'env d'implémentation)
+- [x] Script QA `docs/qa/scripts/verify_feedback.sh` (tests + 1 head + router enregistré)
+
+---
+
+## 5. Risques & points d'attention
+- **Zone à risque DB** : nouvelle table → relire safety-guardrails, 1 head Alembic, SQL via Supabase.
+- **Gating** : la fenêtre « ≥5 sur ≥7j » est ajustable — valeur de départ, à tuner selon données réelles.
+- **Double-affichage** : backend = source de vérité, SharedPreferences = garde-fou session uniquement.
+- **Calendly URL** : à fournir par Laurin avant merge (placeholder sinon).
+
+---
+
+## 6. Fichiers modifiés
+
+### Backend (`packages/api`)
+- `app/models/user_feedback.py` _(nouveau)_ — `DigestSentiment`, `FeedbackInvite`
+- `app/models/__init__.py` — exports
+- `app/schemas/feedback.py` _(nouveau)_
+- `app/routers/feedback.py` _(nouveau)_ — 4 endpoints + `classify_segment` (pure)
+- `app/main.py` — import + include router
+- `alembic/versions/ufb01_create_feedback_tables.py` _(nouveau)_ — SQL Supabase dans le docstring
+- `tests/test_feedback_router.py` _(nouveau)_ — 20 tests
+
+### Mobile (`apps/mobile`)
+- `lib/config/constants.dart` — `ExternalLinks.calendlyUrl` (placeholder)
+- `lib/features/feedback/models/feedback_models.dart` _(nouveau)_
+- `lib/features/feedback/repositories/feedback_repository.dart` _(nouveau)_
+- `lib/features/feedback/providers/feedback_providers.dart` _(nouveau)_ — repo + `inviteStatusProvider`
+- `lib/features/feedback/widgets/sentiment_picker.dart` _(nouveau)_
+- `lib/features/feedback/widgets/call_invite_sheet.dart` _(nouveau)_
+- `lib/features/feedback/widgets/feedback_closing_card.dart` _(nouveau)_
+- `lib/features/flux_continu/screens/flux_continu_screen.dart` — insertion `FeedbackClosingCard` après `ClosingCardV18`
+- `test/features/feedback/widgets/sentiment_picker_test.dart` _(nouveau)_
+- `test/features/feedback/widgets/call_invite_sheet_test.dart` _(nouveau)_
+- `test/features/feedback/widgets/feedback_closing_card_test.dart` _(nouveau)_
+
+### Docs / QA
+- `docs/stories/core/13.1.feedback-system.md` _(cette story)_
+- `docs/qa/scripts/verify_feedback.sh` _(nouveau)_
+
+## 7. À faire avant le merge
+- [ ] **Remplacer le placeholder Calendly** (`ExternalLinks.calendlyUrl`) par le vrai lien.
+- [ ] **Exécuter le SQL** de `ufb01` dans le **Supabase SQL Editor** (jamais sur Railway).
+- [ ] Vérifier `flutter test` + `flutter analyze` verts en CI.

--- a/packages/api/alembic/versions/ufb01_create_feedback_tables.py
+++ b/packages/api/alembic/versions/ufb01_create_feedback_tables.py
@@ -1,0 +1,93 @@
+"""Create feedback tables (digest_sentiments, feedback_invites) for Epic 13.
+
+Revision ID: ufb01
+Revises: au02_api_usage_tokens
+Create Date: 2026-06-29
+
+SQL to run manually in Supabase SQL Editor:
+
+CREATE TABLE IF NOT EXISTS digest_sentiments (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL,
+    digest_date DATE NOT NULL,
+    sentiment VARCHAR(10) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT uq_digest_sentiments_user_date UNIQUE (user_id, digest_date)
+);
+CREATE INDEX IF NOT EXISTS ix_digest_sentiments_user_id ON digest_sentiments (user_id);
+CREATE INDEX IF NOT EXISTS ix_digest_sentiments_digest_date ON digest_sentiments (digest_date);
+
+CREATE TABLE IF NOT EXISTS feedback_invites (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    segment VARCHAR(20),
+    shown_count INTEGER NOT NULL DEFAULT 0,
+    last_shown_at TIMESTAMPTZ,
+    snoozed_until TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT uq_feedback_invites_user UNIQUE (user_id)
+);
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ufb01'
+down_revision: Union[str, Sequence[str]] = 'au02_api_usage_tokens'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Additive only — safe. IF NOT EXISTS pour idempotence si créé
+    # manuellement dans Supabase avant le tracking alembic.
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS digest_sentiments (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id UUID NOT NULL,
+            digest_date DATE NOT NULL,
+            sentiment VARCHAR(10) NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CONSTRAINT uq_digest_sentiments_user_date UNIQUE (user_id, digest_date)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_digest_sentiments_user_id "
+        "ON digest_sentiments (user_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_digest_sentiments_digest_date "
+        "ON digest_sentiments (digest_date)"
+    )
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS feedback_invites (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id UUID NOT NULL,
+            status VARCHAR(20) NOT NULL DEFAULT 'pending',
+            segment VARCHAR(20),
+            shown_count INTEGER NOT NULL DEFAULT 0,
+            last_shown_at TIMESTAMPTZ,
+            snoozed_until TIMESTAMPTZ,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CONSTRAINT uq_feedback_invites_user UNIQUE (user_id)
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('feedback_invites')
+    op.drop_index('ix_digest_sentiments_digest_date', table_name='digest_sentiments')
+    op.drop_index('ix_digest_sentiments_user_id', table_name='digest_sentiments')
+    op.drop_table('digest_sentiments')

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -84,6 +84,7 @@ from app.routers import (
     essentiel,
     event_rsvp,
     feed,
+    feedback,
     grille,
     images,
     internal,
@@ -527,6 +528,7 @@ app.include_router(
     prefix="/api/user/sources",
     tags=["UserSourcesState"],
 )
+app.include_router(feedback.router, prefix="/api/feedback", tags=["Feedback"])
 
 
 @app.exception_handler(Exception)

--- a/packages/api/app/models/__init__.py
+++ b/packages/api/app/models/__init__.py
@@ -28,6 +28,7 @@ from app.models.source_search_log import SourceSearchLog
 from app.models.subscription import UserSubscription
 from app.models.user import UserInterest, UserPreference, UserProfile, UserStreak
 from app.models.user_favorites import UserFavoriteInterest, UserFavoriteSource
+from app.models.user_feedback import DigestSentiment, FeedbackInvite
 from app.models.user_letter_progress import UserLetterProgress
 from app.models.user_notification_preferences import UserNotificationPreferences
 from app.models.user_personalization import UserPersonalization
@@ -127,4 +128,7 @@ __all__ = [
     # La Grille du jour (Story 24.1)
     "GrillePuzzle",
     "GrilleGameState",
+    # User Feedback System (Epic 13)
+    "DigestSentiment",
+    "FeedbackInvite",
 ]

--- a/packages/api/app/models/user_feedback.py
+++ b/packages/api/app/models/user_feedback.py
@@ -1,0 +1,105 @@
+"""Modèles pour le système de feedback utilisateur (Epic 13).
+
+- DigestSentiment : micro-feedback emoji (😴/🙂/🔥) capturé au moment de
+  fermeture, une réponse par (user, jour), en upsert.
+- FeedbackInvite : état de l'invitation à un call qualitatif (Calendly).
+  Pilote l'affichage unique/segmenté de la modal côté mobile.
+"""
+
+import uuid
+from datetime import date, datetime
+from uuid import UUID
+
+from sqlalchemy import Date, DateTime, Index, Integer, String, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class DigestSentiment(Base):
+    """Ressenti emoji d'un utilisateur sur son digest du jour.
+
+    Capté au moment de fermeture. Trois niveaux : "low" (😴), "ok" (🙂),
+    "high" (🔥). Une seule réponse par (user, jour) — l'utilisateur peut
+    changer d'avis (upsert).
+
+    Attributes:
+        user_id: UUID de l'utilisateur.
+        digest_date: Date du digest noté.
+        sentiment: Ressenti ("low" | "ok" | "high").
+    """
+
+    __tablename__ = "digest_sentiments"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id", "digest_date", name="uq_digest_sentiments_user_date"
+        ),
+        Index("ix_digest_sentiments_user_id", "user_id"),
+        Index("ix_digest_sentiments_digest_date", "digest_date"),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    digest_date: Mapped[date] = mapped_column(Date, nullable=False)
+    sentiment: Mapped[str] = mapped_column(String(10), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+
+class FeedbackInvite(Base):
+    """État de l'invitation à un call qualitatif pour un utilisateur.
+
+    Une ligne par utilisateur. Pilote l'affichage segmenté et unique de la
+    modal Calendly côté mobile (cf. story 13.1).
+
+    Attributes:
+        user_id: UUID de l'utilisateur (unique).
+        status: "pending" | "snoozed" | "accepted" | "declined".
+        segment: Segment d'activité au moment du déclenchement
+            ("returning" | "low_active" | "active").
+        shown_count: Nombre de fois où la modal a été affichée.
+        last_shown_at: Dernier affichage.
+        snoozed_until: Ne pas re-proposer avant cette date (snooze "Pas maintenant").
+    """
+
+    __tablename__ = "feedback_invites"
+    __table_args__ = (
+        UniqueConstraint("user_id", name="uq_feedback_invites_user"),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="pending", server_default="pending"
+    )
+    segment: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    shown_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    last_shown_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    snoozed_until: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/packages/api/app/routers/feedback.py
+++ b/packages/api/app/routers/feedback.py
@@ -1,0 +1,265 @@
+"""Router pour le système de feedback utilisateur (Epic 13).
+
+Deux mécaniques :
+- Micro-feedback emoji au moment de fermeture (POST /sentiment).
+- Invitation segmentée à un call qualitatif Calendly (GET /invite,
+  POST /invite/shown, POST /invite/action).
+
+La logique de segmentation (qui décide quand proposer le call selon le
+niveau d'activité) vit dans `classify_segment`, fonction pure et testable.
+"""
+
+from datetime import date, datetime, timedelta
+from uuid import UUID
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies import get_current_user_id
+from app.models.digest_completion import DigestCompletion
+from app.models.user_feedback import DigestSentiment, FeedbackInvite
+from app.schemas.feedback import (
+    FeedbackInviteStatus,
+    InviteActionRequest,
+    SentimentRequest,
+)
+
+logger = structlog.get_logger()
+
+router = APIRouter()
+
+# --- Constantes de gating (ajustables) ---
+# Au-delà de ce nombre de jours d'absence, un utilisateur qui revient est
+# considéré "returning" (de retour) — on le sollicite immédiatement.
+RETURNING_GAP_DAYS = 10
+# "Peu actif" : au moins LOWACTIVE_MIN digests, étalés sur >= LOWACTIVE_SPREAD_DAYS.
+LOWACTIVE_MIN = 2
+LOWACTIVE_SPREAD_DAYS = 7
+# "Actif" : usage dense.
+ACTIVE_MIN = 4
+# Durée du snooze après "Pas maintenant".
+SNOOZE_DAYS = 21
+# Nombre maximum d'affichages avant abandon définitif.
+MAX_SHOWS = 2
+
+
+def classify_segment(completion_dates: list[date], today: date) -> str | None:
+    """Détermine le segment d'activité éligible à l'invitation, ou None.
+
+    Args:
+        completion_dates: dates (distinctes ou non) de complétion de digest
+            pour l'utilisateur, incluant idéalement le jour courant.
+        today: date de référence (jour de la fermeture).
+
+    Returns:
+        "returning" | "low_active" | "active" si le seuil du segment est
+        atteint, sinon None.
+    """
+    if not completion_dates:
+        return None
+
+    dates = sorted(set(completion_dates))
+    total = len(dates)
+
+    # Returning : revient après une longue absence.
+    prior = [d for d in dates if d < today]
+    if prior:
+        gap = (today - max(prior)).days
+        if gap >= RETURNING_GAP_DAYS:
+            return "returning"
+
+    # Actif : usage dense.
+    if total >= ACTIVE_MIN:
+        return "active"
+
+    # Peu actif : usage sporadique étalé dans le temps.
+    if total >= LOWACTIVE_MIN:
+        spread = (dates[-1] - dates[0]).days
+        if spread >= LOWACTIVE_SPREAD_DAYS:
+            return "low_active"
+
+    return None
+
+
+def _parse_digest_date(raw: str | None) -> date:
+    """Parse une date ISO (YYYY-MM-DD), défaut = aujourd'hui (UTC)."""
+    if not raw:
+        return datetime.utcnow().date()
+    try:
+        return date.fromisoformat(raw[:10])
+    except ValueError:
+        raise HTTPException(
+            status_code=400, detail=f"Date invalide: '{raw}' (attendu YYYY-MM-DD)"
+        )
+
+
+@router.post("/sentiment")
+async def submit_sentiment(
+    request: SentimentRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user_id: str = Depends(get_current_user_id),
+):
+    """Enregistre (upsert) le micro-feedback emoji du jour."""
+    user_uuid = UUID(current_user_id)
+    target = _parse_digest_date(request.digest_date)
+
+    try:
+        stmt = (
+            pg_insert(DigestSentiment)
+            .values(
+                user_id=user_uuid,
+                digest_date=target,
+                sentiment=request.sentiment,
+            )
+            .on_conflict_do_update(
+                constraint="uq_digest_sentiments_user_date",
+                set_={
+                    "sentiment": request.sentiment,
+                    "updated_at": datetime.utcnow(),
+                },
+            )
+        )
+        await db.execute(stmt)
+        await db.commit()
+        return {"message": "Merci pour ton retour", "sentiment": request.sentiment}
+    except Exception as e:
+        logger.error(
+            "submit_sentiment_error", error=str(e), user_id=str(user_uuid)
+        )
+        await db.rollback()
+        raise HTTPException(
+            status_code=500, detail=f"Erreur lors de l'enregistrement: {str(e)}"
+        )
+
+
+async def _eligible_segment(db: AsyncSession, user_uuid: UUID) -> str | None:
+    """Charge les dates de complétion et calcule le segment éligible."""
+    rows = await db.execute(
+        select(DigestCompletion.target_date).where(
+            DigestCompletion.user_id == user_uuid
+        )
+    )
+    dates = [r[0] for r in rows.all()]
+    return classify_segment(dates, datetime.utcnow().date())
+
+
+@router.get("/invite", response_model=FeedbackInviteStatus)
+async def get_invite_status(
+    db: AsyncSession = Depends(get_db),
+    current_user_id: str = Depends(get_current_user_id),
+):
+    """Indique si la modal d'invitation au call doit s'afficher."""
+    user_uuid = UUID(current_user_id)
+
+    segment = await _eligible_segment(db, user_uuid)
+    if segment is None:
+        return FeedbackInviteStatus(should_show=False, reason="not_eligible")
+
+    invite = await db.scalar(
+        select(FeedbackInvite).where(FeedbackInvite.user_id == user_uuid)
+    )
+
+    if invite is not None:
+        if invite.status in ("accepted", "declined"):
+            return FeedbackInviteStatus(
+                should_show=False, segment=segment, reason=invite.status
+            )
+        if invite.snoozed_until and datetime.utcnow() < invite.snoozed_until:
+            return FeedbackInviteStatus(
+                should_show=False, segment=segment, reason="snoozed"
+            )
+        if invite.shown_count >= MAX_SHOWS:
+            return FeedbackInviteStatus(
+                should_show=False, segment=segment, reason="max_shows"
+            )
+
+    return FeedbackInviteStatus(should_show=True, segment=segment)
+
+
+@router.post("/invite/shown")
+async def mark_invite_shown(
+    db: AsyncSession = Depends(get_db),
+    current_user_id: str = Depends(get_current_user_id),
+):
+    """Marque la modal comme affichée (incrémente le compteur)."""
+    user_uuid = UUID(current_user_id)
+    segment = await _eligible_segment(db, user_uuid)
+
+    try:
+        stmt = (
+            pg_insert(FeedbackInvite)
+            .values(
+                user_id=user_uuid,
+                status="pending",
+                segment=segment,
+                shown_count=1,
+                last_shown_at=datetime.utcnow(),
+            )
+            .on_conflict_do_update(
+                constraint="uq_feedback_invites_user",
+                set_={
+                    "shown_count": FeedbackInvite.shown_count + 1,
+                    "last_shown_at": datetime.utcnow(),
+                    "segment": segment,
+                    "updated_at": datetime.utcnow(),
+                },
+            )
+        )
+        await db.execute(stmt)
+        await db.commit()
+        return {"message": "ok"}
+    except Exception as e:
+        logger.error("mark_invite_shown_error", error=str(e), user_id=str(user_uuid))
+        await db.rollback()
+        raise HTTPException(
+            status_code=500, detail=f"Erreur lors du suivi de l'affichage: {str(e)}"
+        )
+
+
+@router.post("/invite/action")
+async def submit_invite_action(
+    request: InviteActionRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user_id: str = Depends(get_current_user_id),
+):
+    """Enregistre l'action de l'utilisateur sur la modal.
+
+    - "accepted" : a cliqué pour prendre un call → statut terminal.
+    - "declined" : "Pas maintenant" → snooze, ou abandon définitif après
+      MAX_SHOWS affichages.
+    """
+    user_uuid = UUID(current_user_id)
+
+    invite = await db.scalar(
+        select(FeedbackInvite).where(FeedbackInvite.user_id == user_uuid)
+    )
+    if invite is None:
+        invite = FeedbackInvite(user_id=user_uuid, shown_count=0)
+        db.add(invite)
+
+    try:
+        if request.action == "accepted":
+            invite.status = "accepted"
+            invite.snoozed_until = None
+        else:  # declined
+            if invite.shown_count >= MAX_SHOWS:
+                invite.status = "declined"
+                invite.snoozed_until = None
+            else:
+                invite.status = "snoozed"
+                invite.snoozed_until = datetime.utcnow() + timedelta(days=SNOOZE_DAYS)
+
+        await db.commit()
+        return {"message": "ok", "status": invite.status}
+    except Exception as e:
+        logger.error(
+            "submit_invite_action_error", error=str(e), user_id=str(user_uuid)
+        )
+        await db.rollback()
+        raise HTTPException(
+            status_code=500, detail=f"Erreur lors de l'enregistrement: {str(e)}"
+        )

--- a/packages/api/app/schemas/feedback.py
+++ b/packages/api/app/schemas/feedback.py
@@ -1,0 +1,24 @@
+"""Schemas Pydantic pour le système de feedback utilisateur (Epic 13)."""
+
+from pydantic import BaseModel, Field
+
+
+class SentimentRequest(BaseModel):
+    """Micro-feedback emoji sur le digest du jour."""
+
+    sentiment: str = Field(..., pattern=r"^(low|ok|high)$")
+    digest_date: str | None = None
+
+
+class FeedbackInviteStatus(BaseModel):
+    """Réponse indiquant si la modal d'invitation au call doit s'afficher."""
+
+    should_show: bool
+    segment: str | None = None
+    reason: str | None = None
+
+
+class InviteActionRequest(BaseModel):
+    """Action de l'utilisateur sur la modal d'invitation."""
+
+    action: str = Field(..., pattern=r"^(accepted|declined)$")

--- a/packages/api/tests/test_feedback_router.py
+++ b/packages/api/tests/test_feedback_router.py
@@ -1,0 +1,280 @@
+"""Tests du système de feedback utilisateur (Epic 13)."""
+
+from datetime import date, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.routers.feedback import (
+    ACTIVE_MIN,
+    LOWACTIVE_SPREAD_DAYS,
+    MAX_SHOWS,
+    RETURNING_GAP_DAYS,
+    SNOOZE_DAYS,
+    classify_segment,
+    get_invite_status,
+    mark_invite_shown,
+    submit_invite_action,
+    submit_sentiment,
+)
+from app.schemas.feedback import InviteActionRequest, SentimentRequest
+
+
+# --- classify_segment (fonction pure) ---
+
+
+def test_classify_segment_empty():
+    assert classify_segment([], date(2026, 6, 29)) is None
+
+
+def test_classify_segment_new_user_not_eligible():
+    # 1 seul digest aujourd'hui, aucun historique → pas encore éligible
+    today = date(2026, 6, 29)
+    assert classify_segment([today], today) is None
+
+
+def test_classify_segment_returning():
+    # Revient après une longue absence → "returning" dès 1 lecture
+    today = date(2026, 6, 29)
+    old = today - timedelta(days=RETURNING_GAP_DAYS + 5)
+    assert classify_segment([old, today], today) == "returning"
+
+
+def test_classify_segment_returning_takes_priority_over_active():
+    # Même un utilisateur avec assez de lectures mais revenu après un gap
+    # est classé "returning" en priorité.
+    today = date(2026, 6, 29)
+    old = today - timedelta(days=RETURNING_GAP_DAYS + 1)
+    dates = [old - timedelta(days=i) for i in range(ACTIVE_MIN)] + [today]
+    assert classify_segment(dates, today) == "returning"
+
+
+def test_classify_segment_active():
+    today = date(2026, 6, 29)
+    dates = [today - timedelta(days=i) for i in range(ACTIVE_MIN)]
+    assert classify_segment(dates, today) == "active"
+
+
+def test_classify_segment_low_active():
+    # 2 lectures étalées sur >= 7 jours, pas de gap de retour
+    today = date(2026, 6, 29)
+    first = today - timedelta(days=LOWACTIVE_SPREAD_DAYS)
+    assert classify_segment([first, today], today) == "low_active"
+
+
+def test_classify_segment_two_reads_too_close_not_eligible():
+    # 2 lectures rapprochées (pas étalées) → pas encore "low_active"
+    today = date(2026, 6, 29)
+    yesterday = today - timedelta(days=1)
+    assert classify_segment([yesterday, today], today) is None
+
+
+def test_classify_segment_dedups_dates():
+    today = date(2026, 6, 29)
+    # Doublons ne doivent pas gonfler artificiellement le total
+    assert classify_segment([today, today, today], today) is None
+
+
+# --- submit_sentiment ---
+
+
+@pytest.mark.asyncio
+async def test_submit_sentiment_upsert():
+    mock_db = AsyncMock()
+    user_id = str(uuid4())
+    request = SentimentRequest(sentiment="high", digest_date="2026-06-29")
+
+    response = await submit_sentiment(
+        request=request, db=mock_db, current_user_id=user_id
+    )
+
+    assert response["sentiment"] == "high"
+    assert mock_db.execute.called
+    assert mock_db.commit.called
+
+
+@pytest.mark.asyncio
+async def test_submit_sentiment_invalid_date():
+    from fastapi import HTTPException
+
+    mock_db = AsyncMock()
+    request = SentimentRequest(sentiment="ok", digest_date="not-a-date")
+
+    with pytest.raises(HTTPException) as exc:
+        await submit_sentiment(
+            request=request, db=mock_db, current_user_id=str(uuid4())
+        )
+    assert exc.value.status_code == 400
+
+
+# --- get_invite_status ---
+
+
+@pytest.mark.asyncio
+async def test_get_invite_status_not_eligible():
+    mock_db = AsyncMock()
+    with patch(
+        "app.routers.feedback._eligible_segment",
+        AsyncMock(return_value=None),
+    ):
+        result = await get_invite_status(db=mock_db, current_user_id=str(uuid4()))
+    assert result.should_show is False
+    assert result.reason == "not_eligible"
+
+
+@pytest.mark.asyncio
+async def test_get_invite_status_eligible_no_prior_invite():
+    mock_db = AsyncMock()
+    mock_db.scalar = AsyncMock(return_value=None)
+    with patch(
+        "app.routers.feedback._eligible_segment",
+        AsyncMock(return_value="active"),
+    ):
+        result = await get_invite_status(db=mock_db, current_user_id=str(uuid4()))
+    assert result.should_show is True
+    assert result.segment == "active"
+
+
+@pytest.mark.asyncio
+async def test_get_invite_status_accepted_is_terminal():
+    invite = type("I", (), {})()
+    invite.status = "accepted"
+    invite.snoozed_until = None
+    invite.shown_count = 1
+    mock_db = AsyncMock()
+    mock_db.scalar = AsyncMock(return_value=invite)
+    with patch(
+        "app.routers.feedback._eligible_segment",
+        AsyncMock(return_value="active"),
+    ):
+        result = await get_invite_status(db=mock_db, current_user_id=str(uuid4()))
+    assert result.should_show is False
+    assert result.reason == "accepted"
+
+
+@pytest.mark.asyncio
+async def test_get_invite_status_snoozed_blocks():
+    invite = type("I", (), {})()
+    invite.status = "snoozed"
+    invite.snoozed_until = datetime.utcnow() + timedelta(days=5)
+    invite.shown_count = 1
+    mock_db = AsyncMock()
+    mock_db.scalar = AsyncMock(return_value=invite)
+    with patch(
+        "app.routers.feedback._eligible_segment",
+        AsyncMock(return_value="low_active"),
+    ):
+        result = await get_invite_status(db=mock_db, current_user_id=str(uuid4()))
+    assert result.should_show is False
+    assert result.reason == "snoozed"
+
+
+@pytest.mark.asyncio
+async def test_get_invite_status_snooze_expired_reshows():
+    invite = type("I", (), {})()
+    invite.status = "snoozed"
+    invite.snoozed_until = datetime.utcnow() - timedelta(days=1)
+    invite.shown_count = 1
+    mock_db = AsyncMock()
+    mock_db.scalar = AsyncMock(return_value=invite)
+    with patch(
+        "app.routers.feedback._eligible_segment",
+        AsyncMock(return_value="returning"),
+    ):
+        result = await get_invite_status(db=mock_db, current_user_id=str(uuid4()))
+    assert result.should_show is True
+
+
+@pytest.mark.asyncio
+async def test_get_invite_status_max_shows_blocks():
+    invite = type("I", (), {})()
+    invite.status = "snoozed"
+    invite.snoozed_until = None
+    invite.shown_count = MAX_SHOWS
+    mock_db = AsyncMock()
+    mock_db.scalar = AsyncMock(return_value=invite)
+    with patch(
+        "app.routers.feedback._eligible_segment",
+        AsyncMock(return_value="active"),
+    ):
+        result = await get_invite_status(db=mock_db, current_user_id=str(uuid4()))
+    assert result.should_show is False
+    assert result.reason == "max_shows"
+
+
+# --- mark_invite_shown ---
+
+
+@pytest.mark.asyncio
+async def test_mark_invite_shown():
+    mock_db = AsyncMock()
+    with patch(
+        "app.routers.feedback._eligible_segment",
+        AsyncMock(return_value="active"),
+    ):
+        response = await mark_invite_shown(db=mock_db, current_user_id=str(uuid4()))
+    assert response["message"] == "ok"
+    assert mock_db.execute.called
+    assert mock_db.commit.called
+
+
+# --- submit_invite_action ---
+
+
+@pytest.mark.asyncio
+async def test_submit_invite_action_accepted():
+    invite = type("I", (), {})()
+    invite.status = "pending"
+    invite.shown_count = 1
+    invite.snoozed_until = None
+    mock_db = AsyncMock()
+    mock_db.scalar = AsyncMock(return_value=invite)
+
+    response = await submit_invite_action(
+        request=InviteActionRequest(action="accepted"),
+        db=mock_db,
+        current_user_id=str(uuid4()),
+    )
+    assert invite.status == "accepted"
+    assert response["status"] == "accepted"
+    assert mock_db.commit.called
+
+
+@pytest.mark.asyncio
+async def test_submit_invite_action_declined_snoozes():
+    invite = type("I", (), {})()
+    invite.status = "pending"
+    invite.shown_count = 1  # < MAX_SHOWS
+    invite.snoozed_until = None
+    mock_db = AsyncMock()
+    mock_db.scalar = AsyncMock(return_value=invite)
+
+    await submit_invite_action(
+        request=InviteActionRequest(action="declined"),
+        db=mock_db,
+        current_user_id=str(uuid4()),
+    )
+    assert invite.status == "snoozed"
+    assert invite.snoozed_until is not None
+    # snooze ~ SNOOZE_DAYS dans le futur
+    delta = invite.snoozed_until - datetime.utcnow()
+    assert timedelta(days=SNOOZE_DAYS - 1) < delta <= timedelta(days=SNOOZE_DAYS)
+
+
+@pytest.mark.asyncio
+async def test_submit_invite_action_declined_terminal_after_max():
+    invite = type("I", (), {})()
+    invite.status = "snoozed"
+    invite.shown_count = MAX_SHOWS  # >= MAX_SHOWS → définitif
+    invite.snoozed_until = datetime.utcnow()
+    mock_db = AsyncMock()
+    mock_db.scalar = AsyncMock(return_value=invite)
+
+    await submit_invite_action(
+        request=InviteActionRequest(action="declined"),
+        db=mock_db,
+        current_user_id=str(uuid4()),
+    )
+    assert invite.status == "declined"
+    assert invite.snoozed_until is None


### PR DESCRIPTION
- Show update modal on digest launch when an update is available
- Replace onNotInterested with topicChipWidget in topic section cards
- Increase badge bottom padding (6→14px) in carousels and topic sections
- Add badge height constant for accurate card height computation
- Bump transitive dependency versions in pubspec.lock

Co-authored-by: Laurin Boujon <laurinboujon@mbp-de-laurin.home>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>