### PR TITLE
fix(feed): badge « Lu » qui disparaît au refresh (overlay set consommé)

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,8 +1,14 @@
 {
   "unreleased": [
     {
+      "tag": "Lecture",
+      "summary": "Les articles lus restent marqués « Lu » de façon fiable, même après un rafraîchissement du flux."
+    },
+    {
       "tag": "Widget",
       "summary": "Le widget se rafraîchit à nouveau, avec un bouton pour forcer la mise à jour."
+    },
+    {
       "tag": "Mise à jour",
       "summary": "Sur Android, les mises à jour passent désormais par une invite native du Play Store, plus fiable, avec téléchargement en arrière-plan."
     },

--- a/apps/mobile/lib/features/feed/providers/feed_provider.dart
+++ b/apps/mobile/lib/features/feed/providers/feed_provider.dart
@@ -9,6 +9,7 @@ import '../models/content_model.dart';
 import '../repositories/feed_repository.dart';
 import '../repositories/personalization_repository.dart';
 import '../services/feed_cache_service.dart';
+import '../services/read_sync_service.dart';
 import '../../custom_topics/providers/personalization_provider.dart';
 import '../../digest/providers/serein_toggle_provider.dart';
 import '../../saved/providers/saved_feed_provider.dart';
@@ -307,12 +308,16 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
         if (ageSeconds >= _silentRevalSkipSeconds) {
           _scheduleSilentRevalidation();
         }
-        _globalItems = parsed.items;
+        // Le patch disque du statut consommé (patchContentStatus) est
+        // best-effort/asynchrone et peut être en retard sur le set durable —
+        // on superpose pour garantir le badge « Lu » (cf. _overlayConsumed).
+        final overlaid = _overlayConsumed(parsed.items, parsed.carousels);
+        _globalItems = overlaid.items;
         print(
-          '[PERF] feedProvider.build(): cache hit (${parsed.items.length} items, age=${ageSeconds}s, silent_reval=${ageSeconds >= _silentRevalSkipSeconds})',
+          '[PERF] feedProvider.build(): cache hit (${overlaid.items.length} items, age=${ageSeconds}s, silent_reval=${ageSeconds >= _silentRevalSkipSeconds})',
         );
-        unawaited(_prefetchForWidget(parsed.items));
-        return FeedState(items: parsed.items, carousels: parsed.carousels);
+        unawaited(_prefetchForWidget(overlaid.items));
+        return FeedState(items: overlaid.items, carousels: overlaid.carousels);
       } catch (e) {
         // Corrupted cache or schema drift — drop silently and fall through.
         print('FeedNotifier: cached feed parse failed, evicting: $e');
@@ -328,9 +333,53 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
       '[PERF] feedProvider.build(): ${sw.elapsedMilliseconds}ms (${response.items.length} items)',
     );
 
-    _globalItems = response.items;
-    unawaited(_prefetchForWidget(response.items));
-    return FeedState(items: response.items, carousels: response.carousels);
+    // Cold-load : le set consommé peut déjà être réamorcé depuis la file
+    // durable Hive (flushCurrentUser au boot) avant que cette première page
+    // réseau — encore `unseen` — n'arrive. On superpose pour ne pas repeindre
+    // un article lu en non-lu (cf. _overlayConsumed).
+    final overlaid = _overlayConsumed(response.items, response.carousels);
+    _globalItems = overlaid.items;
+    unawaited(_prefetchForWidget(overlaid.items));
+    return FeedState(items: overlaid.items, carousels: overlaid.carousels);
+  }
+
+  /// Ré-applique le statut « consommé » sur une liste fraîchement fetchée
+  /// (réseau/cache) pour qu'un reload n'efface pas le badge « Lu » tant que le
+  /// POST backend `/status` n'a pas abouti.
+  ///
+  /// Source d'autorité = le Set durable en mémoire [consumedContentIdsProvider]
+  /// (alimenté par [ReadSyncService.markConsumed] dès l'ouverture d'un article)
+  /// **∪** les ids déjà `consumed` dans l'état courant (filet pour une course
+  /// tap → réponse réseau). On élargit volontairement au provider car l'état
+  /// courant a pu être vidé par un refresh antérieur.
+  ({List<Content> items, List<FeedCarouselData> carousels}) _overlayConsumed(
+    List<Content> items,
+    List<FeedCarouselData> carousels,
+  ) {
+    final currentState = state.value;
+    final consumedIds = <String>{
+      ...ref.read(consumedContentIdsProvider),
+      ...?(currentState?.items
+          .where((c) => c.status == ContentStatus.consumed)
+          .map((c) => c.id)),
+      ...?(currentState?.carousels.expand(
+        (carousel) => carousel.items
+            .where((c) => c.status == ContentStatus.consumed)
+            .map((c) => c.id),
+      )),
+    };
+    if (consumedIds.isEmpty) {
+      return (items: items, carousels: carousels);
+    }
+    Content preserve(Content c) => consumedIds.contains(c.id)
+        ? c.copyWith(status: ContentStatus.consumed)
+        : c;
+    return (
+      items: items.map(preserve).toList(),
+      carousels: carousels
+          .map((car) => car.copyWith(items: car.items.map(preserve).toList()))
+          .toList(),
+    );
   }
 
   /// Fire-and-forget background refresh triggered after a cache hit. Keeps
@@ -353,40 +402,12 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
         }
         // Preserve consumed status for items that the user marked while the API
         // call was in flight (race: tap → markContentAsConsumed sets optimistic
-        // state before response arrives and would overwrite it).
-        final currentState = state.value;
-        final consumedIds = <String>{
-          ...?(currentState?.items
-              .where((c) => c.status == ContentStatus.consumed)
-              .map((c) => c.id)),
-          ...?(currentState?.carousels.expand(
-            (carousel) => carousel.items
-                .where((c) => c.status == ContentStatus.consumed)
-                .map((c) => c.id),
-          )),
-        };
-        if (consumedIds.isEmpty) {
-          _globalItems = response.items;
-          state = AsyncData(
-            FeedState(items: response.items, carousels: response.carousels),
-          );
-          return;
-        }
-        Content preserve(Content c) => consumedIds.contains(c.id)
-            ? c.copyWith(status: ContentStatus.consumed)
-            : c;
-        final mergedItems = response.items.map(preserve).toList();
-        _globalItems = mergedItems;
+        // state before response arrives and would overwrite it). Source =
+        // [consumedContentIdsProvider] ∪ état courant (cf. [_overlayConsumed]).
+        final overlaid = _overlayConsumed(response.items, response.carousels);
+        _globalItems = overlaid.items;
         state = AsyncData(
-          FeedState(
-            items: mergedItems,
-            carousels: response.carousels
-                .map(
-                  (car) =>
-                      car.copyWith(items: car.items.map(preserve).toList()),
-                )
-                .toList(),
-          ),
+          FeedState(items: overlaid.items, carousels: overlaid.carousels),
         );
       } catch (e) {
         // Silent: user still sees the cached feed.
@@ -747,10 +768,17 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
         return;
       }
 
+      // Superpose le statut « Lu » optimiste sur les nouveaux items : une page
+      // suivante peut contenir un article déjà lu dans la session mais encore
+      // `unseen` côté backend (cf. _overlayConsumed).
+      final overlaid = _overlayConsumed(
+        [...currentItems, ...dedupedNewItems],
+        currentCarousels,
+      );
       state = AsyncData(
         FeedState(
-          items: [...currentItems, ...dedupedNewItems],
-          carousels: currentCarousels, // Keep page 1 carousels
+          items: overlaid.items,
+          carousels: overlaid.carousels, // Keep page 1 carousels
         ),
       );
     } catch (e) {
@@ -782,11 +810,15 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
       // call (the backend cache will still give a fast response, but the
       // user has the right to ask for fresh data).
       final response = await _fetchPage(page: 1, forceFresh: true);
+      // Ré-applique le statut « Lu » optimiste : le backend renvoie encore
+      // `unseen` tant que le POST /status n'a pas abouti — sans ça, un
+      // pull-to-refresh / reprise d'app efface le badge (cf. _overlayConsumed).
+      final overlaid = _overlayConsumed(response.items, response.carousels);
       if (_isUnfiltered) {
-        _globalItems = response.items;
+        _globalItems = overlaid.items;
       }
       state = AsyncData(
-        FeedState(items: response.items, carousels: response.carousels),
+        FeedState(items: overlaid.items, carousels: overlaid.carousels),
       );
     } catch (e, stack) {
       // Recovery policy : ne JAMAIS figer le provider en AsyncError si on a

--- a/apps/mobile/test/features/feed/feed_consumed_overlay_test.dart
+++ b/apps/mobile/test/features/feed/feed_consumed_overlay_test.dart
@@ -1,0 +1,204 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:facteur/features/feed/providers/feed_provider.dart';
+import 'package:facteur/features/feed/models/content_model.dart';
+import 'package:facteur/features/feed/services/read_sync_service.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
+import 'package:facteur/features/feed/repositories/feed_repository.dart';
+import 'package:facteur/features/feed/repositories/personalization_repository.dart';
+import 'package:facteur/core/auth/auth_state.dart' as app_auth;
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+/// Régression : le badge « Lu » disparaissait au retour dans le feed quand un
+/// reload (pull-to-refresh, reprise d'app, pagination) reconstruisait les
+/// `Content` depuis la réponse réseau — encore `unseen` tant que le POST
+/// `/status` n'avait pas abouti — sans ré-appliquer le set consommé en mémoire.
+///
+/// Le fix fait de [consumedContentIdsProvider] la source d'autorité ré-appliquée
+/// sur chaque reload via `_overlayConsumed`. Ces tests vérifient que refresh()
+/// et loadMore() préservent le statut consommé même quand le serveur répond
+/// `unseen`.
+class MockFeedRepository extends Mock implements FeedRepository {}
+
+class MockPersonalizationRepository extends Mock
+    implements PersonalizationRepository {}
+
+class MockAuthStateNotifier extends StateNotifier<app_auth.AuthState>
+    implements app_auth.AuthStateNotifier {
+  MockAuthStateNotifier()
+    : super(
+        const app_auth.AuthState(
+          user: supabase.User(
+            id: 'u1',
+            appMetadata: {},
+            userMetadata: {},
+            aud: 'authenticated',
+            createdAt: '2023-01-01',
+            emailConfirmedAt: '2023-01-01',
+          ),
+        ),
+      );
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late MockFeedRepository mockFeedRepo;
+  late MockPersonalizationRepository mockPersoRepo;
+  late MockAuthStateNotifier mockAuthNotifier;
+  late ProviderContainer container;
+
+  final mockSource = Source(
+    id: 's1',
+    name: 'Source 1',
+    url: 'url',
+    type: SourceType.article,
+    theme: 'TECH',
+  );
+
+  // Toujours `unseen` : simule la réponse serveur stale (POST /status pas
+  // encore abouti).
+  Content makeContent(String id) => Content(
+    id: id,
+    title: 'Title $id',
+    url: 'url',
+    contentType: ContentType.article,
+    publishedAt: DateTime.now(),
+    source: mockSource,
+  );
+
+  FeedResponse feedOf(List<Content> items, {bool hasNext = false}) =>
+      FeedResponse(
+        items: items,
+        pagination: Pagination(
+          page: 1,
+          perPage: 20,
+          total: items.length,
+          hasNext: hasNext,
+        ),
+      );
+
+  setUp(() {
+    mockFeedRepo = MockFeedRepository();
+    mockPersoRepo = MockPersonalizationRepository();
+    mockAuthNotifier = MockAuthStateNotifier();
+
+    container = ProviderContainer(
+      overrides: [
+        feedRepositoryProvider.overrideWithValue(mockFeedRepo),
+        personalizationRepositoryProvider.overrideWithValue(mockPersoRepo),
+        app_auth.authStateProvider.overrideWith((ref) => mockAuthNotifier),
+      ],
+    );
+  });
+
+  tearDown(() {
+    container.dispose();
+  });
+
+  void stubGetFeed(FeedResponse Function() answer) {
+    when(
+      () => mockFeedRepo.getFeed(
+        page: any(named: 'page'),
+        limit: any(named: 'limit'),
+        mode: any(named: 'mode'),
+        theme: any(named: 'theme'),
+        topic: any(named: 'topic'),
+        sourceId: any(named: 'sourceId'),
+        entity: any(named: 'entity'),
+        keyword: any(named: 'keyword'),
+        serein: any(named: 'serein'),
+      ),
+    ).thenAnswer((_) async => answer());
+  }
+
+  test(
+    'refresh() ré-applique le statut consommé depuis consumedContentIdsProvider '
+    'même quand le serveur renvoie unseen',
+    () async {
+      stubGetFeed(() => feedOf([makeContent('a'), makeContent('b')]));
+
+      final notifier = container.read(feedProvider.notifier);
+      await container.read(feedProvider.future);
+
+      // L'utilisateur ouvre 'a' → markConsumed alimente le set durable.
+      container.read(consumedContentIdsProvider.notifier).state = {'a'};
+
+      await notifier.refresh();
+
+      final items = container.read(feedProvider).value!.items;
+      expect(
+        items.firstWhere((c) => c.id == 'a').status,
+        ContentStatus.consumed,
+        reason: 'le badge « Lu » doit survivre à un pull-to-refresh',
+      );
+      expect(items.firstWhere((c) => c.id == 'b').status, ContentStatus.unseen);
+    },
+  );
+
+  test(
+    'loadMore() superpose le statut consommé sur les items appendus',
+    () async {
+      var callCount = 0;
+      stubGetFeed(() {
+        callCount++;
+        if (callCount == 1) {
+          return feedOf([makeContent('a')], hasNext: true);
+        }
+        // Page 2 contient 'c' déjà lu dans la session.
+        return feedOf([makeContent('c')]);
+      });
+
+      final notifier = container.read(feedProvider.notifier);
+      await container.read(feedProvider.future);
+
+      container.read(consumedContentIdsProvider.notifier).state = {'c'};
+
+      await notifier.loadMore();
+
+      final items = container.read(feedProvider).value!.items;
+      expect(
+        items.firstWhere((c) => c.id == 'c').status,
+        ContentStatus.consumed,
+        reason: 'un article lu en session reste « Lu » à la pagination',
+      );
+    },
+  );
+
+  test(
+    'build() initial superpose le set consommé déjà réamorcé (cold-load) '
+    'avant l\'arrivée de la page réseau unseen',
+    () async {
+      stubGetFeed(() => feedOf([makeContent('a'), makeContent('b')]));
+
+      // La file durable Hive a réamorcé le set avant le premier build réseau.
+      container.read(consumedContentIdsProvider.notifier).state = {'a'};
+
+      await container.read(feedProvider.future);
+
+      final items = container.read(feedProvider).value!.items;
+      expect(
+        items.firstWhere((c) => c.id == 'a').status,
+        ContentStatus.consumed,
+        reason: 'le cold-load ne doit pas repeindre un article lu en non-lu',
+      );
+      expect(items.firstWhere((c) => c.id == 'b').status, ContentStatus.unseen);
+    },
+  );
+
+  test(
+    'refresh() sans aucun id consommé laisse tous les items unseen',
+    () async {
+      stubGetFeed(() => feedOf([makeContent('a'), makeContent('b')]));
+
+      final notifier = container.read(feedProvider.notifier);
+      await container.read(feedProvider.future);
+      await notifier.refresh();
+
+      final items = container.read(feedProvider).value!.items;
+      expect(items.every((c) => c.status == ContentStatus.unseen), isTrue);
+    },
+  );
+}

--- a/docs/bugs/bug-read-state-feed-overlay.md
+++ b/docs/bugs/bug-read-state-feed-overlay.md
@@ -1,0 +1,52 @@
+# Bug — marquage « Lu » qui disparaît au retour dans le feed
+
+## Symptôme
+
+Le bandeau « Lu » / « Lu jusqu'au bout » (`ReadingBadge`) sur les cartes du feed
+Flâner disparaît de façon **inconstante** après qu'un article a été ouvert et lu.
+
+## Racine
+
+Le marquage « Lu » a deux niveaux :
+
+1. **Optimiste local** — à l'ouverture (timer 1 s), `ReadSyncService.markConsumed`
+   écrit dans la file Hive `pending_reads` et propage en mémoire via
+   `_propagateLocal` : ajout de l'id à `consumedContentIdsProvider` (Set durable)
+   + passage des items `feedProvider` en `status = consumed`.
+2. **Backend** — POST `/api/contents/{id}/status` async ; le feed ne renvoie
+   `status=consumed` qu'**après** que ce POST a abouti.
+
+Le rendu de la carte feed lit **uniquement** `content.status` et **ne consulte
+pas** `consumedContentIdsProvider`. Plusieurs chemins de reload reconstruisent
+les `Content` depuis la réponse réseau (encore `unseen`) **sans** ré-appliquer le
+set consommé :
+
+| Chemin | Ré-appliquait l'état consommé ? |
+|--------|---------------------------------|
+| `_scheduleSilentRevalidation()` | ✅ oui (mais source = état courant uniquement) |
+| `refresh()` (pull-to-refresh / reprise) | ❌ **non — culprit principal** |
+| `loadMore()` | ❌ non |
+
+⇒ Un `refresh()` déclenché entre le marquage « Lu » et l'aboutissement du POST
+écrase le badge par la réponse serveur `unseen`. D'où l'inconstance.
+
+Le Flux Continu n'est pas affecté : sa carte superpose déjà
+`consumedContentIdsProvider` au rendu — pattern de résilience copié ici.
+
+## Fix
+
+`apps/mobile/lib/features/feed/providers/feed_provider.dart` : nouveau helper
+`_overlayConsumed(items, carousels)` qui ré-applique `status = consumed` à partir
+de `consumedContentIdsProvider` **∪** des items déjà consommés dans l'état
+courant. Appliqué dans `refresh()`, `loadMore()` et
+`_scheduleSilentRevalidation()` (dont il généralise la dérivation locale).
+
+Aucun changement de widget, aucune migration, aucun appel réseau supplémentaire.
+
+## Tests
+
+- `test/features/feed/feed_consumed_overlay_test.dart` — refresh()/loadMore()
+  préservent le statut consommé quand le serveur répond `unseen` ; no-op quand
+  le set est vide.
+- Non-régression : `feed_carousel_consumed_state_test.dart`,
+  `feed_refresh_recovery_test.dart`.


### PR DESCRIPTION
## Quoi

Le bandeau « Lu » / « Lu jusqu'au bout » (`ReadingBadge`) sur les cartes du feed Flâner disparaissait de façon **inconstante** après lecture d'un article. Cette PR le rend fiable, sans toucher aux widgets, sans migration ni appel réseau supplémentaire.

## Pourquoi

Le marquage « Lu » a deux niveaux : un **état optimiste local** (set durable `consumedContentIdsProvider` alimenté dès l'ouverture) et la **persistance backend** (POST `/status` async). La carte feed ne lit que `content.status` ; or plusieurs chemins de reload reconstruisaient les `Content` depuis la réponse réseau — encore `unseen` tant que le POST n'avait pas abouti — **sans** ré-appliquer le set consommé. Un `refresh()` (pull-to-refresh, reprise d'app, ré-amorçage home-screen) déclenché dans cette fenêtre écrasait le badge → d'où l'inconstance. (Le Flux Continu n'était pas touché car sa carte superpose déjà ce set au rendu.)

## Comment

Nouveau helper `_overlayConsumed(items, carousels)` dans `FeedNotifier` qui fait de `consumedContentIdsProvider` la **source d'autorité** (∪ items déjà consommés de l'état courant) et ré-applique `status = consumed`. Branché sur **tous** les chemins de (re)load pour qu'aucun ne puisse l'oublier :
- `build()` initial **+ cache-hit** (cold-load : le set peut être réamorcé depuis la file Hive avant l'arrivée de la page réseau)
- `refresh()` (pull-to-refresh / reprise)
- `loadMore()` (pagination)
- `_scheduleSilentRevalidation()` (généralise sa dérivation locale ad hoc — comportement identique, source plus robuste)

Au passage : **réparation d'une corruption JSON pré-existante** de `apps/mobile/assets/changelog.json` (premier objet `unreleased` avec deux paires tag/summary fusionnées par un merge — le fichier ne parsait plus) + entrée changelog « Lecture ».

## Comment ça a été vérifié
- [x] `flutter test test/features/feed/` — 224 passed (dont 4 nouveaux tests d'overlay : build cold-load, refresh, loadMore, no-op). Les 6 reds restants (`diff_title_uniform_color`, `perspectives_bottom_sheet_intro`) sont **pré-existants** et n'importent rien du code touché.
- [x] `flutter analyze lib/features/feed/providers/feed_provider.dart` — aucune erreur/warning introduit (seuls des `avoid_print` pré-existants)
- [x] `changelog_asset_test` vert (JSON réparé valide)
- [x] `/simplify` passé (reuse/simplification/efficiency clean ; altitude → couverture build()/cache-hit ajoutée)

## Zones à risque

`feed_provider.dart` (Router/DB feed côté mobile). Fix purement mobile, additif, idempotent (no-op quand le set consommé est vide). Pas de backend, pas d'Alembic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)