### PR TITLE
feat(feed): rotation déterministe seedée pour les carrousels sources récentes

### DIFF
--- a/packages/api/app/services/recommendation/randomization.py
+++ b/packages/api/app/services/recommendation/randomization.py
@@ -59,6 +59,11 @@ def randomized_sort[T](
     return [(item, score) for item, score, _ in noisy_items]
 
 
+def seeded_shuffle[T](items: list[T], seed: int) -> list[T]:
+    """Shuffle déterministe d'une liste sans score (pure randomisation)."""
+    return [x for x, _ in randomized_sort([(x, 0.0) for x in items], temperature=1.0, seed=seed)]
+
+
 def compute_seed(user_id: str, granularity: str = "hourly") -> int:
     """Compute a deterministic seed for stable ordering within a time window.
 

--- a/packages/api/app/services/recommendation/randomization.py
+++ b/packages/api/app/services/recommendation/randomization.py
@@ -61,7 +61,12 @@ def randomized_sort[T](
 
 def seeded_shuffle[T](items: list[T], seed: int) -> list[T]:
     """Shuffle déterministe d'une liste sans score (pure randomisation)."""
-    return [x for x, _ in randomized_sort([(x, 0.0) for x in items], temperature=1.0, seed=seed)]
+    return [
+        x
+        for x, _ in randomized_sort(
+            [(x, 0.0) for x in items], temperature=1.0, seed=seed
+        )
+    ]
 
 
 def compute_seed(user_id: str, granularity: str = "hourly") -> int:

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -1595,11 +1595,16 @@ class RecommendationService:
                     new_sources_found=len(new_src_rows),
                     source_names=[r.name for r in new_src_rows[:5]],
                 )
-                # T3A: iterate per source, pick first with enough articles
-                for src_row in new_src_rows:
-                    if len(carousels) >= max_carousels:
-                        break
-
+                # Rotation jour à jour : au lieu de s'arrêter à la première
+                # source valide (toujours la plus récente → carrousel figé), on
+                # collecte TOUTES les sources récentes valides puis on en tire UNE
+                # seedée par le jour. Variété jour à jour, stable dans la journée.
+                # Borne de coût : on ne sonde que les 8 sources les plus récentes
+                # (1 requête article par source).
+                MAX_NEW_SOURCE_PROBES = 8
+                now = datetime.datetime.now(datetime.UTC)
+                candidates: list[tuple[object, list[Content]]] = []
+                for src_row in new_src_rows[:MAX_NEW_SOURCE_PROBES]:
                     # T2: exclude promoted + consumed articles
                     exclusions = []
                     if promoted_ids:
@@ -1629,10 +1634,30 @@ class RecommendationService:
                     # Cooldown post-add 6 h — laisse les articles de la source
                     # remonter naturellement dans le main feed avant de pousser
                     # un carrousel "Récemment ajouté".
-                    now = datetime.datetime.now(datetime.UTC)
                     source_age_seconds = (now - src_row.added_at).total_seconds()
                     if source_age_seconds < 6 * 3600:
                         continue
+
+                    candidates.append((src_row, items))
+
+                if candidates:
+                    from app.services.recommendation.randomization import (
+                        compute_seed,
+                        randomized_sort,
+                    )
+
+                    # Shuffle déterministe seedé par le jour (scores uniformes 0.0
+                    # ⇒ pur shuffle) : la source en tête change jour à jour mais
+                    # reste stable dans la journée (cohérent avec le jitter de
+                    # position).
+                    seed = compute_seed(str(user_id), "daily")
+                    src_row, items = randomized_sort(
+                        [(c, 0.0) for c in candidates],
+                        temperature=1.0,
+                        seed=seed,
+                    )[0][0]
+
+                    source_age_seconds = (now - src_row.added_at).total_seconds()
                     position = self._jitter_carousel_position(
                         "new_source", user_id, today
                     )
@@ -1643,6 +1668,7 @@ class RecommendationService:
                         article_count=len(items),
                         position=position,
                         source_age_hours=round(source_age_seconds / 3600, 1),
+                        candidate_count=len(candidates),
                     )
                     badge = {
                         "code": "new_source",
@@ -1661,7 +1687,6 @@ class RecommendationService:
                     )
                     for item in items:
                         promoted_ids.add(item.id)
-                    break  # T3A: only 1 source carousel
 
             # --- quiet_sources: latest article from followed low-volume sources ---
             if len(carousels) < max_carousels:
@@ -1729,8 +1754,26 @@ class RecommendationService:
                             quiet_articles = list(
                                 (await quiet_s.scalars(latest_per_source)).all()
                             )
-                    quiet_articles.sort(key=lambda c: c.published_at, reverse=True)
-                    quiet_articles = quiet_articles[:MAX_CAROUSEL_ITEMS]
+                    # Round-robin au fil des refresh : au lieu de toujours
+                    # garder les 5 articles les plus récents (mêmes sources
+                    # discrètes en boucle), on shuffle déterministe seedé à
+                    # l'heure sur TOUT le pool avant de couper à 5. Granularité
+                    # "hourly" = varie au fil des refresh, stable dans la fenêtre
+                    # de cache feed 30 s.
+                    from app.services.recommendation.randomization import (
+                        compute_seed,
+                        randomized_sort,
+                    )
+
+                    seed = compute_seed(str(user_id), "hourly")
+                    quiet_articles = [
+                        a
+                        for a, _ in randomized_sort(
+                            [(a, 0.0) for a in quiet_articles],
+                            temperature=1.0,
+                            seed=seed,
+                        )
+                    ][:MAX_CAROUSEL_ITEMS]
                 except Exception as exc:
                     logger.warning(
                         "carousel_quiet_sources_skipped",

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -1638,26 +1638,17 @@ class RecommendationService:
                     if source_age_seconds < 6 * 3600:
                         continue
 
-                    candidates.append((src_row, items))
+                    candidates.append((src_row, items, source_age_seconds))
 
                 if candidates:
                     from app.services.recommendation.randomization import (
                         compute_seed,
-                        randomized_sort,
+                        seeded_shuffle,
                     )
 
-                    # Shuffle déterministe seedé par le jour (scores uniformes 0.0
-                    # ⇒ pur shuffle) : la source en tête change jour à jour mais
-                    # reste stable dans la journée (cohérent avec le jitter de
-                    # position).
                     seed = compute_seed(str(user_id), "daily")
-                    src_row, items = randomized_sort(
-                        [(c, 0.0) for c in candidates],
-                        temperature=1.0,
-                        seed=seed,
-                    )[0][0]
+                    src_row, items, source_age_seconds = seeded_shuffle(candidates, seed)[0]
 
-                    source_age_seconds = (now - src_row.added_at).total_seconds()
                     position = self._jitter_carousel_position(
                         "new_source", user_id, today
                     )
@@ -1762,18 +1753,11 @@ class RecommendationService:
                     # de cache feed 30 s.
                     from app.services.recommendation.randomization import (
                         compute_seed,
-                        randomized_sort,
+                        seeded_shuffle,
                     )
 
                     seed = compute_seed(str(user_id), "hourly")
-                    quiet_articles = [
-                        a
-                        for a, _ in randomized_sort(
-                            [(a, 0.0) for a in quiet_articles],
-                            temperature=1.0,
-                            seed=seed,
-                        )
-                    ][:MAX_CAROUSEL_ITEMS]
+                    quiet_articles = seeded_shuffle(quiet_articles, seed)[:MAX_CAROUSEL_ITEMS]
                 except Exception as exc:
                     logger.warning(
                         "carousel_quiet_sources_skipped",

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -1647,7 +1647,9 @@ class RecommendationService:
                     )
 
                     seed = compute_seed(str(user_id), "daily")
-                    src_row, items, source_age_seconds = seeded_shuffle(candidates, seed)[0]
+                    src_row, items, source_age_seconds = seeded_shuffle(
+                        candidates, seed
+                    )[0]
 
                     position = self._jitter_carousel_position(
                         "new_source", user_id, today
@@ -1757,7 +1759,9 @@ class RecommendationService:
                     )
 
                     seed = compute_seed(str(user_id), "hourly")
-                    quiet_articles = seeded_shuffle(quiet_articles, seed)[:MAX_CAROUSEL_ITEMS]
+                    quiet_articles = seeded_shuffle(quiet_articles, seed)[
+                        :MAX_CAROUSEL_ITEMS
+                    ]
                 except Exception as exc:
                     logger.warning(
                         "carousel_quiet_sources_skipped",

--- a/packages/api/tests/test_feed_carousels.py
+++ b/packages/api/tests/test_feed_carousels.py
@@ -5,7 +5,7 @@ import pytest
 from collections import namedtuple
 from datetime import UTC, datetime, timedelta
 from uuid import uuid4, UUID
-from unittest.mock import MagicMock, AsyncMock
+from unittest.mock import MagicMock, AsyncMock, patch
 
 from app.services.recommendation_service import RecommendationService
 
@@ -514,6 +514,70 @@ class TestBuildCarouselsNewSource:
         )
 
         assert not any(c["carousel_type"] == "new_source" for c in carousels)
+
+    @pytest.mark.asyncio
+    async def test_new_source_rotates_by_seed(self):
+        """≥3 sources récentes valides : la source mise en avant change selon le
+        seed (déterminisme jour à jour), et un seul carrousel new_source sort."""
+        user_id = uuid4()
+        src_ids = [uuid4() for _ in range(3)]
+        names = ["Alpha", "Bravo", "Charlie"]
+        two_days_ago = datetime.now(UTC) - timedelta(days=2)
+        src_rows = [
+            _SourceRow(source_id=sid, name=name, added_at=two_days_ago)
+            for sid, name in zip(src_ids, names, strict=True)
+        ]
+
+        def _build_service():
+            service = _setup_service_with_no_overflow()
+            articles = [
+                MockContent(
+                    title=f"Article {i}",
+                    source=MockSource(name="Alpha", source_id=src_ids[0]),
+                )
+                for i in range(3)
+            ]
+
+            execute_calls = 0
+
+            async def mock_execute(stmt):
+                nonlocal execute_calls
+                execute_calls += 1
+                if execute_calls == 1:
+                    return _mock_execute_result([])  # consumed_ids
+                if execute_calls == 2:
+                    return _mock_execute_result(src_rows)  # new_source
+                return _mock_execute_result([])  # quiet_sources + community
+
+            service.session.execute = AsyncMock(side_effect=mock_execute)
+            # Chaque sonde par source renvoie les mêmes 3 articles → 3 candidats.
+            service.session.scalars = AsyncMock(
+                return_value=_mock_scalars_result(articles),
+            )
+            return service
+
+        async def _selected_title(seed_value):
+            service = _build_service()
+            with patch(
+                "app.services.recommendation.randomization.compute_seed",
+                return_value=seed_value,
+            ):
+                _, carousels = await service._build_carousels(
+                    [], {}, user_id=user_id,
+                )
+            new_src = [c for c in carousels if c["carousel_type"] == "new_source"]
+            assert len(new_src) == 1  # toujours un seul carrousel new_source
+            return new_src[0]["title"]
+
+        # seed 0 → Alpha, seed 4 → Charlie (cf. shuffle Gumbel déterministe)
+        title_seed0 = await _selected_title(0)
+        title_seed4 = await _selected_title(4)
+        assert "Alpha" in title_seed0
+        assert "Charlie" in title_seed4
+        assert title_seed0 != title_seed4  # rotation selon le seed
+
+        # Déterminisme : même seed ⇒ même source
+        assert await _selected_title(0) == title_seed0
 
     @pytest.mark.asyncio
     async def test_new_source_skipped_when_no_new_sources(self):

--- a/packages/api/tests/test_feed_carousels_quiet_sources.py
+++ b/packages/api/tests/test_feed_carousels_quiet_sources.py
@@ -6,6 +6,7 @@ source rare. Carrousel émis seulement si ≥ 2 items.
 """
 
 import datetime
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
@@ -98,14 +99,54 @@ async def test_quiet_sources_carousel_basic(db_session, fake_session_maker):
     assert len(quiet) == 1
     c = quiet[0]
     assert c["title"] == "Tes sources discrètes"
+    # ≤ 5 sources : le shuffle déterministe ne change pas l'ENSEMBLE, juste
+    # l'ordre (l'ancien "most recent first" n'est plus garanti).
     assert {i.id for i in c["items"]} == {content_a.id, content_b.id}
-    # Most recent first
-    assert c["items"][0].id == content_a.id
     assert len(c["badges"]) == 2
-    assert c["badges"][0]["code"] == "quiet_source"
-    # Badge label = source name of the matching item
-    assert c["badges"][0]["label"] == "Rare A"
+    assert all(b["code"] == "quiet_source" for b in c["badges"])
+    # Badge label = source name de l'item correspondant (ordre seedé → on
+    # vérifie la correspondance item↔badge plutôt qu'une position fixe).
+    name_by_id = {content_a.id: "Rare A", content_b.id: "Rare B"}
+    for item, badge in zip(c["items"], c["badges"], strict=True):
+        assert badge["label"] == name_by_id[item.id]
     assert c["position"] >= 5
+
+
+@pytest.mark.asyncio
+async def test_quiet_sources_rotate_subset_by_seed(db_session, fake_session_maker):
+    """> 5 sources discrètes : deux seeds différents sélectionnent des
+    sous-ensembles différents (rotation au fil des refresh), même seed ⇒ même
+    sous-ensemble (stabilité dans la fenêtre de cache)."""
+    user_id = uuid4()
+    # 7 sources discrètes valides → pool > MAX_CAROUSEL_ITEMS (5).
+    all_ids = set()
+    for i in range(7):
+        _, content = await _seed_quiet_source(
+            db_session, f"Rare {i}", user_id, article_days_ago=5 + i
+        )
+        all_ids.add(content.id)
+
+    async def _subset(seed_value):
+        with patch(
+            "app.services.recommendation.randomization.compute_seed",
+            return_value=seed_value,
+        ):
+            carousels = await _build(db_session, fake_session_maker, user_id)
+        quiet = _quiet(carousels)
+        assert len(quiet) == 1
+        items = quiet[0]["items"]
+        assert len(items) == 5  # coupe à MAX_CAROUSEL_ITEMS
+        ids = {i.id for i in items}
+        assert ids <= all_ids  # sous-ensemble du pool
+        return frozenset(ids)
+
+    # seed 0 et seed 4 donnent des top-5 différents (shuffle Gumbel déterministe)
+    subset0 = await _subset(0)
+    subset4 = await _subset(4)
+    assert subset0 != subset4  # rotation selon le seed
+
+    # Déterminisme : même seed ⇒ même sous-ensemble
+    assert await _subset(0) == subset0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Quoi

Remplace la sélection statique « première source valide » par une rotation déterministe dans deux carrousels :

- **Récemment ajouté** : collecte toutes les sources valides (≤8 sondes), tire la gagnante via shuffle Gumbel seedé par `(user, day)` → source différente chaque jour, stable dans la journée.
- **Sources discrètes** : shuffle hourly sur l'ensemble du pool avant de couper à 5 → round-robin au fil des refresh.

Ajoute `seeded_shuffle()` dans `randomization.py` pour encapsuler le pattern (évite de répéter `randomized_sort([(x, 0.0)…], temperature=1.0)`).

## Pourquoi

Le carrousel « Récemment ajouté » affichait toujours la même source (la plus récente dans la liste). Un utilisateur qui ajoute 3 sources ne voyait que la dernière ajoutée. La rotation jour à jour garantit de la variété sans sacrifier la cohérence intra-journée.

## Comment ça a été vérifié

- [x] pytest 1956 passed, 0 échecs (suite complète backend)
- [x] `test_new_source_rotates_by_seed` — vérifie que seed 0 et seed 4 donnent des sources différentes, et que le même seed donne toujours la même source
- [x] `test_quiet_sources_rotate_subset_by_seed` — vérifie la rotation sur pool de 7 sources (> MAX=5)
- [x] `test_quiet_sources_carousel_basic` — adapté : vérifie la correspondance item↔badge sans supposer un ordre fixe
- [x] /simplify passé

## Zones à risque

`app/services/recommendation_service.py` — logique carrousel (chemins `new_source` + `quiet_sources`)
`app/services/recommendation/randomization.py` — nouveau helper `seeded_shuffle`