### PR TITLE
fix(flux): bind isPlaceholder in FeedThemeSection case (build AAB)

### DIFF
--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -242,6 +242,7 @@ class SectionBlock extends StatelessWidget {
           :final underfilled,
           :final themeSlug,
           :final label,
+          :final isPlaceholder,
         ):
         // Issue #1 — « squelette stable » : une coquille seed-ée AVANT le
         // fan-out réserve sa hauteur finale (N cartes squelette) pour que


### PR DESCRIPTION
## What
Bind `isPlaceholder` in the `FeedThemeSection` case of `_buildCards()`
(section_block.dart) so the placeholder/skeleton branch compiles.

## Why
The Build AAB job on `main` failed: `_buildCards()` switches over the
`section` field, so the `FeedThemeSection(...)` case must destructure its
fields. `isPlaceholder` was used but not listed, so it resolved against the
SectionBlock widget class and broke `bundlePlaystoreRelease`.

## Type
- [x] Bug fix