### PR TITLE
Boujonlaurin dotcom/notif bug double image placeholder

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,34 +1,54 @@
-# PR2 — Affinité entités (le levier)
+## Fix notif matin : avatar dupliqué + corps sans bullets (Part 1) + réanimation push serveur (Part 2)
 
-Apprend une **affinité positive** sur les entités nommées (`contents.entities`) — jusqu'ici utilisées seulement pour le mute — en **miroir exact** de la boucle sujets de PR1, et la récompense de façon **bornée, calibrée et transparente** dans le pilier Pertinence (feed + digest). Aucune vectorisation.
+Capture prod : la notif quotidienne affichait un **corps générique sans bullets**
++ un **avatar dupliqué** (logo + rond orange « T »). Diagnostic confirmé sur la
+DB partagée : le **push serveur n'a jamais enregistré un seul device** en prod
+(`push_devices`=0, `push_deliveries`=0, alors que 31 users `push_enabled`) → 100 %
+retombent sur la notif **locale**, qui avait deux défauts. PO : Part 1 + Part 2 en
+**une seule PR**.
 
-## Ce que ça change (user-visible)
-- Le flux récompense désormais les personnalités / sujets que tu lis souvent, avec une raison claire : « Parce que tu lis souvent {entité} ».
-- Borné (cap diversité), calibrable sur la jauge PR1.
+### Part 1 — Notif locale (mobile, 100 % des users la reçoivent)
+- **Avatar dupliqué** : `MessagingStyleInformation` → `BigTextStyleInformation`
+  (digest, bonnes nouvelles, `showRemoteNotification`). Le `Person` sans icône
+  générait le monogramme « T ». `senderName` supprimé.
+- **Bullets restaurés** : on ne supprime plus les teasers Essentiel de Hive ;
+  `syncDigestTeasers` les **persiste** (+ flag serène). Les 3 chemins de fallback
+  (`_restoreGenericFallback`, `_reschedule`, cold-start `main.dart`) planifient
+  **variantB + teasers** quand un digest existe, sinon variantA. `buildCopy(variantB)`
+  existait déjà (testé). Tradeoff PO assumé : bullets = dernier fetch (J-1 possible).
 
-## Implémentation
-- **Modèle + migration** : `UserEntityAffinity` (`user_entity_affinity`), enregistré dans `app/models/__init__.py` (sinon non créé par `Base.metadata.create_all` selon l'ordre de collecte des tests) ; migration additive idempotente `ue01_user_entity_affinity` chaînée sur `ufb01` (head courant de main après rebase, #909) → 1 seul head. `CREATE TABLE` pur + index → sûre en expand-contract sur la DB partagée staging/prod.
-- **Boucle d'apprentissage** : `ContentService._adjust_entity_affinity` (miroir de `_adjust_subtopic_weights`), câblée aux 5 mêmes call sites (read/like-unlike/save/hide/note) avec le même delta. Clamp [0.1, 3.0], cap 5 entités/article, skip entités mutées.
-- **Decay quotidien** : `decay_user_entity_affinity` à 06:50 Paris (avant digest), miroir du decay subtopics.
-- **Scoring** : `ScoringContext.user_entity_affinity` + `PertinencePillar._score_entities` (bonus `BASE*(aff-1)` plafonné à `ENTITY_AFFINITY_MAX_BONUS`). `MAX_PERTINENCE_RAW` 130→160 pour laisser le bonus respirer dans la normalisation.
-- **Raison** : `reason_builder` reconnaît la phrase entité comme top label si elle domine la pertinence. Préfixe `ENTITY_AFFINITY_REASON_PREFIX` partagé (pilier construit / reason_builder détecte) — pas de chaîne magique dupliquée.
-- **Chargement contexte** : feed (`_load_entity_affinity_safe`, défensif, dans `_batch_personalization`) + digest (`DigestContext.user_entity_affinity`). Tolérant au schema drift.
-- **Helper partagé** : `helpers/entities.py::iter_entity_names` (parse `Content.entities` une fois, réutilisé par la boucle d'apprentissage et le pilier). Skip des entités mutées via `_load_muted_entities_safe` (loader défensif réutilisé, tolérant au drift).
+### Part 2 — Réanimer le push serveur (cause « 0 device »)
+Racine = **config/ops hors repo**, 2 suspects compounding : `FIREBASE_SERVICE_ACCOUNT_*`
+non set sur Railway (→ `PUT /api/devices` 503 + dispatcher désactivé) et/ou
+`google-services.json` par flavor (→ `getToken()` null). La `DioException` 503 était
+**avalée**, d'où l'impossibilité de trancher. Code livré pour rendre le diag décidable
++ bullets hors-app :
+- **Instrumentation** : event PostHog `push_register`
+  {outcome: token_null | session_null | endpoint_error(+status_code) | registered |
+  exception}. `PushDevicesApiService.upsert` surface désormais le `statusCode`.
+- **FCM data-only Android** : `_send_fcm` retire le bloc `notification` top-level →
+  Android réveille `firebaseMessagingBackgroundHandler` qui rend le BigText à bullets
+  (réutilise `showRemoteNotification`). **iOS garde un alert APNS visible** (corps =
+  1er titre, sans bullets — acceptable).
 
-## Constantes (défauts de spec, tunables sur la jauge)
-`ENTITY_AFFINITY_BASE=8.0`, `ENTITY_AFFINITY_MAX_BONUS=30.0`, `ENTITY_AFFINITY_MAX_ENTITIES=5`, `ENTITY_AFFINITY_DECAY=0.98`, `MAX_PERTINENCE_RAW=160.0`.
+### ⚠️ Actions ops/PO restantes (non codables)
+1. Poser `FIREBASE_SERVICE_ACCOUNT_JSON` (ou `_BASE64`) sur **les 2** services Railway
+   (`api-staging-40d3` + `facteur-production`).
+2. Vérifier Firebase console (applicationIds `facteur.app` / `com.example.facteur.staging`,
+   sender ID = secrets CI) + injection `google-services.json` par flavor au build.
 
-## Changelog
-- Ajout de l'entrée PR2 (tag « Pour toi ») dans `unreleased` ; conflit de rebase avec l'entrée « Tournée » (#912) résolu en gardant les deux. JSON valide.
+Après ça + une release : l'event `push_register` dira l'outcome dominant, `push_devices`
+se peuple, et `dispatch_daily_essentiel_pushes` envoie (status `sent`).
 
-## Vérification
-- Backend : suite complète verte (**1998 passed**, 0 échec). Migration `upgrade head` OK sur DB **vide** (1 head `ue01`, table/index/FK/contrainte conformes).
-- `ruff check app/` + `ruff format --check app/` : clean (gate CI, ruff 0.15.14 épinglé).
-- Mobile : `flutter test test/features/release_notes/` → 18 passed (changelog valide). `flutter analyze` : seulement des `info` pré-existants, aucun sur les fichiers touchés.
-- Tests ajoutés : `_adjust_entity_affinity` (parse/cap5/skip-muté/clamp/count/négatif-no-op), `_score_entities` (bonus/cap/raison/0-si-aff≤1), reason_builder (top label entité), job decay scheduler.
+### Bonus
+`assets/changelog.json` était **déjà corrompu** par un merge (2 paires tag/summary
+fusionnées → JSON invalide, cassait la modal « Quoi de neuf »). Corrigé + entrée
+Notifications ajoutée.
 
-## Calibration (post-merge, gate PO)
-Comparer le CTR par entité et global avant/après sur la jauge PR1 (staging ≥1 sem.) ; ajuster `ENTITY_AFFINITY_BASE` sans écraser la diversité (nb sources/sujets distincts au digest).
+### Tests
+- `flutter test` : copy variantB (25/25) + notifications + flux_continu OK. Analyze : 0 nouvel issue.
+- `pytest` : `test_send_fcm_is_data_only_with_teasers_preserved` (fake firebase_admin). Ruff clean.
+  (Tests dispatcher/route DB-backed = Connection refused en local Conductor → tournent en CI.)
+- Validation on-device Android (`--flavor staging`) restante : 1 seul avatar + bullets dépliés.
 
-## Hors scope (= spec)
-Feed + digest uniquement. `topic_selector` hérite du dict amont ; veille passe `{}`.
+Doc : `docs/bugs/bug-notif-matin-avatar-double-sans-bullets.md`.

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,8 +1,14 @@
 {
   "unreleased": [
     {
+      "tag": "Notifications",
+      "summary": "La notif du matin affiche de nouveau les titres à la une, sans doublon visuel."
+    },
+    {
       "tag": "Tournée",
       "summary": "Au pied de chaque thème de ta Tournée, des sources de qualité à suivre pour enrichir ton actu, et une recherche pour trouver les tiennes."
+    },
+    {
       "tag": "Pour toi",
       "summary": "Le flux récompense désormais les personnalités et sujets que tu lis souvent, avec une raison claire (« Parce que tu lis souvent … »)."
     },

--- a/apps/mobile/lib/core/api/push_devices_api_service.dart
+++ b/apps/mobile/lib/core/api/push_devices_api_service.dart
@@ -8,7 +8,14 @@ class PushDevicesApiService {
 
   final ApiClient _apiClient;
 
-  Future<bool> upsert({
+  /// Enregistre l'appareil. Retourne `(ok, statusCode)` :
+  /// - `ok` = succès 2xx ;
+  /// - `statusCode` = code HTTP de la réponse d'erreur (ex. 503 si le push
+  ///   serveur n'est pas configuré côté backend), ou `null` pour une erreur
+  ///   réseau/timeout sans réponse. Surfacé pour le diagnostic de registration
+  ///   (cf. bug-notif-matin-avatar-double-sans-bullets, Part 2 : root cause
+  ///   « 0 device »).
+  Future<({bool ok, int? statusCode})> upsert({
     required String deviceId,
     required String token,
     required String platform,
@@ -26,10 +33,13 @@ class PushDevicesApiService {
           if (appVersion != null) 'app_version': appVersion,
         },
       );
-      return true;
+      return (ok: true, statusCode: null);
     } on DioException catch (e) {
-      debugPrint('PushDevicesApi: PUT failed: ${e.message}');
-      return false;
+      debugPrint(
+        'PushDevicesApi: PUT failed: ${e.message} '
+        '(status ${e.response?.statusCode})',
+      );
+      return (ok: false, statusCode: e.response?.statusCode);
     }
   }
 

--- a/apps/mobile/lib/core/services/push_notification_service.dart
+++ b/apps/mobile/lib/core/services/push_notification_service.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
@@ -138,9 +140,6 @@ class PushNotificationService {
 
   // --- Copy variants -------------------------------------------------------
 
-  /// Nom affiché comme expéditeur dans la notif Android (MessagingStyle).
-  static const String senderName = 'Ton facteur';
-
   /// Variante A — défaut, sans teaser éditorial.
   static const String defaultTitle = 'Facteur';
   static const String defaultBody = "Ton récap du jour t'attend quand tu veux.";
@@ -269,11 +268,6 @@ class PushNotificationService {
         ? AndroidScheduleMode.exactAllowWhileIdle
         : AndroidScheduleMode.inexactAllowWhileIdle;
 
-    const sender = Person(
-      name: senderName,
-      key: 'facteur',
-      important: true,
-    );
     final androidDetails = AndroidNotificationDetails(
       'digest_channel',
       'Digest quotidien',
@@ -282,12 +276,13 @@ class PushNotificationService {
       priority: Priority.high,
       icon: '@drawable/ic_stat_facteur',
       color: const Color(0xFFD35400),
-      styleInformation: MessagingStyleInformation(
-        const Person(name: 'Toi'),
-        groupConversation: false,
-        messages: [
-          Message(copy.bigText, DateTime.now(), sender),
-        ],
+      // BigText (et non MessagingStyle) : le multi-ligne est rendu sans avatar
+      // par message — un MessagingStyle sans icône d'expéditeur produit un
+      // monogramme « T » coloré dupliqué à côté de l'icône launcher
+      // (cf. bug-notif-matin-avatar-double-sans-bullets).
+      styleInformation: BigTextStyleInformation(
+        copy.bigText,
+        contentTitle: copy.title,
       ),
     );
     const iosDetails = DarwinNotificationDetails();
@@ -387,11 +382,6 @@ class PushNotificationService {
         ? AndroidScheduleMode.exactAllowWhileIdle
         : AndroidScheduleMode.inexactAllowWhileIdle;
 
-    const sender = Person(
-      name: senderName,
-      key: 'facteur',
-      important: true,
-    );
     final androidDetails = AndroidNotificationDetails(
       'good_news_channel',
       'Bonnes nouvelles du jour',
@@ -401,12 +391,11 @@ class PushNotificationService {
       priority: Priority.high,
       icon: '@drawable/ic_stat_facteur',
       color: const Color(0xFFD35400),
-      styleInformation: MessagingStyleInformation(
-        const Person(name: 'Toi'),
-        groupConversation: false,
-        messages: [
-          Message(copy.bigText, DateTime.now(), sender),
-        ],
+      // BigText (et non MessagingStyle) : évite l'avatar monogramme dupliqué
+      // (cf. bug-notif-matin-avatar-double-sans-bullets).
+      styleInformation: BigTextStyleInformation(
+        copy.bigText,
+        contentTitle: copy.title,
       ),
     );
     const iosDetails = DarwinNotificationDetails();
@@ -556,28 +545,78 @@ class PushNotificationService {
 
   Future<void> showRemoteNotification(RemoteMessage message) async {
     final notification = message.notification;
-    if (notification == null) return;
-    final route = message.data['route'] as String? ?? '/digest';
-    const androidDetails = AndroidNotificationDetails(
+    final data = message.data;
+    final route = data['route'] as String? ?? '/digest';
+
+    // Le push digest est data-only sur Android (cf. push_dispatcher._send_fcm) :
+    // `message.notification` est null et c'est NOUS qui rendons la notif. On
+    // ignore donc le push uniquement s'il n'y a ni bloc `notification`, ni
+    // données exploitables (teasers / title|body dans `data`).
+    final teasers = _parseTeasers(data['teasers']);
+    final dataTitle = data['title'] as String?;
+    final dataBody = data['body'] as String?;
+    if (notification == null &&
+        teasers.isEmpty &&
+        dataTitle == null &&
+        dataBody == null) {
+      return;
+    }
+
+    // Si le push porte des teasers (`data['teasers']` = JSON liste de titres),
+    // on rend de vrais bullets (variantB) au lieu du corps une-ligne. Sinon,
+    // fallback sur le bloc `notification` FCM, puis sur `data` title/body.
+    final String title;
+    final String body;
+    final String bigText;
+    if (teasers.isNotEmpty) {
+      final copy = buildCopy(variant: NotifVariant.variantB, teasers: teasers);
+      title = copy.title;
+      body = copy.body;
+      bigText = copy.bigText;
+    } else {
+      title = notification?.title ?? dataTitle ?? defaultTitle;
+      body = notification?.body ?? dataBody ?? defaultBody;
+      bigText = body;
+    }
+
+    final androidDetails = AndroidNotificationDetails(
       'digest_channel',
       'Digest quotidien',
       channelDescription: 'Notification quotidienne quand ton récap est prêt',
       importance: Importance.high,
       priority: Priority.high,
       icon: '@drawable/ic_stat_facteur',
-      color: Color(0xFFD35400),
+      color: const Color(0xFFD35400),
+      styleInformation: BigTextStyleInformation(bigText, contentTitle: title),
     );
     const iosDetails = DarwinNotificationDetails();
     await _plugin.show(
       id: message.messageId?.hashCode ?? DateTime.now().millisecondsSinceEpoch,
-      title: notification.title ?? defaultTitle,
-      body: notification.body ?? defaultBody,
-      notificationDetails: const NotificationDetails(
+      title: title,
+      body: body,
+      notificationDetails: NotificationDetails(
         android: androidDetails,
         iOS: iosDetails,
       ),
       payload: 'route:$route',
     );
+  }
+
+  /// Décode `data['teasers']` (JSON liste de titres) de façon défensive :
+  /// renvoie une liste vide si la charge est absente, mal formée, ou non-liste.
+  static List<String> _parseTeasers(Object? raw) {
+    if (raw is! String || raw.isEmpty) return const [];
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! List) return const [];
+      return decoded
+          .whereType<String>()
+          .map((t) => t.trim())
+          .where((t) => t.isNotEmpty)
+          .toList(growable: false);
+    } catch (_) {
+      return const [];
+    }
   }
 
   static void openRoute(String route) {

--- a/apps/mobile/lib/core/services/server_push_service.dart
+++ b/apps/mobile/lib/core/services/server_push_service.dart
@@ -14,11 +14,23 @@ import 'package:uuid/uuid.dart';
 import '../api/api_client.dart';
 import '../api/notification_preferences_api_service.dart';
 import '../api/push_devices_api_service.dart';
+import 'posthog_service.dart';
 import 'push_notification_service.dart';
 
 @pragma('vm:entry-point')
 Future<void> firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   await Firebase.initializeApp();
+  // Push Android = data-only (cf. push_dispatcher._send_fcm) : le système ne
+  // rend rien tout seul, c'est ici qu'on construit la notif à bullets depuis
+  // `data['teasers']`. Réutilise le chemin de rendu foreground
+  // (cf. bug-notif-matin-avatar-double-sans-bullets, Part 2).
+  try {
+    final service = PushNotificationService();
+    await service.init();
+    await service.showRemoteNotification(message);
+  } catch (e) {
+    debugPrint('ServerPushService: background render failed: $e');
+  }
 }
 
 class ServerPushService {
@@ -27,6 +39,25 @@ class ServerPushService {
   static final ServerPushService instance = ServerPushService._();
   static const serverRegisteredKey = 'notif_server_device_registered';
   static const _deviceIdKey = 'push_device_id';
+
+  /// Clés Hive (box `settings`) des teasers Essentiel persistés pour le
+  /// fallback local (notif digest en variantB quand le push serveur est
+  /// indisponible). Source = dernier fetch du Flux Continu.
+  static const essentielTeasersKey = 'notif_essentiel_teasers';
+  static const essentielSereneKey = 'notif_essentiel_serene';
+
+  /// Lecture défensive des teasers Essentiel persistés. Hive rend des
+  /// `List<dynamic>` ; on filtre aux `String` non vides pour éviter un crash de
+  /// cast. Partagée par les 3 chemins de fallback (this, provider, main.dart).
+  static List<String> readEssentielTeasers(Box<dynamic> box) {
+    final raw = box.get(essentielTeasersKey);
+    if (raw is! List) return const [];
+    return raw
+        .whereType<String>()
+        .map((t) => t.trim())
+        .where((t) => t.isNotEmpty)
+        .toList(growable: false);
+  }
 
   // Singleton vivant pendant toute la durée du process.
   // ignore: cancel_subscriptions
@@ -62,10 +93,19 @@ class ServerPushService {
       }
 
       final token = await FirebaseMessaging.instance.getToken();
-      if (token == null) return _setRegistered(false);
+      if (token == null) {
+        // FCM n'a pas pu produire de token : typiquement un
+        // `google-services.json` absent/incohérent pour le flavor courant.
+        // C'est l'un des deux suspects « 0 device » (cf. Part 2).
+        unawaited(_capturePushRegister(outcome: 'token_null'));
+        return _setRegistered(false);
+      }
       return _registerToken(token);
     } catch (e) {
       debugPrint('ServerPushService: initialization failed: $e');
+      unawaited(
+        _capturePushRegister(outcome: 'exception', reason: e.runtimeType.toString()),
+      );
       await _setRegistered(false);
       await _restoreGenericFallback();
       return false;
@@ -74,7 +114,13 @@ class ServerPushService {
 
   Future<bool> _registerToken(String token) async {
     final session = Supabase.instance.client.auth.currentSession;
-    if (session == null) return _setRegistered(false);
+    if (session == null) {
+      // Token FCM présent mais pas de session Supabase au moment de l'appel.
+      // Mitigé par le listener onAuthStateChange (main.dart), mais on trace le
+      // cas pour distinguer cette course du suspect config (cf. Part 2).
+      unawaited(_capturePushRegister(outcome: 'session_null'));
+      return _setRegistered(false);
+    }
 
     final prefs = await SharedPreferences.getInstance();
     var deviceId = prefs.getString(_deviceIdKey);
@@ -85,22 +131,54 @@ class ServerPushService {
     final timezone = await FlutterTimezone.getLocalTimezone();
     final package = await PackageInfo.fromPlatform();
     final api = PushDevicesApiService(ApiClient(Supabase.instance.client));
-    final registered = await api.upsert(
+    final result = await api.upsert(
       deviceId: deviceId,
       token: token,
       platform: Platform.isIOS ? 'ios' : 'android',
       timezone: timezone,
       appVersion: '${package.version}+${package.buildNumber}',
     );
+    final registered = result.ok;
+    // Le 503 ici = `FIREBASE_SERVICE_ACCOUNT_*` non configuré côté backend
+    // Railway (l'autre suspect « 0 device » avec token_null). Le status_code
+    // est tracé pour trancher le diagnostic après release (cf. Part 2).
+    unawaited(_capturePushRegister(
+      outcome: registered ? 'registered' : 'endpoint_error',
+      statusCode: result.statusCode,
+    ));
     await _setRegistered(registered);
     if (registered) {
+      // Le push serveur prend le relais : on annule la notif locale planifiée.
+      // Les teasers Essentiel persistés en Hive sont conservés — ils servent de
+      // fallback si la registration serveur se perd plus tard
+      // (cf. bug-notif-matin-avatar-double-sans-bullets, Part 1).
       await PushNotificationService().cancelDigestNotification();
-      final box = await Hive.openBox<dynamic>('settings');
-      await box.delete('notif_essentiel_teasers');
     } else {
       await _restoreGenericFallback();
     }
     return registered;
+  }
+
+  /// Trace l'issue de l'enregistrement push serveur pour PostHog. Permet de
+  /// trancher la cause racine « 0 device » après une release :
+  /// - `token_null` → `google-services.json` du flavor (config app/CI) ;
+  /// - `endpoint_error` + `status_code: 503` → `FIREBASE_SERVICE_ACCOUNT_*`
+  ///   non configuré sur le backend Railway ;
+  /// - `session_null` → course session/boot ; `registered` → succès.
+  Future<void> _capturePushRegister({
+    required String outcome,
+    int? statusCode,
+    String? reason,
+  }) async {
+    await PostHogService().capture(
+      event: 'push_register',
+      properties: {
+        'outcome': outcome,
+        'platform': Platform.isIOS ? 'ios' : 'android',
+        if (statusCode != null) 'status_code': statusCode,
+        if (reason != null) 'reason': reason,
+      },
+    );
   }
 
   Future<void> revokeCurrentDevice() async {
@@ -127,12 +205,17 @@ class ServerPushService {
     if (!enabled) return;
     final slot = NotifTimeSlotX.fromWire(box.get('notif_time_slot') as String?);
     final localPush = PushNotificationService();
+    final teasers = readEssentielTeasers(box);
+    final serene = box.get(essentielSereneKey, defaultValue: false) as bool;
     // Pas de demande exact-alarm automatique ici (rejouée à chaque FCM raté →
     // pop-up « Alarmes et rappels » intempestif, cf. bug-modals-intrusives).
     // Planification directe : retombe en mode inexact si la permission manque.
+    // variantB + teasers (bullets) si on a un dernier digest, sinon variantA.
     await localPush.scheduleDailyDigestNotification(
       timeSlot: slot,
-      variant: NotifVariant.variantA,
+      variant: teasers.isEmpty ? NotifVariant.variantA : NotifVariant.variantB,
+      teasers: teasers.isEmpty ? null : teasers,
+      serene: serene,
     );
   }
 

--- a/apps/mobile/lib/core/services/server_push_service.dart
+++ b/apps/mobile/lib/core/services/server_push_service.dart
@@ -59,6 +59,26 @@ class ServerPushService {
         .toList(growable: false);
   }
 
+  /// Planifie la notif digest LOCALE de fallback depuis l'état persisté (box
+  /// `settings`) : variantB + teasers (bullets) si un dernier digest existe,
+  /// sinon variantA générique. Source unique de la décision de variante,
+  /// partagée par les 3 chemins de fallback (`_restoreGenericFallback`, le
+  /// provider Réglages, le cold start `main.dart`) pour ne pas dupliquer la
+  /// règle. Renvoie `true` si la planification a réussi (cf. exact-alarm).
+  static Future<bool> scheduleDigestFallback({
+    required Box<dynamic> box,
+    required NotifTimeSlot timeSlot,
+  }) {
+    final teasers = readEssentielTeasers(box);
+    final serene = box.get(essentielSereneKey, defaultValue: false) as bool;
+    return PushNotificationService().scheduleDailyDigestNotification(
+      timeSlot: timeSlot,
+      variant: teasers.isEmpty ? NotifVariant.variantA : NotifVariant.variantB,
+      teasers: teasers.isEmpty ? null : teasers,
+      serene: serene,
+    );
+  }
+
   // Singleton vivant pendant toute la durée du process.
   // ignore: cancel_subscriptions
   StreamSubscription<String>? _tokenSubscription;
@@ -204,19 +224,10 @@ class ServerPushService {
         box.get('push_notifications_enabled', defaultValue: false) as bool;
     if (!enabled) return;
     final slot = NotifTimeSlotX.fromWire(box.get('notif_time_slot') as String?);
-    final localPush = PushNotificationService();
-    final teasers = readEssentielTeasers(box);
-    final serene = box.get(essentielSereneKey, defaultValue: false) as bool;
     // Pas de demande exact-alarm automatique ici (rejouée à chaque FCM raté →
     // pop-up « Alarmes et rappels » intempestif, cf. bug-modals-intrusives).
     // Planification directe : retombe en mode inexact si la permission manque.
-    // variantB + teasers (bullets) si on a un dernier digest, sinon variantA.
-    await localPush.scheduleDailyDigestNotification(
-      timeSlot: slot,
-      variant: teasers.isEmpty ? NotifVariant.variantA : NotifVariant.variantB,
-      teasers: teasers.isEmpty ? null : teasers,
-      serene: serene,
-    );
+    await scheduleDigestFallback(box: box, timeSlot: slot);
   }
 
   Future<bool> _setRegistered(bool value) async {

--- a/apps/mobile/lib/features/settings/providers/notifications_settings_provider.dart
+++ b/apps/mobile/lib/features/settings/providers/notifications_settings_provider.dart
@@ -229,15 +229,27 @@ class NotificationsSettingsNotifier
     await push.cancelGoodNewsNotification();
     final box = await _box();
     final goodNewsTeasers = readTeasers(box, kGoodNewsTeasers);
+    final essentielTeasers = ServerPushService.readEssentielTeasers(box);
+    final essentielSerene = box.get(
+      ServerPushService.essentielSereneKey,
+      defaultValue: false,
+    ) as bool;
     final serverRegistered = box.get(
       ServerPushService.serverRegisteredKey,
       defaultValue: false,
     ) as bool;
     if (state.pushEnabled) {
       if (!serverRegistered) {
+        // variantB + teasers (bullets) si on a un dernier digest persisté,
+        // sinon variantA générique
+        // (cf. bug-notif-matin-avatar-double-sans-bullets).
         await push.scheduleDailyDigestNotification(
           timeSlot: state.timeSlot,
-          variant: NotifVariant.variantA,
+          variant: essentielTeasers.isEmpty
+              ? NotifVariant.variantA
+              : NotifVariant.variantB,
+          teasers: essentielTeasers.isEmpty ? null : essentielTeasers,
+          serene: essentielSerene,
         );
       }
       if (state.preset == NotifPreset.curieux) {
@@ -262,15 +274,26 @@ class NotificationsSettingsNotifier
     return raw.whereType<String>().toList(growable: false);
   }
 
-  /// Les teasers Essentiel sont désormais construits côté serveur à partir du
-  /// digest exact du jour. On purge l'ancienne persistance locale.
+  /// Persiste les teasers du dernier fetch Flux Continu pour alimenter la notif
+  /// digest LOCALE en bullets (variantB) quand le push serveur est indisponible
+  /// (cf. bug-notif-matin-avatar-double-sans-bullets, Part 1).
+  ///
+  /// > Tradeoff assumé (phasé) : ces bullets viennent du dernier fetch
+  /// > (potentiellement J-1) ; le digest exact du jour viendra du push serveur
+  /// > (Part 2).
   Future<void> syncDigestTeasers({
     required List<String> essentielTeasers,
     required List<String> goodNewsTeasers,
     required bool sereinEnabled,
   }) async {
     final box = await _box();
-    await box.delete('notif_essentiel_teasers');
+    if (essentielTeasers.isNotEmpty) {
+      await box.put(ServerPushService.essentielTeasersKey, essentielTeasers);
+      await box.put(ServerPushService.essentielSereneKey, sereinEnabled);
+    } else {
+      await box.delete(ServerPushService.essentielTeasersKey);
+      await box.delete(ServerPushService.essentielSereneKey);
+    }
     if (goodNewsTeasers.isNotEmpty) {
       await box.put(kGoodNewsTeasers, goodNewsTeasers);
     }

--- a/apps/mobile/lib/features/settings/providers/notifications_settings_provider.dart
+++ b/apps/mobile/lib/features/settings/providers/notifications_settings_provider.dart
@@ -229,27 +229,15 @@ class NotificationsSettingsNotifier
     await push.cancelGoodNewsNotification();
     final box = await _box();
     final goodNewsTeasers = readTeasers(box, kGoodNewsTeasers);
-    final essentielTeasers = ServerPushService.readEssentielTeasers(box);
-    final essentielSerene = box.get(
-      ServerPushService.essentielSereneKey,
-      defaultValue: false,
-    ) as bool;
     final serverRegistered = box.get(
       ServerPushService.serverRegisteredKey,
       defaultValue: false,
     ) as bool;
     if (state.pushEnabled) {
       if (!serverRegistered) {
-        // variantB + teasers (bullets) si on a un dernier digest persisté,
-        // sinon variantA générique
-        // (cf. bug-notif-matin-avatar-double-sans-bullets).
-        await push.scheduleDailyDigestNotification(
+        await ServerPushService.scheduleDigestFallback(
+          box: box,
           timeSlot: state.timeSlot,
-          variant: essentielTeasers.isEmpty
-              ? NotifVariant.variantA
-              : NotifVariant.variantB,
-          teasers: essentielTeasers.isEmpty ? null : essentielTeasers,
-          serene: essentielSerene,
         );
       }
       if (state.preset == NotifPreset.curieux) {

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -405,9 +405,23 @@ Future<void> _initDeferredServices({required PostHogService posthog}) async {
         // Le pop-up OS « Alarmes et rappels » ne doit jamais se rouvrir tout
         // seul (bug-modals-intrusives) ; l'opt-in exact-alarm est strictement
         // initié par l'utilisateur (modal d'activation / Réglages).
+        //
+        // variantB + teasers persistés (bullets) si un dernier digest existe,
+        // sinon variantA générique
+        // (cf. bug-notif-matin-avatar-double-sans-bullets, Part 1).
+        final essentielTeasers =
+            ServerPushService.readEssentielTeasers(settingsBox);
+        final essentielSerene = settingsBox.get(
+          ServerPushService.essentielSereneKey,
+          defaultValue: false,
+        ) as bool;
         final scheduled =
             await pushNotificationService.scheduleDailyDigestNotification(
-          variant: NotifVariant.variantA,
+          variant: essentielTeasers.isEmpty
+              ? NotifVariant.variantA
+              : NotifVariant.variantB,
+          teasers: essentielTeasers.isEmpty ? null : essentielTeasers,
+          serene: essentielSerene,
           timeSlot: timeSlot,
         );
         if (!scheduled) {

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -406,22 +406,8 @@ Future<void> _initDeferredServices({required PostHogService posthog}) async {
         // seul (bug-modals-intrusives) ; l'opt-in exact-alarm est strictement
         // initié par l'utilisateur (modal d'activation / Réglages).
         //
-        // variantB + teasers persistés (bullets) si un dernier digest existe,
-        // sinon variantA générique
-        // (cf. bug-notif-matin-avatar-double-sans-bullets, Part 1).
-        final essentielTeasers =
-            ServerPushService.readEssentielTeasers(settingsBox);
-        final essentielSerene = settingsBox.get(
-          ServerPushService.essentielSereneKey,
-          defaultValue: false,
-        ) as bool;
-        final scheduled =
-            await pushNotificationService.scheduleDailyDigestNotification(
-          variant: essentielTeasers.isEmpty
-              ? NotifVariant.variantA
-              : NotifVariant.variantB,
-          teasers: essentielTeasers.isEmpty ? null : essentielTeasers,
-          serene: essentielSerene,
+        final scheduled = await ServerPushService.scheduleDigestFallback(
+          box: settingsBox,
           timeSlot: timeSlot,
         );
         if (!scheduled) {

--- a/docs/bugs/bug-notif-matin-avatar-double-sans-bullets.md
+++ b/docs/bugs/bug-notif-matin-avatar-double-sans-bullets.md
@@ -1,0 +1,112 @@
+# Bug — Notif matin : avatar dupliqué + corps générique sans bullets
+
+**Type :** Bug
+**Statut :** Part 1 + Part 2 (code) livrés dans une seule PR. Reste 2 actions **ops/PO** (cf. § Part 2 → Actions ops).
+
+## Symptôme (capture prod)
+
+La notification quotidienne « Ton facteur » affiche :
+- un **corps générique** (« Ton récap du jour t'attend quand tu veux. ») **sans
+  bullet points d'articles** ;
+- un **avatar dupliqué** : le logo Facteur (icône launcher) + un rond orange « T ».
+
+## Diagnostic
+
+Le titre `Ton facteur` + le corps `Ton récap du jour t'attend quand tu veux.`
+correspondent à la notif **LOCALE** `variantA`
+(`PushNotificationService.buildCopy(variant: variantA)` → `defaultBody`). Ce
+**n'est pas** le push serveur.
+
+100 % des users prod reçoivent le push local parce que le **push serveur n'a
+enregistré aucun device** en prod (`push_devices` = 0 ; `push_deliveries` 7j =
+0 ; alors que `push_enabled = true` pour 31 users). Tous retombent sur le
+fallback local (`main.dart` + `server_push_service._restoreGenericFallback`).
+
+### Deux défauts de la notif locale
+
+1. **Avatar dupliqué.** `scheduleDailyDigestNotification` et
+   `scheduleDailyGoodNewsNotification` utilisaient `MessagingStyleInformation`
+   avec un `sender = Person(name: senderName)` **sans icône** → Android génère un
+   monogramme « T » coloré à côté de l'icône launcher.
+2. **Pas de bullets.** Le fallback local planifiait **toujours** `variantA`, et
+   les teasers Essentiel étaient supprimés de Hive
+   (`server_push_service.dart:99`, `syncDigestTeasers`). Cold-start n'avait donc
+   rien à rendre en bullets.
+
+## Fix — Part 1 (mobile-only, aucune migration)
+
+### 1a. Supprimer l'avatar dupliqué
+`MessagingStyleInformation` → `BigTextStyleInformation` (pattern déjà utilisé par
+`scheduleWeeklyCommunityPick` / `scheduleVeilleNotification`, sans ce bug) pour
+le digest, les bonnes nouvelles, et `showRemoteNotification`.
+
+### 1b. Restaurer les bullets en local (variantB)
+- `server_push_service.dart` : ne plus supprimer `notif_essentiel_teasers` ;
+  `_restoreGenericFallback` planifie `variantB` + teasers si présents.
+- `syncDigestTeasers` : **persiste** les teasers Essentiel (au lieu de les
+  supprimer) puis replanifie `variantB` quand présents.
+- `main.dart` cold-start : lit les teasers persistés et planifie `variantB`.
+
+> **Tradeoff (PO ok, phasé) :** les bullets locaux viennent du dernier fetch
+> (potentiellement J-1). Le digest exact du jour viendra du push serveur (Part 2).
+
+### 1c. `showRemoteNotification` (foreground)
+Parse `message.data['teasers']` (JSON) → `buildCopy(variantB, teasers)` →
+`BigTextStyleInformation`. Fallback sur `notification.title/body` sinon.
+
+## Part 2 — Réanimer le push serveur (cause « 0 device »)
+
+**État live confirmé (DB prod partagée, 2026-06-30) :** `push_devices` = 0,
+`push_deliveries` (total **et** 7j) = 0, `user_notification_preferences.push_enabled`
+= 31. La registration n'a **jamais** réussi une seule fois.
+
+### Cause racine = config/ops (hors repo), deux suspects compounding
+1. **Backend non configuré.** `PUT /api/devices` renvoie **503** si
+   `FIREBASE_SERVICE_ACCOUNT_{JSON,BASE64}` n'est pas set côté Railway
+   (`push_devices.py:43-50`). Le mobile **avale** la `DioException`
+   (`return false`) → fallback local silencieux. Et `dispatch_daily_essentiel_pushes`
+   se **désactive** sans ce secret (`push_dispatcher._firebase_configured`).
+2. **App : token FCM null.** `google-services.json` absent/incohérent pour le
+   flavor (`facteur.app` prod / `com.example.facteur.staging` staging, fournis
+   au build, hors repo) ⇒ `getToken()` null avant même d'appeler le backend.
+
+### Code livré dans cette PR (rend le diagnostic décidable + bullets hors-app)
+- **Instrumentation registration** (`server_push_service.dart`) : event PostHog
+  `push_register` avec `outcome` ∈ {`token_null`, `session_null`,
+  `endpoint_error`(+`status_code`), `registered`, `exception`}. Après la
+  prochaine release on lit l'outcome dominant pour trancher suspect 1 vs 2.
+  `PushDevicesApiService.upsert` surface désormais le `statusCode` (le 503 était
+  jeté).
+- **FCM data-only Android + bullets hors-app** : `push_dispatcher._send_fcm`
+  passe en data-only (plus de bloc `notification` top-level → Android réveille
+  `firebaseMessagingBackgroundHandler`, qui rend le BigText à bullets via le
+  chemin de `showRemoteNotification`). iOS garde un **alert APNS visible**
+  (corps = 1er titre, sans bullets — acceptable). `showRemoteNotification` gère
+  le cas data-only (notification null).
+
+### Actions ops/PO restantes (NON codables — hors repo)
+1. **Railway** : vérifier/poser `FIREBASE_SERVICE_ACCOUNT_JSON` (ou `_BASE64`)
+   sur **les deux** services (`api-staging-40d3` **et** `facteur-production`).
+   Sans ça, `PUT /api/devices` = 503 et le dispatcher reste désactivé.
+2. **Firebase console + CI** : confirmer que les applicationIds `facteur.app`
+   (prod) et `com.example.facteur.staging` (staging) sont enregistrés, sender ID
+   = secrets CI, et que `google-services.json` par flavor est bien injecté au
+   build (`android/app/src/{prod,staging}/`).
+
+Après ces 2 actions + une release : relancer un opt-in → vérifier qu'une ligne
+apparaît dans `push_devices`, puis déclencher `dispatch_daily_essentiel_pushes`
+→ `push_deliveries.status = 'sent'` + rendu on-device (bullets).
+
+## Fichiers
+
+**Part 1 (mobile)**
+- `apps/mobile/lib/core/services/push_notification_service.dart` — BigTextStyle, parse teasers, data-only render
+- `apps/mobile/lib/core/services/server_push_service.dart` — persistance teasers, fallback variantB, bg handler, instrumentation
+- `apps/mobile/lib/features/settings/providers/notifications_settings_provider.dart` — persiste teasers, reschedule variantB
+- `apps/mobile/lib/main.dart` — cold-start variantB
+
+**Part 2**
+- `apps/mobile/lib/core/api/push_devices_api_service.dart` — surface `statusCode` (503)
+- `apps/mobile/lib/core/services/server_push_service.dart` — event `push_register`
+- `packages/api/app/services/push_dispatcher.py` — FCM data-only Android + alert APNS iOS
+- `packages/api/tests/services/test_push_dispatcher.py` — test data-only

--- a/packages/api/app/services/push_dispatcher.py
+++ b/packages/api/app/services/push_dispatcher.py
@@ -68,23 +68,30 @@ def _send_fcm(token: str, title: str, body: str, data: dict[str, str]) -> str:
 
     from firebase_admin import messaging
 
+    # Data-only sur Android (pas de bloc `notification` top-level ni
+    # `AndroidNotification`) : sinon le système rend le push directement en une
+    # ligne et IGNORE les `teasers` du `data` → pas de bullets hors-app. Sans
+    # bloc notification, FCM réveille l'app en arrière-plan
+    # (`firebaseMessagingBackgroundHandler`) qui construit le BigText à bullets.
+    # Le titre/corps sont dupliqués dans `data` pour ce rendu client.
+    # iOS ne sait PAS rendre un push depuis le seul `data` (il faut un alert
+    # APNS ou une Notification Service Extension) : on garde donc un alert APNS
+    # visible côté iOS (corps = 1er titre d'article, sans bullets — acceptable,
+    # cf. plan Part 2 étape 3).
+    payload_data = {**data, "title": title, "body": body}
     return messaging.send(
         messaging.Message(
             token=token,
-            notification=messaging.Notification(title=title, body=body),
-            data=data,
-            android=messaging.AndroidConfig(
-                priority="high",
-                notification=messaging.AndroidNotification(
-                    channel_id="digest_channel",
-                    icon="ic_stat_facteur",
-                    color="#D35400",
-                ),
-            ),
+            data=payload_data,
+            android=messaging.AndroidConfig(priority="high"),
             apns=messaging.APNSConfig(
                 headers={"apns-priority": "10"},
                 payload=messaging.APNSPayload(
-                    aps=messaging.Aps(sound="default", content_available=True)
+                    aps=messaging.Aps(
+                        alert=messaging.ApsAlert(title=title, body=body),
+                        sound="default",
+                        content_available=True,
+                    )
                 ),
             ),
         ),

--- a/packages/api/app/services/source_recommendation_gate.py
+++ b/packages/api/app/services/source_recommendation_gate.py
@@ -67,9 +67,7 @@ def passes_safety_gate(source: Source) -> bool:
     """
     if _reliability(source) in PUSHED_EXCLUDED_RELIABILITY:
         return False
-    if _bias(source) in PUSHED_EXCLUDED_BIAS:
-        return False
-    return True
+    return _bias(source) not in PUSHED_EXCLUDED_BIAS
 
 
 def is_quality_catalog(source: Source) -> bool:
@@ -83,6 +81,4 @@ def is_quality_catalog(source: Source) -> bool:
         return False
     if _reliability(source) not in QUALITY_CATALOG_RELIABILITY:
         return False
-    if _bias(source) in QUALITY_CATALOG_EXCLUDED_BIAS:
-        return False
-    return True
+    return _bias(source) not in QUALITY_CATALOG_EXCLUDED_BIAS

--- a/packages/api/tests/services/test_push_dispatcher.py
+++ b/packages/api/tests/services/test_push_dispatcher.py
@@ -187,3 +187,58 @@ def test_due_time_uses_each_users_local_timezone():
 
     assert _is_due(montreal_morning, "morning") is True
     assert _is_due(paris_before_evening, "evening") is False
+
+
+def test_send_fcm_is_data_only_with_teasers_preserved():
+    """Android doit recevoir un message data-only (pas de bloc `notification`
+    top-level) pour que le background handler rende les bullets ; les teasers
+    et le title/body doivent rester lisibles dans `data`. iOS garde un alert
+    APNS visible.
+    """
+    import sys
+    from types import SimpleNamespace
+
+    captured: dict[str, object] = {}
+
+    def _message(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(**kwargs)
+
+    fake_messaging = SimpleNamespace(
+        Message=_message,
+        Notification=lambda **k: SimpleNamespace(**k),
+        AndroidConfig=lambda **k: SimpleNamespace(kind="android", **k),
+        AndroidNotification=lambda **k: SimpleNamespace(**k),
+        APNSConfig=lambda **k: SimpleNamespace(kind="apns", **k),
+        APNSPayload=lambda **k: SimpleNamespace(**k),
+        Aps=lambda **k: SimpleNamespace(**k),
+        ApsAlert=lambda **k: SimpleNamespace(kind="aps_alert", **k),
+        send=lambda *_args, **_kwargs: "message-id",
+    )
+    fake_firebase_admin = SimpleNamespace(messaging=fake_messaging)
+
+    from app.services import push_dispatcher
+
+    data = {
+        "route": "/digest",
+        "kind": "daily_digest",
+        "teasers": '["Trump", "Climat"]',
+    }
+    with (
+        patch.object(push_dispatcher, "_firebase_app", return_value=object()),
+        patch.dict(sys.modules, {"firebase_admin": fake_firebase_admin}),
+    ):
+        result = push_dispatcher._send_fcm("tok", "Facteur", "Trump", data)
+
+    assert result == "message-id"
+    # Pas de notification top-level (data-only) → Android invoque le bg handler.
+    assert captured.get("notification") is None
+    # Android config sans rendu notification.
+    assert getattr(captured["android"], "kind", None) == "android"
+    assert getattr(captured["android"], "notification", None) is None
+    # teasers + title/body conservés dans data pour le rendu client.
+    assert captured["data"]["teasers"] == '["Trump", "Climat"]'
+    assert captured["data"]["title"] == "Facteur"
+    assert captured["data"]["body"] == "Trump"
+    # iOS conserve un alert visible.
+    assert getattr(captured["apns"], "kind", None) == "apns"


### PR DESCRIPTION
## Fix notif matin : avatar dupliqué + corps sans bullets (Part 1) + réanimation push serveur (Part 2)

Capture prod : la notif quotidienne affichait un **corps générique sans bullets** + un **avatar dupliqué** (logo + rond orange « T »). Diagnostic confirmé sur la DB partagée : le **push serveur n'a jamais enregistré un seul device** en prod (`push_devices`=0, `push_deliveries`=0, alors que 31 users `push_enabled`) → 100 % retombent sur la notif **locale**, qui avait deux défauts. PO : Part 1 + Part 2 en **une seule PR**.

### Part 1 — Notif locale (mobile, 100 % des users la reçoivent)
- **Avatar dupliqué** : `MessagingStyleInformation` → `BigTextStyleInformation` (digest, bonnes nouvelles, `showRemoteNotification`). Le `Person` sans icône générait le monogramme « T ». `senderName` supprimé.
- **Bullets restaurés** : on ne supprime plus les teasers Essentiel de Hive ; `syncDigestTeasers` les **persiste** (+ flag serène). Les chemins de fallback planifient **variantB + teasers** quand un digest existe, sinon variantA.

### Part 2 — Réanimer le push serveur (cause « 0 device »)
- **Instrumentation** : event PostHog `push_register` {outcome: token_null | session_null | endpoint_error(+status_code) | registered | exception}. `PushDevicesApiService.upsert` surface désormais le `statusCode`.
- **FCM data-only Android** : `_send_fcm` retire le bloc `notification` top-level → Android réveille `firebaseMessagingBackgroundHandler` qui rend le BigText à bullets. **iOS garde un alert APNS visible** (corps = 1er titre, sans bullets — acceptable).

### ⚠️ Actions ops/PO restantes (non codables)
1. Poser `FIREBASE_SERVICE_ACCOUNT_JSON` (ou `_BASE64`) sur **les 2** services Railway (`api-staging-40d3` + `facteur-production`).
2. Vérifier Firebase console (applicationIds, sender ID = secrets CI) + injection `google-services.json` par flavor au build.

### Bonus
`assets/changelog.json` était **déjà corrompu** par un merge (JSON invalide, cassait la modal « Quoi de neuf »). Corrigé + entrée Notifications ajoutée.

### /go — vérification & nettoyage
- **Merge `origin/main`** : la branche précédait le hotfix #918 (`bind isPlaceholder in FeedThemeSection`) → la suite Flutter ne compilait pas. Mergé (1 ligne, hors diff), compile OK.
- **SIMPLIFY** : la décision de fallback (lecture teasers/serène + règle variantB/A) était triplée sur 3 call sites → extraite dans un seul `ServerPushService.scheduleDigestFallback({box, timeSlot})`.

## Comment ça a été vérifié
- [x] `pytest` : nouveau `test_send_fcm_is_data_only_with_teasers_preserved` vert (3 tests dispatcher DB-backed = Connection refused en local Conductor, tournent en CI).
- [x] `flutter test` : 1352 passed / 23 pré-existants (Hive/Supabase non init + stubs `fail("not implemented")`, hors domaine notif). Copy variantB 14/14.
- [x] `flutter analyze` sur les fichiers touchés : 0 nouvel issue.
- [x] `/simplify` passé (refactor ci-dessus, re-vérifié).
- [ ] Validation on-device Android (`--flavor staging`) : 1 seul avatar + bullets dépliés — action restante.

## Zones à risque
Notifications push (FCM/APNS), service notif local, startup `main.dart` (chemin différé, hors hot path). Backend `push_dispatcher._send_fcm`.

Doc : `docs/bugs/bug-notif-matin-avatar-double-sans-bullets.md`.
