### PR TITLE
chore(mobile): bump iOS version to 1.0.2+8

### DIFF
--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: facteur
 description: Facteur - Curation intelligente de contenus
 publish_to: 'none'
-version: 1.0.1+8
+version: 1.0.2+8
 environment:
   sdk: '>=3.0.0 <4.0.0'
 


### PR DESCRIPTION
## What

Bump Flutter app version from 1.0.1+8 to 1.0.2+8 for iOS release via Codemagic.

## Why

Required for Codemagic build pipeline to generate new iOS release.

## Type

- [ ] Feature
- [x] Bug fix
- [x] Maintenance / Refactor

## Checklist

- [x] Tests pass locally (no tests required — version-only change)
- [x] Linting passes (no code changes)
- [x] No new Python `List[]` imports (N/A — mobile only)
- [x] If touching auth/DB: read Safety Guardrails (N/A)
- [x] Peer Review Conductor completed (N/A — config-only change)

## Staging

- [x] N/A (config only change)