### PR TITLE
fix(mobile): réordre non destructif des favoris Tournée/Flâner (sources qui se perdent)

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Tournée",
+      "summary": "Les sources que tu ranges dans ta Tournée y restent : elles ne se perdent plus ni ne réapparaissent ailleurs après un réagencement."
+    },
+    {
       "tag": "Notifications",
       "summary": "La notif du matin affiche de nouveau les titres à la une, sans doublon visuel."
     },

--- a/apps/mobile/lib/features/feed/providers/tab_order_prefs_provider.dart
+++ b/apps/mobile/lib/features/feed/providers/tab_order_prefs_provider.dart
@@ -53,6 +53,45 @@ List<T> applyOrder<T>(
   return [for (final e in indexed) e.item];
 }
 
+/// Fusionne un réordre **partiel** dans l'ordre complet sans rien perdre.
+///
+/// [visibleOrder] est la nouvelle séquence des seules clés effectivement rendues
+/// (et donc réordonnables) à cet instant. Toute clé de [prevOrder] absente de
+/// [visibleOrder] (tuile non matérialisée : catalogue en cours de chargement,
+/// source hors catalogue, clé masquée) est **préservée à sa position absolue** —
+/// on ne permute que les emplacements occupés par des clés visibles. Les clés
+/// visibles nouvelles (absentes de [prevOrder]) sont ajoutées en queue.
+///
+/// Garanties : (1) aucune clé d'ordre n'est perdue (seul un retrait explicite
+/// retire une clé) ; (2) l'ordre relatif des clés visibles == [visibleOrder] ;
+/// (3) les clés non rendues gardent leur place → l'ordre rendu reste aligné sur
+/// le paramétrage. Remplace un `setOrder(visibleOrder)` destructeur qui élaguait
+/// silencieusement les clés non matérialisées.
+List<String> mergeVisibleReorder(
+  List<String> prevOrder,
+  List<String> visibleOrder,
+) {
+  if (prevOrder.isEmpty) return List<String>.from(visibleOrder);
+  final visibleSet = visibleOrder.toSet();
+  final result = <String>[];
+  var ri = 0;
+  for (final k in prevOrder) {
+    if (visibleSet.contains(k)) {
+      // Emplacement occupé par une clé visible → on y place la prochaine clé de
+      // la séquence réordonnée (l'ordre relatif des visibles est ainsi celui de
+      // [visibleOrder]). Garde anti-dépassement si [prevOrder] dupliquait une
+      // clé (ne devrait pas arriver) : la 2ᵉ occurrence est simplement ignorée.
+      if (ri < visibleOrder.length) result.add(visibleOrder[ri++]);
+    } else {
+      result.add(k); // clé non rendue : préservée à sa place.
+    }
+  }
+  while (ri < visibleOrder.length) {
+    result.add(visibleOrder[ri++]); // clés visibles nouvelles → en queue.
+  }
+  return result;
+}
+
 final tabOrderPrefsProvider =
     StateNotifierProvider<TabOrderPrefsNotifier, List<String>>((ref) {
   return TabOrderPrefsNotifier();

--- a/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
@@ -334,10 +334,25 @@ class _ManageFavoritesContentState
 
   // ── Réordres ──────────────────────────────────────────────────────────────
 
+  /// Garde-fou des réordres : ne pas réécrire l'ordre tant que les données
+  /// d'appartenance (intérêts + sources) ne sont pas chargées — sinon un favori
+  /// non matérialisé serait élagué de l'ordre (cf. `mergeVisibleReorder`).
+  bool get _membershipDataReady =>
+      ref.read(userInterestsProvider).valueOrNull != null &&
+      ref.read(userSourcesStateProvider).valueOrNull != null;
+
   Future<void> _persistEssentielReorder(List<_FavItem> ordered) async {
+    if (!_membershipDataReady) return;
+
+    // Réordre non destructif : on ne permute que les clés rendues ; toute clé
+    // d'ordre non rendue cette frame (catalogue en cours, source absente du
+    // catalogue, clé masquée) est préservée à sa position. Seul `_onRemove`
+    // retire une clé.
+    final prevOrder = ref.read(tourneeOrderPrefsProvider).order;
+    final renderedKeys = ordered.map((e) => e.key).toList();
     await ref
         .read(tourneeOrderPrefsProvider.notifier)
-        .setOrder(ordered.map((e) => e.key).toList());
+        .setOrder(mergeVisibleReorder(prevOrder, renderedKeys));
     final themeRefs = <FavoriteRef>[
       for (final e in ordered)
         if (e.kind == _FavKind.theme) ThemeFavoriteRef(slug: e.id),
@@ -353,9 +368,16 @@ class _ManageFavoritesContentState
   }
 
   Future<void> _persistFlanerReorder(List<_FavItem> ordered) async {
+    // Même garde-fou + réordre non destructif que côté Essentiel (cf.
+    // `_persistEssentielReorder`) : une clé `source:`/`topic:` non résolue dans
+    // `pinned_tabs_order_v1` est préservée à sa place, jamais élaguée.
+    if (!_membershipDataReady) return;
+
+    final prevOrder = ref.read(tabOrderPrefsProvider);
+    final renderedKeys = ordered.map((e) => e.key).toList();
     await ref
         .read(tabOrderPrefsProvider.notifier)
-        .setOrder(ordered.map((e) => e.key).toList());
+        .setOrder(mergeVisibleReorder(prevOrder, renderedKeys));
     final topicIds = [
       for (final e in ordered)
         if (e.kind == _FavKind.subject) e.id,

--- a/apps/mobile/test/features/feed/providers/tab_order_prefs_test.dart
+++ b/apps/mobile/test/features/feed/providers/tab_order_prefs_test.dart
@@ -42,4 +42,64 @@ void main() {
       expect(tabOrderSourceKey('s1'), 'source:s1');
     });
   });
+
+  group('mergeVisibleReorder', () {
+    test('prevOrder vide → renvoie visibleOrder tel quel', () {
+      expect(mergeVisibleReorder(const [], const ['a', 'b']), ['a', 'b']);
+    });
+
+    test('permute uniquement les clés visibles, préserve les non rendues', () {
+      // s2 n'est pas rendu (catalogue en cours) → doit rester dans l'ordre.
+      // L'utilisateur a permuté tech avant s1 parmi les tuiles visibles.
+      expect(
+        mergeVisibleReorder(
+          const ['source:s1', 'source:s2', 'theme:tech'],
+          const ['theme:tech', 'source:s1'],
+        ),
+        // s2 préservé à sa position absolue (slot du milieu) ; l'ordre relatif
+        // des visibles == visibleOrder.
+        ['theme:tech', 'source:s2', 'source:s1'],
+      );
+    });
+
+    test('une clé non rendue ne peut jamais être perdue', () {
+      final merged = mergeVisibleReorder(
+        const ['source:s1', 'source:s2'],
+        const ['source:s1'], // s2 non matérialisé
+      );
+      expect(merged, contains('source:s2'));
+    });
+
+    test('clés visibles nouvelles (absentes de prevOrder) → en queue', () {
+      expect(
+        mergeVisibleReorder(
+          const ['source:s1'],
+          const ['source:s1', 'theme:tech', 'essentiel'],
+        ),
+        ['source:s1', 'theme:tech', 'essentiel'],
+      );
+    });
+
+    test('préserve une clé masquée à sa place lors d\'un réordre', () {
+      // `bonnes` masquée (non rendue) entre deux blocs réordonnés.
+      expect(
+        mergeVisibleReorder(
+          const ['essentiel', 'bonnes', 'source:s1'],
+          const ['source:s1', 'essentiel'],
+        ),
+        ['source:s1', 'bonnes', 'essentiel'],
+      );
+    });
+
+    test('aucune clé visible n\'est perdue ni dupliquée', () {
+      final merged = mergeVisibleReorder(
+        const ['a', 'b', 'c', 'd'],
+        const ['c', 'a'], // b, d non rendus
+      );
+      expect(merged.toSet(), {'a', 'b', 'c', 'd'});
+      expect(merged.length, 4);
+      // Ordre relatif des visibles respecté : c avant a.
+      expect(merged.indexOf('c'), lessThan(merged.indexOf('a')));
+    });
+  });
 }

--- a/apps/mobile/test/features/flux_continu/widgets/manage_favorites_sheet_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/manage_favorites_sheet_test.dart
@@ -472,6 +472,94 @@ void main() {
     );
   });
 
+  testWidgets(
+      'réordre avec catalogue partiel ne perd pas une source Essentiel non '
+      'résolue (régression « sources qui se perdent »)', (tester) async {
+    // `source:s2` est favorite + Essentiel (clé dans l'ordre) mais ABSENTE du
+    // catalogue (chargement en cours) → sa tuile n'est pas matérialisée. Un
+    // réordre des tuiles rendues ne doit pas l'élaguer de `tournee_order_v1`.
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      'tournee_order_v1': ['source:s1', 'source:s2', 'theme:tech'],
+    });
+    await _openSheet(
+      tester,
+      interests: _interests(favorites: const [ThemeFavoriteRef(slug: 'tech')]),
+      sources: _sources(favorites: const [
+        SourceFavoriteRef(sourceId: 's1', position: 0),
+        SourceFavoriteRef(sourceId: 's2', position: 1),
+      ]),
+      catalog: [_source('s1', 'Le Monde')], // s2 non résolu volontairement.
+    );
+
+    // s1 rendu (Essentiel), s2 sauté faute de catalogue.
+    expect(find.text('Le Monde'), findsOneWidget);
+
+    // Réordre réel : on attrape la 1ʳᵉ poignée de drag et on descend d'environ
+    // deux hauteurs de tuile pour franchir une frontière → déclenche onReorder.
+    final handle = find
+        .byIcon(PhosphorIcons.dotsSixVertical(PhosphorIconsStyle.bold))
+        .first;
+    final gesture = await tester.startGesture(tester.getCenter(handle));
+    await tester.pump(const Duration(milliseconds: 200));
+    await gesture.moveBy(const Offset(0, 40));
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.moveBy(const Offset(0, 120));
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    // Le réordre est non destructif : la source non rendue survit dans l'ordre
+    // (avant le fix, `setOrder(renderedKeys)` l'élaguait → repassait en Flâner).
+    final prefs = await SharedPreferences.getInstance();
+    final order = prefs.getStringList('tournee_order_v1') ?? const <String>[];
+    expect(order, contains('source:s2'));
+  });
+
+  testWidgets(
+      'symétrie Flâner : réordre avec catalogue partiel préserve une source '
+      'Flâner non résolue', (tester) async {
+    // s1 (Flâner, rendu) + t1 (sujet, rendu) + s2 (Flâner, NON résolu) dans
+    // `pinned_tabs_order_v1`. Un réordre des tuiles rendues ne doit pas perdre
+    // `source:s2` (même garde-fou que l'Essentiel, code path partagé).
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      'pinned_tabs_order_v1': ['topic:t1', 'source:s1', 'source:s2'],
+    });
+    await _openSheet(
+      tester,
+      interests: _interests(
+        favorites: const [CustomTopicFavoriteRef(id: 't1')],
+        customTopics: [_topic('t1', 'Climat')],
+      ),
+      sources: _sources(favorites: const [
+        SourceFavoriteRef(sourceId: 's1', position: 0),
+        SourceFavoriteRef(sourceId: 's2', position: 1),
+      ]),
+      catalog: [_source('s1', 'Le Monde')], // s2 non résolu.
+      entry: ManageFavoritesEntry.flaner,
+    );
+
+    expect(find.text('Climat'), findsOneWidget);
+    expect(find.text('Le Monde'), findsOneWidget);
+
+    // Réordre de la liste Flâner (Climat + Le Monde rendus). Dernière poignée
+    // (Le Monde) glissée vers le haut pour franchir une frontière.
+    final handles = find
+        .byIcon(PhosphorIcons.dotsSixVertical(PhosphorIconsStyle.bold));
+    final gesture = await tester.startGesture(tester.getCenter(handles.last));
+    await tester.pump(const Duration(milliseconds: 200));
+    await gesture.moveBy(const Offset(0, -40));
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.moveBy(const Offset(0, -120));
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    final prefs = await SharedPreferences.getInstance();
+    final order =
+        prefs.getStringList('pinned_tabs_order_v1') ?? const <String>[];
+    expect(order, contains('source:s2'));
+  });
+
   testWidgets('🔭 sur un sujet ouvre la config veille (pop + route)',
       (tester) async {
     SharedPreferences.setMockInitialValues(<String, Object>{});

--- a/docs/bugs/bug-tournee-sources-not-saving.md
+++ b/docs/bugs/bug-tournee-sources-not-saving.md
@@ -1,0 +1,80 @@
+# Bug — Sources de la Tournée du Jour qui se perdent / reviennent en Flâner
+
+## Symptôme
+
+Les sources ajoutées à la **Tournée du Jour** (l'Essentiel) ne s'enregistrent pas
+durablement : elles « se perdent régulièrement », disparaissent des paramètres et de
+la modal « Mes favoris », et **réapparaissent en Flâner** (hors Tournée).
+
+## Racine
+
+L'appartenance d'une source à l'Essentiel = présence de la clé `source:<id>` dans la
+liste locale `tournee_order_v1` (`tourneeOrderPrefsProvider`). Le statut « favori » vit
+côté serveur. Une source favorite **absente** de `tournee_order_v1` est rendue en
+Flâner → d'où la réapparition « hors Tournée » dès que la clé quitte l'ordre.
+
+Chemin destructeur : le réordre dans `manage_favorites_sheet.dart`.
+
+- `onReorder` → `_persistEssentielReorder(reordered)` fait
+  `setOrder(ordered.map((e) => e.key))` : **réécrit tout `tournee_order_v1` à partir des
+  seules tuiles rendues à cet instant**.
+- Une tuile peut ne pas être matérialisée : `final source = sourceById[f.sourceId];
+  if (source == null) continue;` — si le catalogue (`userSourcesProvider`) n'a pas encore
+  résolu cet id, le favori est **sauté**. Idem pour une clé dans `hiddenKeys`.
+- Résultat : un réordre alors que les données ne sont pas pleinement chargées
+  **supprime silencieusement** du `tournee_order_v1` les clés non rendues → la source
+  cesse d'être Essentiel → repasse en Flâner.
+
+Même défaut en miroir dans `_persistFlanerReorder` sur `tabOrderPrefsProvider`.
+
+Vérifié : aucun autre appelant de `setOrder` n'élague (append-only ou remove d'une seule
+clé). Le listener Tournée ne réécrit jamais l'ordre.
+
+## Fix (prefs locales uniquement — aucun changement backend/schéma)
+
+Rendre la persistance du réordre **non destructive** : un réordre ne fait que permuter
+les clés effectivement rendues ; toute clé d'ordre préexistante non rendue cette frame
+est **préservée**. Seul `_onRemove` retire une clé.
+
+**Bonus alignement de l'ordre** (demande PO) : au lieu d'ajouter les clés préservées
+*en queue*, on **préserve leur position absolue** dans l'ordre (on ne permute que les
+emplacements occupés par des clés visibles). Ainsi l'ordre rendu de la Tournée reste
+aligné sur ce que l'utilisateur a paramétré, sauf dépriorisation « manque de contenu »
+(thin demotion, qui ne joue que sur l'ordre par défaut non-customisé — un ordre
+customisé est déjà sticky via `applyOrder`).
+
+### Helper partagé : `mergeVisibleReorder` (dans `tab_order_prefs_provider.dart`)
+
+Fonction pure, à côté de `applyOrder` (déjà réexportée par le provider Tournée) :
+fusionne le réordre partiel `visibleOrder` dans `prevOrder` sans rien perdre, en gardant
+les clés non rendues à leur place. Testable unitairement.
+
+### `manage_favorites_sheet.dart`
+
+- `_persistEssentielReorder` : garde-fou de chargement (interests + sourcesState non
+  null) ; `setOrder(mergeVisibleReorder(prevOrder, renderedKeys))` ; le reste inchangé.
+- `_persistFlanerReorder` : même pattern contre `tabOrderPrefsProvider`.
+
+### Aucune modification de
+- `tournee_order_prefs_provider.dart` — `setOrder` reste un writer « liste entière ».
+- `flux_continu_provider.dart` — `_orderedTourneeKeys` honore déjà `order` via
+  `applyOrder` (la demotion thin ne touche que l'ordre par défaut).
+
+## Tests (lock de régression)
+
+`apps/mobile/test/features/flux_continu/widgets/manage_favorites_sheet_test.dart` :
+1. Réordre avec catalogue partiellement chargé ne perd pas une source Essentiel non
+   résolue (clé `source:s2` survit + `sourceIsEssentiel('s2') == true`).
+2. Réordre préserve une clé éditoriale masquée (`hiddenKeys`).
+3. Symétrie Flâner : clé `source:` non résolue dans `pinned_tabs_order_v1` survit.
+
+Unitaire `mergeVisibleReorder` : préservation de position + pas de perte + clés visibles
+nouvelles en queue.
+
+## Vérification
+
+```bash
+cd apps/mobile
+flutter test test/features/flux_continu/widgets/manage_favorites_sheet_test.dart
+flutter test && flutter analyze
+```


### PR DESCRIPTION
## Quoi
Les sources rangées dans la **Tournée du Jour** (Essentiel) se perdaient et **réapparaissaient en Flâner**. Ce PR rend le réordre dans « Mes favoris » **non destructif**.

## Pourquoi
L'appartenance d'une source à l'Essentiel = présence de `source:<id>` dans `tournee_order_v1`. Le réordre faisait `setOrder(ordered.map((e) => e.key))` — il **réécrivait tout l'ordre à partir des seules tuiles rendues**. Une source dont le catalogue n'était pas encore résolu (`sourceById[id] == null` → `continue`) ou une clé masquée était **silencieusement supprimée** de l'ordre → la source repassait en Flâner. Même défaut en miroir dans `_persistFlanerReorder`.

## Comment
- Nouveau helper pur **`mergeVisibleReorder(prevOrder, visibleOrder)`** (à côté de `applyOrder` dans `tab_order_prefs_provider.dart`) : ne permute que les clés rendues, **préserve les non rendues à leur position absolue**. Garanties : aucune clé perdue + ordre relatif des visibles respecté + **ordre rendu aligné sur le paramétrage** (bonus PO).
- `_persistEssentielReorder` / `_persistFlanerReorder` : garde-fou de chargement (`_membershipDataReady`) + `setOrder(mergeVisibleReorder(...))`.
- Aucun changement backend / schéma / migration. Prefs locales uniquement.

Note sur le bonus « ordre aligné » : la dépriorisation « manque de contenu » (thin demotion) ne joue que sur l'ordre **par défaut non-customisé** ; un ordre customisé est déjà rendu tel quel via `applyOrder`. Donc une fois le bug corrigé, l'ordre paramétré est honoré, l'exception « manque de contenu » étant déjà bornée au non-customisé — aucun changement nécessaire dans `flux_continu_provider.dart`.

## Comment ça a été vérifié
- [x] `flutter test` ciblé : 24/24 (sheet + provider). Les 2 tests de régression de drag **échouent sans le fix** (vérifié en restaurant le code destructeur → `source:s2` élaguée).
- [x] 6 tests unitaires `mergeVisibleReorder` (préservation position, non-perte, clés masquées, queue).
- [x] `flutter analyze` : No issues found.
- [x] Suite complète `flutter test` : 1360 OK, 23 échecs pré-existants sans lien (Hive/Supabase non init — cf. CI backend-only).
- [x] `/simplify` passé (garde-fou dupliqué extrait en `_membershipDataReady`).

## Zones à risque
`manage_favorites_sheet.dart` (réordre favoris) + `tab_order_prefs_provider.dart` (utilitaire d'ordre partagé Essentiel/Flâner). Pas de backend.