### PR TITLE
feat(sources): reconnexion abonnements + login sources étrangères

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Abonnements",
+      "summary": "Reconnecte tes abonnements en un geste après une mise à jour, et connecte ton compte à plus de médias, y compris la presse étrangère."
+    },
+    {
       "tag": "Notifications",
       "summary": "La notif du matin affiche de nouveau les titres à la une, sans doublon visuel."
     },

--- a/apps/mobile/lib/features/settings/screens/subscriptions_screen.dart
+++ b/apps/mobile/lib/features/settings/screens/subscriptions_screen.dart
@@ -196,7 +196,11 @@ class _SubscriptionTile extends ConsumerWidget {
   }
 
   Future<void> _reconnect(BuildContext context, WidgetRef ref) async {
-    final connection = resolvePremiumConnection(source);
+    // `forceGenericConnection` est un superset : renvoie la connexion curée si
+    // utilisable, sinon un flux générique depuis l'URL. Couvre donc aussi les
+    // sources libres connectées génériquement (backend sans `premium_connection`).
+    final connection =
+        resolvePremiumConnection(source) ?? forceGenericConnection(source);
     if (connection == null) return;
     await Navigator.of(context).push<void>(
       MaterialPageRoute(
@@ -258,11 +262,23 @@ class _AddSubscriptionSheetState extends ConsumerState<_AddSubscriptionSheet> {
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
     final eligible = ref.watch(eligibleSubscriptionSourcesProvider);
-    final visible = _query.isEmpty
-        ? eligible
-        : eligible
-            .where((source) => source.name.toLowerCase().contains(_query))
-            .toList();
+    final loginConnectable = ref.watch(loginConnectableSourcesProvider);
+    bool matchesQuery(Source source) =>
+        _query.isEmpty || source.name.toLowerCase().contains(_query);
+    final eligibleVisible = eligible.where(matchesQuery).toList();
+    final loginVisible = loginConnectable.where(matchesQuery).toList();
+    final hasAny = eligible.isNotEmpty || loginConnectable.isNotEmpty;
+    final hasVisible = eligibleVisible.isNotEmpty || loginVisible.isNotEmpty;
+    List<Widget> tilesFor(
+      List<Source> sources,
+      PremiumConnection Function(Source) resolve,
+    ) =>
+        [
+          for (final source in sources) ...[
+            _EligibleSourceTile(source: source, connection: resolve(source)),
+            Divider(color: colors.border.withValues(alpha: 0.5)),
+          ],
+        ];
 
     return FractionallySizedBox(
       heightFactor: 0.82,
@@ -312,7 +328,7 @@ class _AddSubscriptionSheetState extends ConsumerState<_AddSubscriptionSheet> {
                   ],
                 ),
               ),
-              if (eligible.isNotEmpty)
+              if (hasAny)
                 Padding(
                   padding: const EdgeInsets.fromLTRB(
                     FacteurSpacing.space4,
@@ -334,7 +350,7 @@ class _AddSubscriptionSheetState extends ConsumerState<_AddSubscriptionSheet> {
                   ),
                 ),
               Expanded(
-                child: eligible.isEmpty
+                child: !hasAny
                     ? _NoEligibleSources(
                         onChooseSources: () {
                           final router = GoRouter.of(context);
@@ -342,7 +358,7 @@ class _AddSubscriptionSheetState extends ConsumerState<_AddSubscriptionSheet> {
                           router.pushNamed(RouteNames.sources);
                         },
                       )
-                    : visible.isEmpty
+                    : !hasVisible
                         ? Center(
                             child: Text(
                               'Aucun média ne correspond à cette recherche.',
@@ -352,20 +368,59 @@ class _AddSubscriptionSheetState extends ConsumerState<_AddSubscriptionSheet> {
                                   ?.copyWith(color: colors.textSecondary),
                             ),
                           )
-                        : ListView.separated(
+                        : ListView(
                             padding: const EdgeInsets.fromLTRB(
                               FacteurSpacing.space4,
                               0,
                               FacteurSpacing.space4,
                               FacteurSpacing.space6,
                             ),
-                            itemCount: visible.length,
-                            separatorBuilder: (_, __) => Divider(
-                              color: colors.border.withValues(alpha: 0.5),
-                            ),
-                            itemBuilder: (_, index) => _EligibleSourceTile(
-                              source: visible[index],
-                            ),
+                            children: [
+                              ...tilesFor(
+                                eligibleVisible,
+                                (source) => resolvePremiumConnection(source)!,
+                              ),
+                              if (loginVisible.isNotEmpty) ...[
+                                Padding(
+                                  padding: const EdgeInsets.only(
+                                    top: FacteurSpacing.space2,
+                                    bottom: FacteurSpacing.space1,
+                                  ),
+                                  child: Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      Text(
+                                        'Un autre site demande une connexion ?',
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .titleSmall
+                                            ?.copyWith(
+                                              fontWeight: FontWeight.w700,
+                                            ),
+                                      ),
+                                      const SizedBox(height: 2),
+                                      Text(
+                                        'Connecte ton compte sur n’importe quel '
+                                        'média que tu suis pour lire ses articles '
+                                        'dans Facteur.',
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .bodySmall
+                                            ?.copyWith(
+                                              color: colors.textSecondary,
+                                              height: 1.4,
+                                            ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                                ...tilesFor(
+                                  loginVisible,
+                                  (source) => forceGenericConnection(source)!,
+                                ),
+                              ],
+                            ],
                           ),
               ),
             ],
@@ -427,14 +482,14 @@ class _NoEligibleSources extends StatelessWidget {
 }
 
 class _EligibleSourceTile extends ConsumerWidget {
-  const _EligibleSourceTile({required this.source});
+  const _EligibleSourceTile({required this.source, required this.connection});
 
   final Source source;
+  final PremiumConnection connection;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.facteurColors;
-    final connection = resolvePremiumConnection(source)!;
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: FacteurSpacing.space2),

--- a/apps/mobile/lib/features/sources/models/source_model.dart
+++ b/apps/mobile/lib/features/sources/models/source_model.dart
@@ -40,14 +40,12 @@ class PremiumConnection {
   bool get isUsable => enabled && loginUrl.isNotEmpty && testUrl.isNotEmpty;
 }
 
-/// Returns the usable premium connection for [source].
-///
-/// Paid sources without curated connection metadata fall back to their home
-/// page so users can still authenticate through the generic WebView flow.
-PremiumConnection? resolvePremiumConnection(Source source) {
+/// Connexion existante si utilisable, sinon flux générique (login=test=home)
+/// dès qu'il y a une URL http(s) valide ; `null` sinon. Cœur partagé par
+/// [resolvePremiumConnection] et [forceGenericConnection].
+PremiumConnection? _genericConnectionFor(Source source) {
   final existing = source.premiumConnection;
   if (existing != null && existing.isUsable) return existing;
-  if (!source.hasPaywall) return null;
 
   final url = source.url?.trim() ?? '';
   if (!url.startsWith('http://') && !url.startsWith('https://')) return null;
@@ -61,6 +59,30 @@ PremiumConnection? resolvePremiumConnection(Source source) {
     isGeneric: true,
   );
 }
+
+/// Returns the usable premium connection for [source].
+///
+/// Paid sources without curated connection metadata fall back to their home
+/// page so users can still authenticate through the generic WebView flow.
+PremiumConnection? resolvePremiumConnection(Source source) {
+  final existing = source.premiumConnection;
+  if (existing != null && existing.isUsable) return existing;
+  if (!source.hasPaywall) return null;
+  return _genericConnectionFor(source);
+}
+
+/// Connexion à associer **intentionnellement** à une source (geste explicite de
+/// l'utilisateur « ce site demande un compte »), sans exiger [Source.hasPaywall].
+///
+/// Superset de [resolvePremiumConnection] : renvoie la connexion existante (curée
+/// ou explicite) si elle est utilisable, sinon synthétise un flux générique dès
+/// qu'il y a une URL http(s) valide. Sert au flux « connecter un login à toute
+/// source suivie » (sources étrangères à login) et à la reconnexion d'un
+/// abonnement même quand le backend n'expose pas de `premium_connection`
+/// (source libre connectée génériquement). [resolvePremiumConnection] reste
+/// réservé au CTA automatique des sources payantes.
+PremiumConnection? forceGenericConnection(Source source) =>
+    _genericConnectionFor(source);
 
 class Source {
   final String id;

--- a/apps/mobile/lib/features/sources/providers/sources_providers.dart
+++ b/apps/mobile/lib/features/sources/providers/sources_providers.dart
@@ -52,6 +52,48 @@ final eligibleSubscriptionSourcesProvider = Provider<List<Source>>((ref) {
     ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
 });
 
+/// Sources suivies (non abonnées) auxquelles on peut associer un login générique
+/// au-delà des sources payantes curées : tout média suivi avec une URL http(s)
+/// valide. Alimente l'entrée « Un autre site demande une connexion ? » de la
+/// feuille « Ajouter un abonnement » (décision PO « toute source suivie »).
+/// Exclut celles déjà couvertes par [eligibleSubscriptionSourcesProvider]
+/// (sources payantes curées / paywall), qui ont leur propre liste.
+final loginConnectableSourcesProvider = Provider<List<Source>>((ref) {
+  final sources =
+      ref.watch(userSourcesProvider).valueOrNull ?? const <Source>[];
+  final alreadyEligible = ref
+      .watch(eligibleSubscriptionSourcesProvider)
+      .map((s) => s.id)
+      .toSet();
+  return sources
+      .where(
+        (source) =>
+            source.isTrusted &&
+            !source.hasSubscription &&
+            !alreadyEligible.contains(source.id) &&
+            forceGenericConnection(source) != null,
+      )
+      .toList()
+    ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+});
+
+/// Abonnements connectés dont la session locale (cookies) est absente : statut
+/// « Ajouté » conservé côté serveur mais cookies effacés (réinstallation, reset
+/// OS…). Auto-clearing : dès qu'une source est reconnectée (`hasSession` vrai),
+/// elle quitte la liste. Source de vérité du bandeau de reconnexion au lancement.
+final subscriptionsNeedingReconnectProvider =
+    FutureProvider<List<Source>>((ref) async {
+  final subscribed = ref.watch(subscribedSourcesProvider);
+  if (subscribed.isEmpty) return const <Source>[];
+  final store = ref.watch(premiumSessionStoreProvider);
+  // Les lectures de session sont indépendantes : on les parallélise.
+  final sessions = await Future.wait(subscribed.map(store.hasSession));
+  return [
+    for (var i = 0; i < subscribed.length; i++)
+      if (!sessions[i]) subscribed[i],
+  ];
+});
+
 typedef SmartSearchQuery = ({String query, String? contentType, bool expand});
 
 final smartSearchProvider =

--- a/apps/mobile/lib/features/sources/widgets/reconnect_subscriptions_banner.dart
+++ b/apps/mobile/lib/features/sources/widgets/reconnect_subscriptions_banner.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/routes.dart';
+import '../../../config/theme.dart';
+import '../providers/sources_providers.dart';
+
+/// Délai après un « plus tard » avant de re-proposer la reconnexion. Le bandeau
+/// reste auto-clearing : si tout est reconnecté avant la fin du cooldown, il
+/// disparaît de lui-même (liste vide).
+const Duration kReconnectBannerCooldown = Duration(days: 7);
+
+/// Box Hive partagée des réglages (même box que les clés re-nudge / géoloc).
+const String _kSettingsBox = 'settings';
+
+/// Persistance Hive (box `settings`) du dernier dismiss du bandeau de
+/// reconnexion. Même pattern que les clés re-nudge / géoloc.
+class ReconnectBannerController {
+  ReconnectBannerController(this._ref);
+
+  final Ref _ref;
+
+  static const kDismissedAt = 'reconnect_banner_dismissed_at';
+
+  /// Enregistre un dismiss (« plus tard ») : démarre le cooldown.
+  Future<void> dismiss() async {
+    try {
+      final box = await Hive.openBox<dynamic>(_kSettingsBox);
+      await box.put(kDismissedAt, DateTime.now().toUtc().toIso8601String());
+    } catch (e) {
+      debugPrint('ReconnectBanner: Hive write failed: $e');
+    }
+    _ref.invalidate(reconnectBannerCooldownActiveProvider);
+  }
+}
+
+final reconnectBannerControllerProvider =
+    Provider<ReconnectBannerController>((ref) {
+  return ReconnectBannerController(ref);
+});
+
+/// `true` tant que le cooldown du dernier dismiss n'est pas écoulé (bandeau
+/// masqué). Défaut prudent : `true` en cas d'échec de lecture Hive (on ne
+/// flashe pas le bandeau si l'état de dismiss est inconnu).
+final reconnectBannerCooldownActiveProvider = FutureProvider<bool>((ref) async {
+  try {
+    final box = await Hive.openBox<dynamic>(_kSettingsBox);
+    final raw =
+        box.get(ReconnectBannerController.kDismissedAt) as String?;
+    if (raw == null || raw.isEmpty) return false;
+    final dismissedAt = DateTime.tryParse(raw);
+    if (dismissedAt == null) return false;
+    return DateTime.now().toUtc().difference(dismissedAt) <
+        kReconnectBannerCooldown;
+  } catch (e) {
+    debugPrint('ReconnectBanner: Hive read failed: $e');
+    return true;
+  }
+});
+
+/// Bandeau inline (haut du shell) qui repropose de reconnecter les abonnements
+/// dont la session locale a été perdue (réinstallation / reset OS). On ne
+/// restaure jamais la session côté serveur (choix privacy) : on détecte
+/// « abonné mais session locale absente » et on renvoie vers l'écran
+/// Abonnements existant. Se masque seul une fois tout reconnecté.
+class ReconnectSubscriptionsBanner extends ConsumerStatefulWidget {
+  const ReconnectSubscriptionsBanner({super.key});
+
+  @override
+  ConsumerState<ReconnectSubscriptionsBanner> createState() =>
+      _ReconnectSubscriptionsBannerState();
+}
+
+class _ReconnectSubscriptionsBannerState
+    extends ConsumerState<ReconnectSubscriptionsBanner> {
+  /// Dismiss de session : tant que le shell vit, on ne ré-affiche pas après un
+  /// « plus tard ». Le cooldown Hive prend le relais au prochain cold start.
+  bool _dismissedThisSession = false;
+
+  Future<void> _onDismiss() async {
+    await ref.read(reconnectBannerControllerProvider).dismiss();
+    if (!mounted) return;
+    setState(() => _dismissedThisSession = true);
+  }
+
+  void _onReconnect() {
+    context.pushNamed(RouteNames.subscriptions);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_dismissedThisSession) return const SizedBox.shrink();
+
+    final needing =
+        ref.watch(subscriptionsNeedingReconnectProvider).valueOrNull ??
+            const <Object>[];
+    if (needing.isEmpty) return const SizedBox.shrink();
+
+    // Défaut `true` (cooldown actif) tant que la lecture Hive n'a pas résolu :
+    // évite un flash du bandeau au premier frame.
+    final cooldownActive =
+        ref.watch(reconnectBannerCooldownActiveProvider).valueOrNull ?? true;
+    if (cooldownActive) return const SizedBox.shrink();
+
+    final colors = context.facteurColors;
+    final theme = Theme.of(context);
+    final count = needing.length;
+    final subtitle = count == 1
+        ? '1 abonnement à reconnecter après la mise à jour.'
+        : '$count abonnements à reconnecter après la mise à jour.';
+
+    return Container(
+      margin: const EdgeInsets.symmetric(
+        horizontal: FacteurSpacing.space4,
+        vertical: FacteurSpacing.space3,
+      ),
+      padding: const EdgeInsets.all(FacteurSpacing.space4),
+      decoration: BoxDecoration(
+        color: colors.primary.withValues(alpha: 0.08),
+        border: Border.all(color: colors.primary.withValues(alpha: 0.25)),
+        borderRadius: BorderRadius.circular(FacteurRadius.large),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            PhosphorIcons.link(PhosphorIconsStyle.bold),
+            size: 22,
+            color: colors.primary,
+          ),
+          const SizedBox(width: FacteurSpacing.space3),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Reconnecte tes abonnements',
+                  style: theme.textTheme.bodyMedium
+                      ?.copyWith(fontWeight: FontWeight.w600),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  subtitle,
+                  style: theme.textTheme.bodySmall
+                      ?.copyWith(color: colors.textSecondary),
+                ),
+                const SizedBox(height: FacteurSpacing.space2),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: TextButton(
+                    onPressed: _onReconnect,
+                    style: TextButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: FacteurSpacing.space2,
+                      ),
+                      minimumSize: const Size(0, 36),
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
+                    child: const Text('Reconnecter'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          IconButton(
+            tooltip: 'Plus tard',
+            visualDensity: VisualDensity.compact,
+            onPressed: _onDismiss,
+            icon: Icon(
+              PhosphorIcons.x(PhosphorIconsStyle.regular),
+              size: 18,
+              color: colors.textSecondary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/shared/widgets/navigation/main_shell.dart
+++ b/apps/mobile/lib/shared/widgets/navigation/main_shell.dart
@@ -10,6 +10,7 @@ import '../../../features/app_update/widgets/ios_update_banner.dart';
 import '../../../features/app_update/widgets/ios_update_gate.dart';
 import '../../../features/feed/widgets/profile_avatar_button.dart';
 import '../../../features/gamification/widgets/streak_indicator.dart';
+import '../../../features/sources/widgets/reconnect_subscriptions_banner.dart';
 import '../../../features/tour/tour_anchors.dart';
 import '../../../features/tour/widgets/guided_tour_bridge.dart';
 import '../../../widgets/design/facteur_logo.dart';
@@ -114,6 +115,10 @@ class MainTabPageScaffold extends ConsumerWidget {
           // Bannière incitative « nouvelle version dispo » (iOS) : non bloquante,
           // app-wide sur les deux onglets. SizedBox.shrink au cas nominal.
           const IosUpdateBanner(),
+          // Bandeau de reconnexion des abonnements (session locale perdue après
+          // une réinstallation). App-wide, auto-clearing, SizedBox.shrink au
+          // cas nominal.
+          const ReconnectSubscriptionsBanner(),
           Expanded(child: child),
         ],
       ),

--- a/apps/mobile/test/features/settings/screens/subscriptions_screen_test.dart
+++ b/apps/mobile/test/features/settings/screens/subscriptions_screen_test.dart
@@ -99,13 +99,14 @@ void main() {
     expect(find.text('Ajouter un abonnement'), findsOneWidget);
   });
 
-  testWidgets('empty state opens fallback when no followed paid source',
+  testWidgets('empty state opens fallback when no connectable source',
       (tester) async {
     await tester.pumpWidget(_wrap([
+      // Source libre NON suivie → ni payante éligible, ni login-connectable.
       _source(
         id: 'freeblog',
         name: 'Free Blog',
-        isTrusted: true,
+        isTrusted: false,
         hasPaywall: false,
         premiumConnection: null,
       ),
@@ -122,12 +123,13 @@ void main() {
     expect(find.text('Choisir mes sources'), findsOneWidget);
   });
 
-  testWidgets('lists only followed connectable paid sources in add sheet',
+  testWidgets('add sheet lists paid sources + login-connectable followed sites',
       (tester) async {
     await tester.pumpWidget(_wrap([
       _source(id: 'lemonde', name: 'Le Monde', isTrusted: true),
       _source(id: 'mediapart', name: 'Mediapart', isTrusted: true),
       _source(id: 'unfollowed', name: 'Non suivi'),
+      // Source libre suivie : connectable via login générique (décision PO).
       _source(
         id: 'freeblog',
         name: 'Gratuit suivi',
@@ -156,8 +158,15 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('Non suivi'), findsNothing);
-    expect(find.text('Gratuit suivi'), findsNothing);
-    expect(find.text('Déjà connecté'), findsOneWidget);
+    // La source libre suivie apparaît sous la section « autre site à login ».
+    expect(find.text('Un autre site demande une connexion ?'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byType(ListView),
+        matching: find.text('Gratuit suivi'),
+      ),
+      findsOneWidget,
+    );
 
     await tester.enterText(
       find.byType(TextField),

--- a/apps/mobile/test/features/sources/models/source_model_test.dart
+++ b/apps/mobile/test/features/sources/models/source_model_test.dart
@@ -56,6 +56,57 @@ void main() {
     });
   });
 
+  group('forceGenericConnection', () {
+    test('reuses the existing usable connection (curated or explicit)', () {
+      const curated = PremiumConnection(
+        loginUrl: 'https://example.com/login',
+        testUrl: 'https://example.com/article',
+      );
+      final source = Source(
+        id: 'source',
+        name: 'Source',
+        type: SourceType.article,
+        hasPaywall: true,
+        premiumConnection: curated,
+      );
+
+      expect(forceGenericConnection(source), same(curated));
+    });
+
+    test('synthesizes a generic connection for a free source with http url', () {
+      final source = Source(
+        id: 'free',
+        name: 'Free Followed',
+        type: SourceType.article,
+        url: 'https://nytimes.com',
+      );
+
+      final connection = forceGenericConnection(source);
+
+      expect(connection, isNotNull);
+      expect(connection!.isGeneric, isTrue);
+      expect(connection.loginUrl, 'https://nytimes.com');
+      expect(connection.testUrl, 'https://nytimes.com');
+    });
+
+    test('returns null without a valid http(s) url', () {
+      final source = Source(
+        id: 'nourl',
+        name: 'No URL',
+        type: SourceType.article,
+        url: 'example.com',
+      );
+
+      expect(forceGenericConnection(source), isNull);
+      expect(
+        forceGenericConnection(
+          Source(id: 'nil', name: 'Nil', type: SourceType.article),
+        ),
+        isNull,
+      );
+    });
+  });
+
   group('Source.fromJson premiumConnection', () {
     test('parses usable premium_connection', () {
       final source = Source.fromJson({

--- a/apps/mobile/test/features/sources/providers/subscriptions_reconnect_provider_test.dart
+++ b/apps/mobile/test/features/sources/providers/subscriptions_reconnect_provider_test.dart
@@ -1,0 +1,143 @@
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
+import 'package:facteur/features/sources/providers/sources_providers.dart';
+import 'package:facteur/features/sources/services/premium_session_store.dart';
+
+class _FakeUserSourcesNotifier extends UserSourcesNotifier {
+  _FakeUserSourcesNotifier(this._sources);
+  final List<Source> _sources;
+
+  @override
+  Future<List<Source>> build() async => _sources;
+}
+
+class _FakeCookieJar implements PremiumCookieJar {
+  @override
+  Future<List<Cookie>> getCookies(WebUri url) async => const [];
+  @override
+  Future<void> setCookie(
+    WebUri url, {
+    required String name,
+    required String value,
+    String? domain,
+    String path = '/',
+    int? expiresDate,
+    bool? isSecure,
+    bool? isHttpOnly,
+    HTTPCookieSameSitePolicy? sameSite,
+  }) async {}
+  @override
+  Future<void> deleteCookies(WebUri url) async {}
+}
+
+class _InMemorySecureStore implements SecureKeyValueStore {
+  final Map<String, String> map = {};
+  @override
+  Future<String?> read(String key) async => map[key];
+  @override
+  Future<void> write(String key, String value) async => map[key] = value;
+  @override
+  Future<void> delete(String key) async => map.remove(key);
+}
+
+Source _sub(String id, String name) => Source(
+      id: id,
+      name: name,
+      type: SourceType.article,
+      url: 'https://$id.example',
+      isTrusted: true,
+      hasSubscription: true,
+      hasPaywall: true,
+    );
+
+/// Clé de session telle que la calcule [PremiumSessionStore] (miroir privé).
+String _sessionKey(Source s) =>
+    'premium_session::${s.id}::${premiumDomainKey(s.url)}';
+
+void main() {
+  test('lists subscribed sources whose local session is missing', () async {
+    final lemonde = _sub('lemonde', 'Le Monde');
+    final mediapart = _sub('mediapart', 'Mediapart');
+    final secure = _InMemorySecureStore();
+    // Mediapart a une session locale, Le Monde non.
+    secure.map[_sessionKey(mediapart)] = '[{"name":"sid","value":"x"}]';
+
+    final container = ProviderContainer(
+      overrides: [
+        userSourcesProvider
+            .overrideWith(() => _FakeUserSourcesNotifier([lemonde, mediapart])),
+        premiumSessionStoreProvider.overrideWithValue(
+          PremiumSessionStore(jar: _FakeCookieJar(), secureStore: secure),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    // Laisse `userSourcesProvider` résoudre avant de lire le dérivé.
+    await container.read(userSourcesProvider.future);
+
+    final needing =
+        await container.read(subscriptionsNeedingReconnectProvider.future);
+
+    expect(needing.map((s) => s.id), ['lemonde']);
+  });
+
+  test('is empty once every subscription has a local session', () async {
+    final lemonde = _sub('lemonde', 'Le Monde');
+    final secure = _InMemorySecureStore();
+    secure.map[_sessionKey(lemonde)] = '[{"name":"sid","value":"x"}]';
+
+    final container = ProviderContainer(
+      overrides: [
+        userSourcesProvider
+            .overrideWith(() => _FakeUserSourcesNotifier([lemonde])),
+        premiumSessionStoreProvider.overrideWithValue(
+          PremiumSessionStore(jar: _FakeCookieJar(), secureStore: secure),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(userSourcesProvider.future);
+
+    final needing =
+        await container.read(subscriptionsNeedingReconnectProvider.future);
+
+    expect(needing, isEmpty);
+  });
+
+  test('loginConnectableSourcesProvider surfaces free followed http sources',
+      () async {
+    final paid = _sub('lemonde', 'Le Monde')
+        .copyWith(hasSubscription: false); // payant éligible
+    final freeFollowed = Source(
+      id: 'blog',
+      name: 'Blog Suivi',
+      type: SourceType.article,
+      url: 'https://blog.example',
+      isTrusted: true,
+    );
+    final freeUnfollowed = Source(
+      id: 'other',
+      name: 'Autre',
+      type: SourceType.article,
+      url: 'https://other.example',
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        userSourcesProvider.overrideWith(
+          () => _FakeUserSourcesNotifier([paid, freeFollowed, freeUnfollowed]),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(userSourcesProvider.future);
+
+    final connectable = container.read(loginConnectableSourcesProvider);
+
+    // Le payant éligible est exclu (couvert par eligibleSubscriptionSources) ;
+    // la source libre non suivie aussi. Seul le libre suivi reste.
+    expect(connectable.map((s) => s.id), ['blog']);
+  });
+}

--- a/apps/mobile/test/features/sources/widgets/reconnect_subscriptions_banner_test.dart
+++ b/apps/mobile/test/features/sources/widgets/reconnect_subscriptions_banner_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
+import 'package:facteur/features/sources/providers/sources_providers.dart';
+import 'package:facteur/features/sources/widgets/reconnect_subscriptions_banner.dart';
+
+Source _source(String id, String name) => Source(
+      id: id,
+      name: name,
+      type: SourceType.article,
+      url: 'https://$id.example',
+      isTrusted: true,
+      hasSubscription: true,
+      hasPaywall: true,
+    );
+
+Widget _wrap({
+  required List<Source> needing,
+  required bool cooldownActive,
+}) {
+  return ProviderScope(
+    overrides: [
+      subscriptionsNeedingReconnectProvider.overrideWith(
+        (ref) async => needing,
+      ),
+      reconnectBannerCooldownActiveProvider.overrideWith(
+        (ref) async => cooldownActive,
+      ),
+    ],
+    child: MaterialApp(
+      theme: FacteurTheme.lightTheme,
+      home: const Scaffold(body: ReconnectSubscriptionsBanner()),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('shows when sessions are missing and cooldown is inactive',
+      (tester) async {
+    await tester.pumpWidget(_wrap(
+      needing: [_source('lemonde', 'Le Monde'), _source('mediapart', 'Mediapart')],
+      cooldownActive: false,
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Reconnecte tes abonnements'), findsOneWidget);
+    expect(find.text('2 abonnements à reconnecter après la mise à jour.'),
+        findsOneWidget);
+    expect(find.text('Reconnecter'), findsOneWidget);
+  });
+
+  testWidgets('uses the singular copy for a single subscription',
+      (tester) async {
+    await tester.pumpWidget(_wrap(
+      needing: [_source('lemonde', 'Le Monde')],
+      cooldownActive: false,
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('1 abonnement à reconnecter après la mise à jour.'),
+        findsOneWidget);
+  });
+
+  testWidgets('hides when nothing needs reconnecting (auto-clearing)',
+      (tester) async {
+    await tester.pumpWidget(_wrap(needing: const [], cooldownActive: false));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Reconnecte tes abonnements'), findsNothing);
+  });
+
+  testWidgets('hides while the dismiss cooldown is active', (tester) async {
+    await tester.pumpWidget(_wrap(
+      needing: [_source('lemonde', 'Le Monde')],
+      cooldownActive: true,
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Reconnecte tes abonnements'), findsNothing);
+  });
+}

--- a/docs/stories/core/29.1.reconnexion-abonnements-sources-login.md
+++ b/docs/stories/core/29.1.reconnexion-abonnements-sources-login.md
@@ -1,0 +1,91 @@
+# 29.1 — Reconnexion des abonnements + sources étrangères à login
+
+> Type : **Feature** · Cible : `main` (staging continu) · 1 PR · **Sans migration**
+
+## Contexte
+
+Deux demandes PO, regroupées en une PR (cf. plan validé `.context/attachments/.../plan.md`).
+
+1. **Reconnexion après mise à jour.** Le statut « Ajouté » (abonné) survit à une
+   réinstallation (persisté backend `user_sources.has_subscription`), mais la **session du
+   média** (cookies) est stockée **appareil-only** (`flutter_secure_storage`, clé
+   `premium_session::{sourceId}::{domain}`) et l'OS l'efface à la désinstallation. ⇒ après
+   réinstallation : statut « Ajouté » présent, cookies perdus → paywall. **Choix privacy
+   assumé (PO) : on ne stocke jamais les credentials/cookies côté serveur.** On ne *restaure*
+   pas la session ; on **détecte** « abonné mais session locale absente » et on **repropose une
+   reconnexion express** en réutilisant le flux existant.
+
+2. **Sources étrangères à login.** Permettre de connecter un login sur des sites qui exigent un
+   compte pour lire (NY Times, The Athletic, WaPo, FT, The Economist, WSJ…), pas seulement les
+   sources FR curées.
+
+L'infra existe déjà : détection « reconnexion nécessaire » (`subscriptions_screen.dart`,
+`_PremiumSessionExpiredBanner`), flux 3 étapes `PremiumSourceConnection`, fallback générique
+(`resolvePremiumConnection` / `PremiumConnectionResponse.from_source`), enrichissement de la map
+curée sans migration. Ce qui manque est du **surfacing** + de la **config**.
+
+## Décisions PO
+
+1. Détecter + reproposer (pas de stockage serveur).
+2. Surfacer **uniquement via un nudge/bandeau au lancement** (pas de ré-onboarding).
+3. Sources étrangères : **les deux** — map curée pour les gros titres EN + fallback générique
+   ouvert à **toute source suivie**.
+4. **Une seule PR** vers `main`.
+
+## Plan technique
+
+### Partie A — Nudge de reconnexion au lancement
+
+- **`subscriptionsNeedingReconnectProvider`** (FutureProvider) dans `sources_providers.dart` :
+  watch `subscribedSourcesProvider`, pour chaque source teste `PremiumSessionStore.hasSession`.
+  Renvoie la `List<Source>` à reconnecter. Auto-clearing : une source reconnectée sort de la liste.
+- **`ReconnectSubscriptionsBanner`** (nouveau widget), calqué sur `notification_renudge_banner.dart` :
+  dismissible (session) + cooldown persisté Hive (box `settings`, clé `reconnect_banner_dismissed_at`,
+  cooldown 7 j). Tap → ouvre l'écran **Abonnements** existant.
+- **Montage** dans `main_shell.dart` (`MainTabPageScaffold`, sous le header, à côté de
+  `IosUpdateBanner`) — bandeau app-wide qui se masque seul (liste vide / cooldown / session).
+
+### Partie B — Sources étrangères à login
+
+- **B1 (backend, sans migration).** Étendre `PREMIUM_CURATED_MAP` avec les grands titres EN
+  (nytimes.com, theathletic.com, washingtonpost.com, ft.com, economist.com, wsj.com). Effet
+  automatique via `from_source` : `has_paywall=true` + `premium_connection` peuplé.
+- **B2 (mobile).** `forceGenericConnection(Source)` dans `source_model.dart` : synthétise une
+  connexion générique dès qu'il y a une URL http(s) valide, **sans exiger `hasPaywall`**.
+  `loginConnectableSourcesProvider` : sources `isTrusted` à URL http(s), non abonnées, au-delà de
+  `eligibleSubscriptionSourcesProvider`. Entrée « Un autre site demande une connexion ? » dans la
+  feuille « Ajouter un abonnement ».
+- **B2 (backend, gap du plan corrigé).** Le guard `update_source_subscription`
+  (`source_service.py:542`) levait `PremiumConnectionNotEnabled` dès que `_premium_connection`
+  est `None` — ce qui **bloquait** B2 pour toute source libre. Relâché via `_can_connect_login` :
+  autorise la connexion si une connexion premium se résout **OU** si la source a une URL http(s)
+  valide (login générique possible). L'opt-out explicite `premium_connection_config.enabled=false`
+  reste respecté (blocklist). Additif, sans migration. Reconnexion mobile bascule sur
+  `forceGenericConnection` (superset : renvoie la connexion existante si curée/usable, sinon
+  générique depuis l'URL).
+
+## Tâches
+
+- [x] Backend : étendre `PREMIUM_CURATED_MAP` (6 titres EN).
+- [x] Backend : `_can_connect_login` + relâcher le guard `update_source_subscription`.
+- [x] Backend : tests premium (cas EN + connexion générique autorisée + opt-out respecté).
+- [x] Mobile : `forceGenericConnection()`.
+- [x] Mobile : `subscriptionsNeedingReconnectProvider` + `loginConnectableSourcesProvider`.
+- [x] Mobile : `ReconnectSubscriptionsBanner` + montage `main_shell.dart`.
+- [x] Mobile : reconnexion via `forceGenericConnection` + entrée « autre site à login ».
+- [x] Mobile : tests provider reconnexion + `forceGenericConnection` + rendu bandeau.
+- [x] Changelog `unreleased`.
+
+## Vérification
+
+- Backend `pytest -v` (cibler `test_premium_*`), `uvicorn` + `curl` sources EN.
+- Mobile `flutter test` + `flutter analyze`.
+- Alembic : aucune migration → 1 head inchangé.
+- Caveat WebView : flux de login média = validation on-device (non automatisable web).
+
+## Fichiers
+
+**Backend** : `premium_curated_sources.py`, `source_service.py`, `tests/test_premium_*`.
+**Mobile** : `source_model.dart`, `sources_providers.dart`, `reconnect_subscriptions_banner.dart`
+(nouveau), `main_shell.dart`, `subscriptions_screen.dart`, tests.
+**Divers** : `assets/changelog.json`.

--- a/packages/api/app/services/premium_curated_sources.py
+++ b/packages/api/app/services/premium_curated_sources.py
@@ -87,6 +87,38 @@ PREMIUM_CURATED_MAP: dict[str, dict] = {
         "test_url": "https://www.telerama.fr/",
         "display_hint": "Connecte-toi à ton compte Télérama pour lire les articles abonnés.",
     },
+    # Grands titres EN à login (PO) : le fallback générique couvre tout le reste,
+    # mais une config curée donne une page de connexion fiable + un libellé clair.
+    "nytimes.com": {
+        "login_url": "https://myaccount.nytimes.com/auth/login",
+        "test_url": "https://www.nytimes.com/",
+        "display_hint": "Connecte-toi à ton compte New York Times pour lire les articles abonnés.",
+    },
+    "theathletic.com": {
+        "login_url": "https://www.theathletic.com/login/",
+        "test_url": "https://www.theathletic.com/",
+        "display_hint": "Connecte-toi à ton compte The Athletic pour lire les articles abonnés.",
+    },
+    "washingtonpost.com": {
+        "login_url": "https://www.washingtonpost.com/subscribe/signin/",
+        "test_url": "https://www.washingtonpost.com/",
+        "display_hint": "Connecte-toi à ton compte Washington Post pour lire les articles abonnés.",
+    },
+    "ft.com": {
+        "login_url": "https://accounts.ft.com/login",
+        "test_url": "https://www.ft.com/",
+        "display_hint": "Connecte-toi à ton compte Financial Times pour lire les articles abonnés.",
+    },
+    "economist.com": {
+        "login_url": "https://www.economist.com/login",
+        "test_url": "https://www.economist.com/",
+        "display_hint": "Connecte-toi à ton compte The Economist pour lire les articles abonnés.",
+    },
+    "wsj.com": {
+        "login_url": "https://accounts.wsj.com/login",
+        "test_url": "https://www.wsj.com/",
+        "display_hint": "Connecte-toi à ton compte Wall Street Journal pour lire les articles abonnés.",
+    },
 }
 
 

--- a/packages/api/app/services/source_service.py
+++ b/packages/api/app/services/source_service.py
@@ -48,6 +48,30 @@ class SourceService:
     def _has_paywall(s: Source) -> bool:
         return is_paywalled_source(s, curated_map=PREMIUM_CURATED_MAP)
 
+    @staticmethod
+    def _can_connect_login(s: Source) -> bool:
+        """Une connexion (login) peut-elle être associée à cette source ?
+
+        Vrai si une connexion premium se résout (config explicite / map curée /
+        fallback paywall) **OU** si la source a une URL http(s) valide : décision
+        PO « connecter un login à toute source suivie » (sites étrangers à login).
+        L'utilisateur se connecte alors génériquement sur le site du média ; aucun
+        identifiant n'est stocké côté serveur.
+
+        L'opt-out explicite ``premium_connection_config.enabled = false`` reste une
+        blocklist : il bloque la connexion même si l'URL est valide (source dont la
+        connexion WebView est connue comme incompatible).
+        """
+        config = getattr(s, "premium_connection_config", None)
+        if PremiumConnectionResponse.is_explicitly_disabled(config):
+            return False
+        if SourceService._premium_connection(s) is not None:
+            return True
+        url = getattr(s, "url", None)
+        return isinstance(url, str) and url.strip().lower().startswith(
+            ("http://", "https://")
+        )
+
     async def _load_user_source_context(
         self, user_id: UUID
     ) -> tuple[set[UUID], dict[UUID, float], dict[UUID, bool]]:
@@ -526,11 +550,13 @@ class SourceService:
     ) -> SourceResponse | None:
         """Met à jour le has_subscription d'une source.
 
-        La connexion positive exige une connexion premium résolue : config
-        explicite, domaine curé, ou fallback générique pour source paywalled.
-        La config curée améliore donc l'expérience sans servir de whitelist
-        bloquante. La dissociation reste autorisée même si la config source a
-        été retirée.
+        La connexion positive exige seulement qu'un login soit possible
+        (``_can_connect_login``) : connexion premium résolue (config explicite /
+        map curée / fallback paywall) **ou** simple URL http(s) valide (login
+        générique sur le site, décision PO « toute source suivie »). La config
+        curée améliore l'expérience sans servir de whitelist bloquante ; seul
+        l'opt-out explicite ``premium_connection_config.enabled = false`` bloque.
+        La dissociation reste toujours autorisée.
         """
         user_uuid = UUID(user_id)
         source_uuid = UUID(source_id)
@@ -539,7 +565,7 @@ class SourceService:
         if not source:
             return None
 
-        if has_subscription and self._premium_connection(source) is None:
+        if has_subscription and not self._can_connect_login(source):
             raise PremiumConnectionNotEnabled
 
         user_source = await self.db.scalar(

--- a/packages/api/tests/test_premium_discoverability.py
+++ b/packages/api/tests/test_premium_discoverability.py
@@ -77,6 +77,28 @@ def test_from_source_curated_map_is_not_generic():
     assert resp.test_url == MAP["lemonde.fr"]["test_url"]
 
 
+@pytest.mark.parametrize(
+    "url,domain",
+    [
+        ("https://www.nytimes.com/2026/01/01/world/x.html", "nytimes.com"),
+        ("https://theathletic.com/123/article/", "theathletic.com"),
+        ("https://www.washingtonpost.com/world/x/", "washingtonpost.com"),
+        ("https://www.ft.com/content/abc", "ft.com"),
+        ("https://www.economist.com/leaders/x", "economist.com"),
+        ("https://www.wsj.com/articles/x", "wsj.com"),
+    ],
+)
+def test_from_source_english_titles_are_curated_not_generic(url, domain):
+    """Les grands titres EN ajoutés à la map (PO) exposent une connexion curée."""
+    src = _stub(url=url)
+    assert is_paywalled_source(src) is True
+    resp = PremiumConnectionResponse.from_source(src, curated_map=MAP)
+    assert resp is not None
+    assert resp.is_generic is False
+    assert resp.login_url == MAP[domain]["login_url"]
+    assert resp.test_url == MAP[domain]["test_url"]
+
+
 def test_from_source_paywall_config_only_is_generic_using_source_url():
     src = _stub(
         url="https://unknown-paper.example/news/x",

--- a/packages/api/tests/test_premium_source_connection.py
+++ b/packages/api/tests/test_premium_source_connection.py
@@ -160,14 +160,46 @@ async def test_subscription_false_clears_timestamps(db_session: AsyncSession):
 
 
 @pytest.mark.asyncio
-async def test_subscription_true_rejects_free_non_paywalled_source(
+async def test_subscription_true_allows_free_source_with_http_url(
     db_session: AsyncSession,
 ):
+    """Décision PO « connecter un login à toute source suivie » : une source
+    libre avec une URL http(s) valide est désormais connectable (login générique
+    sur le site), même sans connexion premium résolue. La réponse n'expose pas de
+    ``premium_connection`` (le mobile synthétise alors un flux générique)."""
     source = Source(
         id=uuid4(),
         name="Regular Source",
         url="https://example.com",
         feed_url=f"https://example.com/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_curated=True,
+        is_active=True,
+    )
+    db_session.add(source)
+    await db_session.flush()
+
+    response = await SourceService(db_session).update_source_subscription(
+        str(uuid4()), str(source.id), True
+    )
+
+    assert response is not None
+    assert response.has_subscription is True
+    assert response.has_paywall is False
+    assert response.premium_connection is None
+
+
+@pytest.mark.asyncio
+async def test_subscription_true_rejects_source_without_http_url(
+    db_session: AsyncSession,
+):
+    """Sans connexion premium ni URL http(s) valide, aucun login n'est possible."""
+    source = Source(
+        id=uuid4(),
+        name="Schemeless Source",
+        url="ftp://weird-host",
+        feed_url=f"https://schemeless.example/feed-{uuid4()}.xml",
         type=SourceType.ARTICLE,
         theme="society",
         is_curated=True,


### PR DESCRIPTION
## Quoi

Deux demandes PO regroupées en une PR (sans migration Alembic) :

**A — Reconnexion des abonnements après une mise à jour.** Le statut « Ajouté »
survit à une réinstallation (persisté backend), mais la session du média
(cookies) est appareil-only et l'OS l'efface → paywall au retour. On ne stocke
jamais les credentials côté serveur (choix privacy PO) : on **détecte**
« abonné mais session locale absente » et on **repropose** une reconnexion via
un bandeau au lancement, qui renvoie vers l'écran Abonnements existant. Le
bandeau est auto-clearing (disparaît une fois tout reconnecté).

**B — Login sur sources étrangères.** Connecter un compte sur des sites qui
exigent un login pour lire (NY Times, The Athletic, WaPo, FT, The Economist,
WSJ ajoutés à la map curée) + fallback ouvert à **toute source suivie** avec une
URL http(s), via une entrée « Un autre site demande une connexion ? » dans la
feuille « Ajouter un abonnement ».

## Pourquoi

Bug rapporté : Mediapart restait « Ajouté » mais reparaissait paywallé après une
réinstallation. Et demande d'élargir le login au-delà des 7 sources FR curées.

## Comment

- **Backend (sans migration)** : `PREMIUM_CURATED_MAP` étendue aux 6 grands
  titres EN. Guard `update_source_subscription` relâché via `_can_connect_login`
  (une URL http(s) valide suffit à autoriser la connexion ; l'opt-out explicite
  `premium_connection_config.enabled=false` reste respecté). *Corrige un gap du
  plan : l'ancien guard rejetait toute source non-payante, ce qui bloquait B.*
- **Mobile** : `forceGenericConnection` (superset de `resolvePremiumConnection`,
  n'exige pas `hasPaywall`), providers `subscriptionsNeedingReconnectProvider` +
  `loginConnectableSourcesProvider`, `ReconnectSubscriptionsBanner` monté dans
  `main_shell`, reconnexion basculée sur `forceGenericConnection`.

## Vérifié

- [x] Backend `pytest` : premium/sources verts (37) ; suite complète 2031 passed
      (les 2 échecs restants = artefacts de fuseau `+02:00` local sur
      notification-prefs / recent-items, endpoints non touchés — verts en CI UTC).
- [x] `flutter test` (24 tests ciblés : provider reconnexion, `forceGenericConnection`,
      rendu bandeau, feuille abonnements) + `flutter analyze` : 0 issue.
- [x] Alembic : 1 head inchangé, aucune migration.
- [x] `/simplify` passé (dedup construction connexion, parallélisation des
      lectures de session, dedup constante box Hive + boucle tuile/divider).

## Zones à risque

- **Auth/abonnements** : relâchement du guard de souscription (backend). L'opt-out
  `enabled:false` reste bloquant ; côté mobile la liste est gatée aux sources
  suivies (`isTrusted`).
- **DB partagée staging/prod** : aucune migration, changement purement additif.

## Non automatisable (validation on-device)

Le flux de login média (WebView `flutter_inappwebview`, natif-only) ne tourne pas
sur le build web : smoke manuel restant sur Mediapart + une source EN.
