### PR TITLE
fix: Android nav bar contrast, launcher icon, perspectives spacing

### DIFF
--- a/apps/mobile/android/app/src/main/res/mipmap-anydpi-v26/launcher_icon.xml
+++ b/apps/mobile/android/app/src/main/res/mipmap-anydpi-v26/launcher_icon.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
   <background android:drawable="@color/ic_launcher_background"/>
-  <!-- Inset négatif = zoom centré sur le logo (~+10% : -5% par côté). -->
+  <!-- Inset négatif = zoom centré sur le logo (~+20% : -10% par côté). -->
   <foreground>
     <inset
       android:drawable="@drawable/ic_launcher_foreground"
-      android:inset="-5%"/>
+      android:inset="-10%"/>
   </foreground>
 </adaptive-icon>

--- a/apps/mobile/lib/config/theme.dart
+++ b/apps/mobile/lib/config/theme.dart
@@ -463,7 +463,9 @@ class FacteurTheme {
           statusBarIconBrightness:
               brightness == Brightness.dark ? Brightness.light : Brightness.dark,
           statusBarBrightness: brightness,
-          systemNavigationBarColor: Colors.transparent,
+          // Voile noir léger : contraste de la barre de navigation système
+          // sur fonds clairs, sans repeindre en noir opaque.
+          systemNavigationBarColor: Colors.black.withValues(alpha: 0.15),
           systemNavigationBarContrastEnforced: false,
           systemNavigationBarIconBrightness:
               brightness == Brightness.dark ? Brightness.light : Brightness.dark,

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -2881,11 +2881,18 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                             bodyPlaceholder: !_contentResolved
                                 ? _buildArticleBodySkeleton(colors)
                                 : null,
-                            footerSpacing:
-                                isPartial ? 0 : FacteurSpacing.space8,
-                            footer: SizedBox(
-                              height: _kFooterContentHeight + bottomInset,
-                            ),
+                            // Clearance de bas de page : quand la bande
+                            // Perspectives suit (elle a son propre spacer final),
+                            // on supprime la clearance du reader pour éviter un
+                            // grand vide entre le corps et Perspectives.
+                            footerSpacing: (isPartial || _showPerspectivesBand)
+                                ? 0
+                                : FacteurSpacing.space8,
+                            footer: _showPerspectivesBand
+                                ? null
+                                : SizedBox(
+                                    height: _kFooterContentHeight + bottomInset,
+                                  ),
                           ),
                         ),
 

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -66,11 +66,13 @@ Future<void> _bootstrap() async {
   await SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
 
   SystemChrome.setSystemUIOverlayStyle(
-    const SystemUiOverlayStyle(
+    SystemUiOverlayStyle(
       statusBarColor: Colors.transparent,
       statusBarIconBrightness: Brightness.light,
       statusBarBrightness: Brightness.dark,
-      systemNavigationBarColor: Colors.transparent,
+      // Voile noir léger (pas full transparent) : garantit le contraste de la
+      // pilule gestuelle / des boutons système sur les fonds clairs.
+      systemNavigationBarColor: Colors.black.withValues(alpha: 0.15),
       // Désactive le scrim/contraste auto qui réintroduit un fond opaque
       systemNavigationBarContrastEnforced: false,
       systemNavigationBarIconBrightness: Brightness.light,

--- a/docs/maintenance/maintenance-android-footer-transparency.md
+++ b/docs/maintenance/maintenance-android-footer-transparency.md
@@ -21,17 +21,19 @@ Deux causes :
 
 - **`main.dart`** :
   - Activation du mode `SystemUiMode.edgeToEdge` (le contenu dessine derrière les barres système).
-  - `systemNavigationBarColor: Colors.transparent`
+  - `systemNavigationBarColor: Colors.black.withValues(alpha: 0.15)` — voile noir léger
+    (et non full transparent) pour garantir le contraste de la pilule gestuelle / des
+    boutons système sur les fonds clairs, tout en restant discret sur fonds sombres.
   - `systemNavigationBarContrastEnforced: false` (désactive le scrim auto d'Android qui
     réintroduit un fond opaque).
   - `systemNavigationBarIconBrightness` ajouté pour la lisibilité des icônes système.
-- **`theme.dart`** : remplacement de `SystemUiOverlayStyle.light/.dark` par un style custom
-  transparent, avec la luminosité d'icônes (status bar + nav bar) adaptée au thème
-  (clair / sombre).
+- **`theme.dart`** : remplacement de `SystemUiOverlayStyle.light/.dark` par un style custom,
+  avec le même voile noir léger (`Colors.black.withValues(alpha: 0.15)`) et la luminosité
+  d'icônes (status bar + nav bar) adaptée au thème (clair / sombre).
 
 Aucun changement Android natif requis : `_BottomNavBar` (shell_scaffold.dart) enveloppe déjà
 sa `SafeArea` dans un `Container` coloré (`backgroundPrimary`), dont le fond peint
-naturellement derrière la barre système désormais transparente.
+naturellement derrière la barre système (désormais un voile noir léger, quasi transparent).
 
 ## Vérification
 


### PR DESCRIPTION
## What

Android UI polish: improved system navigation bar contrast with light black overlay (instead of full transparency), increased launcher icon zoom, and optimized reader footer spacing when perspectives band follows content.

## Why

Navigation bar elements (gesture pill, system buttons) need sufficient contrast on light backgrounds. Full transparency caused visibility issues on light app backgrounds. Launcher icon needed more prominent zoom effect for app identity. Reader footer spacing optimization prevents excessive whitespace when perspectives band immediately follows article content.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Maintenance / Refactor

## Checklist

- [x] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [x] Tests pass locally (mobile: `flutter analyze`)
- [ ] If touching auth/DB: read Safety Guardrails (N/A)
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (UI-only change, no migration)