### PR TITLE
fix(mobile): add PLAYSTORE_BUILD flag to AAB workflow

### DIFF
--- a/.github/workflows/build-aab.yml
+++ b/.github/workflows/build-aab.yml
@@ -69,6 +69,7 @@ jobs:
             --dart-define="POSTHOG_HOST=${{ vars.POSTHOG_HOST || 'https://eu.i.posthog.com' }}" \
             --dart-define="SENTRY_DSN=${{ secrets.SENTRY_DSN_FLUTTER }}" \
             --dart-define="SENTRY_ENVIRONMENT=production" \
+            --dart-define="PLAYSTORE_BUILD=true" \
             --dart-define="UPDATE_CHANNEL=playstore" \
             --dart-define="APP_RELEASE_TAG=android-aab-${{ github.run_number }}"
 


### PR DESCRIPTION
## What

Add `PLAYSTORE_BUILD=true` flag to the AAB build workflow to ensure the store update nudge feature is properly enabled for Play Store builds.

## Why

The store update nudge feature requires this flag to be set during the Play Store build process. This fix ensures the feature works correctly when distributed through Google Play Store.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Maintenance / Refactor

## Checklist

- [x] N/A (workflow configuration only)
- [x] No new Python imports
- [ ] Tests pass locally
- [ ] N/A (no auth/DB changes)

## Staging

- [ ] Deployed to staging
- [ ] N/A (configuration only change)