### PR TITLE
feat(mobile): intégrer feedback + chevrons Essentiel

### DIFF
--- a/apps/mobile/lib/features/feedback/widgets/feedback_closing_card.dart
+++ b/apps/mobile/lib/features/feedback/widgets/feedback_closing_card.dart
@@ -19,7 +19,17 @@ class FeedbackClosingCard extends ConsumerStatefulWidget {
   /// Date de la tournée notée (par défaut : aujourd'hui côté backend).
   final DateTime? digestDate;
 
-  const FeedbackClosingCard({super.key, this.digestDate});
+  /// Notifie l'hôte quand la hauteur rendue change en asynchrone (résolution
+  /// de l'invitation call → +Divider/teaser, ou vote emoji → ligne « Merci »).
+  /// L'Essentiel y branche son recompute d'ancres de snap : sans ça, l'ancre
+  /// de la section de clôture reste calée sur l'ancienne hauteur.
+  final VoidCallback? onLayoutChanged;
+
+  const FeedbackClosingCard({
+    super.key,
+    this.digestDate,
+    this.onLayoutChanged,
+  });
 
   @override
   ConsumerState<FeedbackClosingCard> createState() =>
@@ -41,6 +51,9 @@ class _FeedbackClosingCardState extends ConsumerState<FeedbackClosingCard> {
       _shownMarked = true;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         ref.read(feedbackRepositoryProvider).markInviteShown();
+        // La résolution de l'invite ajoute Divider + teaser (~+90px) : la
+        // section de clôture a grandi ⇒ rafraîchir les ancres de snap.
+        widget.onLayoutChanged?.call();
       });
     }
 
@@ -85,7 +98,10 @@ class _FeedbackClosingCardState extends ConsumerState<FeedbackClosingCard> {
             const SizedBox(height: 6),
 
             // Micro-feedback emoji (toujours présent).
-            SentimentPicker(digestDate: widget.digestDate),
+            SentimentPicker(
+              digestDate: widget.digestDate,
+              onLayoutChanged: widget.onLayoutChanged,
+            ),
 
             // Invitation au call (conditionnelle, gated backend).
             if (showCall) ...[

--- a/apps/mobile/lib/features/feedback/widgets/sentiment_picker.dart
+++ b/apps/mobile/lib/features/feedback/widgets/sentiment_picker.dart
@@ -12,7 +12,12 @@ class SentimentPicker extends ConsumerStatefulWidget {
   /// Date du digest noté (par défaut : aujourd'hui côté backend).
   final DateTime? digestDate;
 
-  const SentimentPicker({super.key, this.digestDate});
+  /// Notifie l'hôte quand le vote fait basculer la colonne prompt+emojis vers
+  /// la ligne « Merci » (la hauteur rendue change). L'Essentiel y branche son
+  /// recompute d'ancres de snap.
+  final VoidCallback? onLayoutChanged;
+
+  const SentimentPicker({super.key, this.digestDate, this.onLayoutChanged});
 
   @override
   ConsumerState<SentimentPicker> createState() => _SentimentPickerState();
@@ -30,6 +35,11 @@ class _SentimentPickerState extends ConsumerState<SentimentPicker> {
   Future<void> _onTap(String value) async {
     if (_selected != null) return;
     setState(() => _selected = value);
+    // La bascule vers la ligne « Merci » rétrécit la carte : signale le relayout
+    // à l'hôte (post-frame, quand la nouvelle hauteur est mesurable).
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      widget.onLayoutChanged?.call();
+    });
     await ref
         .read(feedbackRepositoryProvider)
         .submitSentiment(value, date: widget.digestDate);

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -1248,21 +1248,36 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
             // ferme réellement l'app sur Android (SystemNavigator.pop) ; sur iOS,
             // la fermeture programmatique est interdite → on masque le bouton et
             // on affiche une phrase de clôture à la place.
+            // La carte feedback (Epic 13) est fusionnée SOUS `_closingKey` avec
+            // la carte « Fin de tournée » : c'est la boîte portée par cette clé
+            // que [_recomputeSnapAnchors] mesure pour cadrer le bas de la
+            // section de clôture. Rendue en sliver séparé sans clé, elle était
+            // invisible du calcul d'ancres → le snap la « repoussait » hors zone
+            // de repos. La Column les réunit en une seule section mesurable.
             SliverToBoxAdapter(
               child: KeyedSubtree(
                 key: _closingKey,
-                child: ClosingCardV18(
-                  onContinue: () => context.go(RoutePaths.flaner),
-                  onClose: isAndroid ? () => SystemNavigator.pop() : null,
-                  closeHint: isAndroid
-                      ? null
-                      : 'Vous pouvez refermer l’app — à demain',
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    ClosingCardV18(
+                      onContinue: () => context.go(RoutePaths.flaner),
+                      onClose: isAndroid ? () => SystemNavigator.pop() : null,
+                      closeHint: isAndroid
+                          ? null
+                          : 'Vous pouvez refermer l’app — à demain',
+                    ),
+                    // Micro-feedback emoji + invitation au call qualitatif
+                    // (gating segmenté côté backend). Sa hauteur change en
+                    // asynchrone (résolution invite / vote → « Merci ») ⇒ elle
+                    // signale ces relayouts pour rafraîchir les ancres de snap.
+                    FeedbackClosingCard(
+                      onLayoutChanged: _scheduleAnchorRecompute,
+                    ),
+                  ],
                 ),
               ),
             ),
-            // Carte feedback de fin de tournée (Epic 13) — micro-feedback emoji
-            // + invitation au call qualitatif (gating segmenté côté backend).
-            const SliverToBoxAdapter(child: FeedbackClosingCard()),
             const SliverToBoxAdapter(child: SizedBox(height: 92)),
           ],
         ),

--- a/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
@@ -243,19 +243,25 @@ class SectionBanner extends StatelessWidget {
                             TextSpan(
                               text: title,
                               children: <InlineSpan>[
-                                if (tappable)
-                                  // Chevron « > » intégré au titre comme glyphe
-                                  // texte : hérite de Fraunces w700 du TextSpan
-                                  // parent et s'aligne sur la baseline du titre.
-                                  // Rendu plus gros que le titre pour épaissir
-                                  // le trait et signaler la tappabilité.
-                                  TextSpan(
-                                    text: ' >',
-                                    style: TextStyle(
-                                      fontSize: large ? 30 : 22,
+                                if (tappable) ...[
+                                  // Chevron de tappabilité rendu comme icône
+                                  // centrée verticalement sur le titre (même
+                                  // pattern que l'étoile favorite ci-dessous) :
+                                  // trait épais et alignement propre, là où le
+                                  // glyphe texte « > » héritait d'une baseline
+                                  // décalée et d'un trait fin.
+                                  const WidgetSpan(child: SizedBox(width: 3)),
+                                  WidgetSpan(
+                                    alignment: PlaceholderAlignment.middle,
+                                    child: Icon(
+                                      PhosphorIcons.caretRight(
+                                        PhosphorIconsStyle.bold,
+                                      ),
+                                      size: large ? 24 : 17,
                                       color: colors.textPrimary,
                                     ),
                                   ),
+                                ],
                                 if (onTapFavorite != null) ...[
                                   const TextSpan(text: '  '),
                                   WidgetSpan(


### PR DESCRIPTION
## What

Intègre la carte FeedbackClosingCard (micro-feedback emoji + invitation call) dans la section de clôture de l'Essentiel, avec recalcul des ancres de snap quand sa hauteur change. Remplace aussi le chevron « > » texte par une icône bold centrée.

## Why

- **Snap anchors** : FeedbackClosingCard était rendue en sliver isolé, invisible du calcul d'ancres → le snap la repoussait hors zone de repos. En la montant dans une Column avec KeyedSubtree, elle devient mesurable et ses relayouts (résolution invite / vote) rafraîchissent les ancres.
- **Chevron UX** : le glyphe texte « > » héritait d'une baseline décalée et d'un trait fin. L'icône PhosphorIcons bold est centrée verticalement et bien alignée.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [x] Tests pass locally (`flutter test`)
- [x] Linting passes (`flutter analyze`)
- [x] No new Python imports
- [ ] If touching auth/DB: read Safety Guardrails
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (mobile UI only)