### PR TITLE
fix(mobile): point rouge disparaît après install APK

### DIFF
--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -15,6 +15,7 @@ import 'features/feed/services/read_sync_service.dart';
 import 'features/flux_continu/providers/flux_continu_preload_provider.dart';
 import 'features/flux_continu/services/tournee_progress_service.dart';
 import 'features/my_interests/services/interests_sync_service.dart';
+import 'features/app_update/providers/app_update_provider.dart';
 import 'features/app_update/services/playstore_update_service.dart';
 import 'features/onboarding/providers/onboarding_sync_provider.dart';
 import 'features/settings/providers/theme_provider.dart';
@@ -101,6 +102,11 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
       // playstore : re-check au retour foreground (no-op sur beta/dev ; garde
       // anti-ré-entrance interne au service).
       unawaited(ref.read(playStoreUpdateServiceProvider).checkAndStart());
+      // Android self-update : ré-évalue le point rouge au retour au premier
+      // plan (typiquement juste après l'install de l'APK). Le provider
+      // autoDispose re-fetch /api/app/update ; version installée == dernière
+      // release -> updateAvailable repasse false et le point rouge disparaît.
+      ref.invalidate(appUpdateProvider);
       if (_wasBackgrounded) {
         _wasBackgrounded = false;
         final elapsed = _backgroundedAt != null

--- a/apps/mobile/lib/features/app_update/providers/app_update_provider.dart
+++ b/apps/mobile/lib/features/app_update/providers/app_update_provider.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../config/constants.dart';
@@ -38,11 +38,39 @@ class AppUpdateInfo {
     );
   }
 
-  /// Lexicographic comparison works for date-based tags:
-  /// "beta-20260221-1430" > "beta-20260220-0900"
+  /// Tags émis par la CI au format `<canal>-YYYYMMDD-HHMM`
+  /// (ex. "beta-20260221-1430", "release-20260221-1430").
+  ///
+  /// On parse la structure plutôt que de comparer lexicographiquement : si
+  /// l'un des deux tags n'est pas au format attendu, ou si les canaux diffèrent
+  /// (formats incomparables), on renvoie `false` — jamais de point rouge
+  /// fantôme sur une comparaison ambiguë.
+  static final RegExp _tagPattern =
+      RegExp(r'^(beta|release)-(\d{8})-(\d{4})$');
+
+  /// Clé numérique triable `YYYYMMDD * 10000 + HHMM`, préfixée du canal.
+  /// `null` si le tag n'est pas au format attendu.
+  static ({String channel, int key})? _parseTag(String tag) {
+    final m = _tagPattern.firstMatch(tag);
+    if (m == null) return null;
+    return (
+      channel: m.group(1)!,
+      key: int.parse(m.group(2)!) * 10000 + int.parse(m.group(3)!),
+    );
+  }
+
+  /// Exposé pour les tests (le vrai `local` est un `String.fromEnvironment`
+  /// figé à la compilation, impossible à piloter depuis un test).
+  @visibleForTesting
+  static bool isNewer(String remote, String local) => _isNewer(remote, local);
+
   static bool _isNewer(String remote, String local) {
     if (local.isEmpty) return false; // dev build: hide update
-    return remote.compareTo(local) > 0;
+    final r = _parseTag(remote);
+    final l = _parseTag(local);
+    // Formats incomparables (parse échoué ou canaux différents) : pas de MAJ.
+    if (r == null || l == null || r.channel != l.channel) return false;
+    return r.key > l.key;
   }
 
   /// Format APK size for display (e.g. "62.3 MB")

--- a/apps/mobile/test/features/app_update/app_update_info_test.dart
+++ b/apps/mobile/test/features/app_update/app_update_info_test.dart
@@ -1,0 +1,60 @@
+import 'package:facteur/features/app_update/providers/app_update_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AppUpdateInfo.isNewer', () {
+    test('remote plus récent (même canal) -> true', () {
+      expect(
+        AppUpdateInfo.isNewer('beta-20260221-1430', 'beta-20260220-0900'),
+        isTrue,
+      );
+      // même jour, heure plus tardive
+      expect(
+        AppUpdateInfo.isNewer('beta-20260221-1430', 'beta-20260221-0900'),
+        isTrue,
+      );
+    });
+
+    test('remote == local -> false', () {
+      expect(
+        AppUpdateInfo.isNewer('release-20260221-1430', 'release-20260221-1430'),
+        isFalse,
+      );
+    });
+
+    test('remote plus ancien -> false', () {
+      expect(
+        AppUpdateInfo.isNewer('beta-20260220-0900', 'beta-20260221-1430'),
+        isFalse,
+      );
+    });
+
+    test('canaux différents (incomparables) -> false', () {
+      expect(
+        AppUpdateInfo.isNewer('release-20260221-1430', 'beta-20260220-0900'),
+        isFalse,
+      );
+      expect(
+        AppUpdateInfo.isNewer('beta-20260221-1430', 'release-20260220-0900'),
+        isFalse,
+      );
+    });
+
+    test('format non conforme -> false', () {
+      // semver
+      expect(AppUpdateInfo.isNewer('1.0.3', '1.0.2'), isFalse);
+      // remote malformé
+      expect(AppUpdateInfo.isNewer('beta-2026-1430', 'beta-20260221-1430'),
+          isFalse);
+      // préfixe inconnu
+      expect(
+        AppUpdateInfo.isNewer('ios-beta-20260221-1430', 'beta-20260220-0900'),
+        isFalse,
+      );
+    });
+
+    test('local vide (dev build) -> false', () {
+      expect(AppUpdateInfo.isNewer('beta-20260221-1430', ''), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## What

Corrige l'affichage du point rouge (update badge) qui ne disparaît pas après l'installation d'une mise à jour via le self-update Android.

## Why

Deux problèmes : (1) le provider app_update n'était pas réinvalidé au retour au premier plan après l'install, et (2) la comparaison de versions était lexicographique brute, ce qui pouvait générer des points rouges fantômes sur des comparaisons ambiguës (canaux différents, formats malformés).

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Maintenance / Refactor

## Changes

- Invalider `appUpdateProvider` au retour au premier plan (quand l'app reprend le focus)
- Parser les tags de version au format `<canal>-YYYYMMDD-HHMM` et comparer les timestamps au lieu de faire une comparaison lexicographique
- Rejeter les comparaisons entre canaux différents ou avec formats malformés (pas de MAJ)
- Tests complets pour le parsing et la comparaison de versions

## Checklist

- [x] Tests pass locally
- [x] Linting passes
- [ ] Deployed to staging
- [ ] Smoke test passed