### PR TITLE
feat(flux): footers d'ouverture de section + réserve fit anti-snap

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Flâner",
+      "summary": "Ouverture des sections plus visible et ajout de sources simplifié."
+    },
+    {
       "tag": "Lettres",
       "summary": "Le rappel des lettres est plus discret, et ta progression ne recule plus une fois une étape franchie."
     },

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -1000,15 +1000,35 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     // déborder » ne doit pas tomber à 1). Borné au pool réel pour ne pas
     // inventer de carte.
     final minCount = math.min(2, s.totalCount);
+    // Certains footers (« Tout lire › » sur digest/source, « Ajouter plus de
+    // sources » replié sur un thème riche) ajoutent de la hauteur **réelle sous
+    // les cartes** que la mesure de snap voit (box.size.height footer inclus).
+    // On la réserve dans le budget pour que l'estimation classe la section comme
+    // la mesure la classera — sinon bascule *tall* parasite (cf. plan snap).
+    final footerReserve = estimateSectionFooterReserve(
+      isDigest: s is DigestTopicSection,
+      isSourceNonEmpty: s is FeedThemeSection &&
+          s.kind == SectionKind.source &&
+          s.items.isNotEmpty,
+      isRichThemeWithSlug: s is FeedThemeSection &&
+          s.kind == SectionKind.theme &&
+          !s.underfilled &&
+          s.themeSlug != null &&
+          s.items.isNotEmpty,
+    );
+    // Crédit de la marge basse de la dernière carte (espace blanc sous le pli,
+    // aucun contenu) : sinon une section reste à N−1 alors qu'une Nᵉ carte tient
+    // à 12px près — cf. kLastCardBottomMargin. **Sauf** quand un footer suit la
+    // dernière carte (footerReserve > 0) : sa marge basse n'est plus sous le pli
+    // (le footer la recouvre), donc pas de crédit.
+    final lastCardMarginCredit =
+        footerReserve > 0 ? 0.0 : kLastCardBottomMargin;
     final fitCap = fitVisibleCount(
-      // Crédit de la marge basse de la dernière carte (espace blanc sous le pli,
-      // aucun contenu) : sinon une section reste à N−1 alors qu'une Nᵉ carte tient
-      // à 12px près — cf. kLastCardBottomMargin.
-      usableHeight: usableHeight + kLastCardBottomMargin,
+      usableHeight: usableHeight + lastCardMarginCredit,
       bannerHeight: hasBlurb ? kBannerHeightWithBlurb : kBannerHeightNoBlurb,
-      // Le footer (gap de fin de section) glisse hors écran au scroll : il ne
-      // doit pas coûter une carte → exclu du budget.
-      footerHeight: 0,
+      // Réserve du footer réel de la section (0 quand aucun footer contenu ne
+      // suit les cartes : seul le gap de fin de section, qui glisse hors écran).
+      footerHeight: footerReserve,
       cardHeight: estimateRegularCardHeight(spec),
       maxCount: maxCount,
       minCount: minCount,

--- a/apps/mobile/lib/features/flux_continu/utils/section_fit.dart
+++ b/apps/mobile/lib/features/flux_continu/utils/section_fit.dart
@@ -65,6 +65,22 @@ const double kBannerHeightWithBlurb = 82;
 /// (SizedBox 16 du SectionBlock).
 const double kSectionFooterHeight = 16;
 
+/// Hauteur réelle (px) réservée par le footer discret « Tout lire › »
+/// (`SectionBlock._seeAllFooter`) rendu en pied des sections **sans** footer
+/// d'ajout de sources (Actus du jour, sources non vides). `TextButton` compact
+/// (`minimumSize` (0, 32)) + marge basse ≈ 36. Doit être **retirée du budget de
+/// fit** : contrairement au gap de fin de section, ce footer porte du contenu
+/// (bouton cliquable) sous les cartes → `_recomputeSnapAnchors` le mesure
+/// (`box.size.height`), donc l'estimation doit l'anticiper sous peine de bascule
+/// *tall* parasite.
+const double kSeeAllFooterHeight = 36;
+
+/// Hauteur réelle (px) réservée par le footer replié « Ajouter plus de sources »
+/// (`EtofferThemeFooter._collapsedButton`) en pied d'un thème riche : bouton
+/// compact (`minimumSize` (0, 30)) + marge basse ≈ 40. Même raison que
+/// [kSeeAllFooterHeight] : mesurée au runtime, donc réservée au fit.
+const double kEtofferCollapsedFooterHeight = 40;
+
 /// Plancher de plausibilité (px) du viewport utile mesuré. En dessous, la mesure
 /// est considérée **non fiable** (mesure transitoire / render box détachée au
 /// moment d'un changement de mode d'affichage ou d'une recompose hors-écran) :
@@ -134,6 +150,31 @@ int fitVisibleCount({
   if (budget <= 0) return lo;
   final fit = (budget / cardHeight).floor();
   return fit.clamp(lo, maxCount);
+}
+
+/// Hauteur (px) que le footer d'une section ajoute **réellement sous les
+/// cartes** — donc à réserver dans le budget de fit pour que l'estimation
+/// (`fitVisibleCount`) et la mesure runtime (`_recomputeSnapAnchors`, qui lit
+/// `box.size.height` footer inclus) s'accordent. Sans cette réserve, une section
+/// que le fit croit *courte* (footer ignoré) est mesurée *tall* (footer
+/// compris) → un point de snap intermédiaire parasite se glisse et le scroll par
+/// snaps se dérègle. Arithmétique pure côté section_fit ; la logique de *type*
+/// (quel footer une section rend) reste côté provider, qui dérive les booléens.
+///
+/// - [isDigest] : Actus du jour → footer « Tout lire › » ([kSeeAllFooterHeight]).
+/// - [isSourceNonEmpty] : section source avec articles → « Tout lire › ».
+/// - [isRichThemeWithSlug] : thème riche (footer replié « Ajouter plus de
+///   sources ») → [kEtofferCollapsedFooterHeight].
+/// - Sinon (thème vide/maigre = footer déplié 0-1 carte, empty-states) → `0` :
+///   la section est courte, le fit n'est pas contraignant.
+double estimateSectionFooterReserve({
+  required bool isDigest,
+  required bool isSourceNonEmpty,
+  required bool isRichThemeWithSlug,
+}) {
+  if (isDigest || isSourceNonEmpty) return kSeeAllFooterHeight;
+  if (isRichThemeWithSlug) return kEtofferCollapsedFooterHeight;
+  return 0;
 }
 
 /// Number of articles the hero card may show so it fits within [usableHeight].

--- a/apps/mobile/lib/features/flux_continu/widgets/etoffer_theme_footer.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/etoffer_theme_footer.dart
@@ -102,14 +102,18 @@ class _EtofferThemeFooterState extends ConsumerState<EtofferThemeFooter> {
   // --- Sous-vues -------------------------------------------------------------
 
   Widget _collapsedButton() {
+    // Rapproché des cartes (marge haute nulle, bouton compact) et rendu plus
+    // discret (police 12, gris atténué, icône « + » plus petite) : c'est un
+    // vecteur de croissance, pas une action proéminente. Libellé générique
+    // (sans le thème) — le contexte de section suffit.
     return Container(
       margin: const EdgeInsets.fromLTRB(12, 0, 12, 4),
       alignment: Alignment.center,
       child: TextButton.icon(
         onPressed: widget.onSearch,
-        icon: const Icon(Icons.add_circle_outline_rounded, size: 15),
-        label: Text('Plus de sources (${widget.label})'),
-        style: _discreetCtaStyle,
+        icon: const Icon(Icons.add_rounded, size: 14),
+        label: const Text('Ajouter plus de sources'),
+        style: _collapsedCtaStyle,
       ),
     );
   }
@@ -312,6 +316,16 @@ class _EtofferThemeFooterState extends ConsumerState<EtofferThemeFooter> {
     padding: const EdgeInsets.symmetric(horizontal: 8),
     minimumSize: const Size(0, 32),
     textStyle: const TextStyle(fontSize: 12.5, fontWeight: FontWeight.w500),
+  );
+
+  /// Variante encore plus discrète et compacte pour le footer **replié**
+  /// « Ajouter plus de sources » (thème riche) : plus proche des cartes, moins
+  /// proéminente que le CTA de recherche du footer déplié.
+  static final _collapsedCtaStyle = TextButton.styleFrom(
+    foregroundColor: const Color(0xFF807E7C),
+    padding: const EdgeInsets.symmetric(horizontal: 8),
+    minimumSize: const Size(0, 30),
+    textStyle: const TextStyle(fontSize: 12, fontWeight: FontWeight.w500),
   );
 
   // --- Action ----------------------------------------------------------------

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -235,6 +235,9 @@ class SectionBlock extends StatelessWidget {
                 onSwipeConversion: onSwipeConversion,
                 onLongPressConversion: onLongPressConversion,
               ),
+          // Actus du jour — pas de footer d'ajout de sources → on re-signale
+          // l'ouverture de la section par un « Tout lire › » discret cliquable.
+          if (onSeeAll != null) _seeAllFooter(),
         ];
       case FeedThemeSection(
           :final items,
@@ -380,8 +383,49 @@ class SectionBlock extends StatelessWidget {
               label: label,
               onSearch: onAddSources,
             ),
+          // Section source non vide — pas de footer « Ajouter plus de sources »
+          // (réservé aux thèmes) → « Tout lire › » discret pour re-signaler
+          // l'ouverture de la page source. Exclut la veille (rendue plus haut).
+          if (section.kind == SectionKind.source && onSeeAll != null)
+            _seeAllFooter(),
         ];
     }
+  }
+
+  /// « Tout lire › » — CTA discret de bas de section, re-signalant l'ouverture
+  /// de la page dédiée sur les sections **sans** footer d'ajout de sources
+  /// (Actus du jour, sources non vides ; les thèmes portent déjà « Ajouter plus
+  /// de sources »). Icône *après* le texte (chevron de progression), donc un
+  /// `Row` explicite plutôt que `TextButton.icon`. Rendu seulement si [onSeeAll]
+  /// est câblé. La hauteur réservée par ce footer est anticipée par le fit
+  /// (`kSeeAllFooterHeight`) pour ne pas dérégler le snap.
+  /// Style du CTA « Tout lire › » — figé en `static final` (et non alloué à
+  /// chaque build) : `SectionBlock` se reconstruit par section à chaque frame
+  /// au scroll, un `styleFrom` inline y rebâtirait le `ButtonStyle` inutilement.
+  static final _seeAllFooterStyle = TextButton.styleFrom(
+    foregroundColor: const Color(0xFF5D5B5A),
+    padding: const EdgeInsets.symmetric(horizontal: 8),
+    minimumSize: const Size(0, 32),
+    textStyle: const TextStyle(fontSize: 12.5, fontWeight: FontWeight.w500),
+  );
+
+  Widget _seeAllFooter() {
+    return Container(
+      margin: const EdgeInsets.fromLTRB(12, 0, 12, 4),
+      alignment: Alignment.center,
+      child: TextButton(
+        onPressed: onSeeAll,
+        style: _seeAllFooterStyle,
+        child: const Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text('Tout lire'),
+            SizedBox(width: 2),
+            Icon(Icons.chevron_right_rounded, size: 16),
+          ],
+        ),
+      ),
+    );
   }
 
   /// Pied d'une section thématique : footer « Étoffer [thème] » (vrai vecteur

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
@@ -1153,9 +1153,11 @@ void main() {
 
         final state = await settle(container);
         final theme = state.sections.whereType<FeedThemeSection>().single;
-        // Normal sur la référence 640 (banner 54, footer 0, +12 crédit marge
-        // basse) : floor((640-54+12)/146)=4, borné [2,4] ⇒ 4.
-        expect(theme.coreVisibleCount, 4);
+        // Normal sur la référence 640. Thème riche 'tech' → réserve du footer
+        // replié « Ajouter plus de sources » (40) au budget (et donc pas de
+        // crédit marge basse, le footer suivant la dernière carte) :
+        // floor((640-54-40)/146)=3, borné [2,4] ⇒ 3.
+        expect(theme.coreVisibleCount, 3);
       },
     );
 
@@ -1234,9 +1236,10 @@ void main() {
 
       final state = await settle(container);
       final theme = state.sections.whereType<FeedThemeSection>().single;
-      // 500px utiles, banner 54, footer 0, +12 crédit marge basse :
-      // floor((500-54+12)/146)=3, borné [2,4] ⇒ 3.
-      expect(theme.coreVisibleCount, 3);
+      // 500px utiles, banner 54. Thème riche 'tech' → réserve du footer replié
+      // « Ajouter plus de sources » (40), pas de crédit marge basse :
+      // floor((500-54-40)/146)=2, borné [2,4] ⇒ 2.
+      expect(theme.coreVisibleCount, 2);
 
       // Dismissing an item routes through _filterSections → copyWith, which must
       // NOT reset the capped coreVisibleCount.
@@ -1245,7 +1248,7 @@ void main() {
 
       final after = container.read(fluxContinuProvider).requireValue;
       final themeAfter = after.sections.whereType<FeedThemeSection>().single;
-      expect(themeAfter.coreVisibleCount, 3);
+      expect(themeAfter.coreVisibleCount, 2);
       expect(themeAfter.items.map((c) => c.id), isNot(contains('x4')));
     });
   });

--- a/apps/mobile/test/features/flux_continu/utils/section_fit_test.dart
+++ b/apps/mobile/test/features/flux_continu/utils/section_fit_test.dart
@@ -72,6 +72,75 @@ void main() {
     });
   });
 
+  group('estimateSectionFooterReserve', () {
+    test('digest → réserve le footer « Tout lire › »', () {
+      expect(
+        estimateSectionFooterReserve(
+          isDigest: true,
+          isSourceNonEmpty: false,
+          isRichThemeWithSlug: false,
+        ),
+        kSeeAllFooterHeight,
+      );
+    });
+
+    test('source non vide → réserve le footer « Tout lire › »', () {
+      expect(
+        estimateSectionFooterReserve(
+          isDigest: false,
+          isSourceNonEmpty: true,
+          isRichThemeWithSlug: false,
+        ),
+        kSeeAllFooterHeight,
+      );
+    });
+
+    test('thème riche → réserve le footer replié « Ajouter plus de sources »',
+        () {
+      expect(
+        estimateSectionFooterReserve(
+          isDigest: false,
+          isSourceNonEmpty: false,
+          isRichThemeWithSlug: true,
+        ),
+        kEtofferCollapsedFooterHeight,
+      );
+    });
+
+    test('aucun footer contenu (empty-state, thème maigre) → 0', () {
+      expect(
+        estimateSectionFooterReserve(
+          isDigest: false,
+          isSourceNonEmpty: false,
+          isRichThemeWithSlug: false,
+        ),
+        0,
+      );
+    });
+
+    test('réserver le footer retire une carte au seuil (bascule 3 → 2)', () {
+      // no-blurb chrome 54 + 3·146 = 492. À usable = 495 le fit tient 3 cartes
+      // SANS footer, mais le footer « Tout lire › » (36) fait déborder → 2.
+      const usable = 495.0;
+      final withoutFooter = fitVisibleCount(
+        usableHeight: usable,
+        bannerHeight: kBannerHeightNoBlurb,
+        footerHeight: 0,
+        cardHeight: kRegularCardHeight,
+        maxCount: 3,
+      );
+      final withFooter = fitVisibleCount(
+        usableHeight: usable,
+        bannerHeight: kBannerHeightNoBlurb,
+        footerHeight: kSeeAllFooterHeight,
+        cardHeight: kRegularCardHeight,
+        maxCount: 3,
+      );
+      expect(withoutFooter, 3);
+      expect(withFooter, 2);
+    });
+  });
+
   group('fitHeroCount', () {
     int fit(double usable, {int maxCount = 5, int minCount = 1}) =>
         fitHeroCount(

--- a/apps/mobile/test/features/flux_continu/widgets/etoffer_theme_footer_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/etoffer_theme_footer_test.dart
@@ -140,7 +140,7 @@ void main() {
     expect(find.text('Chercher une source Tech'), findsOneWidget);
   });
 
-  testWidgets('Cas A — replié : bouton « Plus de sources (Tech) » '
+  testWidgets('Cas A — replié : bouton « Ajouter plus de sources » '
       'seul, tap → onSearch (catalogue filtré), pas de dépli in-place',
       (tester) async {
     var searched = false;
@@ -159,13 +159,15 @@ void main() {
     ));
     await tester.pump();
 
-    // Replié : ni recherche, ni source — juste le bouton renommé.
-    expect(find.text('Plus de sources (Tech)'), findsOneWidget);
+    // Replié : ni recherche, ni source — juste le bouton renommé (générique,
+    // sans le libellé du thème).
+    expect(find.text('Ajouter plus de sources'), findsOneWidget);
+    expect(find.text('Plus de sources (Tech)'), findsNothing);
     expect(find.text('Étoffer Tech'), findsNothing);
     expect(find.text('Chercher une source Tech'), findsNothing);
     expect(find.text('Heidi.news'), findsNothing);
 
-    await tester.tap(find.text('Plus de sources (Tech)'));
+    await tester.tap(find.text('Ajouter plus de sources'));
     await tester.pumpAndSettle();
 
     // Plus de dépli in-place : l'action mène au catalogue via onSearch.

--- a/apps/mobile/test/features/flux_continu/widgets/section_block_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/section_block_test.dart
@@ -118,9 +118,11 @@ FeedThemeSection _sourceSection({
   );
 }
 
-/// Finder du chevron « > » de navigation, rendu comme glyphe texte intégré au
-/// titre du banner (Text.rich) plutôt qu'une icône Phosphor.
-Finder _chevron() => find.textContaining('>', findRichText: true);
+/// Finder du chevron de navigation, désormais rendu comme **icône** Phosphor
+/// (`caretRight` bold) en WidgetSpan dans le titre du banner — le glyphe texte
+/// « > » historique héritait d'une baseline décalée (cf. section_banner.dart).
+Finder _chevron() =>
+    find.byIcon(PhosphorIcons.caretRight(PhosphorIconsStyle.bold));
 
 void main() {
   setUpAll(() {
@@ -242,8 +244,10 @@ void main() {
       expect(find.byType(FluxContinuArticleCard), findsOneWidget);
       // Le footer « riche » reste replié : un simple bouton renommé qui mène
       // droit au catalogue filtré (plus de dépli in-place).
-      expect(find.text('Plus de sources (Tech)'), findsOneWidget);
+      expect(find.text('Ajouter plus de sources'), findsOneWidget);
       expect(find.text('Chercher une source Tech'), findsNothing);
+      // Thème → pas de « Tout lire › » (il porte déjà le footer d'ajout).
+      expect(find.textContaining('Tout lire'), findsNothing);
     });
   });
 
@@ -417,6 +421,79 @@ void main() {
 
       expect(_chevron(), findsNothing);
       expect(find.textContaining('+4'), findsNothing);
+    });
+  });
+
+  group('SectionBlock — « Tout lire › » (sections sans footer d\'ajout)', () {
+    testWidgets('Actus du jour rend « Tout lire › » cliquable → onSeeAll',
+        (tester) async {
+      var opened = false;
+      await tester.pumpWidget(_wrap(
+        SectionBlock(
+          section: _digestTopicSection(topics: 5, coreVisibleCount: 3),
+          onTapArticle: (_) {},
+          onSeeAll: () => opened = true,
+        ),
+      ));
+
+      expect(find.text('Tout lire'), findsOneWidget);
+      await tester.tap(find.text('Tout lire'));
+      await tester.pumpAndSettle();
+      expect(opened, isTrue);
+    });
+
+    testWidgets('section source non vide rend « Tout lire › »', (tester) async {
+      await tester.pumpWidget(_wrap(
+        SectionBlock(
+          section: _sourceSection(items: 3),
+          onTapArticle: (_) {},
+          onSeeAll: () {},
+        ),
+      ));
+
+      expect(find.text('Tout lire'), findsOneWidget);
+    });
+
+    testWidgets('section source vide (empty-state) : pas de « Tout lire › » '
+        '(le CTA curation le remplace)', (tester) async {
+      await tester.pumpWidget(_wrap(
+        SectionBlock(
+          section: _sourceSection(items: 0),
+          onTapArticle: (_) {},
+          onSeeAll: () {},
+        ),
+      ));
+
+      expect(find.text('Tout lire'), findsNothing);
+      expect(find.text('Voir toute la curation'), findsOneWidget);
+    });
+
+    testWidgets('thème riche : pas de « Tout lire › » (footer d\'ajout déjà là)',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        SectionBlock(
+          section: _themeSection(items: 7, coreVisibleCount: 3),
+          onTapArticle: (_) {},
+          onSeeAll: () {},
+          onAddSources: () {},
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Tout lire'), findsNothing);
+      expect(find.text('Ajouter plus de sources'), findsOneWidget);
+    });
+
+    testWidgets('sans onSeeAll : pas de « Tout lire › » sur digest',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        SectionBlock(
+          section: _digestTopicSection(topics: 5, coreVisibleCount: 3),
+          onTapArticle: (_) {},
+        ),
+      ));
+
+      expect(find.textContaining('Tout lire'), findsNothing);
     });
   });
 


### PR DESCRIPTION
## Quoi
Rend l'ouverture des sections du Flâner plus visible et simplifie l'ajout de sources :
- « Tout lire › » discret cliquable en pied des sections **sans** footer d'ajout (Actus du jour, sources non vides) ;
- footer replié « **Ajouter plus de sources** » (libellé générique, plus compact et discret) sur les thèmes riches ;
- **réserve fit** : la hauteur réelle de ces footers est réservée dans le budget de fit (`estimateSectionFooterReserve`) pour que l'estimation s'accorde à la mesure runtime de snap.

## Pourquoi
Les footers portent du contenu **sous** les cartes que `_recomputeSnapAnchors` mesure (`box.size.height` footer inclus). Sans réserve, une section que le fit croit *courte* était mesurée *tall* → point de snap intermédiaire parasite et scroll par snaps déréglé.

## Comment ça a été vérifié
- [x] `flutter test` sur les fichiers touchés (fit / section_block / etoffer_footer / provider) — All tests passed
- [x] `flutter analyze` sur le code modifié — No issues found
- [x] `/simplify` passé (style CTA figé en `static final` anti-réalloc/build ; crédit marge nommé)
- [ ] Playwright : non exécuté (polish visuel bas de section, couvert par les widget tests)

## Zones à risque
- `flux_continu` fit/snap : la réserve de footer et le crédit de marge basse influent sur `coreVisibleCount` (tests provider mis à jour). Décision de *type* de footer dupliquée provider↔widget (documentée) — candidate à un `SectionFooter` enum en follow-up.