### PR TITLE
feat(mobile): reader — modal collections instantanée + badge tournesol + retour WebView

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Lecture",
+      "summary": "Le navigateur intégré garde ta navigation : un retour arrière remonte les pages visitées au lieu de te renvoyer au feed. Le choix des collections s'ouvre instantanément, et le bouton tournesol indique mieux qu'il partage l'article."
+    },
+    {
       "tag": "Lettres",
       "summary": "Le rappel des lettres est plus discret, et ta progression ne recule plus une fois une étape franchie."
     },

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -873,6 +873,34 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     _scrollController.jumpTo(0);
   }
 
+  /// Gère le retour arrière du reader (bouton header + bouton système Android).
+  ///
+  /// En mode WebView, on remonte d'abord l'historique interne du navigateur
+  /// (l'utilisateur a pu suivre des liens dans la page) : un retour ne quitte
+  /// le WebView vers le reader que lorsqu'on est revenu sur la page d'origine.
+  /// Hors WebView, on ferme l'écran normalement (retour au feed).
+  Future<void> _handleReaderBack() async {
+    if (!_isWebViewActive) {
+      if (mounted) context.pop(_content);
+      return;
+    }
+    // `_premiumWebController` n'est renseigné que sur le chemin premium
+    // (flutter_inappwebview) ; sinon on est sur le WebView gratuit
+    // (webview_flutter). Les deux exposent canGoBack()/goBack() mais sans
+    // interface commune (packages distincts) : on capture le contrôleur actif
+    // via ses deux méthodes pour n'avoir qu'un seul chemin de retour.
+    final premium = _premiumWebController;
+    final free = _webViewController;
+    final Future<bool> Function()? canGoBack =
+        premium?.canGoBack ?? free?.canGoBack;
+    final Future<void> Function()? goBack = premium?.goBack ?? free?.goBack;
+    if (canGoBack != null && await canGoBack()) {
+      await goBack!();
+      return;
+    }
+    if (mounted) _exitWebViewMode();
+  }
+
   /// Scroll listener driving WebView activation.
   void _onScrollToSite() {
     if (!_ctaTapped || !_offsetsComputed) return;
@@ -1173,6 +1201,17 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       _content = content.copyWith(isSaved: newSaved);
     });
 
+    // Ouverture immédiate de la modal au save (pas à l'unsave), sans attendre
+    // les appels réseau : la sheet lit les collections déjà en cache. Le
+    // toggleSave + l'ajout à la collection par défaut se poursuivent en fond.
+    if (newSaved) {
+      CollectionPickerSheet.show(
+        context,
+        content.id,
+        onAddNote: () => _openNoteSheet(),
+      );
+    }
+
     try {
       final supabase = Supabase.instance.client;
       final apiClient = ApiClient(supabase);
@@ -1187,11 +1226,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           ref.invalidate(collectionsProvider);
           unawaited(ref.read(lettersProvider.notifier).silentRefresh());
         }
-        CollectionPickerSheet.show(
-          context,
-          content.id,
-          onAddNote: () => _openNoteSheet(),
-        );
       }
     } catch (e) {
       // Rollback on error
@@ -1847,131 +1881,142 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       return _buildWebOpenPrompt(context, content);
     }
 
-    return Scaffold(
-      backgroundColor: colors.backgroundPrimary,
-      body: AnimatedBuilder(
-        animation: _exitAnimController,
-        builder: (context, child) {
-          final scale = 1.0 - 0.03 * _exitAnimController.value;
-          return Transform.scale(
-            scale: _isExitAnimating ? scale : 1.0,
-            child: child,
-          );
-        },
-        child: Stack(
-          children: [
-            NotificationListener<ScrollNotification>(
-              onNotification: (notification) {
-                if (notification is ScrollUpdateNotification) {
-                  final delta = notification.scrollDelta ?? 0.0;
-                  final metrics = notification.metrics;
-                  if (metrics.pixels <= 0 &&
-                      !_isWebViewActive &&
-                      !_footerRevealLocked) {
-                    _footerOffset.value = 0.0;
-                  }
+    return PopScope(
+      // En mode WebView, on intercepte le retour système pour remonter
+      // l'historique interne du navigateur avant de quitter vers le reader.
+      canPop: !_isWebViewActive,
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) return;
+        _handleReaderBack();
+      },
+      child: Scaffold(
+        backgroundColor: colors.backgroundPrimary,
+        body: AnimatedBuilder(
+          animation: _exitAnimController,
+          builder: (context, child) {
+            final scale = 1.0 - 0.03 * _exitAnimController.value;
+            return Transform.scale(
+              scale: _isExitAnimating ? scale : 1.0,
+              child: child,
+            );
+          },
+          child: Stack(
+            children: [
+              NotificationListener<ScrollNotification>(
+                onNotification: (notification) {
+                  if (notification is ScrollUpdateNotification) {
+                    final delta = notification.scrollDelta ?? 0.0;
+                    final metrics = notification.metrics;
+                    if (metrics.pixels <= 0 &&
+                        !_isWebViewActive &&
+                        !_footerRevealLocked) {
+                      _footerOffset.value = 0.0;
+                    }
 
-                  _onScrollDelta(delta);
-                  // Track reading progress from any scrollable (including in-app reader)
-                  if (metrics.maxScrollExtent > 0) {
-                    final rawProgress =
-                        metrics.pixels / metrics.maxScrollExtent;
-                    // Footer becomes permanent at end of ALL content (incl.
-                    // perspectives) for native in-app reading. Skip for
-                    // scroll-to-site (CTA tapped) where reaching the end means
-                    // revealing the WebView, not finishing reading — locking
-                    // the footer there would freeze it visible during the
-                    // entire WebView session.
-                    if (!_footerPermanent.value &&
-                        !_ctaTapped &&
-                        rawProgress >= 0.98) {
-                      _footerPermanent.value = true;
-                      _animateFooterTo(0.0);
-                    }
-                    // Progress bar uses article-only extent so perspectives don't dilute it
-                    final articleExtent =
-                        _articleContentExtent ?? metrics.maxScrollExtent;
-                    final barProgress = metrics.pixels / articleExtent;
-                    final capped = _isPartialContent
-                        ? (barProgress * 0.25).clamp(0.0, 0.25)
-                        : barProgress.clamp(0.0, 1.0);
-                    _readingProgress.value = capped;
-                    if (capped > _maxReadingProgress) {
-                      _maxReadingProgress = capped;
+                    _onScrollDelta(delta);
+                    // Track reading progress from any scrollable (including in-app reader)
+                    if (metrics.maxScrollExtent > 0) {
+                      final rawProgress =
+                          metrics.pixels / metrics.maxScrollExtent;
+                      // Footer becomes permanent at end of ALL content (incl.
+                      // perspectives) for native in-app reading. Skip for
+                      // scroll-to-site (CTA tapped) where reaching the end means
+                      // revealing the WebView, not finishing reading — locking
+                      // the footer there would freeze it visible during the
+                      // entire WebView session.
+                      if (!_footerPermanent.value &&
+                          !_ctaTapped &&
+                          rawProgress >= 0.98) {
+                        _footerPermanent.value = true;
+                        _animateFooterTo(0.0);
+                      }
+                      // Progress bar uses article-only extent so perspectives don't dilute it
+                      final articleExtent =
+                          _articleContentExtent ?? metrics.maxScrollExtent;
+                      final barProgress = metrics.pixels / articleExtent;
+                      final capped = _isPartialContent
+                          ? (barProgress * 0.25).clamp(0.0, 0.25)
+                          : barProgress.clamp(0.0, 1.0);
+                      _readingProgress.value = capped;
+                      if (capped > _maxReadingProgress) {
+                        _maxReadingProgress = capped;
+                      }
                     }
                   }
-                }
-                return false;
-              },
-              child: Positioned.fill(
-                child: isVideoContent
-                    ? _buildVideoContent(context, content)
-                    : useScrollToSite
-                        ? _buildScrollToSiteContent(context, content)
-                        : useInAppReading
-                            ? _buildInAppContent(context, content)
-                            : _buildWebViewFallback(
-                                content,
-                                isConnectedPremiumSource:
-                                    isConnectedPremiumSource,
-                              ),
+                  return false;
+                },
+                child: Positioned.fill(
+                  child: isVideoContent
+                      ? _buildVideoContent(context, content)
+                      : useScrollToSite
+                          ? _buildScrollToSiteContent(context, content)
+                          : useInAppReading
+                              ? _buildInAppContent(context, content)
+                              : _buildWebViewFallback(
+                                  content,
+                                  isConnectedPremiumSource:
+                                      isConnectedPremiumSource,
+                                ),
+                ),
               ),
-            ),
-            // Header — pinned at the top of the screen; no scroll-driven
-            // translation. Earlier iterations slid the header up/down on
-            // scroll but the result felt unstable in the WebView, so the
-            // header is now permanently visible.
-            Positioned(
-              top: 0,
-              left: 0,
-              right: 0,
-              child: RepaintBoundary(child: _buildHeader(context, content)),
-            ),
-            // Reading progress bar — pinned right below the header.
-            if (content.hasInAppContent ||
-                _isWebViewActive ||
-                isVideoContent ||
-                (!useScrollToSite && !useInAppReading))
+              // Header — pinned at the top of the screen; no scroll-driven
+              // translation. Earlier iterations slid the header up/down on
+              // scroll but the result felt unstable in the WebView, so the
+              // header is now permanently visible.
               Positioned(
-                top: MediaQuery.of(context).padding.top + _kHeaderVisualBottom,
+                top: 0,
                 left: 0,
                 right: 0,
-                child: RepaintBoundary(child: _buildReadingProgressBar(colors)),
+                child: RepaintBoundary(child: _buildHeader(context, content)),
               ),
-            // Exit animation overlay — fade-to-white + scale-down
-            if (_isExitAnimating)
-              AnimatedBuilder(
-                animation: _exitAnimController,
-                builder: (context, _) {
-                  return Positioned.fill(
-                    child: IgnorePointer(
-                      child: ColoredBox(
-                        color: Colors.white.withValues(
-                          alpha: 0.6 * _exitAnimController.value,
+              // Reading progress bar — pinned right below the header.
+              if (content.hasInAppContent ||
+                  _isWebViewActive ||
+                  isVideoContent ||
+                  (!useScrollToSite && !useInAppReading))
+                Positioned(
+                  top:
+                      MediaQuery.of(context).padding.top + _kHeaderVisualBottom,
+                  left: 0,
+                  right: 0,
+                  child:
+                      RepaintBoundary(child: _buildReadingProgressBar(colors)),
+                ),
+              // Exit animation overlay — fade-to-white + scale-down
+              if (_isExitAnimating)
+                AnimatedBuilder(
+                  animation: _exitAnimController,
+                  builder: (context, _) {
+                    return Positioned.fill(
+                      child: IgnorePointer(
+                        child: ColoredBox(
+                          color: Colors.white.withValues(
+                            alpha: 0.6 * _exitAnimController.value,
+                          ),
                         ),
                       ),
-                    ),
-                  );
-                },
+                    );
+                  },
+                ),
+              // Footer — always rendered, mirrors header slide behavior.
+              // Article: full layout. Video/audio: external CTA + bookmark + sunflower.
+              Positioned(
+                bottom: 0,
+                left: 0,
+                right: 0,
+                child: _buildContentFooter(
+                  context,
+                  content,
+                  isPureWebview:
+                      _showWebView && !useScrollToSite && !useInAppReading,
+                ),
               ),
-            // Footer — always rendered, mirrors header slide behavior.
-            // Article: full layout. Video/audio: external CTA + bookmark + sunflower.
-            Positioned(
-              bottom: 0,
-              left: 0,
-              right: 0,
-              child: _buildContentFooter(
-                context,
-                content,
-                isPureWebview:
-                    _showWebView && !useScrollToSite && !useInAppReading,
-              ),
-            ),
-          ],
+            ],
+          ),
         ),
+        // All actions migrated to the persistent footer (article + video/audio).
+        floatingActionButton: null,
       ),
-      // All actions migrated to the persistent footer (article + video/audio).
-      floatingActionButton: null,
     );
   }
 
@@ -2322,22 +2367,52 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                   ),
 
                   // 🌻 Recommander
-                  ScaleTransition(
-                    scale: _likeScaleAnimation,
-                    child: IconButton(
-                      style: iconButtonStyle.copyWith(
-                        backgroundColor: content.isLiked
-                            ? WidgetStatePropertyAll(colors.primary)
-                            : null,
+                  Stack(
+                    clipBehavior: Clip.none,
+                    children: [
+                      ScaleTransition(
+                        scale: _likeScaleAnimation,
+                        child: IconButton(
+                          style: iconButtonStyle.copyWith(
+                            backgroundColor: content.isLiked
+                                ? WidgetStatePropertyAll(colors.primary)
+                                : null,
+                          ),
+                          onPressed: _toggleLike,
+                          icon: SunflowerIcon(
+                            isActive: content.isLiked,
+                            size: 26,
+                            inactiveColor: colors.textSecondary,
+                          ),
+                          tooltip: 'Recommander',
+                        ),
                       ),
-                      onPressed: _toggleLike,
-                      icon: SunflowerIcon(
-                        isActive: content.isLiked,
-                        size: 26,
-                        inactiveColor: colors.textSecondary,
+                      // Petit glyphe « republier » (style retweet) pour signifier
+                      // que le tournesol partage l'article aux autres lecteurs.
+                      // Purement décoratif, toujours visible, ne capte pas le tap.
+                      Positioned(
+                        right: 2,
+                        bottom: 2,
+                        child: IgnorePointer(
+                          child: Container(
+                            padding: const EdgeInsets.all(2),
+                            decoration: BoxDecoration(
+                              color: content.isLiked
+                                  ? colors.primary
+                                  : colors.backgroundSecondary,
+                              shape: BoxShape.circle,
+                            ),
+                            child: Icon(
+                              PhosphorIcons.repeat(PhosphorIconsStyle.bold),
+                              size: 11,
+                              color: content.isLiked
+                                  ? Colors.white
+                                  : colors.textSecondary,
+                            ),
+                          ),
+                        ),
                       ),
-                      tooltip: 'Recommander',
-                    ),
+                    ],
                   ),
                 ],
               ),
@@ -2460,9 +2535,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                     size: 16,
                     color: colors.textSecondary,
                   ),
-                  onPressed: _isWebViewActive
-                      ? _exitWebViewMode
-                      : () => context.pop(_content),
+                  onPressed: _handleReaderBack,
                 ),
                 const SizedBox(width: 4),
 

--- a/apps/mobile/lib/features/saved/widgets/collection_picker_sheet.dart
+++ b/apps/mobile/lib/features/saved/widgets/collection_picker_sheet.dart
@@ -183,24 +183,8 @@ class _CollectionPickerSheetState extends ConsumerState<CollectionPickerSheet>
             // Divider
             Divider(color: colors.border.withOpacity(0.3)),
 
-            // Collections list
-            collectionsAsync.when(
-              data: (collections) {
-                _preSelectDefault(collections);
-                return _buildCollectionsList(collections, colors);
-              },
-              loading: () => const Padding(
-                padding: EdgeInsets.all(24),
-                child: Center(child: CircularProgressIndicator.adaptive()),
-              ),
-              error: (_, __) => Padding(
-                padding: const EdgeInsets.all(24),
-                child: Text(
-                  'Erreur de chargement',
-                  style: TextStyle(color: colors.textSecondary),
-                ),
-              ),
-            ),
+            // Collections list (voir _buildCollectionsSection).
+            _buildCollectionsSection(collectionsAsync, colors),
 
             // Confirm button
             if (_selectedIds.isNotEmpty) ...[
@@ -308,6 +292,40 @@ class _CollectionPickerSheetState extends ConsumerState<CollectionPickerSheet>
           constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
         ),
       ],
+    );
+  }
+
+  /// Section liste des collections.
+  ///
+  /// Ouverture instantanée : le provider est gardé en cache (pas d'autoDispose),
+  /// donc on rend d'abord la dernière liste connue (`valueOrNull`, préservée
+  /// pendant un refresh) au lieu d'un spinner plein écran. Le loader n'apparaît
+  /// que si aucune donnée n'a jamais été chargée.
+  ///
+  /// Appel *synchrone* (et non un `Builder`) pour que `_preSelectDefault`
+  /// s'exécute pendant le build parent, avant l'évaluation du bouton
+  /// « Confirmer » plus bas (qui dépend de `_selectedIds`).
+  Widget _buildCollectionsSection(
+    AsyncValue<List<Collection>> collectionsAsync,
+    FacteurColors colors,
+  ) {
+    final cached = collectionsAsync.valueOrNull;
+    if (cached != null) {
+      _preSelectDefault(cached);
+      return _buildCollectionsList(cached, colors);
+    }
+    if (collectionsAsync.hasError) {
+      return Padding(
+        padding: const EdgeInsets.all(24),
+        child: Text(
+          'Erreur de chargement',
+          style: TextStyle(color: colors.textSecondary),
+        ),
+      );
+    }
+    return const Padding(
+      padding: EdgeInsets.all(24),
+      child: Center(child: CircularProgressIndicator.adaptive()),
     );
   }
 

--- a/docs/maintenance/maintenance-reader-improvements.md
+++ b/docs/maintenance/maintenance-reader-improvements.md
@@ -1,0 +1,80 @@
+# Maintenance — Évolutions Reader (collections, tournesol, retour WebView)
+
+> Type : Maintenance (UX + perf). Cible : `main` (staging). Mobile-only + 1 refacto SQL additif backend.
+
+## Contexte
+
+Trois évolutions du Reader (`content_detail_screen.dart`) demandées par le PO, plus
+une vérification légale traitée à part (voir
+[maintenance-rss-no-scraping-verdict.md](maintenance-rss-no-scraping-verdict.md)).
+
+## 1. Ouverture instantanée de la modal Collections
+
+**Symptôme** : au clic sur le bookmark, la sheet `CollectionPickerSheet` met un temps
+visible à s'afficher.
+
+**Racines** :
+1. `_toggleBookmark()` attendait `toggleSave` **puis** `addToCollection` **avant**
+   d'ouvrir la sheet (2 allers-retours réseau bloquants).
+2. `GET /collections/` recalculait, **par collection**, un `item_count` **et** un
+   `read_count` (jointure sur `UserContentStatus`) → `2N` requêtes.
+3. La sheet affichait un spinner plein écran pendant le refetch (le provider est
+   invalidé juste avant l'ouverture).
+
+**Fix** :
+- **Mobile** (`content_detail_screen.dart`) : au save, la modal s'ouvre
+  **immédiatement**, avant les appels réseau (poursuivis en fond). L'ouverture au
+  long-press était déjà instantanée.
+- **Mobile** (`collection_picker_sheet.dart`) : `_buildCollectionsSection` rend la
+  dernière liste connue via `valueOrNull` (le provider n'est pas `autoDispose`, la
+  donnée précédente est préservée pendant le refresh). Loader uniquement si aucune
+  donnée n'a jamais été chargée. Appel **synchrone** (pas un `Builder`) pour que
+  `_preSelectDefault` mute `_selectedIds` avant l'évaluation du bouton « Confirmer »
+  (sinon régression : bouton absent — couvert par
+  `collection_picker_sheet_test.dart`).
+- **Backend** (`collection_service.list_collections`) : les 2 comptages passent de
+  `2N` requêtes à **2 requêtes agrégées `GROUP BY`**. `read_count` est **conservé**
+  (il alimente les badges « X non lus » de l'écran Sauvegardés —
+  `saved_screen.dart`, `collection_grid_cell.dart`). Réponse API inchangée
+  (additif, aucune migration).
+
+## 2. Badge « republier » sur le bouton Tournesol
+
+Le bouton 🌻 « Recommander » reçoit un petit glyphe `PhosphorIcons.repeat` (style
+retweet) en `Positioned(bottom, right)` dans un `Stack`, sous `IgnorePointer`
+(purement décoratif, toujours visible, ne capte pas le tap). Couleur adaptée à
+l'état liké. Objectif : faire comprendre que le tournesol partage l'article aux
+autres lecteurs.
+
+## 3. Retour arrière DANS le WebView
+
+**Avant** : en mode WebView, le retour (bouton header + retour système) appelait
+`_exitWebViewMode()` / `context.pop()` → sortie immédiate vers le reader/feed, même
+après avoir suivi des liens dans la page.
+
+**Fix** : nouveau `_handleReaderBack()` :
+- hors WebView → `context.pop(_content)` (comportement inchangé) ;
+- en WebView → `canGoBack()` → `goBack()` sur le contrôleur actif, sinon
+  `_exitWebViewMode()`.
+
+Couvre les **deux** WebViews : `_premiumWebController` (flutter_inappwebview, chemin
+premium) testé en premier — il n'est renseigné que sur ce chemin ; sinon
+`_webViewController` (webview_flutter, sources gratuites, toujours pré-créé).
+
+Branché sur (a) le bouton retour du header et (b) un `PopScope` racine
+(`canPop: !_isWebViewActive`, `onPopInvokedWithResult`) pour intercepter le bouton
+retour système Android.
+
+## Tests / vérifs
+
+- `flutter analyze` (2 fichiers) : 0 erreur / 0 warning (infos de style pré-existantes).
+- `flutter test collection_picker_sheet_test.dart` : vert (régression `Builder`
+  détectée et corrigée).
+- Backend : `py_compile` + `ruff check` (0.15.14) OK ; tests DB en CI (pas de DB
+  test en Conductor).
+- Changelog : entrée `unreleased` « Lecture » ajoutée.
+
+## À valider on-device (post-merge)
+
+- Retour arrière WebView après navigation multi-pages (gratuit + premium).
+- `PopScope` Android : geste retour système remonte bien l'historique WebView.

--- a/docs/maintenance/maintenance-rss-no-scraping-verdict.md
+++ b/docs/maintenance/maintenance-rss-no-scraping-verdict.md
@@ -1,0 +1,50 @@
+# Maintenance — Vérification légale : ingestion RSS, pas de scraping
+
+> Type : Maintenance (investigation, **aucun code**). Question du PO : le corps
+> complet de certains articles (ex. The Conversation) s'affiche dans le reader
+> Facteur — est-ce du scraping illégal ?
+
+## Verdict : RSS-only, aucun scraping d'article
+
+Le backend **n'extrait jamais** le texte d'article depuis la page web. Tout le
+contenu affiché provient **exclusivement du flux RSS/Atom fourni par l'éditeur
+lui-même**.
+
+## Preuves
+
+1. **Peuplement de `Content.html_content`** — `sync_service.py` (~l.388-399) : la
+   valeur vient **uniquement** de `entry.content` (`content:encoded` en RSS, full
+   content en Atom) ou `entry.summary`, tous deux des champs `feedparser` du flux.
+   Aucune ligne ne fetch l'URL de l'article pour en extraire le corps.
+
+2. **Seul fetch vers l'URL de l'article** — `_fetch_html_head()`
+   (`sync_service.py` ~l.500-519) : **50 KB max** (`Range: bytes=0-50000`), utilisé
+   **uniquement** pour la détection de paywall (JSON-LD `isAccessibleForFree`,
+   meta `og:article:content_tier`). Le résultat n'est **ni stocké ni affiché**.
+
+3. **BeautifulSoup** (`requirements.txt`) sert **seulement à la découverte de flux
+   RSS** (`rss_parser.py` : scan des `<link rel="alternate">` / `<a href>`), jamais
+   à extraire du contenu d'article. Aucune lib d'extraction full-text
+   (trafilatura, newspaper, goose, readability, justext) n'est présente.
+
+4. **Aucun worker/cron d'enrichissement** de corps post-ingestion (workers/, jobs/,
+   tasks/ audités).
+
+## Pourquoi The Conversation s'affiche en entier
+
+The Conversation **publie volontairement le full-text dans son RSS** (contenu sous
+licence Creative Commons, republication explicitement encouragée). Facteur ne fait
+que rendre ce que l'éditeur diffuse dans son propre flux.
+
+## Question résiduelle (produit/légal, hors scope technique)
+
+Il ne s'agit **pas** d'un problème de scraping (inexistant), mais d'un choix
+produit : republier inline le full-text RSS de **toutes** les sources — y compris
+celles qui le mettent en RSS sans souhaiter un réaffichage sans leur habillage.
+
+Piste éventuelle si on veut durcir la posture (option « B » écartée par le PO le
+2026-07-02, à replanifier si besoin) : n'afficher inline le full-text que pour les
+sources l'autorisant (flag `source.allow_full_reader` / allowlist type CC), sinon
+teaser + « Lire sur le site ». Migration additive requise.
+
+**Décision du 2026-07-02** : ne rien coder, documenter le verdict (ce fichier).

--- a/packages/api/app/services/collection_service.py
+++ b/packages/api/app/services/collection_service.py
@@ -115,19 +115,25 @@ class CollectionService:
         result = await self.session.execute(stmt)
         collections = result.scalars().all()
 
-        response = []
-        for col in collections:
-            # Count items
-            count_stmt = (
-                select(func.count())
-                .select_from(CollectionItem)
-                .where(CollectionItem.collection_id == col.id)
-            )
-            item_count = await self.session.scalar(count_stmt) or 0
+        col_ids = [col.id for col in collections]
 
-            # Count read items
+        # Comptages agrégés en 2 requêtes (au lieu de 2 requêtes par collection)
+        # pour tenir l'ouverture instantanée de la modal de collections côté
+        # mobile. `item_count` sert au picker ; `read_count` alimente les badges
+        # « X non lus » de l'écran Sauvegardés (conservé).
+        item_counts: dict[UUID, int] = {}
+        read_counts: dict[UUID, int] = {}
+        if col_ids:
+            item_stmt = (
+                select(CollectionItem.collection_id, func.count())
+                .where(CollectionItem.collection_id.in_(col_ids))
+                .group_by(CollectionItem.collection_id)
+            )
+            for cid, cnt in (await self.session.execute(item_stmt)).all():
+                item_counts[cid] = cnt or 0
+
             read_stmt = (
-                select(func.count())
+                select(CollectionItem.collection_id, func.count())
                 .select_from(CollectionItem)
                 .join(
                     UserContentStatus,
@@ -135,11 +141,18 @@ class CollectionService:
                     & (UserContentStatus.user_id == user_id),
                 )
                 .where(
-                    CollectionItem.collection_id == col.id,
+                    CollectionItem.collection_id.in_(col_ids),
                     UserContentStatus.status == ContentStatus.CONSUMED,
                 )
+                .group_by(CollectionItem.collection_id)
             )
-            read_count = await self.session.scalar(read_stmt) or 0
+            for cid, cnt in (await self.session.execute(read_stmt)).all():
+                read_counts[cid] = cnt or 0
+
+        response = []
+        for col in collections:
+            item_count = item_counts.get(col.id, 0)
+            read_count = read_counts.get(col.id, 0)
 
             # Get 4 most recent thumbnails for mosaic
             thumb_stmt = (


### PR DESCRIPTION
## Quoi

Trois évolutions du Reader (`content_detail_screen`) + un refacto SQL additif backend.

### 1. Ouverture instantanée de la modal Collections
- **Mobile** : au save, la sheet `CollectionPickerSheet` s'ouvre **immédiatement**, avant les appels réseau (poursuivis en fond). `_buildCollectionsSection` rend la dernière liste connue via `valueOrNull` (provider non `autoDispose`) au lieu d'un spinner plein écran ; appel **synchrone** (pas un `Builder`) pour que `_preSelectDefault` mute `_selectedIds` avant l'évaluation du bouton « Confirmer » (régression couverte par `collection_picker_sheet_test.dart`).
- **Backend** (`collection_service.list_collections`) : les comptages passent de **2N → 2 requêtes agrégées `GROUP BY`**. `read_count` **conservé** (badges « X non lus » de l'écran Sauvegardés). Réponse API inchangée, **additif, aucune migration**.

### 2. Badge « republier » sur le bouton 🌻 Recommander
Glyphe `PhosphorIcons.repeat` (style retweet) en `Positioned` dans un `Stack`, sous `IgnorePointer` (décoratif, ne capte pas le tap). Signifie que le tournesol partage l'article aux autres lecteurs.

### 3. Retour arrière DANS le WebView
`_handleReaderBack()` : hors WebView → `context.pop(_content)` ; en WebView → `canGoBack()`/`goBack()` du contrôleur actif (premium `flutter_inappwebview` ou gratuit `webview_flutter`), sinon `_exitWebViewMode()`. Branché sur le bouton retour du header **et** un `PopScope` racine (`canPop: !_isWebViewActive`) pour intercepter le retour système Android.

## Pourquoi
Latence visible à l'ouverture de la modal collections (2 allers-retours réseau bloquants + 2N requêtes backend + spinner au refetch) ; le retour arrière quittait le WebView même après navigation multi-pages ; le tournesol ne communiquait pas son rôle de partage. Cf. `docs/maintenance/maintenance-reader-improvements.md`.

## Comment ça a été vérifié
- [x] `collection_picker_sheet_test.dart` vert (régression `Builder`/`_selectedIds` couverte)
- [x] `flutter analyze` (2 fichiers) : uniquement des `info` de style pré-existants, 0 erreur/warning
- [x] backend `py_compile` + `ruff check` OK ; `test_read_endpoints_retry.py` vert contre DB test
- [x] exactement **1 head Alembic**, aucune migration ajoutée
- [x] `/simplify` passé (unification des branches `_handleReaderBack`, tear-off, `dart format`)
- ℹ️ `list_collections` n'a pas de test dédié → couverture CI (refacto additif, réponse API inchangée)

## Zones à risque
- `content_detail_screen.dart` (WebView premium + gratuit, `PopScope`, footer actions) — **à valider on-device post-merge** : retour WebView multi-pages (gratuit + premium) + geste retour système Android.
- `collection_service.list_collections` : requêtes agrégées (réponse inchangée, `read_count` conservé pour Sauvegardés).

🤖 Generated with [Claude Code](https://claude.com/claude-code)