### PR TITLE
feat(mobile): reader garde la couverture pour sources abonnées + connexion login générique

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Abonnements",
+      "summary": "Tes sources abonnées gardent la couverture médiatique avant d'ouvrir l'article complet, et tu peux connecter ton compte depuis la fiche de n'importe quelle source suivie."
+    },
+    {
       "tag": "Lecture",
       "summary": "Le navigateur intégré garde ta navigation : un retour arrière remonte les pages visitées au lieu de te renvoyer au feed. Le choix des collections s'ouvre instantanément, et le bouton tournesol indique mieux qu'il partage l'article."
     },

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -537,11 +537,28 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   }
 
   /// Pre-load the WebView controller for progressive scroll-to-site.
+  /// Vrai si [content] provient d'une source premium suivie dont l'abonnement
+  /// est connecté (session cookies) — on sert alors le `PremiumWebView` plutôt
+  /// que le contrôleur gratuit. Lecture ponctuelle (non réactive).
+  bool _isConnectedPremiumSource(Content? content) {
+    if (content == null) return false;
+    final userSources = ref.read(userSourcesProvider).valueOrNull ?? const [];
+    return userSources.any(
+      (s) => s.id == content.source.id && s.hasSubscription,
+    );
+  }
+
   void _initScrollToSiteWebView() {
     final content = _content;
     if (content == null || kIsWeb) return;
     if (content.contentType != ContentType.article) return;
     if (!content.hasInAppContent) return;
+
+    // Source premium connectée : la couche révélée au scroll rend un
+    // `PremiumWebView` (cookies) — inutile (et contre-productif : paywall)
+    // de charger le contrôleur gratuit sur l'URL payante. `_buildWebViewLayer`
+    // court-circuite avant de toucher `_webViewController` sur ce chemin.
+    if (_isConnectedPremiumSource(content)) return;
 
     _webViewController = WebViewController()
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
@@ -1857,14 +1874,17 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     );
     final articleText = content.htmlContent ?? content.description;
     final hasEnoughContent = plainTextLength(articleText) >= 100;
-    final useScrollToSite = !isConnectedPremiumSource &&
-        content.hasInAppContent &&
+    // Les sources premium connectées gardent l'intermédiaire (reader +
+    // couverture médiatique) comme les sources non-premium : la révélation du
+    // site au scroll bascule sur le `PremiumWebView` (cookies) plutôt que sur
+    // le contrôleur gratuit (cf. `_buildWebViewLayer`), pour ne pas retomber
+    // sur le paywall. On n'exclut donc plus `isConnectedPremiumSource` ici.
+    final useScrollToSite = content.hasInAppContent &&
         content.contentType == ContentType.article &&
         hasEnoughContent &&
         !_showWebView &&
         !kIsWeb;
-    final useInAppReading = !isConnectedPremiumSource &&
-        content.hasInAppContent &&
+    final useInAppReading = content.hasInAppContent &&
         !_showWebView &&
         !useScrollToSite;
     final isVideoContent = content.isVideo;
@@ -2735,6 +2755,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   Widget _buildPartialArticleInlineButton(BuildContext context) {
     final colors = context.facteurColors;
     final textTheme = Theme.of(context).textTheme;
+    // Source premium connectée : signaler que l'article complet est débloqué
+    // par l'abonnement (badge premium en fin de libellé).
+    final content = _content;
+    final isConnectedPremiumSource = _isConnectedPremiumSource(content);
     return Padding(
       padding: const EdgeInsets.symmetric(
         horizontal: FacteurSpacing.space4,
@@ -2766,6 +2790,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                   overflow: TextOverflow.ellipsis,
                 ),
               ),
+              if (isConnectedPremiumSource) ...[
+                const SizedBox(width: 6),
+                _PremiumBadge(colors: colors),
+              ],
               const SizedBox(width: 4),
               Icon(
                 PhosphorIcons.arrowDown(PhosphorIconsStyle.regular),
@@ -2819,6 +2847,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     final articleText = content.htmlContent ?? content.description;
     final isPartial = isPartialContent(articleText);
 
+    // Source premium connectée : la couche WebView révélée au scroll doit
+    // basculer sur le `PremiumWebView` (cookies) pour servir l'article complet.
+    final isConnectedPremiumSource = _isConnectedPremiumSource(content);
+
     String? readingTime;
     if (content.durationSeconds != null && content.durationSeconds! > 0) {
       final minutes = (content.durationSeconds! / 60).ceil();
@@ -2842,7 +2874,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           left: 0,
           right: 0,
           bottom: 0,
-          child: _buildWebViewLayer(),
+          child: _buildWebViewLayer(
+            isConnectedPremiumSource: isConnectedPremiumSource,
+          ),
         ),
 
         // LAYER 1: Scrollable article content with opaque background.
@@ -3026,8 +3060,52 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   }
 
   /// WebView layer — fixed in viewport behind the scrollable content.
-  Widget _buildWebViewLayer() {
+  Widget _buildWebViewLayer({bool isConnectedPremiumSource = false}) {
     if (kIsWeb) return _buildWebViewFallback(_content!);
+
+    // Source premium connectée : révéler le `PremiumWebView` (cookies +
+    // détection paywall), pas le contrôleur gratuit `webview_flutter` — sinon
+    // l'abonné retomberait sur le paywall. La machinerie scroll-to-site est
+    // agnostique du contrôleur (pilotée par le `_scrollController` Flutter et
+    // les callbacks ScrollBridge que `PremiumWebView` émet à l'identique).
+    if (isConnectedPremiumSource) {
+      final content = _content;
+      if (content == null) return const SizedBox.shrink();
+      final webView = PremiumWebView(
+        source: content.source,
+        url: WebUri(content.url),
+        sessionStore: ref.read(premiumSessionStoreProvider),
+        enableScrollBridge: true,
+        detectPaywall: true,
+        onWebViewCreated: (c) => _premiumWebController = c,
+        onGestureStart: _onGestureStart,
+        onGestureDelta: _onGestureDelta,
+        onGestureEnd: _onGestureEnd,
+        onScrollY: _updateWebScrollY,
+        onProgress: _applyWebReadingProgress,
+        onPaywallDetected: _onPremiumPaywallDetected,
+        gestureRecognizers: _isWebViewActive
+            ? swipeBackCompatiblePlatformViewGestureRecognizers()
+            : const {},
+      );
+      // La couche 0 est full-bleed (pas de Column) → on héberge la bannière de
+      // session expirée dans un Stack, alignée en haut quand la WebView est
+      // active.
+      return Stack(
+        children: [
+          Positioned.fill(child: webView),
+          if (_premiumSessionExpired && _isWebViewActive)
+            Positioned(
+              top: 0,
+              left: 0,
+              right: 0,
+              child: _PremiumSessionExpiredBanner(
+                onReconnect: () => _reconnectPremium(content),
+              ),
+            ),
+        ],
+      );
+    }
 
     // Initialize WebView if not already done (e.g. content loaded after init)
     if (_webViewController == null) {
@@ -3758,6 +3836,45 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 /// Bandeau non-bloquant affiché en mode reader premium quand un paywall est
 /// détecté (session du média expirée). Propose de se reconnecter sans
 /// dissocier l'abonnement.
+/// Petit badge premium (couronne) affiché en fin de libellé du bouton
+/// « Article complet » quand l'article est débloqué par un abonnement connecté.
+class _PremiumBadge extends StatelessWidget {
+  final FacteurColors colors;
+
+  const _PremiumBadge({required this.colors});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+      decoration: BoxDecoration(
+        color: colors.primary.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            PhosphorIcons.crown(PhosphorIconsStyle.fill),
+            size: 12,
+            color: colors.primary,
+          ),
+          const SizedBox(width: 3),
+          Text(
+            'Premium',
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: colors.primary,
+                  fontWeight: FontWeight.w700,
+                  fontSize: 10.5,
+                  letterSpacing: 0,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _PremiumSessionExpiredBanner extends StatelessWidget {
   final VoidCallback onReconnect;
 

--- a/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
@@ -1762,11 +1762,18 @@ class _FsManage extends StatelessWidget {
   Widget build(BuildContext context) {
     // Le masquage est désormais porté par le curseur de priorité (palier
     // « Masqué »). Cette section ne subsiste que pour la connexion premium.
-    if (source.premiumConnection == null) return const SizedBox.shrink();
+    // Sources payantes curées (paywall) : bouton visible indépendamment du
+    // suivi (aligné sur `eligibleSubscriptionSourcesProvider`). Nouveau cas
+    // générique (source suivie avec URL http(s) mais sans `premium_connection`
+    // curé, ex. Cerveau & Psycho) : réservé aux sources suivies, aligné sur
+    // `loginConnectableSourcesProvider` de la feuille Réglages.
+    final connection = resolvePremiumConnection(source) ??
+        (source.isTrusted ? forceGenericConnection(source) : null);
+    if (connection == null) return const SizedBox.shrink();
 
     return _FsSection(
       title: 'Gestion de la source',
-      child: _FsPremium(source: source),
+      child: _FsPremium(source: source, connection: connection),
     );
   }
 }
@@ -1775,19 +1782,21 @@ class _FsManage extends StatelessWidget {
 /// propose un, indépendamment du suivi.
 class _FsPremium extends ConsumerWidget {
   final Source source;
-  const _FsPremium({required this.source});
+  final PremiumConnection connection;
+  const _FsPremium({required this.source, required this.connection});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.facteurColors;
     final textTheme = Theme.of(context).textTheme;
     final linked = source.hasSubscription;
+    // Une connexion générique = source sans abonnement payant curé : on parle
+    // de « compte » (connexion login) plutôt que d'« abonnement ».
+    final isGeneric = connection.isGeneric;
 
     final title = linked
-        ? 'Abonnement associé'
-        : (source.premiumConnection!.isGeneric
-              ? 'Associer mon abonnement'
-              : 'Connecter mon abonnement');
+        ? (isGeneric ? 'Compte connecté' : 'Abonnement associé')
+        : (isGeneric ? 'Connecter mon compte' : 'Connecter mon abonnement');
 
     return InkWell(
       borderRadius: BorderRadius.circular(FacteurRadius.large),
@@ -1827,8 +1836,11 @@ class _FsPremium extends ConsumerWidget {
                   ),
                   const SizedBox(height: 1),
                   Text(
-                    'Lis les articles réservés aux abonnés directement dans '
-                    'Facteur.',
+                    isGeneric
+                        ? 'Connecte ton compte pour lire les articles de ce '
+                              'média directement dans Facteur.'
+                        : 'Lis les articles réservés aux abonnés directement '
+                              'dans Facteur.',
                     style: textTheme.labelSmall?.copyWith(
                       color: colors.textTertiary,
                       height: 1.4,
@@ -1877,6 +1889,7 @@ class _FsPremium extends ConsumerWidget {
       MaterialPageRoute(
         builder: (_) => PremiumSourceConnection(
           source: source,
+          connection: connection,
           onConnected: () => ref
               .read(userSourcesProvider.notifier)
               .connectSubscription(source.id),

--- a/apps/mobile/test/features/sources/widgets/source_detail_modal_test.dart
+++ b/apps/mobile/test/features/sources/widgets/source_detail_modal_test.dart
@@ -264,7 +264,44 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text('Gestion de la source'), findsOneWidget);
-        expect(find.text('Associer mon abonnement'), findsOneWidget);
+        // Connexion générique (isGeneric) → CTA « compte », pas « abonnement ».
+        expect(find.text('Connecter mon compte'), findsOneWidget);
+      });
+
+      testWidgets(
+          'followed source without curated premiumConnection shows generic '
+          'connect CTA (http url + isTrusted)', (tester) async {
+        final source = Source(
+          id: 'cerveau-psycho',
+          name: 'Cerveau & Psycho',
+          url: 'https://www.cerveauetpsycho.fr',
+          type: SourceType.article,
+          isTrusted: true,
+        );
+
+        await tester.pumpWidget(_wrap(source: source, state: _emptyState));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Gestion de la source'), findsOneWidget);
+        expect(find.text('Connecter mon compte'), findsOneWidget);
+      });
+
+      testWidgets(
+          'unfollowed source without curated premiumConnection hides the '
+          'generic connect CTA', (tester) async {
+        final source = Source(
+          id: 'cerveau-psycho',
+          name: 'Cerveau & Psycho',
+          url: 'https://www.cerveauetpsycho.fr',
+          type: SourceType.article,
+          isTrusted: false,
+        );
+
+        await tester.pumpWidget(_wrap(source: source));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Gestion de la source'), findsNothing);
+        expect(find.text('Connecter mon compte'), findsNothing);
       });
     },
   );


### PR DESCRIPTION
## Quoi
Deux améliorations autour des sources abonnées dans le reader :
- **Couverture médiatique conservée** : une source premium suivie et connectée (session cookies) garde l'écran intermédiaire reader + couverture médiatique avant l'article complet, comme les sources non-premium. La couche révélée au scroll bascule sur `PremiumWebView` (cookies + détection paywall) au lieu du contrôleur gratuit `webview_flutter`, pour ne pas retomber sur le paywall. Badge « Premium » ajouté sur le bouton « Article complet ».
- **Connexion login générique depuis la fiche source** : le bouton « Connecter mon compte » apparaît désormais pour toute source suivie à URL http(s) (`forceGenericConnection`), pas uniquement les abonnements payants curés (aligné sur `loginConnectableSourcesProvider` de la feuille Réglages).

## Pourquoi
Avant, une source premium connectée sautait directement au WebView complet — l'utilisateur perdait la couverture médiatique / le reader. Et certaines sources suivies (ex. Cerveau & Psycho) sans `premium_connection` curé n'exposaient aucun moyen de connecter un compte depuis leur fiche.

## Comment ça a été vérifié
- [x] `flutter test` sur `source_detail_modal_test.dart` (25/25, dont 2 nouveaux tests : source suivie sans premiumConnection → CTA générique ; source non suivie → CTA caché)
- [x] `flutter analyze` clean sur les fichiers modifiés (seuls des `info` unawaited_futures pré-existants, hors lignes touchées)
- [x] `/simplify` passé — 4 agents ont convergé sur l'extraction d'un helper `_isConnectedPremiumSource(content)` (3 duplications supprimées), appliqué
- [ ] Playwright non lancé : le chemin premium WebView est natif uniquement (`kIsWeb` → fallback), non exerçable sur le build web

## Zones à risque
- `content_detail_screen.dart` : chemins d'affichage reader / scroll-to-site / WebView premium (couche 0). L'intermédiaire premium repose sur `PremiumWebView` + ScrollBridge.
- Fiche source : élargissement de la visibilité du bouton de connexion aux sources suivies génériques.