### PR TITLE
fix(mobile): reader WebView — sortie en 1 clic sur l'article

### DIFF
--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -37,6 +37,7 @@ import '../../sources/widgets/premium_web_view.dart';
 import '../../sources/widgets/source_logo_avatar.dart';
 import '../../../widgets/sunflower_icon.dart';
 import '../providers/nudge_provider.dart' show NudgeTracker;
+import '../utils/webview_history_tracker.dart';
 import '../widgets/article_reader_widget.dart';
 import '../widgets/audio_player_widget.dart';
 import '../widgets/deep_recommendation_card.dart';
@@ -223,6 +224,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   // pour réutiliser la session du média (cookies). Distinct du WebView
   // webview_flutter du scroll-to-site des sources gratuites.
   InAppWebViewController? _premiumWebController;
+  // Suit la profondeur de navigation utilisateur dans le WebView pour sortir
+  // en 1 clic sur l'article et ne remonter l'historique que pour de vraies
+  // navigations de liens suivies (cf. WebViewHistoryTracker).
+  final _historyTracker = WebViewHistoryTracker();
   // Bandeau non-bloquant « Session expirée — Reconnecter » (paywall détecté en
   // mode reader sur une source connectée).
   bool _premiumSessionExpired = false;
@@ -548,6 +553,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     );
   }
 
+  /// Horodatage courant (ms) pour [_historyTracker] — centralisé pour alléger
+  /// le câblage des callbacks WebView.
+  int _nowMs() => DateTime.now().millisecondsSinceEpoch;
+
   void _initScrollToSiteWebView() {
     final content = _content;
     if (content == null || kIsWeb) return;
@@ -560,10 +569,18 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     // court-circuite avant de toucher `_webViewController` sur ce chemin.
     if (_isConnectedPremiumSource(content)) return;
 
+    _historyTracker.reset(_nowMs());
     _webViewController = WebViewController()
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
       ..setNavigationDelegate(
-        NavigationDelegate(onPageFinished: (_) => _injectScrollBridgeScript()),
+        NavigationDelegate(
+          onPageStarted: (_) =>
+              _historyTracker.onNavStart(_nowMs()),
+          onPageFinished: (_) {
+            _injectScrollBridgeScript();
+            _historyTracker.onNavFinish();
+          },
+        ),
       )
       ..addJavaScriptChannel(
         'ScrollBridge',
@@ -892,9 +909,12 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
   /// Gère le retour arrière du reader (bouton header + bouton système Android).
   ///
-  /// En mode WebView, on remonte d'abord l'historique interne du navigateur
-  /// (l'utilisateur a pu suivre des liens dans la page) : un retour ne quitte
-  /// le WebView vers le reader que lorsqu'on est revenu sur la page d'origine.
+  /// En mode WebView, on remonte l'historique interne du navigateur **seulement**
+  /// pour de vraies navigations de liens suivies par l'utilisateur (profondeur
+  /// suivie par [_historyTracker]) : sur la page d'origine de l'article la
+  /// profondeur est nulle, donc **1 clic suffit** pour sortir vers le reader.
+  /// `canGoBack()` reste une simple garde de sécurité (les entrées d'historique
+  /// fantômes du chargement le rendraient sinon toujours `true`).
   /// Hors WebView, on ferme l'écran normalement (retour au feed).
   Future<void> _handleReaderBack() async {
     if (!_isWebViewActive) {
@@ -911,7 +931,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     final Future<bool> Function()? canGoBack =
         premium?.canGoBack ?? free?.canGoBack;
     final Future<void> Function()? goBack = premium?.goBack ?? free?.goBack;
-    if (canGoBack != null && await canGoBack()) {
+    if (_historyTracker.canClimb &&
+        canGoBack != null &&
+        await canGoBack()) {
+      _historyTracker.willGoBack();
       await goBack!();
       return;
     }
@@ -3077,7 +3100,13 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         sessionStore: ref.read(premiumSessionStoreProvider),
         enableScrollBridge: true,
         detectPaywall: true,
-        onWebViewCreated: (c) => _premiumWebController = c,
+        onWebViewCreated: (c) {
+          _premiumWebController = c;
+          _historyTracker.reset(_nowMs());
+        },
+        onLoadStart: (_) =>
+            _historyTracker.onNavStart(_nowMs()),
+        onLoadStop: (_) => _historyTracker.onNavFinish(),
         onGestureStart: _onGestureStart,
         onGestureDelta: _onGestureDelta,
         onGestureEnd: _onGestureEnd,
@@ -3727,7 +3756,13 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         sessionStore: ref.read(premiumSessionStoreProvider),
         enableScrollBridge: true,
         detectPaywall: true,
-        onWebViewCreated: (c) => _premiumWebController = c,
+        onWebViewCreated: (c) {
+          _premiumWebController = c;
+          _historyTracker.reset(_nowMs());
+        },
+        onLoadStart: (_) =>
+            _historyTracker.onNavStart(_nowMs()),
+        onLoadStop: (_) => _historyTracker.onNavFinish(),
         onGestureStart: _onGestureStart,
         onGestureDelta: _onGestureDelta,
         onGestureEnd: _onGestureEnd,
@@ -3750,16 +3785,26 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     }
 
     // Mobile: Use native WebView with ScrollBridge for progress + auto-hide
-    _webViewController ??= WebViewController()
-      ..setJavaScriptMode(JavaScriptMode.unrestricted)
-      ..setNavigationDelegate(
-        NavigationDelegate(onPageFinished: (_) => _injectScrollBridgeScript()),
-      )
-      ..addJavaScriptChannel(
-        'ScrollBridge',
-        onMessageReceived: _onScrollBridgeMessage,
-      )
-      ..loadRequest(Uri.parse(content.url));
+    if (_webViewController == null) {
+      _historyTracker.reset(_nowMs());
+      _webViewController = WebViewController()
+        ..setJavaScriptMode(JavaScriptMode.unrestricted)
+        ..setNavigationDelegate(
+          NavigationDelegate(
+            onPageStarted: (_) => _historyTracker
+                .onNavStart(_nowMs()),
+            onPageFinished: (_) {
+              _injectScrollBridgeScript();
+              _historyTracker.onNavFinish();
+            },
+          ),
+        )
+        ..addJavaScriptChannel(
+          'ScrollBridge',
+          onMessageReceived: _onScrollBridgeMessage,
+        )
+        ..loadRequest(Uri.parse(content.url));
+    }
 
     // CTA discret : source payante non connectée → proposer de lire avec son
     // abonnement (ouvre le flow de connexion).

--- a/apps/mobile/lib/features/detail/utils/webview_history_tracker.dart
+++ b/apps/mobile/lib/features/detail/utils/webview_history_tracker.dart
@@ -1,0 +1,72 @@
+/// Suit la profondeur de navigation **utilisateur** dans le WebView du reader
+/// pour décider si un retour doit remonter l'historique (`goBack`) ou quitter le
+/// WebView (`_exitWebViewMode`).
+///
+/// Problème résolu : `canGoBack()` renvoie quasi toujours `true` sur la page
+/// d'origine d'un article, car le chargement initial empile des entrées
+/// d'historique fantômes (redirections consent-wall/CMP, `http→https`, AMP,
+/// sauts de tracking, `location.replace`…). S'y fier imposait **2 clics** pour
+/// sortir d'un article.
+///
+/// Heuristique : une navigation ne compte comme « utilisateur » que si elle
+/// survient **après un temps de repos** ([redirectSettleMs]) depuis la dernière
+/// navigation. Les rafales de redirection du boot s'enchaînent en < ~1,2 s sans
+/// interaction → elles n'incrémentent pas la profondeur.
+///
+/// Logique pure : `nowMs` est injecté à chaque appel (aucune dépendance à
+/// `DateTime.now()` interne), donc entièrement testable en unitaire.
+class WebViewHistoryTracker {
+  WebViewHistoryTracker({this.redirectSettleMs = 1200});
+
+  /// Délai minimal (ms) entre deux navigations main-frame pour qu'une nav
+  /// compte comme « utilisateur » et non comme une rafale de redirection.
+  final int redirectSettleMs;
+
+  /// Profondeur de navigation utilisateur (nombre de crans remontables).
+  int _depth = 0;
+
+  /// Horodatage de la dernière navigation observée.
+  int _lastNavAtMs = 0;
+
+  /// Vrai entre notre `willGoBack()` et le prochain `onNavFinish()` : la
+  /// navigation en cours est notre propre `goBack`, elle ne doit pas compter.
+  bool _backInProgress = false;
+
+  /// Appelé quand le contrôleur (re)charge la page d'origine.
+  void reset(int nowMs) {
+    _depth = 0;
+    _lastNavAtMs = nowMs;
+    _backInProgress = false;
+  }
+
+  /// Début de navigation main-frame (`onPageStarted` / `onLoadStart`).
+  void onNavStart(int nowMs) {
+    final elapsed = nowMs - _lastNavAtMs;
+    _lastNavAtMs = nowMs;
+    // Notre propre goBack : ne compte pas comme une nav utilisateur.
+    if (_backInProgress) return;
+    // Vraie nav utilisateur uniquement après un temps de repos ; sinon rafale
+    // de redirection au chargement → ignorée.
+    if (elapsed >= redirectSettleMs) {
+      _depth++;
+    }
+  }
+
+  /// Fin de navigation (`onPageFinished` / `onLoadStop`) : lève la garde.
+  void onNavFinish() {
+    _backInProgress = false;
+  }
+
+  /// Vrai s'il reste au moins un cran d'historique utilisateur à remonter.
+  bool get canClimb => _depth > 0;
+
+  /// Avant notre `goBack` : décrémente la profondeur et arme la garde pour que
+  /// le `onNavStart` déclenché par ce `goBack` ne recompte pas.
+  void willGoBack() {
+    if (_depth > 0) _depth--;
+    _backInProgress = true;
+  }
+
+  /// Profondeur courante (exposée pour les tests).
+  int get depth => _depth;
+}

--- a/apps/mobile/lib/features/sources/widgets/premium_web_view.dart
+++ b/apps/mobile/lib/features/sources/widgets/premium_web_view.dart
@@ -39,6 +39,7 @@ class PremiumWebView extends StatefulWidget {
     this.enableScrollBridge = false,
     this.detectPaywall = false,
     this.onWebViewCreated,
+    this.onLoadStart,
     this.onLoadStop,
     this.onGestureStart,
     this.onGestureDelta,
@@ -60,6 +61,7 @@ class PremiumWebView extends StatefulWidget {
   final bool detectPaywall;
 
   final ValueChanged<InAppWebViewController>? onWebViewCreated;
+  final ValueChanged<WebUri?>? onLoadStart;
   final ValueChanged<WebUri?>? onLoadStop;
   final VoidCallback? onGestureStart;
   final ValueChanged<double>? onGestureDelta;
@@ -102,6 +104,7 @@ class _PremiumWebViewState extends State<PremiumWebView> {
       initialSettings: settings,
       gestureRecognizers: widget.gestureRecognizers,
       onWebViewCreated: _handleCreated,
+      onLoadStart: (controller, url) => widget.onLoadStart?.call(url),
       onLoadStop: _handleLoadStop,
     );
   }

--- a/apps/mobile/test/features/detail/webview_history_tracker_test.dart
+++ b/apps/mobile/test/features/detail/webview_history_tracker_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:facteur/features/detail/utils/webview_history_tracker.dart';
+
+void main() {
+  group('WebViewHistoryTracker', () {
+    test('rafale de redirection au boot ne remonte pas la profondeur', () {
+      final t = WebViewHistoryTracker();
+      t.reset(0);
+      // 3 navigations rapprochées (< settle) → redirections consent-wall, AMP…
+      t.onNavStart(100);
+      t.onNavFinish();
+      t.onNavStart(400);
+      t.onNavFinish();
+      t.onNavStart(900);
+      t.onNavFinish();
+
+      expect(t.canClimb, isFalse, reason: 'sortie 1 clic sur l\'article');
+      expect(t.depth, 0);
+    });
+
+    test('lien suivi après lecture compte comme nav utilisateur', () {
+      final t = WebViewHistoryTracker();
+      t.reset(0);
+      // Boot : rafale de redirections.
+      t.onNavStart(200);
+      t.onNavFinish();
+      // L'utilisateur lit puis suit un lien bien après le settle.
+      t.onNavStart(10000);
+      t.onNavFinish();
+
+      expect(t.canClimb, isTrue);
+      expect(t.depth, 1);
+
+      // Le retour remonte ce cran → retour sur l'article, profondeur nulle.
+      t.willGoBack();
+      expect(t.depth, 0);
+      expect(t.canClimb, isFalse);
+    });
+
+    test('notre propre goBack ne réincrémente pas la profondeur', () {
+      final t = WebViewHistoryTracker();
+      t.reset(0);
+      t.onNavStart(10000); // lien utilisateur
+      t.onNavFinish();
+      expect(t.depth, 1);
+
+      // Retour : willGoBack arme la garde, le onNavStart émis par goBack
+      // (même s'il survient bien après le settle) ne doit pas recompter.
+      t.willGoBack();
+      expect(t.depth, 0);
+      t.onNavStart(30000);
+      expect(t.depth, 0, reason: 'garde backInProgress active');
+      t.onNavFinish();
+      expect(t.canClimb, isFalse);
+    });
+
+    test('profondeur multi-niveaux : 2 liens → 2 climbs avant sortie', () {
+      final t = WebViewHistoryTracker();
+      t.reset(0);
+      t.onNavStart(5000); // 1er lien
+      t.onNavFinish();
+      t.onNavStart(10000); // 2e lien
+      t.onNavFinish();
+      expect(t.depth, 2);
+
+      // 1er retour → remonte au 1er lien.
+      t.willGoBack();
+      t.onNavStart(15000); // notre goBack, gardé
+      t.onNavFinish();
+      expect(t.depth, 1);
+      expect(t.canClimb, isTrue);
+
+      // 2e retour → remonte à l'article.
+      t.willGoBack();
+      t.onNavStart(20000);
+      t.onNavFinish();
+      expect(t.depth, 0);
+      expect(t.canClimb, isFalse, reason: 'prochain retour = sortie');
+    });
+
+    test('reset remet la profondeur à zéro (rechargement page origine)', () {
+      final t = WebViewHistoryTracker();
+      t.reset(0);
+      t.onNavStart(10000);
+      t.onNavFinish();
+      expect(t.depth, 1);
+
+      t.reset(50000);
+      expect(t.depth, 0);
+      expect(t.canClimb, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Quoi

En mode WebView du reader, il fallait **2 clics** pour quitter un article (régression introduite par #933 « remontée d'historique »). Ce fix rétablit la **sortie en 1 clic** sur l'article, tout en gardant la remontée d'historique pour les vrais liens suivis dans la page.

## Pourquoi

`_handleReaderBack()` se fiait à `canGoBack()`, qui renvoie quasi toujours `true` sur la page d'origine : le chargement initial empile des entrées d'historique fantômes (consent-wall/CMP, `http→https`, AMP, sauts de tracking, `location.replace`…). 1er retour → `goBack()` rechargeait la page (scroll à 0, footer réapparaît) ; 2e retour → sortie enfin.

**Approche** : `WebViewHistoryTracker` (classe pure, `nowMs` injecté → unit-testable) compte la profondeur de navigation **utilisateur**. Une nav ne compte que si elle survient après un temps de repos (`redirectSettleMs` = 1200 ms) depuis la dernière ; les rafales de redirection du boot (< ~1,2 s, sans interaction) sont ignorées. Le retour remonte l'historique **seulement si `canClimb`**, sinon `_exitWebViewMode()` (1 clic). `canGoBack()` reste une garde de sécurité (AND). Une garde `backInProgress` empêche notre propre `goBack` de recompter.

Câblé identiquement sur les 2 chemins — WebView gratuit (`webview_flutter`, `onPageStarted`/`onPageFinished`) et premium (`PremiumWebView`/`flutter_inappwebview`, `onLoadStart`/`onLoadStop`). Nouveau callback **additif** `onLoadStart` exposé sur `PremiumWebView` (aucun changement pour les appelants existants).

## Comment ça a été vérifié

- [x] `flutter test webview_history_tracker_test.dart` — 5/5 (rafale boot → sortie 1 clic ; lien suivi → 1 climb ; goBack ne recompte pas ; multi-niveaux ; reset). Suite complète : seuls les ~23 échecs mobiles pré-existants (placeholders `Test not implemented`, sans rapport avec ce diff).
- [x] `flutter analyze` sur les 3 fichiers touchés — 0 nouvelle issue (les 7 `unawaited_futures` sont pré-existants).
- [x] `/simplify` (4 agents reuse/simplification/efficiency/altitude) — extraction `_nowMs()` appliquée ; le reste CLEAN.
- [ ] Manuel natif (à faire par le PO — le WebView n'existe pas sur build web, `kIsWeb` court-circuite, donc non exerçable via Playwright) : APK `--flavor staging` émulateur → article scrollé jusqu'au site → **1 clic = sortie** ; lien suivi → retour à l'article puis sortie.

## Zones à risque

- `content_detail_screen.dart` — logique de retour du reader (`_handleReaderBack`) + init des 2 WebViews. Câblage inline uniquement, comportement hors-WebView inchangé.
- `premium_web_view.dart` — ajout callback optionnel `onLoadStart` (additif).
- Pas de migration, pas de backend, pas de changelog (fix de régression UX ciblé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)