### PR TITLE
fix(mobile): flow connexion premium plus clair (pills + gating CTA + copy honnête)

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -2,6 +2,10 @@
   "unreleased": [
     {
       "tag": "Abonnements",
+      "summary": "Connecter un abonnement est plus clair : une barre d'étapes te situe dans la procédure, et le bouton pour continuer n'apparaît qu'une fois connecté au média."
+    },
+    {
+      "tag": "Abonnements",
       "summary": "Tes sources abonnées gardent la couverture médiatique avant d'ouvrir l'article complet, et tu peux connecter ton compte depuis la fiche de n'importe quelle source suivie."
     },
     {

--- a/apps/mobile/lib/features/sources/widgets/premium_source_connection.dart
+++ b/apps/mobile/lib/features/sources/widgets/premium_source_connection.dart
@@ -13,7 +13,11 @@ import 'premium_web_view.dart';
 import 'source_logo_avatar.dart';
 
 typedef PremiumWebViewBuilder = Widget Function(
-    BuildContext context, String url);
+    BuildContext context, String url, ValueChanged<WebUri?>? onLoadStop);
+
+/// Nombre de pills affichées dans les WebView steps : login → vérification →
+/// terminé. Les écrans intro/succès ne portent pas de pills.
+const int _kTotalSteps = 3;
 
 class PremiumSourceConnection extends ConsumerStatefulWidget {
   final Source source;
@@ -48,8 +52,24 @@ class _PremiumSourceConnectionState
   bool _saving = false;
   String? _error;
 
+  /// Passe à `true` dès que la WebView de login quitte l'URL de connexion
+  /// initiale (l'utilisateur a saisi ses identifiants / a été redirigé). Gate le
+  /// CTA du step 1 pour ne pas inviter à cliquer avant d'avoir navigué.
+  bool _loginNavigated = false;
+
   PremiumConnection get _connection =>
       widget.connection ?? widget.source.premiumConnection!;
+
+  /// Heuristique host+path (query/fragment ignorés) : la moindre différence par
+  /// rapport à l'URL de login initiale signale que l'utilisateur a avancé.
+  void _handleLoginNavigation(WebUri? url) {
+    if (_loginNavigated || url == null) return;
+    final initial = Uri.tryParse(_connection.loginUrl);
+    if (initial == null) return;
+    if (url.host != initial.host || url.path != initial.path) {
+      setState(() => _loginNavigated = true);
+    }
+  }
 
   PremiumSessionStore get _sessionStore =>
       ref.read(premiumSessionStoreProvider);
@@ -121,22 +141,28 @@ class _PremiumSourceConnectionState
         return _WebViewStep(
           key: const ValueKey('premium-webview-login'),
           title: 'Connexion',
+          stepIndex: 1,
+          totalSteps: _kTotalSteps,
           url: _connection.loginUrl,
           source: widget.source,
           sessionStore: _sessionStore,
-          actionLabel: 'Continuer vers l\'article test',
+          actionLabel: 'Continuer',
           webViewBuilder: widget.webViewBuilder,
+          showAction: _loginNavigated,
+          onLoadStop: _handleLoginNavigation,
           onAction: () => setState(() => _step = 2),
           onOpenExternal: () => _openExternal(_connection.loginUrl),
         );
       case 2:
         return _WebViewStep(
           key: const ValueKey('premium-webview-test'),
-          title: 'Article test',
+          title: 'Vérification',
+          stepIndex: 2,
+          totalSteps: _kTotalSteps,
           url: _connection.testUrl,
           source: widget.source,
           sessionStore: _sessionStore,
-          actionLabel: 'L\'article s\'affiche correctement',
+          actionLabel: 'Je suis connecté(e)',
           webViewBuilder: widget.webViewBuilder,
           onAction: _saving ? null : _confirm,
           onOpenExternal: () => _openExternal(_connection.testUrl),
@@ -206,7 +232,7 @@ class _PremiumSourceConnectionState
               const SizedBox(height: FacteurSpacing.space3),
               Text(
                 _connection.displayHint ??
-                    'Connectez-vous dans la WebView du média, puis confirmez qu\'un article abonné s\'affiche correctement.',
+                    'Connectez-vous dans la WebView du média, puis confirmez que votre session est bien active.',
                 textAlign: TextAlign.center,
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                       color: colors.textSecondary,
@@ -229,19 +255,29 @@ class _PremiumSourceConnectionState
 
 class _WebViewStep extends StatelessWidget {
   final String title;
+  final int stepIndex; // 1-based
+  final int totalSteps;
   final String url;
   final Source source;
   final PremiumSessionStore sessionStore;
   final String actionLabel;
   final PremiumWebViewBuilder? webViewBuilder;
+  final ValueChanged<WebUri?>? onLoadStop;
   final VoidCallback? onAction;
   final VoidCallback onOpenExternal;
+
+  /// Masque le CTA principal tant qu'il n'a pas de sens (step login avant que
+  /// l'utilisateur ait navigué). Un `SizedBox` prend sa place pour éviter un
+  /// saut de layout de la WebView à l'apparition du bouton.
+  final bool showAction;
   final bool isLoading;
   final String? error;
 
   const _WebViewStep({
     super.key,
     required this.title,
+    required this.stepIndex,
+    required this.totalSteps,
     required this.url,
     required this.source,
     required this.sessionStore,
@@ -249,6 +285,8 @@ class _WebViewStep extends StatelessWidget {
     required this.onAction,
     required this.onOpenExternal,
     this.webViewBuilder,
+    this.onLoadStop,
+    this.showAction = true,
     this.isLoading = false,
     this.error,
   });
@@ -256,12 +294,13 @@ class _WebViewStep extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
-    final webView = webViewBuilder?.call(context, url) ??
+    final webView = webViewBuilder?.call(context, url, onLoadStop) ??
         PremiumWebView(
           source: source,
           url: WebUri(url),
           sessionStore: sessionStore,
           enableScrollBridge: false,
+          onLoadStop: onLoadStop,
         );
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -276,18 +315,21 @@ class _WebViewStep extends StatelessWidget {
           child: Row(
             children: [
               Expanded(
-                child: Text(
-                  title,
-                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        color: colors.textPrimary,
-                        fontWeight: FontWeight.w700,
-                      ),
+                child: Semantics(
+                  label: title,
+                  child: _PremiumStepPills(
+                    totalSteps: totalSteps,
+                    currentStep: stepIndex,
+                  ),
                 ),
               ),
-              TextButton.icon(
+              const SizedBox(width: FacteurSpacing.space2),
+              IconButton(
                 onPressed: onOpenExternal,
-                icon: Icon(PhosphorIcons.arrowSquareOut(), size: 18),
-                label: const Text('Navigateur'),
+                icon: Icon(PhosphorIcons.arrowSquareOut(), size: 20),
+                tooltip: 'Ouvrir dans le navigateur externe',
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
               ),
             ],
           ),
@@ -302,16 +344,50 @@ class _WebViewStep extends StatelessWidget {
               style: TextStyle(color: colors.error),
             ),
           ),
-        Padding(
-          padding: const EdgeInsets.all(FacteurSpacing.space4),
-          child: FacteurButton(
-            label: isLoading ? 'Connexion...' : actionLabel,
-            type: FacteurButtonType.primary,
-            icon: PhosphorIcons.arrowRight(),
-            onPressed: onAction,
-          ),
-        ),
+        if (showAction)
+          Padding(
+            padding: const EdgeInsets.all(FacteurSpacing.space4),
+            child: FacteurButton(
+              label: isLoading ? 'Connexion...' : actionLabel,
+              type: FacteurButtonType.primary,
+              icon: PhosphorIcons.arrowRight(),
+              onPressed: onAction,
+            ),
+          )
+        else
+          const SizedBox(height: FacteurSpacing.space4),
       ],
+    );
+  }
+}
+
+/// Barre de progression segmentée (pills) des WebView steps. Calquée sur
+/// `_StepPills` de `veille_widgets.dart` ; tokens génériques `colors.primary`
+/// (actif) / `colors.border` (inactif).
+class _PremiumStepPills extends StatelessWidget {
+  final int totalSteps;
+  final int currentStep; // 1-based
+
+  const _PremiumStepPills({required this.totalSteps, required this.currentStep});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Row(
+      children: List.generate(totalSteps, (i) {
+        final n = i + 1;
+        final active = n <= currentStep;
+        return Expanded(
+          child: Container(
+            margin: EdgeInsets.only(right: i == totalSteps - 1 ? 0 : 5),
+            height: 4,
+            decoration: BoxDecoration(
+              color: active ? colors.primary : colors.border,
+              borderRadius: BorderRadius.circular(4),
+            ),
+          ),
+        );
+      }),
     );
   }
 }

--- a/apps/mobile/test/features/sources/widgets/premium_source_connection_test.dart
+++ b/apps/mobile/test/features/sources/widgets/premium_source_connection_test.dart
@@ -57,8 +57,10 @@ void main() {
   });
 
   testWidgets(
-      'PremiumSourceConnection completes login test confirmation flow and '
-      'captures session at confirm', (tester) async {
+      'PremiumSourceConnection gates the login CTA until navigation, then '
+      'completes the confirmation flow and captures session at confirm',
+      (tester) async {
+    final semantics = tester.ensureSemantics();
     var connected = false;
     final jar = _FakeCookieJar();
     // Seed cookies on the media domain so the capture at _confirm persists.
@@ -89,7 +91,18 @@ void main() {
             onConnected: () async {
               connected = true;
             },
-            webViewBuilder: (_, url) => Center(child: Text(url)),
+            // Le builder de test bypass PremiumWebView : on expose un bouton qui
+            // déclenche onLoadStop pour simuler une navigation dans la WebView.
+            webViewBuilder: (_, url, onLoadStop) => Column(
+              children: [
+                Text(url),
+                TextButton(
+                  onPressed: () =>
+                      onLoadStop?.call(WebUri('https://example.com/logged-in')),
+                  child: const Text('simulate-navigation'),
+                ),
+              ],
+            ),
           ),
         ),
       ),
@@ -100,22 +113,33 @@ void main() {
     await tester.ensureVisible(find.text('Commencer'));
     await tester.tap(find.text('Commencer'));
     await tester.pumpAndSettle();
-    expect(find.text('Connexion'), findsOneWidget);
+    // Step 1 (login) : titre porté par la sémantique des pills, URL de login
+    // affichée, et CTA masqué tant que l'utilisateur n'a pas navigué (fix #1).
+    expect(find.bySemanticsLabel('Connexion'), findsOneWidget);
     expect(find.text('https://example.com/login'), findsOneWidget);
+    expect(find.text('Continuer'), findsNothing);
 
-    await tester.ensureVisible(find.text('Continuer vers l\'article test'));
-    await tester.tap(find.text('Continuer vers l\'article test'));
+    // Simule la navigation dans la WebView → le CTA doit apparaître.
+    await tester.tap(find.text('simulate-navigation'));
     await tester.pumpAndSettle();
-    expect(find.text('Article test'), findsOneWidget);
+    expect(find.text('Continuer'), findsOneWidget);
+
+    await tester.ensureVisible(find.text('Continuer'));
+    await tester.tap(find.text('Continuer'));
+    await tester.pumpAndSettle();
+    // Step 2 (vérification) : copy honnête, plus de promesse d'« article test ».
+    expect(find.bySemanticsLabel('Vérification'), findsOneWidget);
     expect(find.text('https://example.com/test'), findsOneWidget);
 
-    await tester.ensureVisible(find.text('L\'article s\'affiche correctement'));
-    await tester.tap(find.text('L\'article s\'affiche correctement'));
+    await tester.ensureVisible(find.text('Je suis connecté(e)'));
+    await tester.tap(find.text('Je suis connecté(e)'));
     await tester.pumpAndSettle();
 
     expect(connected, isTrue);
     expect(find.text('Abonnement connecté'), findsOneWidget);
     // Session captured at confirm.
     expect(await store.hasSession(source), isTrue);
+
+    semantics.dispose();
   });
 }

--- a/docs/bugs/bug-premium-connection-flow-confusion.md
+++ b/docs/bugs/bug-premium-connection-flow-confusion.md
@@ -1,0 +1,113 @@
+# Bug — Confusion du workflow d'ajout de sources premium
+
+> Type : **Bug** (UX + copy trompeuse). Scope : un seul widget Flutter + son test,
+> plus un commentaire TODO traçable côté backend. **Aucun changement DB/Alembic.**
+
+## Symptômes signalés
+
+Le flow « connecter un abonnement premium » (`PremiumSourceConnection` :
+écran intro → WebView de login → WebView de test → succès) présente trois
+problèmes UX, plus une demande bonus.
+
+1. **CTA prématuré (Issue 1).** Le bouton `'Continuer vers l'article test'`
+   (step 1, login) est visible et actif dès l'ouverture de la WebView de login,
+   avant même que l'utilisateur ait tapé ses identifiants. Ça laisse croire
+   qu'il faut cliquer tout de suite.
+2. **Header confus + trop de place (Issue 2).** Le `Row` du header de
+   `_WebViewStep` mélange un titre (« Connexion » / « Article test ») et un
+   `TextButton.icon` « Navigateur » (ouvre l'URL dans le navigateur externe).
+   Le libellé « Navigateur » est incompréhensible dans ce contexte et le bloc
+   prend de la hauteur.
+3. **« Continuer vers l'article test » ne fonctionne pas (Issue 3).** Root cause
+   confirmée en code : `PremiumConnection.testUrl` pointe vers la **home du
+   média** pour les 13 sources curées (`PREMIUM_CURATED_MAP`,
+   `packages/api/app/services/premium_curated_sources.py`) **et** pour tout
+   fallback générique (`_genericConnectionFor`, `source_model.dart`). Il n'existe
+   **aucun** vrai article test abonné dans le système aujourd'hui — le
+   commentaire du code l'admet déjà (« idéalement un article abonné evergreen, à
+   défaut la home du média »). Donc le bouton « fonctionne » techniquement mais
+   ne montre jamais l'article promis → perception de bug.
+4. **Bonus.** Ajouter un système de steps (pills de progression) pour rendre la
+   procédure plus lisible/navigable.
+
+## Décisions
+
+- **Issue 3 — pas de deviner d'URLs d'articles abonnés dans cette PR.** Trouver
+  un article abonné « evergreen » réel par média est une tâche éditoriale
+  séparée (hors scope). On corrige plutôt la **copy** pour ne plus promettre
+  « un article test » quand ce n'est que la home. Un `TODO(product)` traçable
+  est ajouté en tête de `PREMIUM_CURATED_MAP` (sans changement fonctionnel) et
+  pointe vers ce doc.
+- **Issue 1 — heuristique host+path pour V1.** On considère l'utilisateur comme
+  « ayant navigué » dès que la WebView quitte l'URL de login initiale (host ou
+  path différent, query/fragment ignorés). Pas de fallback/timer supplémentaire
+  (validé par l'utilisateur). Pas de reset : le flow n'a pas de retour arrière
+  vers le step 1 (l'AppBar `X` pop tout l'écran).
+- **Issue 2 + Bonus — un seul header repensé.** Le titre texte + « Navigateur »
+  sont remplacés par des pills de progression (3 steps : login → vérification →
+  terminé) + un bouton icône seul avec tooltip « Ouvrir dans le navigateur
+  externe ». L'annonce a11y du titre est préservée via `Semantics(label:)`.
+- **Steps intro (0) et succès (3) : pas de pills.** Ce sont des écrans à part
+  (pas de `_WebViewStep`) ; l'AppBar donne déjà le contexte. Ajouter les pills
+  là demanderait de dupliquer un header inexistant → scope minimal.
+
+## Fichiers concernés
+
+- `apps/mobile/lib/features/sources/widgets/premium_source_connection.dart` —
+  fichier principal, tous les changements de code.
+- `apps/mobile/lib/features/sources/widgets/premium_web_view.dart` — **aucun
+  changement** : `onLoadStart`/`onLoadStop` existent déjà et sont câblés, ils
+  n'étaient simplement jamais passés par l'appelant.
+- `apps/mobile/test/features/sources/widgets/premium_source_connection_test.dart`
+  — MAJ copy + nouveau seam de test pour simuler la navigation.
+- `packages/api/app/services/premium_curated_sources.py` — commentaire TODO
+  traçable (pas de changement fonctionnel).
+
+## Plan technique
+
+### 1. Gating du CTA step 1 (Issue 1)
+
+Nouveau state `bool _loginNavigated = false` + handler `_handleLoginNavigation`
+comparant host+path de l'URL courante à l'URL de login initiale. `_WebViewStep`
+(step 1) reçoit `onLoadStop: _handleLoginNavigation` et `showAction:
+_loginNavigated`. Le step 2 garde `showAction: true`.
+
+### 2. Header : pills + bouton icône (Issue 2 + Bonus)
+
+Nouveau widget privé `_PremiumStepPills` (inline, calqué sur `_StepPills` de
+`veille_widgets.dart`), tokens `colors.primary` (actif) / `colors.border`
+(inactif). Header `_WebViewStep` : pills (dans `Semantics(label: title)`) +
+`IconButton` seul (tooltip « Ouvrir dans le navigateur externe »).
+`_WebViewStep` gagne `stepIndex` (1-based) et `totalSteps` (=3).
+
+### 3. Bouton « en absence » (step 1 avant navigation)
+
+`if (showAction) FacteurButton(...) else SizedBox(height: space4)` pour éviter un
+saut de layout brutal de la WebView quand le bouton apparaît.
+
+### 4. Copy honnête (Issue 3)
+
+| Emplacement | Avant | Après |
+|---|---|---|
+| Titre step 1 | `Connexion` | inchangé |
+| CTA step 1 | `Continuer vers l'article test` | `Continuer` |
+| Titre step 2 | `Article test` | `Vérification` |
+| CTA step 2 | `L'article s'affiche correctement` | `Je suis connecté(e)` |
+| Tooltip nouveau | — | `Ouvrir dans le navigateur externe` |
+| Hint défaut step 0 | `...confirmez qu'un article abonné s'affiche correctement.` | `...confirmez que votre session est bien active.` |
+
+Les `display_hint` déjà présents dans `PREMIUM_CURATED_MAP` et
+`_genericConnectionFor` ne sur-promettent pas et restent inchangés.
+
+### 5. Test
+
+- Étendre le typedef `PremiumWebViewBuilder` pour transmettre `onLoadStop`
+  (seul seam propre — pas de back-door `@visibleForTesting`).
+- Assertions : bouton `Continuer` caché avant navigation, visible après une
+  navigation simulée ; titres/CTA mis à jour ; reste du flow inchangé.
+
+## Vérification
+
+- `flutter analyze` (zéro warning suite au changement de signature du typedef).
+- `flutter test test/features/sources/widgets/premium_source_connection_test.dart`.
+- `flutter test` (suite complète, cf. hook `stop-verify-tests.sh`).

--- a/packages/api/app/services/premium_curated_sources.py
+++ b/packages/api/app/services/premium_curated_sources.py
@@ -51,6 +51,11 @@ def domain_key(url: str | None) -> str:
 # pour vérifier que la session est active (idéalement un article abonné
 # "evergreen", à défaut la home du média). display_hint = consigne affichée à
 # l'utilisateur pendant la connexion. À enrichir éditorialement sans migration.
+#
+# TODO(product): tous les test_url ci-dessous pointent vers la home (pas un
+# article évergreen abonné réel) — nécessite une curation éditoriale par média.
+# En attendant, la copy mobile ne promet plus "un article test" (parle de
+# "vérification"/"session active"). Cf. docs/bugs/bug-premium-connection-flow-confusion.md
 PREMIUM_CURATED_MAP: dict[str, dict] = {
     "lemonde.fr": {
         "login_url": "https://secure.lemonde.fr/sfuser/connexion",


### PR DESCRIPTION
## Quoi

Clarifie le flow de connexion d'un abonnement premium :
- **Barre d'étapes (pills)** dans les WebView steps (login → vérification) pour situer l'utilisateur.
- **Gating du CTA** : le bouton « Continuer » du step login n'apparaît qu'une fois que l'utilisateur a navigué dans la WebView (heuristique `onLoadStop` host+path), pour ne pas inviter à avancer avant d'être connecté au média.
- **Copy honnête** : plus de promesse d'« article test » (les `test_url` pointent vers la home du média, pas un article évergreen abonné) ; on parle désormais de « Vérification » / « session active ».

## Pourquoi

Bug de confusion signalé : le flow promettait un « article test » que la data ne peut pas garantir, et le CTA invitait à continuer avant même la connexion. Cf. `docs/bugs/bug-premium-connection-flow-confusion.md`. Un `TODO(product)` documente la dette éditoriale `test_url` côté backend (aucun changement de comportement, commentaire seul).

## Comment ça a été vérifié

- [x] `flutter test` sur le widget (`premium_source_connection_test.dart`) — vert (gating CTA + copy)
- [x] `flutter analyze` sur les fichiers touchés — No issues found
- [x] Backend : changement commentaire seul, import OK
- [x] `/simplify` passé (4 agents : reuse/simplification/efficiency/altitude — clean, seul nit = duplication pills hors scope)

## Zones à risque

- WebView premium (seam `onLoadStop` ajouté au typedef `PremiumWebViewBuilder` + `PremiumWebView`).
- Copy user-facing (changelog `unreleased` ajouté).