### PR TITLE
fix(digest): restaure la pertinence Bonnes Nouvelles + relève la cible quotidienne à 10

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Bonnes nouvelles",
+      "summary": "Les bonnes nouvelles du jour retrouvent leur pertinence, et ta tournée quotidienne propose un peu plus d'articles à découvrir."
+    },
+    {
       "tag": "Abonnements",
       "summary": "Tes sources abonnées gardent la couverture médiatique avant d'ouvrir l'article complet, et tu peux connecter ton compte depuis la fiche de n'importe quelle source suivie."
     },

--- a/docs/bugs/bug-bonnes-nouvelles-qualite-regression.md
+++ b/docs/bugs/bug-bonnes-nouvelles-qualite-regression.md
@@ -1,0 +1,91 @@
+# Bug — Bonnes Nouvelles plus pertinentes après LR-1 PR 2 (coupes de coût Mistral)
+
+## Symptôme
+
+Le PO signale que les **Bonnes Nouvelles** (feature clé) ne sont plus du tout
+pertinentes depuis la PR de réduction de coûts Mistral. Régression qualitative
+sur la sélection finale des articles « bonnes nouvelles » du jour.
+
+## Diagnostic
+
+Deux PRs de coût ont été mergées récemment sur `main` :
+
+- **#905 — LR-1 PR 1** (mesure tokens + rate-limiter large-only) : purement
+  additif/observabilité côté `good_news_classifier.py` et
+  `classification_service.py`. Le rate-limiter ajouté ne borne que
+  `EditorialLLMClient` (curation/deep_matcher/perspective), **pas**
+  `GoodNewsClassifier` qui a son propre client HTTP. Aucun changement de contenu
+  de prompt ni de taille de batch. **Non suspect.**
+- **#914 — LR-1 PR 2** (batching classif + prompt cache + trims éditoriaux) :
+  contient le vrai suspect (levier 1, batching).
+
+### Root cause — levier 1 de #914 (batching de classification)
+
+`packages/api/app/config.py` a remplacé le batch fixe de la passe 1 de
+classification (`mistral-small`, qui produit entre autres le flag `serene`,
+seul gate d'entrée vers la passe 2 `is_good_news` sur `mistral-large`) par un
+batch accumulé :
+
+```
+classification_worker_batch_size:     5  → 12
+classification_worker_min_batch_size: 1  → 8   (gate d'accumulation)
+classification_worker_max_wait_s:     0  → 300
+classification_worker_interval_s:    10  → 30
+```
+
+Or `batch_size=5` **n'était pas arbitraire** : fixé délibérément par la PR #152
+(mars 2026), passée de 20 → 5 explicitement *« pour maximiser la qualité de
+classification »*. PR #914 a défait cette leçon documentée sans la ré-évaluer,
+pour amortir le prompt système (taxonomie 51 topics) et réduire le coût. Le
+maintenance doc de #914 revendiquait *« zéro changement de comportement
+produit »* — faux : un batch plus gros (2,4×) dilue l'attention du modèle par
+article (plus d'articles à juger simultanément dans un seul prompt), dégradant
+la précision de `serene` → mauvais candidats transmis à la passe 2
+`is_good_news` → sélection finale non pertinente. Le délai d'accumulation
+(jusqu'à 5 min, gate min 8) ajoute de la latence de fraîcheur, secondaire mais
+dans le même sens.
+
+### Leviers de #914 **conservés** (hors scope, sans risque qualité identifié)
+
+- **Prompt cache** (`prompt_cache_key`, passe 1 + entités + good-news) : ne
+  change ni le contenu du prompt ni le comportement du modèle, juste la
+  facturation.
+- **Curation** : drop `article_titles` du prompt de sélection de clusters — ne
+  touche ni la passe 1 ni la passe 2 des Bonnes Nouvelles.
+- **Divergence** : gate LLM sur `divergence_llm_min_perspectives` — hors scope
+  Bonnes Nouvelles.
+
+## Fix
+
+Revenir uniquement sur le levier de batching (celui qui a un historique
+documenté de lien avec la qualité), en gardant les gains de coût sans risque
+qualité (prompt cache, trims éditoriaux).
+
+**`packages/api/app/config.py`** — restaurer les valeurs pré-#914 (chemin de
+rollback env-only documenté par la PR elle-même) :
+
+```python
+classification_worker_batch_size: int = 5
+classification_worker_min_batch_size: int = 1
+classification_worker_max_wait_s: int = 0
+classification_worker_interval_s: int = 10
+```
+
+Avec `min_batch_size=1` et `max_wait_s=0`, la gate d'accumulation
+`_should_process()` (ajoutée par #914 dans `classification_worker.py`) redevient
+un no-op — traite dès qu'il y a ≥1 item pending, comme avant #914. Aucun code du
+worker à toucher : uniquement les 4 constantes de settings + le commentaire.
+
+## Vérification
+
+1. `pytest -v tests/workers/test_classification_worker_gate.py tests/ml/test_classification_service.py tests/ml/test_good_news_classifier.py` — ces tests fixent `min_batch_size`/`max_wait_s` explicitement par cas (indépendants des defaults de `config.py`), donc le revert ne les casse pas.
+2. `pytest -v` suite complète backend.
+3. Alembic inchangé (aucune migration touchée).
+4. Après déploiement staging : contrôle manuel PO des Bonnes Nouvelles du jour
+   sur 2-3 jours pour confirmer le retour à la pertinence (pas de vérif auto
+   sans jeu d'éval ground-truth).
+
+## Fichiers touchés
+
+- `packages/api/app/config.py` (4 constantes + commentaire)
+- `docs/bugs/bug-bonnes-nouvelles-qualite-regression.md` (ce doc)

--- a/packages/api/app/config.py
+++ b/packages/api/app/config.py
@@ -129,9 +129,15 @@ class Settings(BaseSettings):
     # / wait 300s) est ABANDONNÉE suite à régression Bonnes Nouvelles constatée
     # en prod. Avec min_batch_size=1 et max_wait_s=0, la gate d'accumulation
     # `_should_process()` redevient un no-op (traite dès ≥1 pending).
-    classification_worker_batch_size: int = 5  # cible d'articles / appel batch (qualité-safe, cf. #152)
-    classification_worker_min_batch_size: int = 1  # seuil mini avant de traiter (1 = pas d'accumulation)
-    classification_worker_max_wait_s: int = 0  # plafond d'attente du + vieux pending (0 = immédiat)
+    classification_worker_batch_size: int = (
+        5  # cible d'articles / appel batch (qualité-safe, cf. #152)
+    )
+    classification_worker_min_batch_size: int = (
+        1  # seuil mini avant de traiter (1 = pas d'accumulation)
+    )
+    classification_worker_max_wait_s: int = (
+        0  # plafond d'attente du + vieux pending (0 = immédiat)
+    )
     classification_worker_interval_s: int = 10  # intervalle entre 2 vérifications
 
     # Brave Search API (smart source search)

--- a/packages/api/app/config.py
+++ b/packages/api/app/config.py
@@ -119,16 +119,20 @@ class Settings(BaseSettings):
     ml_enabled: bool = False  # Set to True to enable classification worker
     mistral_api_key: str = ""  # Mistral API key (classification + editorial pipeline)
 
-    # Batching de la classification (LR-1 PR 2) — coupe le coût Mistral en
-    # refacturant le gros prompt système (taxonomie 51 topics) moins souvent.
-    # Le worker accumule la file et ne traite que quand `pending >= min_batch`
-    # OU que le plus vieux pending atteint `max_wait_s` (anti-famine du reste
-    # de file). Rollback env-only vers l'ancien comportement : batch_size=5,
-    # min_batch_size=1, max_wait_s=0, interval_s=10.
-    classification_worker_batch_size: int = 12  # cible d'articles / appel batch
-    classification_worker_min_batch_size: int = 8  # seuil mini avant de traiter
-    classification_worker_max_wait_s: int = 300  # plafond d'attente du + vieux pending
-    classification_worker_interval_s: int = 30  # intervalle entre 2 vérifications
+    # Batching de la classification — batch_size=5 est la valeur QUALITÉ-SAFE
+    # (référence PR #152, mars 2026 : passage 20 → 5 explicitement "pour
+    # maximiser la qualité de classification"). La passe 1 `mistral-small`
+    # produit le flag `serene`, seul gate d'entrée vers la passe 2
+    # `is_good_news` : un batch plus gros dilue l'attention du modèle par
+    # article et dégrade la précision de `serene` → mauvais candidats Bonnes
+    # Nouvelles. L'expérimentation de batching plus gros (LR-1 PR 2 : 12 / min 8
+    # / wait 300s) est ABANDONNÉE suite à régression Bonnes Nouvelles constatée
+    # en prod. Avec min_batch_size=1 et max_wait_s=0, la gate d'accumulation
+    # `_should_process()` redevient un no-op (traite dès ≥1 pending).
+    classification_worker_batch_size: int = 5  # cible d'articles / appel batch (qualité-safe, cf. #152)
+    classification_worker_min_batch_size: int = 1  # seuil mini avant de traiter (1 = pas d'accumulation)
+    classification_worker_max_wait_s: int = 0  # plafond d'attente du + vieux pending (0 = immédiat)
+    classification_worker_interval_s: int = 10  # intervalle entre 2 vérifications
 
     # Brave Search API (smart source search)
     brave_api_key: str = ""

--- a/packages/api/app/services/digest_selector.py
+++ b/packages/api/app/services/digest_selector.py
@@ -1,20 +1,22 @@
 from __future__ import annotations
 
-"""Service de sélection d'articles pour le Digest quotidien (7 articles).
+"""Service de sélection d'articles pour le Digest quotidien (cible: 10 articles).
 
 Ce service implémente l'algorithme de sélection intelligent pour Epic 10,
 avec contraintes de diversité et mécanisme de fallback.
 
 Contraintes de diversité:
-- Maximum 1 article par source (fallback à 2 si < 7 sources distinctes)
+- Maximum 1 article par source (fallback à 2 si < cible sources distinctes)
 - Maximum 2 articles par thème
 - Minimum 4 sources différentes
 
 Completion:
-- Seuil de completion à 5/7 interactions (configurable via COMPLETION_THRESHOLD)
+- Seuil de completion à 5 interactions (le "moment de fermeture" reste ancré
+  sur 5, configurable via COMPLETION_THRESHOLD, indépendamment de la taille du
+  pool disponible TARGET_DIGEST_SIZE)
 
 Fallback:
-- Si le pool utilisateur < 7 articles, complète avec les sources curatées
+- Si le pool utilisateur < cible articles, complète avec les sources curatées
 
 Réutilise l'infrastructure de scoring existante sans modification.
 """
@@ -205,7 +207,13 @@ class DiversityConstraints:
 
     MAX_PER_SOURCE = 1
     MAX_PER_THEME = 2
-    TARGET_DIGEST_SIZE = 7
+    # Taille cible du pool quotidien disponible (Actus du jour + Bonnes
+    # nouvelles). Relevée 7 → 10 à la demande du PO pour offrir un pool
+    # légèrement plus profond (8-10 articles disponibles/jour) sans toucher au
+    # clustering (TOPIC_CLUSTER_THRESHOLD / TOPIC_MAX_ARTICLES inchangés). Le
+    # "moment de fermeture" reste ancré sur COMPLETION_THRESHOLD=5 : on élargit
+    # le pool disponible, pas le rituel de complétion.
+    TARGET_DIGEST_SIZE = 10
     COMPLETION_THRESHOLD = 5
     MIN_SOURCES = 4
 
@@ -213,8 +221,9 @@ class DiversityConstraints:
 class DigestSelector:
     """Sélecteur intelligent d'articles pour le digest quotidien.
 
-    Cette classe implémente la logique de sélection des 7 articles
-    du digest avec garanties de diversité et mécanisme de fallback.
+    Cette classe implémente la logique de sélection des articles
+    du digest (cible ``TARGET_DIGEST_SIZE``) avec garanties de diversité
+    et mécanisme de fallback.
 
     Usage:
         selector = DigestSelector(session)
@@ -240,7 +249,7 @@ class DigestSelector:
     async def select_for_user(
         self,
         user_id: UUID,
-        limit: int = 7,
+        limit: int = 10,
         hours_lookback: int = 168,
         mode: str = "pour_vous",
         global_trending_context: GlobalTrendingContext | None = None,
@@ -253,7 +262,7 @@ class DigestSelector:
 
         Args:
             user_id: ID de l'utilisateur
-            limit: Nombre d'articles à sélectionner (défaut: 7)
+            limit: Nombre d'articles à sélectionner (défaut: 10, cf. TARGET_DIGEST_SIZE)
             hours_lookback: Fenêtre temporelle pour les candidats (défaut: 168h/7j)
             mode: Mode de digest (pour_vous ou serein)
             global_trending_context: Contexte trending pré-calculé (batch) ou None (on-demand)
@@ -1499,7 +1508,7 @@ class DigestSelector:
         """Sélectionne les articles avec contraintes de diversité.
 
         Contraintes:
-        - Maximum 1 article par source (fallback à 2 si < 5 sources distinctes)
+        - Maximum 1 article par source (fallback à 2 si < `target_count` sources distinctes)
         - Maximum 2 articles par thème (relaxé à 7 en mode THEME_FOCUS)
         - Minimum 3 sources différentes
         - Diversité revue de presse: score ÷ 2 dès le 2ème article d'une même source
@@ -1515,16 +1524,21 @@ class DigestSelector:
 
         effective_max_per_theme = self.constraints.MAX_PER_THEME
 
-        # Count distinct sources in candidate pool for fallback decision
+        # Count distinct sources in candidate pool for fallback decision.
+        # Seuil = `target_count` réellement demandé (et non la constante
+        # TARGET_DIGEST_SIZE) : on ne relâche à 2 articles/source que si le pool
+        # de sources distinctes ne suffit pas à remplir la cible 1-par-source.
+        # Découplé de TARGET_DIGEST_SIZE pour ne pas sur-relâcher la diversité
+        # des utilisateurs à petit `weekly_goal` quand on relève la cible globale.
         distinct_sources = {candidate[0].source_id for candidate in scored_candidates}
         effective_max_per_source = self.constraints.MAX_PER_SOURCE
 
-        if len(distinct_sources) < self.constraints.TARGET_DIGEST_SIZE:
+        if len(distinct_sources) < target_count:
             effective_max_per_source = 2
             logger.info(
                 "digest_diversity_fallback_max_per_source",
                 distinct_sources=len(distinct_sources),
-                target=self.constraints.TARGET_DIGEST_SIZE,
+                target=target_count,
                 effective_max_per_source=effective_max_per_source,
             )
 

--- a/packages/api/tests/test_digest_selector.py
+++ b/packages/api/tests/test_digest_selector.py
@@ -390,8 +390,9 @@ class TestDiversityConstraints:
     def test_max_per_theme_is_two(self):
         assert DiversityConstraints.MAX_PER_THEME == 2
 
-    def test_target_digest_size_is_seven(self):
-        assert DiversityConstraints.TARGET_DIGEST_SIZE == 7
+    def test_target_digest_size_is_ten(self):
+        # Relevé 7 → 10 (pool quotidien plus profond, cf. demande PO).
+        assert DiversityConstraints.TARGET_DIGEST_SIZE == 10
 
     def test_completion_threshold_is_five(self):
         assert DiversityConstraints.COMPLETION_THRESHOLD == 5


### PR DESCRIPTION
## Quoi

1. **Fix régression Bonnes Nouvelles** — revert du seul levier risqué de la PR #914 (LR-1 PR 2, coupes de coût Mistral) : le **batching de la passe 1 de classification** (`config.py`). Retour aux valeurs qualité-safe documentées par la PR #152 : `batch_size 12→5`, `min_batch_size 8→1`, `max_wait_s 300→0`, `interval_s 30→10`. Les gains de coût sans risque de #914 (prompt cache, trims curation/divergence) sont **conservés**.
2. **Relève la cible quotidienne** — `TARGET_DIGEST_SIZE 7→10` : le pool d'articles disponibles par jour (Actus du jour + Bonnes nouvelles) passe de ~5 observés à 8-10, **sans toucher au clustering**. `COMPLETION_THRESHOLD=5` inchangé (le "moment de fermeture" reste ancré sur 5).

## Pourquoi

Le PO a constaté que les Bonnes Nouvelles n'étaient plus pertinentes depuis les coupes de coût Mistral. Root cause : un batch de classification plus gros (2,4×) dilue l'attention du modèle par article et dégrade la précision du flag `serene`, seul gate d'entrée vers la passe 2 `is_good_news`. `batch_size=5` avait été fixé délibérément "pour qualité" (#152) — #914 l'a défait sans ré-évaluer. Diagnostic complet : `docs/bugs/bug-bonnes-nouvelles-qualite-regression.md`.

Le PO a également demandé de remonter *légèrement* la cible du pool quotidien à 8-10.

## Comment ça a été vérifié

- [x] `pytest` ciblé : classification (worker gate + service + good_news) — **64 OK**
- [x] `pytest` digest selector + service — **68 OK**
- [x] Suite backend complète — **1623 passed** (les 411 erreurs restantes sont des tests `test_veille_*` qui échouent en local faute de DB de test — pré-existant, non lié à ce diff)
- [x] Alembic : 1 head, aucune migration touchée
- [x] `/simplify` passé (diff propre — constantes + commentaires + découplage du seuil de fallback)
- [ ] Contrôle manuel PO des Bonnes Nouvelles sur 2-3 jours après déploiement staging (pas de vérif auto sans éval ground-truth)

## Zones à risque

- **Pipeline de classification** (`config.py`) : revert env-only, réversible. Le worker `_should_process()` redevient un no-op (traite dès ≥1 pending).
- **DigestSelector** : `TARGET_DIGEST_SIZE` gouverne les deux variantes (pour_vous + serein) et le regen. Le fallback diversité-source est découplé de la constante et suit le `target_count` réel → pas de sur-relâchement pour les users à petit `weekly_goal` (clamp [3,10] respecté).

🤖 Generated with [Claude Code](https://claude.com/claude-code)