### PR TITLE
fix(search): fuzzy matching + URL direct-detection in source search

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,36 +1,44 @@
-# feat(mobile): « Notif du jour » — bandeau agrégateur quotidien en tête de l'Essentiel
+# fix(search): recherche de sources — pertinence + latence (backend, sans migration)
 
-## Quoi
+Corrige 3 axes de la recherche de sources (« Ajouter une source » / Veille), confirmés par
+`source_search_logs`. Une seule cause racine côté orchestrateur
+`SmartSourceSearchService.search`. 100 % backend, additif, **aucune migration**.
 
-Une **ligne de notification unique** en tête du feed Essentiel (sous le bandeau Lettres) : chaque jour, le Facteur met en avant une fonctionnalité peu vue, choisie selon le profil. Un seul message à la fois, **jusqu'à 3/jour** (le suivant après action ou dismiss), rotation quotidienne déterministe.
+## Changements
 
-Story : `docs/stories/core/23.1.notif-du-jour.md`.
+1. **URL collée → détection de flux directe.** `_classify_query` renvoyait `url_like` sans
+   jamais brancher le résultat → une URL partait en recherche texte (9-31 s, 0 résultat). Nouvelle
+   branche `(0)` dans `search()` : normalise l'URL, `_detect_with_root_fallback`, renvoie 1 résultat
+   `layer="direct"` et saute Brave/GNews/Mistral. Reddit exclu (path `/r/<sub>` non résolu au root).
+   Pas de flux → fall-through au pipeline normal (jamais vide). Nouveau score `direct: 0.85`.
 
-## Moteur
+2. **Le filtre content_type déclenche sa couche.** Le chip « YouTube » + `micode` n'appelait
+   jamais la couche (heuristique texte ratée). Désormais `content_type == "youtube"` déclenche
+   **toujours** la couche ; `None` garde l'heuristique. Idem Reddit. `external_eligible` déjà False
+   avec un filtre → externes correctement sautés, pas de double-fire.
 
-- **File** : `notifDuJourQueueProvider` trie les messages éligibles par `relevance(profil) + jitter(jour, id)` (ε = 0.15, hash FNV `id#jour` → stable intra-jour, permute inter-jour pour les pertinences proches uniquement).
-- **9 messages** : 6 profil (serein, source, tournée, veille, premium, recommencer-fallback) + **3 nudges absorbés** (renudge notif 0.9, well-informed NPS 0.85 en rendu custom, géoloc 0.7) — leurs `*ShouldShowProvider` et caps existants sont réutilisés tels quels (avancés à la consommation).
-- **Day store** : `notif_du_jour_state_v1` (SharedPreferences), `{day, consumed[]}`, reset à minuit, cap 3.
-- **Rendu hifi** : surface, radius 14, ombre 0x14, carré icône 34 teinté (ocre/green/steel), DM Sans 13.5, CTA-lien + flèche, croix 30 ; repli AnimatedSize + fondu + translation 300ms, reduced-motion instantané, press scale + haptique.
+3. **Gate de pertinence sur les résultats EXTERNES.** Fonction pure `_is_relevant_external`
+   (token overlap / substring dé-espacé / trigrammes de caractères). N'utilise **pas**
+   `jaccard_similarity` (qui drop <3 char + chiffres → tuerait `bdm`/`11`). Appliquée au point de
+   convergence `_detect_candidates` (Brave/GNews) + inline dans `_search_mistral`. **Jamais** sur le
+   catalogue. Validé 7/7 sur cas prod : garde onemondial↔onzemondial, snowball, blog-moderateur→BDM,
+   micode, usine-digitale ; drop insight-clement→BDM, hypertext→BBF.
 
-## Dépréciations (PR 1)
-
-- Supprimés : `NotificationRenudgeBanner`, `WellInformedPrompt`, `GeolocPromptBanner` (widgets standalone) + leurs 3 slivers du feed.
-- `FirstImpressionSlot` réduit aux modales (`iosAddToHome`, `notifModal`) ; la carte cède aussi au bandeau Lettres (`lettresBannerVisibleThisSessionProvider`). Lettres → PR 3.
-
-## Fix CTA (décision PO « taps propres »)
-
-- Source → `RouteNames.addSource` (panneau d'ajout direct).
-- Premium → `/settings/subscriptions?add=1` : `SubscriptionsScreen` auto-ouvre la feuille d'ajout.
-- « Config » sorti de la rotation → tuile « Ma configuration » (barre de progression onboarding) dans `profile_screen.dart`.
+4. **Dédup par feed_url + host.** `seen_urls` (URL exacte) → helper `_dedup_add` : dédup par
+   `feed_url` (toujours) + par host (externes seulement, hors `_PATH_LEVEL_PLATFORMS`). Deux chaînes
+   YouTube / deux Substack survivent ; « blog modérateur » ne renvoie plus BDM ×2.
 
 ## Tests
 
-35 nouveaux (`test/features/notif_du_jour/`) : sélecteur (déterminisme, rotation bornée à ε, fallback), éligibilité par message, day store (reset minuit, cap, idempotence), widget (anti-flash, un-à-la-fois, X → persist + suivant, cap 3, reduced motion, tap Serein in-place, NPS custom, gates). Zones impactées : 446 verts (lettres, flux_continu, well_informed, notifications, settings).
+- `test_smart_source_search.py` : `_classify_query` (url_like/free_text/youtube/reddit),
+  `_is_relevant_external` (7 cas prod + vides + token court `bdm`), `_dedup_add` (feed_url, host
+  externe, 2 chaînes YouTube, 2 catalogue même host), gate `_detect_candidates` on/off-topic.
+- `test_smart_source_search_session.py` : URL avec flux → `layers=["direct"]`, catalog/brave non
+  appelés ; URL sans flux → fall-through catalogue ; `content_type=youtube`+`micode` → couche
+  youtube, externes sautés ; régression `content_type=None`+`micode` → youtube non déclenché.
+- `pytest tests/services/search/` : **95 passed**. `ruff` : clean.
 
-Aucune migration / changement backend. Changelog `unreleased` ajouté (« Notif du jour »).
+## Différé (suivi PO, hors PR)
 
-## Reste hors PR
-
-- Validation on-device Android des demandes OS (renudge/géoloc) via la file.
-- Calibration relevance/ε avec le PO ; PR 3 Lettres.
+Ajout d'Onze Mondial au catalogue + colonne `aliases text[]` (équivalence chiffre↔mot `11`↔`onze`).
+Le gate est calibré pour au moins **ne pas casser** onemondial → onzemondial (trigramme ~0,55).

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Recherche",
+      "summary": "Trouver une source est plus rapide et mieux ciblé."
+    },
+    {
       "tag": "Abonnements",
       "summary": "Tes sources abonnées gardent la couverture médiatique avant d'ouvrir l'article complet, et tu peux connecter ton compte depuis la fiche de n'importe quelle source suivie."
     },

--- a/packages/api/app/services/search/smart_source_search.py
+++ b/packages/api/app/services/search/smart_source_search.py
@@ -376,9 +376,7 @@ class SmartSourceSearchService:
         self.google_news = GoogleNewsProvider()
 
     @staticmethod
-    def _dedup_add(
-        r: dict, seen_feeds: set[str], seen_hosts: set[str]
-    ) -> bool:
+    def _dedup_add(r: dict, seen_feeds: set[str], seen_hosts: set[str]) -> bool:
         """Register *r*'s dedup keys; return True if it is new and kept.
 
         Dedup by ``feed_url`` always (blog-modérateur returned BDM twice under

--- a/packages/api/app/services/search/smart_source_search.py
+++ b/packages/api/app/services/search/smart_source_search.py
@@ -120,6 +120,88 @@ def _is_strong_catalog_match(result: dict, normalized_query: str) -> bool:
     return re.search(rf"\b{re.escape(normalized_query)}\b", name_norm) is not None
 
 
+def _relevance_tokens(s: str) -> list[str]:
+    """Tokenize a string keeping SHORT tokens and pure digits.
+
+    Deliberately different from ``jaccard_similarity`` (text_similarity.py),
+    which drops tokens <3 chars and digits — that would kill legitimate source
+    names like "bdm" or "11". We split ``normalize_query`` output on any
+    non-alphanumeric run.
+    """
+    return [t for t in re.split(r"[^a-z0-9]+", normalize_query(s)) if t]
+
+
+def _char_trigrams(s: str) -> set[str]:
+    """Character trigrams of *s* (de-spaced). Short strings map to themselves."""
+    s = s.replace(" ", "")
+    if len(s) < 3:
+        return {s} if s else set()
+    return {s[i : i + 3] for i in range(len(s) - 2)}
+
+
+def _host_core(host: str) -> str:
+    """Return the significant host labels: drop a leading ``www.`` and the TLD."""
+    host = (host or "").lower()
+    if host.startswith("www."):
+        host = host[4:]
+    parts = [p for p in host.split(".") if p]
+    if len(parts) > 1:
+        parts = parts[:-1]  # drop the TLD label (fr / com / …)
+    return " ".join(parts)
+
+
+def _is_relevant_external(
+    query_normalized: str, cand_name: str, cand_host: str
+) -> bool:
+    """Query↔candidate relevance gate for EXTERNAL results only.
+
+    External providers (Brave / Google News / Mistral) sometimes return feeds
+    unrelated to the query ("insight clement formont" → Blog du Modérateur,
+    "hypertext" → a library bulletin). This drops them. It is NEVER applied to
+    catalog hits.
+
+    Accepts when ANY of these holds:
+      1. token overlap ≥ 50% of the query tokens, or Jaccard ≥ 0.34 ;
+      2. de-spaced substring either direction (query ⊂ name/host or inverse) ;
+      3. char-trigram Jaccard ≥ 0.4 — the rule that keeps
+         "onemondial" ↔ "onzemondial".
+    Empty query or a tokenless candidate returns True (never over-filter).
+    """
+    q_token_list = _relevance_tokens(query_normalized)
+    q_tokens = set(q_token_list)
+    if not q_tokens:
+        return True
+
+    host_core = _host_core(cand_host)
+    name_token_list = _relevance_tokens(cand_name)
+    host_token_list = _relevance_tokens(host_core)
+    name_tokens = set(name_token_list)
+    host_tokens = set(host_token_list)
+    cand_tokens = name_tokens | host_tokens
+    if not cand_tokens:
+        return True
+
+    overlap = q_tokens & cand_tokens
+    if len(overlap) >= 0.5 * len(q_tokens):
+        return True
+    if len(overlap) / len(q_tokens | cand_tokens) >= 0.34:
+        return True
+
+    q_flat = "".join(q_token_list)
+    targets = ["".join(name_token_list), "".join(host_token_list)]
+    if q_flat:
+        for target in targets:
+            if target and (q_flat in target or target in q_flat):
+                return True
+        q_tri = _char_trigrams(q_flat)
+        if q_tri:
+            for target in targets:
+                t_tri = _char_trigrams(target)
+                if t_tri and len(q_tri & t_tri) / len(q_tri | t_tri) >= 0.4:
+                    return True
+    return False
+
+
 async def _record_search_log(
     *,
     user_id: str,
@@ -248,6 +330,9 @@ def _compute_score(
     """Compute composite ranking score."""
     layer_scores = {
         "catalog": 1.0,
+        # A pasted-URL direct hit is an explicit user intent — rank it above
+        # the noisy external layers so it wins the sort in _finalize.
+        "direct": 0.85,
         "youtube": 0.9,
         "reddit": 0.9,
         "brave": 0.8,
@@ -289,6 +374,32 @@ class SmartSourceSearchService:
         self.brave = BraveSearchProvider()
         self.reddit = RedditSearchProvider()
         self.google_news = GoogleNewsProvider()
+
+    @staticmethod
+    def _dedup_add(
+        r: dict, seen_feeds: set[str], seen_hosts: set[str]
+    ) -> bool:
+        """Register *r*'s dedup keys; return True if it is new and kept.
+
+        Dedup by ``feed_url`` always (blog-modérateur returned BDM twice under
+        the old exact-URL dedup). Additionally dedup EXTERNAL results by host,
+        except path-level platforms (two YouTube channels / two Substacks share
+        a host but are distinct sources). Catalog results keep their host so two
+        curated sources on the same host (substack) both survive — feed_url is
+        unique per source in DB.
+        """
+        feed = r.get("feed_url")
+        if feed:
+            if feed in seen_feeds:
+                return False
+            seen_feeds.add(feed)
+        if not r.get("in_catalog"):
+            host = (urlparse(r.get("url", "")).netloc or "").lower()
+            if host and host not in SmartSourceSearchService._PATH_LEVEL_PLATFORMS:
+                if host in seen_hosts:
+                    return False
+                seen_hosts.add(host)
+        return True
 
     async def _release_session(self) -> None:
         """Release the request-scoped DB session before slow externals.
@@ -336,7 +447,8 @@ class SmartSourceSearchService:
         normalized = normalize_query(query)
         layers_called: list[str] = []
         results: list[dict] = []
-        seen_urls: set[str] = set()
+        seen_feeds: set[str] = set()
+        seen_hosts: set[str] = set()
 
         # Rate limit check
         if not _check_user_rate_limit(user_id):
@@ -372,13 +484,45 @@ class SmartSourceSearchService:
         query_type = _classify_query(query)
         user_themes = await self._get_user_themes(user_id)
 
+        # (0) Pasted URL → resolve its feed directly and skip the search
+        # cascade (Brave→GNews→Mistral was 9-31s for zero benefit). Reddit
+        # URLs (/r/<sub>) don't resolve at the root, so they fall through to
+        # the dedicated reddit layer. Explicit intent → ignore `expand`.
+        if query_type == "url_like":
+            probe_url = query.strip()
+            if not probe_url.startswith(("http://", "https://")):
+                probe_url = "https://" + probe_url
+            probe_host = (urlparse(probe_url).netloc or "").lower()
+            if "reddit.com" not in probe_host:
+                detected = await self._detect_with_root_fallback(probe_url)
+                if detected:
+                    resolved_url, feed_meta = detected
+                    results.append(
+                        self._build_result(
+                            resolved_url, "direct", user_themes, feed_meta
+                        )
+                    )
+                    layers_called.append("direct")
+                    return await self._finalize(
+                        normalized,
+                        results,
+                        layers_called,
+                        start,
+                        False,
+                        user_id=user_id,
+                        query_raw=query,
+                        content_type=content_type,
+                        expand=expand,
+                    )
+                # No feed at that URL → fall through to the normal pipeline
+                # rather than returning empty.
+
         # (a) Catalog ILIKE (optionally filtered by type)
         catalog_results = await self._search_catalog(
             normalized, user_themes, content_type
         )
         for r in catalog_results:
-            if r["url"] not in seen_urls:
-                seen_urls.add(r["url"])
+            if self._dedup_add(r, seen_feeds, seen_hosts):
                 results.append(r)
         layers_called.append("catalog")
 
@@ -424,25 +568,31 @@ class SmartSourceSearchService:
         # slow external HTTP call (LLM/Brave/GoogleNews). Mirrors PR #485.
         await self._release_session()
 
-        # (b) YouTube API — if signal and type allows
-        if content_type in (None, "youtube") and (
-            query_type == "youtube_handle" or "youtube" in normalized
+        # (b) YouTube API — an explicit "youtube" filter ALWAYS fires the layer
+        # (the chip + "micode" used to return 0 results because the text
+        # heuristic never matched); unfiltered queries keep the heuristic.
+        if content_type == "youtube" or (
+            content_type is None
+            and (query_type == "youtube_handle" or "youtube" in normalized)
         ):
             yt_results = await self._search_youtube(query, user_themes)
             for r in yt_results:
-                if r["url"] not in seen_urls:
-                    seen_urls.add(r["url"])
+                if self._dedup_add(r, seen_feeds, seen_hosts):
                     results.append(r)
             layers_called.append("youtube")
 
-        # (c) Reddit JSON — if signal and type allows
-        if content_type in (None, "reddit") and (
-            query_type == "reddit_sub" or "reddit" in normalized or "r/" in normalized
+        # (c) Reddit JSON — symmetric: an explicit "reddit" filter always fires.
+        if content_type == "reddit" or (
+            content_type is None
+            and (
+                query_type == "reddit_sub"
+                or "reddit" in normalized
+                or "r/" in normalized
+            )
         ):
             reddit_results = await self._search_reddit(query, user_themes)
             for r in reddit_results:
-                if r["url"] not in seen_urls:
-                    seen_urls.add(r["url"])
+                if self._dedup_add(r, seen_feeds, seen_hosts):
                     results.append(r)
             layers_called.append("reddit")
 
@@ -469,13 +619,11 @@ class SmartSourceSearchService:
                 self._search_google_news(normalized, user_themes),
             )
             for r in brave_results:
-                if r["url"] not in seen_urls:
-                    seen_urls.add(r["url"])
+                if self._dedup_add(r, seen_feeds, seen_hosts):
                     results.append(r)
             layers_called.append("brave")
             for r in gnews_results:
-                if r["url"] not in seen_urls:
-                    seen_urls.add(r["url"])
+                if self._dedup_add(r, seen_feeds, seen_hosts):
                     results.append(r)
             layers_called.append("google_news")
 
@@ -484,8 +632,7 @@ class SmartSourceSearchService:
             if brave_eligible:
                 brave_results = await self._search_brave(normalized, user_themes)
                 for r in brave_results:
-                    if r["url"] not in seen_urls:
-                        seen_urls.add(r["url"])
+                    if self._dedup_add(r, seen_feeds, seen_hosts):
                         results.append(r)
                 layers_called.append("brave")
 
@@ -507,8 +654,7 @@ class SmartSourceSearchService:
             if external_eligible:
                 gnews_results = await self._search_google_news(normalized, user_themes)
                 for r in gnews_results:
-                    if r["url"] not in seen_urls:
-                        seen_urls.add(r["url"])
+                    if self._dedup_add(r, seen_feeds, seen_hosts):
                         results.append(r)
                 layers_called.append("google_news")
 
@@ -536,8 +682,7 @@ class SmartSourceSearchService:
         ):
             mistral_results = await self._search_mistral(normalized, user_themes)
             for r in mistral_results:
-                if r["url"] not in seen_urls:
-                    seen_urls.add(r["url"])
+                if self._dedup_add(r, seen_feeds, seen_hosts):
                     results.append(r)
             layers_called.append("mistral")
 
@@ -902,6 +1047,7 @@ class SmartSourceSearchService:
         candidates: list[tuple[str, str, str]],
         layer: str,
         user_themes: list[str],
+        query_normalized: str = "",
     ) -> list[dict]:
         """Run feed detection on candidates in parallel, short-circuit at 3 hits.
 
@@ -967,16 +1113,27 @@ class SmartSourceSearchService:
         for idx, detected in collected:
             _, fallback_name, fallback_desc = candidates[idx]
             resolved_url, feed_meta = detected
-            results.append(
-                self._build_result(
-                    resolved_url,
-                    layer,
-                    user_themes,
-                    feed_meta,
-                    fallback_name,
-                    fallback_desc,
-                )
+            result = self._build_result(
+                resolved_url,
+                layer,
+                user_themes,
+                feed_meta,
+                fallback_name,
+                fallback_desc,
             )
+            # Relevance gate on the RESOLVED name/host — drops off-topic feeds
+            # returned by external providers (never applied to catalog hits).
+            host = (urlparse(resolved_url).netloc or "").lower()
+            if not _is_relevant_external(query_normalized, result["name"], host):
+                logger.debug(
+                    "smart_search.external_offtopic_drop",
+                    layer=layer,
+                    query=query_normalized,
+                    name=result["name"],
+                    host=host,
+                )
+                continue
+            results.append(result)
         return results
 
     @staticmethod
@@ -1037,7 +1194,9 @@ class SmartSourceSearchService:
         ranked = sorted(raw_candidates, key=_score, reverse=True)
         candidates = ranked[:5]
 
-        return await self._detect_candidates(candidates, "brave", user_themes)
+        return await self._detect_candidates(
+            candidates, "brave", user_themes, query_normalized=query
+        )
 
     async def _search_google_news(
         self, query: str, user_themes: list[str]
@@ -1052,6 +1211,7 @@ class SmartSourceSearchService:
             [(u, "", "") for u in urls],
             "google_news",
             user_themes,
+            query_normalized=query,
         )
 
     async def _search_mistral(self, query: str, user_themes: list[str]) -> list[dict]:
@@ -1109,16 +1269,25 @@ class SmartSourceSearchService:
                 if not detected:
                     continue
                 resolved_url, feed_meta = detected
-                results.append(
-                    self._build_result(
-                        resolved_url,
-                        "mistral",
-                        user_themes,
-                        feed_meta,
-                        name,
-                        fallback_type=stype,
-                    )
+                result = self._build_result(
+                    resolved_url,
+                    "mistral",
+                    user_themes,
+                    feed_meta,
+                    name,
+                    fallback_type=stype,
                 )
+                host = (urlparse(resolved_url).netloc or "").lower()
+                if not _is_relevant_external(query, result["name"], host):
+                    logger.debug(
+                        "smart_search.external_offtopic_drop",
+                        layer="mistral",
+                        query=query,
+                        name=result["name"],
+                        host=host,
+                    )
+                    continue
+                results.append(result)
             return results
 
         except Exception as e:

--- a/packages/api/tests/services/search/test_smart_source_search.py
+++ b/packages/api/tests/services/search/test_smart_source_search.py
@@ -4,8 +4,10 @@ import pytest
 
 from app.services.search.cache import hash_query, normalize_query
 from app.services.search.smart_source_search import (
+    SmartSourceSearchService,
     _classify_query,
     _compute_score,
+    _is_relevant_external,
     _is_strong_catalog_match,
 )
 
@@ -42,6 +44,155 @@ class TestClassifyQuery:
 
     def test_classify_free_text_with_spaces(self):
         assert _classify_query("  la newsletter finance  ") == "free_text"
+
+    def test_classify_bare_domain_url_like(self):
+        assert _classify_query("usine-digitale.fr") == "url_like"
+
+    def test_classify_full_url_url_like(self):
+        assert _classify_query("https://www.usine-digitale.fr/") == "url_like"
+
+    def test_classify_two_word_name_is_free_text(self):
+        # "usine digitale" (space, no dot) must NOT be treated as a URL.
+        assert _classify_query("usine digitale") == "free_text"
+
+    def test_classify_youtube_url_url_like(self):
+        assert _classify_query("youtube.com/@micode") == "url_like"
+
+    def test_classify_reddit_url_url_like(self):
+        assert _classify_query("reddit.com/r/france") == "url_like"
+
+
+# ─── External relevance gate ─────────────────────────────────────
+
+
+class TestIsRelevantExternal:
+    # --- cases that must be KEPT (validated 7/7 on prod logs) ---
+    def test_keeps_onemondial_onzemondial(self):
+        # trigram rule: onemondial ↔ onzemondial ~0.55
+        assert (
+            _is_relevant_external("onemondial", "Onze Mondial", "onzemondial.com")
+            is True
+        )
+
+    def test_keeps_snowball_name_match(self):
+        assert (
+            _is_relevant_external(
+                "snowball", "Snowball Innovation GmbH", "snowball.company"
+            )
+            is True
+        )
+
+    def test_keeps_blog_moderateur_bdm(self):
+        # host is correct (blogdumoderateur) — name token overlap keeps it.
+        assert (
+            _is_relevant_external(
+                "blog moderateur", "Blog du Modérateur", "www.blogdumoderateur.com"
+            )
+            is True
+        )
+
+    def test_keeps_micode(self):
+        assert _is_relevant_external("micode", "Micode", "www.youtube.com") is True
+
+    def test_keeps_usine_digitale(self):
+        assert (
+            _is_relevant_external(
+                "usine digitale", "L'Usine Digitale", "www.usine-digitale.fr"
+            )
+            is True
+        )
+
+    # --- cases that must be DROPPED ---
+    def test_drops_insight_clement_bdm(self):
+        assert (
+            _is_relevant_external(
+                "insight clement formont",
+                "Blog du Modérateur",
+                "www.blogdumoderateur.com",
+            )
+            is False
+        )
+
+    def test_drops_hypertext_library_bulletin(self):
+        assert (
+            _is_relevant_external(
+                "hypertext",
+                "Bulletin des bibliothèques de France",
+                "bbf.enssib.fr",
+            )
+            is False
+        )
+
+    # --- never over-filter ---
+    def test_empty_query_returns_true(self):
+        assert _is_relevant_external("", "Anything", "example.com") is True
+
+    def test_tokenless_candidate_returns_true(self):
+        assert _is_relevant_external("micode", "", "") is True
+
+    def test_keeps_short_token_bdm(self):
+        # "bdm" is <3 chars — jaccard_similarity would drop it; we must not.
+        assert _is_relevant_external("bdm", "BDM", "www.blogdumoderateur.com") is True
+
+
+# ─── feed_url + host dedup helper ────────────────────────────────
+
+
+class TestDedupAdd:
+    def test_dedup_by_feed_url(self):
+        seen_feeds: set[str] = set()
+        seen_hosts: set[str] = set()
+        a = {"feed_url": "https://x.com/feed", "url": "https://x.com/a"}
+        b = {"feed_url": "https://x.com/feed", "url": "https://x.com/b"}
+        assert SmartSourceSearchService._dedup_add(a, seen_feeds, seen_hosts) is True
+        assert SmartSourceSearchService._dedup_add(b, seen_feeds, seen_hosts) is False
+
+    def test_external_dedup_by_host(self):
+        seen_feeds: set[str] = set()
+        seen_hosts: set[str] = set()
+        a = {
+            "feed_url": "https://bdm.com/rss",
+            "url": "https://www.blogdumoderateur.com/a",
+        }
+        b = {
+            "feed_url": "https://bdm.com/atom",  # different feed, same host
+            "url": "https://www.blogdumoderateur.com/b",
+        }
+        assert SmartSourceSearchService._dedup_add(a, seen_feeds, seen_hosts) is True
+        assert SmartSourceSearchService._dedup_add(b, seen_feeds, seen_hosts) is False
+
+    def test_two_youtube_channels_both_survive(self):
+        seen_feeds: set[str] = set()
+        seen_hosts: set[str] = set()
+        a = {
+            "feed_url": "https://www.youtube.com/feeds/videos.xml?channel_id=A",
+            "url": "https://www.youtube.com/@a",
+        }
+        b = {
+            "feed_url": "https://www.youtube.com/feeds/videos.xml?channel_id=B",
+            "url": "https://www.youtube.com/@b",
+        }
+        assert SmartSourceSearchService._dedup_add(a, seen_feeds, seen_hosts) is True
+        # path-level platform → host is NOT deduped, distinct feed → kept.
+        assert SmartSourceSearchService._dedup_add(b, seen_feeds, seen_hosts) is True
+
+    def test_two_catalog_sources_same_host_both_survive(self):
+        # Catalog results are exempt from host dedup: two curated sources on
+        # the same host but distinct feed_url both survive.
+        seen_feeds: set[str] = set()
+        seen_hosts: set[str] = set()
+        a = {
+            "feed_url": "https://shared.substack.com/feed/a",
+            "url": "https://shared.substack.com/a",
+            "in_catalog": True,
+        }
+        b = {
+            "feed_url": "https://shared.substack.com/feed/b",
+            "url": "https://shared.substack.com/b",
+            "in_catalog": True,
+        }
+        assert SmartSourceSearchService._dedup_add(a, seen_feeds, seen_hosts) is True
+        assert SmartSourceSearchService._dedup_add(b, seen_feeds, seen_hosts) is True
 
 
 # ─── compute_score tests ─────────────────────────────────────────
@@ -384,6 +535,59 @@ class TestCacheKey:
         )
 
         assert SmartSourceSearchService._cache_key("not a url") is None
+
+
+class TestDetectCandidatesRelevanceGate:
+    @pytest.mark.asyncio
+    async def test_offtopic_candidate_dropped(self, monkeypatch):
+        """External candidate whose resolved name/host is off-topic is dropped."""
+
+        async def fake_detect(self, url):
+            return (
+                "https://www.blogdumoderateur.com",
+                {
+                    "feed_url": "https://www.blogdumoderateur.com/feed",
+                    "name": "Blog du Modérateur",
+                    "type": "article",
+                },
+            )
+
+        monkeypatch.setattr(
+            SmartSourceSearchService, "_detect_with_root_fallback", fake_detect
+        )
+        svc = SmartSourceSearchService.__new__(SmartSourceSearchService)
+        out = await svc._detect_candidates(
+            [("https://www.blogdumoderateur.com/x", "", "")],
+            "brave",
+            [],
+            query_normalized="insight clement formont",
+        )
+        assert out == []
+
+    @pytest.mark.asyncio
+    async def test_ontopic_candidate_kept(self, monkeypatch):
+        async def fake_detect(self, url):
+            return (
+                "https://www.usine-digitale.fr",
+                {
+                    "feed_url": "https://www.usine-digitale.fr/rss",
+                    "name": "L'Usine Digitale",
+                    "type": "article",
+                },
+            )
+
+        monkeypatch.setattr(
+            SmartSourceSearchService, "_detect_with_root_fallback", fake_detect
+        )
+        svc = SmartSourceSearchService.__new__(SmartSourceSearchService)
+        out = await svc._detect_candidates(
+            [("https://www.usine-digitale.fr/x", "", "")],
+            "brave",
+            [],
+            query_normalized="usine digitale",
+        )
+        assert len(out) == 1
+        assert out[0]["feed_url"] == "https://www.usine-digitale.fr/rss"
 
 
 class TestLooksFrench:

--- a/packages/api/tests/services/search/test_smart_source_search_session.py
+++ b/packages/api/tests/services/search/test_smart_source_search_session.py
@@ -244,6 +244,284 @@ async def test_cache_hit_releases_session():
 
 
 @pytest.mark.asyncio
+async def test_pasted_url_with_feed_short_circuits_direct():
+    """A pasted URL that resolves to a feed returns via the `direct` layer,
+    skipping catalog and every external provider."""
+    db = _FakeSession()
+    user_id = str(uuid4())
+
+    catalog_calls = {"n": 0}
+    brave_calls = {"n": 0}
+
+    async def spy_catalog(self, *a, **k):
+        catalog_calls["n"] += 1
+        return []
+
+    async def spy_brave(self, *a, **k):
+        brave_calls["n"] += 1
+        return []
+
+    async def fake_detect(self, url):
+        return (
+            "https://www.usine-digitale.fr",
+            {
+                "feed_url": "https://www.usine-digitale.fr/rss",
+                "name": "L'Usine Digitale",
+                "type": "article",
+            },
+        )
+
+    async def hook() -> None:
+        await db.close()
+
+    svc = _make_service(db, on_phase1_done=hook)
+
+    with (
+        patch.object(
+            SmartSourceSearchService,
+            "_get_user_themes",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch.object(SmartSourceSearchService, "_search_catalog", new=spy_catalog),
+        patch.object(
+            SmartSourceSearchService,
+            "_detect_with_root_fallback",
+            new=fake_detect,
+        ),
+        patch.object(SmartSourceSearchService, "_search_brave", new=spy_brave),
+        patch(
+            "app.services.search.smart_source_search.search_cache_get",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.search.smart_source_search.search_cache_set",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.search.smart_source_search._record_search_log",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        svc.brave = SimpleNamespace(is_ready=True)  # type: ignore[assignment]
+        out = await svc.search(
+            "https://www.usine-digitale.fr/", user_id, content_type=None, expand=False
+        )
+
+    assert out["layers_called"] == ["direct"]
+    assert catalog_calls["n"] == 0
+    assert brave_calls["n"] == 0
+    assert len(out["results"]) == 1
+    assert out["results"][0]["source_layer"] == "direct"
+
+
+@pytest.mark.asyncio
+async def test_pasted_url_without_feed_falls_through_to_catalog():
+    """A URL with no discoverable feed must NOT return empty — it falls
+    through to the normal pipeline (catalog first)."""
+    db = _FakeSession()
+    user_id = str(uuid4())
+
+    catalog_calls = {"n": 0}
+
+    async def spy_catalog(self, *a, **k):
+        catalog_calls["n"] += 1
+        return []
+
+    async def fake_detect_none(self, url):
+        return None
+
+    async def hook() -> None:
+        await db.close()
+
+    svc = _make_service(db, on_phase1_done=hook)
+
+    with (
+        patch.object(
+            SmartSourceSearchService,
+            "_get_user_themes",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch.object(SmartSourceSearchService, "_search_catalog", new=spy_catalog),
+        patch.object(
+            SmartSourceSearchService,
+            "_detect_with_root_fallback",
+            new=fake_detect_none,
+        ),
+        patch.object(
+            SmartSourceSearchService,
+            "_search_brave",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            SmartSourceSearchService,
+            "_search_google_news",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            SmartSourceSearchService,
+            "_search_mistral",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "app.services.search.smart_source_search.search_cache_get",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.search.smart_source_search.search_cache_set",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.search.smart_source_search._record_search_log",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        svc.brave = SimpleNamespace(is_ready=True)  # type: ignore[assignment]
+        out = await svc.search(
+            "https://no-feed-host.example.com/",
+            user_id,
+            content_type=None,
+            expand=False,
+        )
+
+    assert "direct" not in out["layers_called"]
+    assert "catalog" in out["layers_called"]
+    assert catalog_calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_youtube_filter_always_fires_layer():
+    """content_type='youtube' fires the YouTube layer even without a text
+    heuristic hit, and skips the external providers."""
+    db = _FakeSession()
+    user_id = str(uuid4())
+
+    yt_calls = {"n": 0}
+    brave_calls = {"n": 0}
+
+    async def spy_youtube(self, query, user_themes):
+        yt_calls["n"] += 1
+        return [
+            {
+                "name": "Micode",
+                "type": "youtube",
+                "url": "https://www.youtube.com/@micode",
+                "feed_url": "https://www.youtube.com/feeds/videos.xml?channel_id=X",
+                "in_catalog": False,
+                "score": 0.9,
+                "source_layer": "youtube",
+            }
+        ]
+
+    async def spy_brave(self, *a, **k):
+        brave_calls["n"] += 1
+        return []
+
+    async def hook() -> None:
+        await db.close()
+
+    svc = _make_service(db, on_phase1_done=hook)
+
+    with (
+        patch.object(
+            SmartSourceSearchService,
+            "_get_user_themes",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            SmartSourceSearchService,
+            "_search_catalog",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch.object(SmartSourceSearchService, "_search_youtube", new=spy_youtube),
+        patch.object(SmartSourceSearchService, "_search_brave", new=spy_brave),
+        patch(
+            "app.services.search.smart_source_search.search_cache_get",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.search.smart_source_search.search_cache_set",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.search.smart_source_search._record_search_log",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        svc.brave = SimpleNamespace(is_ready=True)  # type: ignore[assignment]
+        out = await svc.search(
+            "micode", user_id, content_type="youtube", expand=False
+        )
+
+    assert "youtube" in out["layers_called"]
+    assert yt_calls["n"] == 1
+    assert brave_calls["n"] == 0  # content_type filter → externals skipped
+
+
+@pytest.mark.asyncio
+async def test_youtube_layer_not_fired_without_filter_or_heuristic():
+    """Regression: content_type=None + a plain word must NOT fire YouTube."""
+    db = _FakeSession()
+    user_id = str(uuid4())
+
+    yt_calls = {"n": 0}
+
+    async def spy_youtube(self, query, user_themes):
+        yt_calls["n"] += 1
+        return []
+
+    async def hook() -> None:
+        await db.close()
+
+    svc = _make_service(db, on_phase1_done=hook)
+
+    with (
+        patch.object(
+            SmartSourceSearchService,
+            "_get_user_themes",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            SmartSourceSearchService,
+            "_search_catalog",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch.object(SmartSourceSearchService, "_search_youtube", new=spy_youtube),
+        patch.object(
+            SmartSourceSearchService,
+            "_search_brave",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            SmartSourceSearchService,
+            "_search_google_news",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            SmartSourceSearchService,
+            "_search_mistral",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "app.services.search.smart_source_search.search_cache_get",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.search.smart_source_search.search_cache_set",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.search.smart_source_search._record_search_log",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        svc.brave = SimpleNamespace(is_ready=True)  # type: ignore[assignment]
+        out = await svc.search("micode", user_id, content_type=None, expand=False)
+
+    assert "youtube" not in out["layers_called"]
+    assert yt_calls["n"] == 0
+
+
+@pytest.mark.asyncio
 async def test_double_close_is_safe():
     db = _FakeSession()
 


### PR DESCRIPTION
## What

Improves source search query parsing and ranking:
1. URL collée → direct detection (normalizes URL, skips Brave/GNews/Mistral, returns direct layer score 0.85)
2. content_type filter now always triggers its layer (YouTube/Reddit gated correctly)
3. Fuzzy-match fallback for heuristic failures + improved relevance ranking

100% backend, no migration required.

## Why

Confirmed via `source_search_logs`: URLs pasted into "Ajouter une source" / Veille were taking 9-31s with 0 results. Single root cause in `SmartSourceSearchService.search()` orchestrator logic.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Maintenance / Refactor

## Checklist

- [x] Tests pass locally (`cd packages/api && pytest -v`)
- [x] Linting passes (`ruff check app/`)
- [x] No new Python `List[]` imports (use `list[]`)
- [x] Backend-only change, no auth/DB schema changes
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [x] N/A (backend-only, no schema changes)