### PR TITLE
feat(mobile): ajustements UI Essentiel/Tournée — banner, fit/snap, carte de fin

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,14 @@
 {
   "unreleased": [
     {
+      "tag": "Essentiel",
+      "summary": "Les titres de section sont plus lisibles, le « Tout lire » colle à sa section, et « Ton avis compte » est désormais intégré à la carte de fin de tournée."
+    },
+    {
+      "tag": "Tournée",
+      "summary": "La lecture de ta tournée est plus fluide, les sections sont mieux cadrées à l'écran, et tu personnalises ta veille en un geste depuis son titre."
+    },
+    {
       "tag": "Abonnements",
       "summary": "Tes sources abonnées gardent la couverture médiatique avant d'ouvrir l'article complet, et tu peux connecter ton compte depuis la fiche de n'importe quelle source suivie."
     },

--- a/apps/mobile/lib/features/feedback/widgets/feedback_closing_card.dart
+++ b/apps/mobile/lib/features/feedback/widgets/feedback_closing_card.dart
@@ -25,10 +25,16 @@ class FeedbackClosingCard extends ConsumerStatefulWidget {
   /// de la section de clôture reste calée sur l'ancienne hauteur.
   final VoidCallback? onLayoutChanged;
 
+  /// Quand `true`, la carte est rendue **sans son chrome extérieur** (margin +
+  /// decoration + shadow + padding) : juste la Column interne, pour être
+  /// embarquée en sous-bloc d'une autre carte (cf. [ClosingCardV18.secondary]).
+  final bool embedded;
+
   const FeedbackClosingCard({
     super.key,
     this.digestDate,
     this.onLayoutChanged,
+    this.embedded = false,
   });
 
   @override
@@ -57,6 +63,55 @@ class _FeedbackClosingCardState extends ConsumerState<FeedbackClosingCard> {
       });
     }
 
+    final content = Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // Tampon « TON AVIS COMPTE » dans l'esprit des cartes de tournée.
+        Transform.rotate(
+          angle: -2 * math.pi / 180,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            decoration: BoxDecoration(
+              border: Border.all(color: colors.primary, width: 1.5),
+            ),
+            child: Text(
+              'TON AVIS COMPTE',
+              style: GoogleFonts.courierPrime(
+                fontSize: 10,
+                fontWeight: FontWeight.w700,
+                color: colors.primary,
+                letterSpacing: 2.0,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 6),
+
+        // Micro-feedback emoji (toujours présent).
+        SentimentPicker(
+          digestDate: widget.digestDate,
+          onLayoutChanged: widget.onLayoutChanged,
+        ),
+
+        // Invitation au call (conditionnelle, gated backend).
+        if (showCall) ...[
+          const SizedBox(height: 18),
+          Divider(
+            height: 1,
+            color: colors.textTertiary.withValues(alpha: 0.15),
+          ),
+          const SizedBox(height: 16),
+          _CallInviteTeaser(
+            onTap: () =>
+                CallInviteSheet.show(context, segment: invite?.segment),
+          ),
+        ],
+      ],
+    );
+
+    // Embarquée : pas de chrome propre, la carte hôte fournit boîte + padding.
+    if (widget.embedded) return content;
+
     return Container(
       margin: const EdgeInsets.fromLTRB(18, 8, 18, 8),
       clipBehavior: Clip.antiAlias,
@@ -73,51 +128,7 @@ class _FeedbackClosingCardState extends ConsumerState<FeedbackClosingCard> {
       ),
       child: Padding(
         padding: const EdgeInsets.fromLTRB(22, 20, 22, 22),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // Tampon « TON AVIS COMPTE » dans l'esprit des cartes de tournée.
-            Transform.rotate(
-              angle: -2 * math.pi / 180,
-              child: Container(
-                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                decoration: BoxDecoration(
-                  border: Border.all(color: colors.primary, width: 1.5),
-                ),
-                child: Text(
-                  'TON AVIS COMPTE',
-                  style: GoogleFonts.courierPrime(
-                    fontSize: 10,
-                    fontWeight: FontWeight.w700,
-                    color: colors.primary,
-                    letterSpacing: 2.0,
-                  ),
-                ),
-              ),
-            ),
-            const SizedBox(height: 6),
-
-            // Micro-feedback emoji (toujours présent).
-            SentimentPicker(
-              digestDate: widget.digestDate,
-              onLayoutChanged: widget.onLayoutChanged,
-            ),
-
-            // Invitation au call (conditionnelle, gated backend).
-            if (showCall) ...[
-              const SizedBox(height: 18),
-              Divider(
-                height: 1,
-                color: colors.textTertiary.withValues(alpha: 0.15),
-              ),
-              const SizedBox(height: 16),
-              _CallInviteTeaser(
-                onTap: () =>
-                    CallInviteSheet.show(context, segment: invite?.segment),
-              ),
-            ],
-          ],
-        ),
+        child: content,
       ),
     );
   }

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -68,6 +68,15 @@ const double _kStickyThreshold = 60.0;
 /// it feeds the snap framing AND the fit budget ([usableViewportHeightProvider]).
 const double _kStickyBarHeight = 50.0;
 
+/// px. Anti-crop safety inset for section-top snap anchors. Each snap `top` is
+/// pulled up by this much so a section poses a hair **below** the sticky header
+/// rather than flush — absorbing the small measurement jitter that
+/// intermittently cropped a section's first line under the header. Kept minimal
+/// (a few px): large enough to never crop, small enough to never reveal the
+/// previous section. A *mitigation* — the real fix is measuring anchors on a
+/// stabilised layout (gesture-start + post-fit recompute). Tune on device.
+const double kSnapTopSafety = 4.0;
+
 // Section-snap tuning lives in `utils/section_snap.dart` (kSnapCaptureFraction,
 // kBoundaryCrossVelocity, kSnapEpsilon, kSnapSpring) so the resting-position
 // arithmetic stays a pure, unit-testable function. The snap itself is woven
@@ -97,26 +106,10 @@ const _closingTab = StickyTab(
 // Carte de personnalisation (virtuelle — pas de section correspondante).
 const _persoCardTab = StickyTab(label: 'Pour toi', accent: Color(0xFFB0470A));
 
-/// Drag-time feedforward payload for [_SectionPassageDot]. Computed live in
-/// [_FluxContinuScreenState._updateBoundaryApproach] and broadcast via a
-/// [ValueNotifier] so the dots rebuild without a per-frame `setState`.
-/// - [dotIndex] : the passage dot sitting at the boundary the gesture is
-///   approaching (= the section index *before* it, same `k-1` convention as
-///   [_FluxContinuScreenState._pulsePassageForStickyIndex]), or `null` when the
-///   next snap point in the travel direction is **not** an inter-section
-///   boundary (a tall section's free-reading bottom) — so no « va snapper » cue
-///   appears inside the free interior, matching the physics which returns `null`
-///   there too.
-/// - [proximity] : ramps 0→1 as the lift point nears that boundary, reaching 1
-///   exactly at [kSectionEdgeMargin] (the deadband where the snap commits), so
-///   the dot peaks precisely at the switch threshold.
-typedef _BoundaryApproach = ({int? dotIndex, double proximity});
-
 /// Signed *travel* direction from a [ScrollDirection]: +1 scrolling down (offset
-/// increasing), -1 up, 0 idle/unknown. Single mapping shared by the drag-time
-/// feedforward ([_FluxContinuScreenState._updateBoundaryApproach]) and the snap
-/// physics ([_SectionSnapPhysics._resolveTarget]) so the cue and the commit can
-/// never disagree on « which way am I going ».
+/// increasing), -1 up, 0 idle/unknown. Shared mapping used by the snap physics
+/// ([_SectionSnapPhysics._resolveTarget]) and the active-section tracking so
+/// they can never disagree on « which way am I going ».
 double _travelDirection(ScrollDirection d) => switch (d) {
       ScrollDirection.reverse => 1.0,
       ScrollDirection.forward => -1.0,
@@ -135,8 +128,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   final ScrollController _tabsScroll = ScrollController();
   final ValueNotifier<bool> _stickyVisible = ValueNotifier(false);
   final ValueNotifier<int> _activeIndex = ValueNotifier(0);
-  final ValueNotifier<_SectionPassagePulse?> _sectionPassagePulse =
-      ValueNotifier(null);
 
   final List<GlobalKey> _sectionKeys = [];
 
@@ -176,8 +167,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   bool _gestureNudgeRequested = false;
   bool _showSwipeHint = false;
 
-  int _passagePulseSequence = 0;
-
   /// Mutable, stable holder of the section-start anchors (absolute scroll
   /// pixels). Passed *by reference* to the immutable [_SectionSnapPhysics],
   /// which reads it live — the physics is rebuilt every frame and must never
@@ -185,28 +174,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   /// resize mid-session), never per scroll frame.
   final _SnapAnchors _snapAnchors = _SnapAnchors();
   bool _snapAnchorsRecomputeScheduled = false;
-
-  /// Drag-time « distance to the next boundary » cue, written by
-  /// [_updateBoundaryApproach] on every scroll frame (quantized) and read by the
-  /// in-flow [_SectionPassageDot]s. Feedforward twin of [_sectionPassagePulse]
-  /// (the post-validation pulse) — both ride the same dot so the gesture reads
-  /// as a single continuous « j'approche un seuil → je l'ai franchi ».
-  final ValueNotifier<_BoundaryApproach?> _boundaryApproach = ValueNotifier(
-    null,
-  );
-
-  /// Sorted snap points of [_snapAnchors], cached once per layout (frames only
-  /// change on layout, never per scroll frame) so the per-frame
-  /// [_updateBoundaryApproach] doesn't re-allocate + re-sort them every frame.
-  List<double> _snapPoints = const [];
-
-  /// Maps a section *top* (an inter-section boundary) to the passage dot above
-  /// it (section index − 1). Rebuilt alongside the snap anchors in
-  /// [_recomputeSnapAnchors]; [_updateBoundaryApproach] looks up an approached
-  /// snap point here directly (the offsets are bit-identical to the stored
-  /// frame tops). Tops absent here (a tall section's bottom, the first section,
-  /// the virtual cards) carry no « va snapper » cue.
-  final Map<double, int> _dotIndexByTop = {};
 
   /// (A3) Indices (into `state.sections`) of sections taller than the viewport —
   /// the ones with a free-reading interior (`bottom > top`, same predicate as
@@ -254,8 +221,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     _tabsScroll.dispose();
     _stickyVisible.dispose();
     _activeIndex.dispose();
-    _sectionPassagePulse.dispose();
-    _boundaryApproach.dispose();
     _tallSections.dispose();
     _pullHintTimer?.cancel();
     super.dispose();
@@ -270,7 +235,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       _stickyVisible.value = showSticky;
     }
     _updateActiveSection();
-    _updateBoundaryApproach(pos);
 
     if (currentScroll > _maxScrollDepthPx) {
       _maxScrollDepthPx = currentScroll;
@@ -347,7 +311,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       // boundary crossing, so this fires exactly once per step.
       if (_stickyVisible.value) {
         unawaited(_triggerSectionChangeHaptic());
-        _pulsePassageForStickyIndex(activeAt);
       }
       _activeIndex.value = activeAt;
       _alignTabsToActive(activeAt);
@@ -363,86 +326,23 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     return -1;
   }
 
-  void _pulsePassageForStickyIndex(int stickyIndex) {
-    final sectionIndex = _sectionIndexForStickyIndex(stickyIndex);
-    if (sectionIndex <= 0) return;
-    _sectionPassagePulse.value = _SectionPassagePulse(
-      index: sectionIndex - 1,
-      sequence: ++_passagePulseSequence,
-    );
-  }
-
+  /// Fires when a scroll gesture *starts*. Refreshes the snap anchors so the
+  /// ballistic that follows reads frames measured on the current, settled
+  /// layout — not stale ones from before the fit converged (a source of the
+  /// intermittent top-crop). Post-frame + coalesced, so it never runs per
+  /// frame. Returns `false` to let the notification bubble.
   bool _onScrollNotification(ScrollNotification n) {
+    if (n is ScrollStartNotification) {
+      _scheduleAnchorRecompute();
+    }
     return false;
-  }
-
-  /// (A1) Feedforward: as the reader drags toward a section boundary, ramp the
-  /// in-flow passage dot that sits there so the snap reads as « j'approche un
-  /// seuil marqué » *before* the finger lifts — not a post-hoc surprise. Runs
-  /// inside [_onScroll] (already firing every frame); reuses the live snap
-  /// anchors and the shared [snapPointsOf], so the cue is mechanically true to
-  /// where the snap commits. Cheap: writes a quantized value to
-  /// [_boundaryApproach] only when it changes.
-  void _updateBoundaryApproach(ScrollPosition pos) {
-    final points = _snapPoints;
-    final currentScroll = pos.pixels;
-    // Header zone (above the first section): the sticky is hidden anyway ⇒ no
-    // boundary cue.
-    if (points.isEmpty || currentScroll <= points.first) {
-      if (_boundaryApproach.value != null) _boundaryApproach.value = null;
-      return;
-    }
-    // Travel direction (shared mapping with the physics). On idle, keep the
-    // previous value so a pause mid-drag doesn't flicker the cue off.
-    final dir = _travelDirection(pos.userScrollDirection);
-    if (dir == 0) return;
-
-    // The next snap point strictly in the travel direction.
-    double? edge;
-    if (dir > 0) {
-      for (final p in points) {
-        if (p > currentScroll + kSnapEpsilon) {
-          edge = p;
-          break;
-        }
-      }
-    } else {
-      for (var i = points.length - 1; i >= 0; i--) {
-        if (points[i] < currentScroll - kSnapEpsilon) {
-          edge = points[i];
-          break;
-        }
-      }
-    }
-    if (edge == null) {
-      if (_boundaryApproach.value != null) _boundaryApproach.value = null;
-      return;
-    }
-
-    // Proximity ramps to 1 across the deadband where the snap commits, so the
-    // dot peaks exactly at the switch threshold. The cue rides a dot only when
-    // the approached point is an inter-section boundary (present in
-    // [_dotIndexByTop]); a tall section's bottom maps to null ⇒ no « va snapper »
-    // cue inside the free interior.
-    final dist = (edge - currentScroll).abs();
-    final proximity = (1 - dist / kSectionEdgeMargin).clamp(0.0, 1.0);
-    // Quantize (~20 steps) so the small dot rebuilds only a handful of times
-    // per gesture rather than every frame.
-    final quantized = (proximity * 20).round() / 20;
-    final next = (dotIndex: _dotIndexByTop[edge], proximity: quantized);
-    final cur = _boundaryApproach.value;
-    if (cur == null ||
-        cur.dotIndex != next.dotIndex ||
-        cur.proximity != next.proximity) {
-      _boundaryApproach.value = next;
-    }
   }
 
   Future<void> _triggerSectionChangeHaptic() async {
     try {
-      await Haptics.vibrate(HapticsType.medium, usage: HapticsUsage.touch);
+      await Haptics.vibrate(HapticsType.heavy, usage: HapticsUsage.touch);
     } catch (_) {
-      await HapticFeedback.mediumImpact();
+      await HapticFeedback.heavyImpact();
     }
   }
 
@@ -461,8 +361,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   void _recomputeSnapAnchors() {
     if (!_scroll.hasClients) {
       _snapAnchors.values = const [];
-      _snapPoints = const [];
-      _dotIndexByTop.clear();
       _tallSections.value = const {};
       return;
     }
@@ -481,15 +379,21 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     // écriture seulement si la valeur arrondie change.
     _publishUsableHeight(visibleBottom - _kStickyBarHeight);
     final result = <SectionFrame>[];
-    _dotIndexByTop.clear();
     final tall = <int>{};
+    // Measured global top of the currently-active sticky entry — captured for
+    // the debug crop detector below.
+    double? activeTopGlobal;
     for (var k = 0; k < _stickyEntryKeys.length; k++) {
       final ctx = _stickyEntryKeys[k].currentContext;
       if (ctx == null) continue;
       final box = ctx.findRenderObject();
       if (box is! RenderBox || !box.attached) continue;
       final topGlobal = box.localToGlobal(Offset.zero, ancestor: scrollBox).dy;
-      final top = offset + (topGlobal - _kStickyBarHeight);
+      if (k == _activeIndex.value) activeTopGlobal = topGlobal;
+      // Anti-crop safety inset ([kSnapTopSafety]): pose the section a hair below
+      // the header instead of flush, absorbing measurement jitter that would
+      // otherwise crop its first line under the sticky bar.
+      final top = offset + (topGlobal - _kStickyBarHeight) - kSnapTopSafety;
       // Bottom flush to the visible bottom (above the footer). `bottom - top =
       // sectionHeight - usableViewport`, so `bottom > top` exactly when the
       // section is taller than the visible area — i.e. only those gain a
@@ -497,35 +401,41 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       final bottom = offset + (topGlobal + box.size.height) - visibleBottom;
       result.add((top: top, bottom: bottom));
       // Map this entry to its real section index (virtual cards ⇒ −1) for the
-      // A1 passage-dot cue and the A3 free-read fade. Same convention as
-      // [_pulsePassageForStickyIndex].
+      // A3 free-read fade.
       final sectionIndex = _sectionIndexForStickyIndex(k);
-      if (sectionIndex > 0) {
-        _dotIndexByTop[top] = sectionIndex - 1;
-      }
       if (sectionIndex >= 0 && bottom > top + kSnapEpsilon) {
         tall.add(sectionIndex);
       }
     }
     result.sort((a, b) => a.top.compareTo(b.top));
     _snapAnchors.values = result;
-    _snapPoints = snapPointsOf(result);
     if (!setEquals(_tallSections.value, tall)) {
       _tallSections.value = tall;
     }
-    // Filet de vérification (pas de pilotage) : en debug, signale toute section
-    // multi-articles qui reste « tall » malgré le fit côté provider — c'est le
-    // symptôme d'une estimation `section_fit` trop généreuse (constantes à
-    // régler). `_FreeReadEdgeFade` ne devrait plus jamais s'afficher dessus.
+    // Filet de vérification (pas de pilotage), debug only :
+    // 1) toute section multi-articles qui reste « tall » malgré le fit côté
+    //    provider — symptôme d'une estimation `section_fit` trop généreuse.
+    // 2) **détecteur de crop** : la section active dont le haut mesuré est passé
+    //    au-dessus du header (topGlobal < barre sticky) — le signal reproductible
+    //    qu'on cherchait pour caler [kSnapTopSafety] et le durcissement du calcul.
     assert(() {
-      if (tall.isEmpty) return true;
       final sections = ref.read(fluxContinuProvider).valueOrNull?.sections;
-      if (sections == null) return true;
-      for (final idx in tall) {
-        if (idx < 0 || idx >= sections.length) continue;
+      if (sections != null) {
+        for (final idx in tall) {
+          if (idx < 0 || idx >= sections.length) continue;
+          debugPrint(
+            '[fit-net] section "${sections[idx].label}" dépasse l\'écran '
+            '(reste tall) — estimation section_fit trop généreuse, à régler.',
+          );
+        }
+      }
+      if (activeTopGlobal != null &&
+          activeTopGlobal < _kStickyBarHeight - kSnapTopSafety - kSnapEpsilon) {
         debugPrint(
-          '[fit-net] section "${sections[idx].label}" dépasse l\'écran '
-          '(reste tall) — estimation section_fit trop généreuse, à régler.',
+          '[fit-net] CROP — section active haut mesuré à '
+          '${activeTopGlobal.toStringAsFixed(1)}px < header '
+          '($_kStickyBarHeight) : le haut passe sous le sticky bar '
+          '(mesure sur layout non stabilisé — durcir le recompute).',
         );
       }
       return true;
@@ -549,6 +459,12 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     final current = notifier.state;
     if (current != null && (current - rounded).abs() < 1.0) return;
     notifier.state = rounded;
+    // The published budget just moved ⇒ the provider will recompute how many
+    // cards each section shows, changing section heights. Schedule a fresh
+    // anchor recompute so the frames reflect the *final* card count, not the
+    // transient one measured here. Coalesced + idempotent: once the height
+    // stabilises this early-returns above, so the loop terminates.
+    _scheduleAnchorRecompute();
   }
 
   /// Defers an anchor recompute to the next post-frame (when layout is settled),
@@ -762,8 +678,9 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     _gestureNudgeRequested = true;
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (!mounted) return;
-      final location =
-          GoRouter.of(context).routerDelegate.currentConfiguration.uri.path;
+      final location = GoRouter.of(
+        context,
+      ).routerDelegate.currentConfiguration.uri.path;
       if (!location.startsWith(RoutePaths.fluxContinu)) {
         _gestureNudgeRequested = false;
         return;
@@ -926,7 +843,8 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     ref.read(postOnboardingFlowPendingProvider.notifier).state = null;
 
     await ref.read(guidedTourControllerProvider.notifier).start(
-          onComplete: () => unawaited(_runPostOnboardingModals(failedCustomTopics)),
+          onComplete: () =>
+              unawaited(_runPostOnboardingModals(failedCustomTopics)),
         );
   }
 
@@ -968,9 +886,8 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
     // intrusive, conforme à la directive PO « conservateur ».
     if (mounted) {
       final settingsBox = await Hive.openBox<dynamic>('settings');
-      final displayModeModalSeen =
-          settingsBox.get('display_mode_modal_seen', defaultValue: false)
-              as bool;
+      final displayModeModalSeen = settingsBox.get('display_mode_modal_seen',
+          defaultValue: false) as bool;
       if (!displayModeModalSeen && mounted) {
         await showDisplayModeBottomSheet(context, ref);
         await settingsBox.put('display_mode_modal_seen', true);
@@ -1244,24 +1161,21 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
             SliverToBoxAdapter(
               child: KeyedSubtree(
                 key: _closingKey,
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    ClosingCardV18(
-                      onContinue: () => context.go(RoutePaths.flaner),
-                      onClose: isAndroid ? () => SystemNavigator.pop() : null,
-                      closeHint: isAndroid
-                          ? null
-                          : 'Vous pouvez refermer l’app — à demain',
-                    ),
-                    // Micro-feedback emoji + invitation au call qualitatif
-                    // (gating segmenté côté backend). Sa hauteur change en
-                    // asynchrone (résolution invite / vote → « Merci ») ⇒ elle
-                    // signale ces relayouts pour rafraîchir les ancres de snap.
-                    FeedbackClosingCard(
-                      onLayoutChanged: _scheduleAnchorRecompute,
-                    ),
-                  ],
+                // « Ton avis compte » est désormais une sous-carte interne de
+                // « Tu es à jour », séparée par un divider : une seule boîte
+                // visuelle mesurée par les ancres de snap. Sa hauteur change en
+                // asynchrone (résolution invite / vote → « Merci ») ⇒ elle
+                // signale ces relayouts pour rafraîchir les ancres de snap.
+                child: ClosingCardV18(
+                  onContinue: () => context.go(RoutePaths.flaner),
+                  onClose: isAndroid ? () => SystemNavigator.pop() : null,
+                  closeHint: isAndroid
+                      ? null
+                      : 'Vous pouvez refermer l’app — à demain',
+                  secondary: FeedbackClosingCard(
+                    embedded: true,
+                    onLayoutChanged: _scheduleAnchorRecompute,
+                  ),
                 ),
               ),
             ),
@@ -1318,17 +1232,6 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       if (state.grilleSlotIndex == i) {
         slivers.add(_grilleSliver);
       }
-      if (i > 0) {
-        slivers.add(
-          SliverToBoxAdapter(
-            child: _SectionPassageDot(
-              index: i - 1,
-              pulseListenable: _sectionPassagePulse,
-              approachListenable: _boundaryApproach,
-            ),
-          ),
-        );
-      }
       final section = state.sections[i];
       final isFavorite = _isFavoriteSection(section);
       // Story 22.3 — une section suggérée ne porte pas l'étoile « favori »
@@ -1349,79 +1252,80 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
             child: KeyedSubtree(
               key: i == inlineTargetIndex ? tourActusSectionKey : null,
               child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                if (showInlineHere)
-                  MyInterestsIntro(
-                    favoriteCount: favoriteCount,
-                    onTapManage: () => showTourneeComposerSheet(context),
-                  ),
-                _FreeReadEdgeFade(
-                  index: i,
-                  tallSections: _tallSections,
-                  child: SectionBlock(
-                    section: section,
-                    onTapArticle: (a) => _openArticle(context, a),
-                    onDismissArticle: _onSwipeDismiss,
-                    pendingFeedbackIds: _pendingFeedback,
-                    onSelectFeedbackChip: (id, chip) =>
-                        _onSelectFeedbackChip(context, id, chip),
-                    onResolveFeedback: _resolveFeedback,
-                    onUndoFeedback: _undoFeedback,
-                    enableSwipeHintOnFirstCard:
-                        i == firstSwipeableSectionIndex && _showSwipeHint,
-                    onSwipeHintComplete: _onSwipeHintComplete,
-                    firstSwipeableCardAnchor: i == firstSwipeableSectionIndex
-                        ? fluxContinuFirstCardKey
-                        : null,
-                    onSwipeConversion: _recordSwipeConversion,
-                    onLongPressConversion: _recordLongPressConversion,
-                    onTapFavorite: isFavorite && !isSuggested
-                        ? () => showTourneeComposerSheet(context)
-                        : null,
-                    // Story 22.3 — badge « Choisie pour vous » → sheet explicative.
-                    onTapSuggestionInfo: isSuggested
-                        ? () => _openSuggestionSheet(context, section, notifier)
-                        : null,
-                    // Story 23.4 — bouton réglages (tune) sur la section veille →
-                    // ouvre la config en édition. Réutilisé par le CTA d'état vide.
-                    onTapSettings: section.kind == SectionKind.veille
-                        ? () => context.push(
-                              '${RoutePaths.veilleConfig}?mode=edit',
-                            )
-                        : null,
-                    // CTA « Plus de sources (X) » / footer « Étoffer X » d'une
-                    // section thème → page **dédiée** du thème
-                    // (`ThemeSourcesScreen` : catalogue backend complet du
-                    // thème, ajout par source). Sujet custom (hors macro-thème,
-                    // sans page dédiée) → page d'ajout générique.
-                    onAddSources: section is FeedThemeSection &&
-                            section.kind == SectionKind.theme
-                        ? () {
-                            if (isCatalogTheme(section.themeSlug)) {
-                              // Même route que le ThemeExplorer (catalogue
-                              // dédié du thème) : push par chemin + `extra` =
-                              // libellé pour le titre.
-                              context.push(
-                                '/settings/sources/theme/${section.themeSlug}',
-                                extra: section.label,
-                              );
-                            } else {
-                              context.pushNamed(RouteNames.addSource);
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (showInlineHere)
+                    MyInterestsIntro(
+                      favoriteCount: favoriteCount,
+                      onTapManage: () => showTourneeComposerSheet(context),
+                    ),
+                  _FreeReadEdgeFade(
+                    index: i,
+                    tallSections: _tallSections,
+                    child: SectionBlock(
+                      section: section,
+                      onTapArticle: (a) => _openArticle(context, a),
+                      onDismissArticle: _onSwipeDismiss,
+                      pendingFeedbackIds: _pendingFeedback,
+                      onSelectFeedbackChip: (id, chip) =>
+                          _onSelectFeedbackChip(context, id, chip),
+                      onResolveFeedback: _resolveFeedback,
+                      onUndoFeedback: _undoFeedback,
+                      enableSwipeHintOnFirstCard:
+                          i == firstSwipeableSectionIndex && _showSwipeHint,
+                      onSwipeHintComplete: _onSwipeHintComplete,
+                      firstSwipeableCardAnchor: i == firstSwipeableSectionIndex
+                          ? fluxContinuFirstCardKey
+                          : null,
+                      onSwipeConversion: _recordSwipeConversion,
+                      onLongPressConversion: _recordLongPressConversion,
+                      onTapFavorite: isFavorite && !isSuggested
+                          ? () => showTourneeComposerSheet(context)
+                          : null,
+                      // Story 22.3 — badge « Choisie pour vous » → sheet explicative.
+                      onTapSuggestionInfo: isSuggested
+                          ? () =>
+                              _openSuggestionSheet(context, section, notifier)
+                          : null,
+                      // Story 23.4 — bouton réglages (tune) sur la section veille →
+                      // ouvre la config en édition. Réutilisé par le CTA d'état vide.
+                      onTapSettings: section.kind == SectionKind.veille
+                          ? () => context.push(
+                                '${RoutePaths.veilleConfig}?mode=edit',
+                              )
+                          : null,
+                      // CTA « Plus de sources (X) » / footer « Étoffer X » d'une
+                      // section thème → page **dédiée** du thème
+                      // (`ThemeSourcesScreen` : catalogue backend complet du
+                      // thème, ajout par source). Sujet custom (hors macro-thème,
+                      // sans page dédiée) → page d'ajout générique.
+                      onAddSources: section is FeedThemeSection &&
+                              section.kind == SectionKind.theme
+                          ? () {
+                              if (isCatalogTheme(section.themeSlug)) {
+                                // Même route que le ThemeExplorer (catalogue
+                                // dédié du thème) : push par chemin + `extra` =
+                                // libellé pour le titre.
+                                context.push(
+                                  '/settings/sources/theme/${section.themeSlug}',
+                                  extra: section.label,
+                                );
+                              } else {
+                                context.pushNamed(RouteNames.addSource);
+                              }
                             }
-                          }
-                        : null,
-                    onSeeAll: section is FeedThemeSection
-                        ? (section.kind == SectionKind.source
-                            ? () => _openSourceSection(context, section)
-                            : () => _openThemeSection(context, section))
-                        : section is DigestTopicSection
-                            ? () => _openDigestSection(context, section)
-                            : null,
+                          : null,
+                      onSeeAll: section is FeedThemeSection
+                          ? (section.kind == SectionKind.source
+                              ? () => _openSourceSection(context, section)
+                              : () => _openThemeSection(context, section))
+                          : section is DigestTopicSection
+                              ? () => _openDigestSection(context, section)
+                              : null,
+                    ),
                   ),
-                ),
-              ],
-            ),
+                ],
+              ),
             ),
           ),
         ),
@@ -1635,151 +1539,6 @@ double _simulationEndX(Simulation sim, ScrollMetrics position) {
     if (sim.isDone(t)) break;
   }
   return last;
-}
-
-class _SectionPassagePulse {
-  final int index;
-  final int sequence;
-
-  const _SectionPassagePulse({required this.index, required this.sequence});
-}
-
-class _SectionPassageDot extends StatefulWidget {
-  final int index;
-  final ValueListenable<_SectionPassagePulse?> pulseListenable;
-
-  /// (A1) Drag-time feedforward: when `value.dotIndex == index`, the dot grows
-  /// and brightens with `value.proximity` *before* the snap commits, fusing
-  /// feedforward and the post-validation [pulseListenable] pulse in one object.
-  final ValueListenable<_BoundaryApproach?> approachListenable;
-
-  _SectionPassageDot({
-    required this.index,
-    required this.pulseListenable,
-    required this.approachListenable,
-  }) : super(key: ValueKey('section_passage_dot_$index'));
-
-  @override
-  State<_SectionPassageDot> createState() => _SectionPassageDotState();
-}
-
-class _SectionPassageDotState extends State<_SectionPassageDot>
-    with SingleTickerProviderStateMixin {
-  late final AnimationController _pulseController;
-
-  /// Cached rebuild trigger (pulse OR drag-approach) so the merged listenable
-  /// isn't re-allocated on every build. Rebuilt only if [approachListenable]
-  /// identity changes.
-  late Listenable _repaint;
-  int _lastSequence = -1;
-
-  @override
-  void initState() {
-    super.initState();
-    _pulseController = AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 360),
-    );
-    _repaint = Listenable.merge([_pulseController, widget.approachListenable]);
-    widget.pulseListenable.addListener(_onPulse);
-  }
-
-  @override
-  void didUpdateWidget(_SectionPassageDot oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.pulseListenable != widget.pulseListenable) {
-      oldWidget.pulseListenable.removeListener(_onPulse);
-      widget.pulseListenable.addListener(_onPulse);
-    }
-    if (oldWidget.approachListenable != widget.approachListenable) {
-      _repaint = Listenable.merge([
-        _pulseController,
-        widget.approachListenable,
-      ]);
-    }
-  }
-
-  @override
-  void dispose() {
-    widget.pulseListenable.removeListener(_onPulse);
-    _pulseController.dispose();
-    super.dispose();
-  }
-
-  void _onPulse() {
-    final pulse = widget.pulseListenable.value;
-    if (pulse == null || pulse.index != widget.index) return;
-    if (pulse.sequence == _lastSequence) return;
-    _lastSequence = pulse.sequence;
-    _pulseController
-      ..stop()
-      ..value = 0
-      ..forward();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.facteurColors;
-    final dotColor = context.isDarkMode
-        ? Colors.white.withValues(alpha: 0.42)
-        : Colors.black.withValues(alpha: 0.34);
-    return Semantics(
-      label: 'Passage de section',
-      child: SizedBox(
-        height: 26,
-        child: Align(
-          alignment: const Alignment(0, -0.68),
-          child: AnimatedBuilder(
-            // Rebuild on either the post-validation pulse OR the drag-time
-            // approach cue — both feed the same dot (cached merged listenable).
-            animation: _repaint,
-            builder: (context, _) {
-              final t = Curves.easeOutCubic.transform(_pulseController.value);
-              final pulseBump = 0.30 * (1 - (2 * t - 1).abs()).clamp(0.0, 1.0);
-              final glow = (1 - t).clamp(0.0, 1.0);
-              // Feedforward proximity (0 when this dot isn't the one being
-              // approached). Folded into the same scale/alpha/shadow as the
-              // pulse so the two cues read as one continuous gesture.
-              final approach = widget.approachListenable.value;
-              final proximity =
-                  (approach != null && approach.dotIndex == widget.index)
-                      ? approach.proximity
-                      : 0.0;
-              final scale = 1 + pulseBump + 0.9 * proximity;
-              final fillAlpha = (0.76 + 0.14 * glow + 0.20 * proximity).clamp(
-                0.0,
-                1.0,
-              );
-              return Transform.scale(
-                scale: scale,
-                child: Container(
-                  width: 2.5,
-                  height: 2.5,
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    color: dotColor.withValues(alpha: fillAlpha),
-                    boxShadow: [
-                      BoxShadow(
-                        color: dotColor.withValues(
-                          alpha: 0.13 * glow + 0.30 * proximity,
-                        ),
-                        blurRadius: 5 + 4 * proximity,
-                        spreadRadius: 0.5 + proximity,
-                      ),
-                    ],
-                    border: Border.all(
-                      color: colors.backgroundPrimary.withValues(alpha: 0.78),
-                      width: 0.75,
-                    ),
-                  ),
-                ),
-              );
-            },
-          ),
-        ),
-      ),
-    );
-  }
 }
 
 /// (A3) « Carte haute = lecture libre » signifier. A section taller than the

--- a/apps/mobile/lib/features/flux_continu/screens/theme_section_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/theme_section_screen.dart
@@ -213,6 +213,12 @@ class _ThemeSectionScreenState extends ConsumerState<ThemeSectionScreen> {
             accent: section.accent,
             blurb: section.blurb,
             illustrationAsset: section.illustrationAsset,
+            // Bouton réglages (tune) inline aussi sur la page dédiée veille
+            // (ouverte au clic du hero) → même route « ?mode=edit » que la
+            // bannière inline de la Tournée (flux_continu_screen).
+            onTapSettings: section.kind == SectionKind.veille
+                ? () => context.push('${RoutePaths.veilleConfig}?mode=edit')
+                : null,
           ),
         ),
         if (section.kind == SectionKind.veille)

--- a/apps/mobile/lib/features/flux_continu/utils/section_fit.dart
+++ b/apps/mobile/lib/features/flux_continu/utils/section_fit.dart
@@ -72,8 +72,9 @@ const double kSectionFooterHeight = 16;
 /// fit** : contrairement au gap de fin de section, ce footer porte du contenu
 /// (bouton cliquable) sous les cartes → `_recomputeSnapAnchors` le mesure
 /// (`box.size.height`), donc l'estimation doit l'anticiper sous peine de bascule
-/// *tall* parasite.
-const double kSeeAllFooterHeight = 36;
+/// *tall* parasite. Resserré (était 36) après rapprochement du CTA de sa
+/// section (`minimumSize` 32→28 + marge haute −6, marge basse 2).
+const double kSeeAllFooterHeight = 28;
 
 /// Hauteur réelle (px) réservée par le footer replié « Ajouter plus de sources »
 /// (`EtofferThemeFooter._collapsedButton`) en pied d'un thème riche : bouton
@@ -123,9 +124,9 @@ const double kHeroMediumHeight = 88;
 /// Conservative height of one regular article card, for the user's current
 /// display mode. Exposed as a function (not just the constant) so call sites
 /// read intent and a future per-card refinement has a single seam.
-double estimateRegularCardHeight(
-        [DisplayModeSpec spec = DisplayModeSpec.normal]) =>
-    spec.regularCardHeight;
+double estimateRegularCardHeight([
+  DisplayModeSpec spec = DisplayModeSpec.normal,
+]) => spec.regularCardHeight;
 
 /// Largest article count in `[minCount, maxCount]` whose stack
 /// (`bannerHeight + count·cardHeight + footerHeight`) fits within

--- a/apps/mobile/lib/features/flux_continu/utils/section_snap.dart
+++ b/apps/mobile/lib/features/flux_continu/utils/section_snap.dart
@@ -15,6 +15,17 @@ const double kSnapEpsilon = 1.0;
 /// smaller ⇒ switches more readily. 0 reverts to the pure edge-triggered feel.
 const double kSectionEdgeMargin = 120.0;
 
+/// px/s. **The only knob for the UP-only fast-rewind exception** — tune it à
+/// l'œil sur device. Snap is now the default *both* ways (a slow upward scroll
+/// re-frames the section above under the header, same as descent). The single
+/// deliberate escape is a **fast upward fling**: past this velocity the snap
+/// steps aside and lets the native ballistic run free, so the reader can rewind
+/// several sections at once. Slow upward stays snapped (so the settle haptic
+/// still fires — unlike the failed velocity floor that killed the pose buzz by
+/// suppressing the snap at low speed). Higher ⇒ harder to trigger the free
+/// rewind (more sections stay snapped on the way up); lower ⇒ easier to escape.
+const double kFastUpwardVelocity = 1400.0;
+
 // ── Réglages du ressort de snap (le « grain » du switch vers une section) ──
 // Le snap est un [ScrollSpringSimulation] : on tune ces 3 leviers à l'œil pour
 // le rendre à la fois smooth ET net. Repères :
@@ -97,22 +108,35 @@ double? resolveSnapTarget({
 }) {
   if (frames.isEmpty) return null;
 
+  // Travel direction: controller first, then the fling sign (lift velocity).
+  final dir = scrollDirection != 0 ? scrollDirection : velocity.sign;
+
+  // UP-only fast-rewind escape: a vigorous upward fling steps the snap aside so
+  // the native ballistic can rewind several sections at once. This is the sole
+  // deliberate exception to "1 gesture = 1 section" — the descent stays
+  // one-step, and a *slow* upward scroll still snaps (so its settle haptic
+  // fires). See [kFastUpwardVelocity].
+  final freeUpwardEscape = dir < 0 && velocity.abs() >= kFastUpwardVelocity;
+  if (freeUpwardEscape) return null;
+
   // Free reading: the landing rests inside a section that fully fills the
-  // viewport (a tall section's open interior). No edge shows ⇒ leave it free.
-  for (final f in frames) {
-    if (f.bottom > f.top + kSnapEpsilon &&
-        naturalLanding > f.top + kSnapEpsilon &&
-        naturalLanding < f.bottom - kSnapEpsilon) {
-      return null;
+  // viewport (a tall section's open interior). No edge shows ⇒ leave it free —
+  // but only on descent/idle (`dir >= 0`). On a slow upward scroll we fall
+  // through to the snap logic so the section above re-frames under the header
+  // instead of drifting (the fix for the "too permissive" rewind).
+  if (dir >= 0) {
+    for (final f in frames) {
+      if (f.bottom > f.top + kSnapEpsilon &&
+          naturalLanding > f.top + kSnapEpsilon &&
+          naturalLanding < f.bottom - kSnapEpsilon) {
+        return null;
+      }
     }
   }
 
   // Every framing offset is a snap point: each section top, plus the bottom of
   // each tall section (rest on its last cards). Sorted ascending.
   final points = snapPointsOf(frames);
-
-  // Travel direction: controller first, then the fling sign (lift velocity).
-  final dir = scrollDirection != 0 ? scrollDirection : velocity.sign;
 
   // Deadband (« marge »): how far the fling's inertia carries past the lift
   // point. A small overshoot — or no direction at all — re-frames the section

--- a/apps/mobile/lib/features/flux_continu/widgets/closing_card_v18.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/closing_card_v18.dart
@@ -26,11 +26,18 @@ class ClosingCardV18 extends ConsumerWidget {
   /// par l'App Store). Ignorée si [onClose] est fourni (cas Android).
   final String? closeHint;
 
+  /// Sous-carte secondaire rendue à l'intérieur de la carte de clôture, sous
+  /// un divider (ex. « Ton avis compte » = [FeedbackClosingCard] embarquée).
+  /// Fait partie de la même boîte visuelle → mesurée par les ancres de snap
+  /// avec la carte principale.
+  final Widget? secondary;
+
   const ClosingCardV18({
     super.key,
     this.onContinue,
     this.onClose,
     this.closeHint,
+    this.secondary,
   });
 
   @override
@@ -131,6 +138,15 @@ class ClosingCardV18 extends ConsumerWidget {
                   color: colors.textTertiary,
                 ),
               ),
+            ],
+            if (secondary != null) ...[
+              const SizedBox(height: 20),
+              Divider(
+                height: 1,
+                color: colors.textTertiary.withValues(alpha: 0.15),
+              ),
+              const SizedBox(height: 16),
+              secondary!,
             ],
           ],
         ),

--- a/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
@@ -22,10 +22,12 @@ class SectionBanner extends StatelessWidget {
   /// sections (theme1 / theme2) wire this up.
   final VoidCallback? onTapFavorite;
 
-  /// Story 23.4 — optional settings affordance (top-right tune button). Only
-  /// wired for the veille section → opens the veille config in edit mode. As
-  /// an independent hit target it sits **outside** the `IgnorePointer`s so it
-  /// captures taps before the banner's fold InkWell.
+  /// Story 23.4 — optional settings affordance (tune button). Only wired for
+  /// the veille section → opens the veille config in edit mode. Rendered inline
+  /// in the title, right after the favorite star (order: titre ★ ⚙), so it is
+  /// visible in the flow rather than floating. As a nested `InkWell` it stays an
+  /// independent hit target, capturing taps before the banner's fold InkWell
+  /// (descendant wins over ancestor).
   final VoidCallback? onTapSettings;
 
   /// When true, the banner renders in a larger "page hero" variant (bigger
@@ -99,11 +101,6 @@ class SectionBanner extends StatelessWidget {
     fontSize: 12,
     height: 1.36,
   );
-
-  double _trailingControlReserve() {
-    if (onTapSettings != null) return 58;
-    return 0;
-  }
 
   String? _displayBlurbFor(String title, String? rawBlurb) {
     // Keep the visible copy current even when a route was opened with a stale
@@ -180,18 +177,6 @@ class SectionBanner extends StatelessWidget {
               ),
             ),
           ),
-          // Bouton réglages (veille) — hit target indépendant, hors
-          // IgnorePointer pour rester tappable.
-          if (onTapSettings != null)
-            Positioned(
-              top: 8,
-              right: 10,
-              child: _SettingsButton(
-                color: colors.textSecondary,
-                border: colors.border,
-                onTap: onTapSettings!,
-              ),
-            ),
           Padding(
             // With a blurb the content fills `minHeight` exactly, so the
             // centered column has no slack and the accent dash sticks to the
@@ -211,85 +196,94 @@ class SectionBanner extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
                 Expanded(
-                  child: Padding(
-                    padding: EdgeInsets.only(
-                      right: illustrationAsset == null
-                          ? _trailingControlReserve()
-                          : 0,
-                    ),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        if (suggested) ...[
-                          _SuggestedBadge(accent: accent, onTap: onTapInfo),
-                          const SizedBox(height: 8),
-                        ],
-                        _AccentDash(accent: accent, large: large),
-                        Padding(
-                          padding: EdgeInsets.only(
-                            top: 2,
-                            bottom: hasBlurb ? (large ? 10 : 8) : 0,
-                          ),
-                          child: Text.rich(
-                            // Borne le titre : la page Flâner (`large`) tolère
-                            // 2 lignes, mais les bannières inline (dont la
-                            // veille, au label long `Ma veille — {config}`)
-                            // restent sur 1 ligne pour ne jamais dépasser le
-                            // budget de hauteur `kBannerHeightWithBlurb` que le
-                            // snap/fit suppose.
-                            maxLines: large ? 2 : 1,
-                            overflow: TextOverflow.ellipsis,
-                            TextSpan(
-                              text: title,
-                              children: <InlineSpan>[
-                                if (tappable) ...[
-                                  // Chevron de tappabilité rendu comme icône
-                                  // centrée verticalement sur le titre (même
-                                  // pattern que l'étoile favorite ci-dessous) :
-                                  // trait épais et alignement propre, là où le
-                                  // glyphe texte « > » héritait d'une baseline
-                                  // décalée et d'un trait fin.
-                                  const WidgetSpan(child: SizedBox(width: 3)),
-                                  WidgetSpan(
-                                    alignment: PlaceholderAlignment.middle,
-                                    child: Icon(
-                                      PhosphorIcons.caretRight(
-                                        PhosphorIconsStyle.bold,
-                                      ),
-                                      size: large ? 24 : 17,
-                                      color: colors.textPrimary,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (suggested) ...[
+                        _SuggestedBadge(accent: accent, onTap: onTapInfo),
+                        const SizedBox(height: 8),
+                      ],
+                      _AccentDash(accent: accent, large: large),
+                      Padding(
+                        padding: EdgeInsets.only(
+                          top: 2,
+                          bottom: hasBlurb ? (large ? 10 : 8) : 0,
+                        ),
+                        child: Text.rich(
+                          // Borne le titre : la page Flâner (`large`) tolère
+                          // 2 lignes, mais les bannières inline (dont la
+                          // veille, au label long `Ma veille — {config}`)
+                          // restent sur 1 ligne pour ne jamais dépasser le
+                          // budget de hauteur `kBannerHeightWithBlurb` que le
+                          // snap/fit suppose.
+                          maxLines: large ? 2 : 1,
+                          overflow: TextOverflow.ellipsis,
+                          TextSpan(
+                            text: title,
+                            children: <InlineSpan>[
+                              if (tappable) ...[
+                                // Chevron de tappabilité rendu comme icône
+                                // centrée verticalement sur le titre (même
+                                // pattern que l'étoile favorite ci-dessous) :
+                                // trait épais et alignement propre, là où le
+                                // glyphe texte « > » héritait d'une baseline
+                                // décalée et d'un trait fin.
+                                const WidgetSpan(child: SizedBox(width: 3)),
+                                WidgetSpan(
+                                  alignment: PlaceholderAlignment.middle,
+                                  child: Icon(
+                                    PhosphorIcons.caretRight(
+                                      PhosphorIconsStyle.fill,
                                     ),
+                                    size: large ? 24 : 17,
+                                    color: colors.textPrimary,
                                   ),
-                                ],
-                                if (onTapFavorite != null) ...[
-                                  const TextSpan(text: '  '),
-                                  WidgetSpan(
-                                    alignment: PlaceholderAlignment.middle,
-                                    child: _FavoriteStar(
-                                      color: colors.textTertiary,
-                                      onTap: onTapFavorite!,
-                                    ),
-                                  ),
-                                ],
+                                ),
                               ],
-                              style: (large ? _titleStyleLarge : _titleStyleInline)
-                                  .copyWith(color: colors.textPrimary),
-                            ),
+                              if (onTapFavorite != null) ...[
+                                const TextSpan(text: '  '),
+                                WidgetSpan(
+                                  alignment: PlaceholderAlignment.middle,
+                                  child: _FavoriteStar(
+                                    color: colors.textTertiary,
+                                    onTap: onTapFavorite!,
+                                  ),
+                                ),
+                              ],
+                              // Réglages veille inline, juste après l'étoile
+                              // favori (ordre : titre ★ ⚙). Hit target
+                              // indépendant : l'InkWell du bouton gagne sur
+                              // l'InkWell de pli du banner (descendant > ancêtre).
+                              if (onTapSettings != null) ...[
+                                const TextSpan(text: ' '),
+                                WidgetSpan(
+                                  alignment: PlaceholderAlignment.middle,
+                                  child: _SettingsButton(
+                                    color: colors.textSecondary,
+                                    border: colors.border,
+                                    onTap: onTapSettings!,
+                                  ),
+                                ),
+                              ],
+                            ],
+                            style:
+                                (large ? _titleStyleLarge : _titleStyleInline)
+                                    .copyWith(color: colors.textPrimary),
                           ),
                         ),
-                        if (hasBlurb)
-                          Text(
-                            effectiveBlurb,
-                            // Défensif : même budget 82px — borne le blurb pour
-                            // garder une hauteur déterministe.
-                            maxLines: large ? 3 : 2,
-                            overflow: TextOverflow.ellipsis,
-                            style: (large ? _blurbStyleLarge : _blurbStyleInline)
-                                .copyWith(color: colors.textSecondary),
-                          ),
-                      ],
-                    ),
+                      ),
+                      if (hasBlurb)
+                        Text(
+                          effectiveBlurb,
+                          // Défensif : même budget 82px — borne le blurb pour
+                          // garder une hauteur déterministe.
+                          maxLines: large ? 3 : 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: (large ? _blurbStyleLarge : _blurbStyleInline)
+                              .copyWith(color: colors.textSecondary),
+                        ),
+                    ],
                   ),
                 ),
                 if (logoUrl != null) ...[

--- a/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
@@ -234,9 +234,9 @@ class SectionBanner extends StatelessWidget {
                                   alignment: PlaceholderAlignment.middle,
                                   child: Icon(
                                     PhosphorIcons.caretRight(
-                                      PhosphorIconsStyle.fill,
+                                      PhosphorIconsStyle.bold,
                                     ),
-                                    size: large ? 24 : 17,
+                                    size: large ? 24 : 20,
                                     color: colors.textPrimary,
                                   ),
                                 ),

--- a/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
@@ -234,7 +234,7 @@ class SectionBanner extends StatelessWidget {
                                   alignment: PlaceholderAlignment.middle,
                                   child: Icon(
                                     PhosphorIcons.caretRight(
-                                      PhosphorIconsStyle.bold,
+                                      PhosphorIconsStyle.fill,
                                     ),
                                     size: large ? 24 : 20,
                                     color: colors.textPrimary,

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -33,7 +33,7 @@ class SectionBlock extends StatelessWidget {
   /// same position.
   final Set<String> pendingFeedbackIds;
   final void Function(String contentId, FluxFeedbackChip chip)?
-      onSelectFeedbackChip;
+  onSelectFeedbackChip;
   final ValueChanged<String>? onResolveFeedback;
   final ValueChanged<String>? onUndoFeedback;
 
@@ -106,13 +106,16 @@ class SectionBlock extends StatelessWidget {
       );
     }
     final cards = _buildCards();
-    final hiddenCount =
-        (section.totalCount - section.coreVisibleCount).clamp(0, 999);
+    final hiddenCount = (section.totalCount - section.coreVisibleCount).clamp(
+      0,
+      999,
+    );
     // Section source sans article récent (≤72h) mais avec des cartes plus
     // anciennes (repli 30 j backend) → on signale « Pas d'article récent. » dans
     // la blurb du banner. L'empty-state (aucun article même vieux) reste géré
     // par _buildCards et n'affiche pas cette note.
-    final effectiveBlurb = section is FeedThemeSection &&
+    final effectiveBlurb =
+        section is FeedThemeSection &&
             section.kind == SectionKind.source &&
             section.noRecentSource &&
             section.items.isNotEmpty
@@ -130,8 +133,8 @@ class SectionBlock extends StatelessWidget {
           // l'illustration thème.
           logoUrl:
               section is FeedThemeSection && section.kind == SectionKind.source
-                  ? section.sourceLogoUrl
-                  : null,
+              ? section.sourceLogoUrl
+              : null,
           onTapFavorite: onTapFavorite,
           onTapSettings: onTapSettings,
           onTap: onSeeAll,
@@ -222,16 +225,17 @@ class SectionBlock extends StatelessWidget {
                 onSwipeDismiss: onDismissArticle == null
                     ? null
                     : () => onDismissArticle!(
-                          pickTopicLead(visible[i]).contentId,
-                        ),
+                        pickTopicLead(visible[i]).contentId,
+                      ),
                 enableSwipeHint:
                     enableSwipeHintOnFirstCard && i == firstSwipeableIndex,
                 onSwipeHintComplete:
                     enableSwipeHintOnFirstCard && i == firstSwipeableIndex
-                        ? onSwipeHintComplete
-                        : null,
-                nudgeAnchor:
-                    i == firstSwipeableIndex ? firstSwipeableCardAnchor : null,
+                    ? onSwipeHintComplete
+                    : null,
+                nudgeAnchor: i == firstSwipeableIndex
+                    ? firstSwipeableCardAnchor
+                    : null,
                 onSwipeConversion: onSwipeConversion,
                 onLongPressConversion: onLongPressConversion,
               ),
@@ -240,13 +244,13 @@ class SectionBlock extends StatelessWidget {
           if (onSeeAll != null) _seeAllFooter(),
         ];
       case FeedThemeSection(
-          :final items,
-          :final coreVisibleCount,
-          :final underfilled,
-          :final themeSlug,
-          :final label,
-          :final isPlaceholder,
-        ):
+        :final items,
+        :final coreVisibleCount,
+        :final underfilled,
+        :final themeSlug,
+        :final label,
+        :final isPlaceholder,
+      ):
         // Issue #1 — « squelette stable » : une coquille seed-ée AVANT le
         // fan-out réserve sa hauteur finale (N cartes squelette) pour que
         // l'upsert remplace le contenu **sur place**, sans décaler les sections
@@ -305,8 +309,8 @@ class SectionBlock extends StatelessWidget {
             for (final row in rows)
               switch (row) {
                 VeilleHeaderRow(:final label) => VeilleGroupHeader(
-                    label: label,
-                  ),
+                  label: label,
+                ),
                 VeilleArticleRow(:final content, :final index) =>
                   pendingFeedbackIds.contains(content.id)
                       ? _feedbackInlineFor(content.id)
@@ -316,9 +320,11 @@ class SectionBlock extends StatelessWidget {
                           onSwipeDismiss: onDismissArticle == null
                               ? null
                               : () => onDismissArticle!(content.id),
-                          enableSwipeHint: enableSwipeHintOnFirstCard &&
+                          enableSwipeHint:
+                              enableSwipeHintOnFirstCard &&
                               index == firstSwipeableIndex,
-                          onSwipeHintComplete: enableSwipeHintOnFirstCard &&
+                          onSwipeHintComplete:
+                              enableSwipeHintOnFirstCard &&
                                   index == firstSwipeableIndex
                               ? onSwipeHintComplete
                               : null,
@@ -354,10 +360,11 @@ class SectionBlock extends StatelessWidget {
                     enableSwipeHintOnFirstCard && i == firstSwipeableIndex,
                 onSwipeHintComplete:
                     enableSwipeHintOnFirstCard && i == firstSwipeableIndex
-                        ? onSwipeHintComplete
-                        : null,
-                nudgeAnchor:
-                    i == firstSwipeableIndex ? firstSwipeableCardAnchor : null,
+                    ? onSwipeHintComplete
+                    : null,
+                nudgeAnchor: i == firstSwipeableIndex
+                    ? firstSwipeableCardAnchor
+                    : null,
                 onSwipeConversion: onSwipeConversion,
                 onLongPressConversion: onLongPressConversion,
               ),
@@ -376,7 +383,8 @@ class SectionBlock extends StatelessWidget {
           // Thème **riche** (assez d'articles) → footer « Étoffer » **replié** :
           // un bouton discret qui ne charge les sources qu'au tap, pour garder
           // le vecteur de croissance visible sans alourdir la section.
-          if (section.kind == SectionKind.theme && !underfilled &&
+          if (section.kind == SectionKind.theme &&
+              !underfilled &&
               themeSlug != null)
             EtofferThemeFooter(
               slug: themeSlug,
@@ -405,13 +413,20 @@ class SectionBlock extends StatelessWidget {
   static final _seeAllFooterStyle = TextButton.styleFrom(
     foregroundColor: const Color(0xFF5D5B5A),
     padding: const EdgeInsets.symmetric(horizontal: 8),
-    minimumSize: const Size(0, 32),
+    minimumSize: const Size(0, 28),
+    // `shrinkWrap` : sans ça le TextButton réserve un tap-target de 48px de haut
+    // (padded par défaut) → c'est cette hauteur fantôme, pas la marge, qui
+    // éloignait « Tout lire › » de sa section. On la collapse au contenu réel.
+    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
     textStyle: const TextStyle(fontSize: 12.5, fontWeight: FontWeight.w500),
   );
 
   Widget _seeAllFooter() {
     return Container(
-      margin: const EdgeInsets.fromLTRB(12, 0, 12, 4),
+      // Marges resserrées : le CTA colle au bas de la dernière carte (qui porte
+      // déjà 12px de padding bas). `kSeeAllFooterHeight` reflète la hauteur
+      // rendue (tap-target collapsé) pour ne pas dérégler le budget de fit.
+      margin: const EdgeInsets.fromLTRB(12, 0, 12, 2),
       alignment: Alignment.center,
       child: TextButton(
         onPressed: onSeeAll,
@@ -599,6 +614,6 @@ class SectionSkeletonCard extends StatelessWidget {
 /// Issue #1 — [count] cartes squelette réservant la hauteur finale d'une
 /// section. Partagé par le placeholder de [SectionBlock] et le cold-skeleton
 /// (`_FluxContinuSkeleton`) pour garantir la même géométrie de bout en bout.
-List<Widget> sectionSkeletonCards(int count) =>
-    [for (var i = 0; i < count; i++) const SectionSkeletonCard()];
-
+List<Widget> sectionSkeletonCards(int count) => [
+  for (var i = 0; i < count; i++) const SectionSkeletonCard(),
+];

--- a/apps/mobile/test/features/flux_continu/utils/section_fit_test.dart
+++ b/apps/mobile/test/features/flux_continu/utils/section_fit_test.dart
@@ -120,7 +120,7 @@ void main() {
 
     test('réserver le footer retire une carte au seuil (bascule 3 → 2)', () {
       // no-blurb chrome 54 + 3·146 = 492. À usable = 495 le fit tient 3 cartes
-      // SANS footer, mais le footer « Tout lire › » (36) fait déborder → 2.
+      // SANS footer, mais le footer « Tout lire › » (28) fait déborder → 2.
       const usable = 495.0;
       final withoutFooter = fitVisibleCount(
         usableHeight: usable,

--- a/apps/mobile/test/features/flux_continu/utils/section_snap_test.dart
+++ b/apps/mobile/test/features/flux_continu/utils/section_snap_test.dart
@@ -48,10 +48,13 @@ void main() {
   });
 
   group('resolveSnapTarget', () {
-    test('free while inside a tall section (it fills the screen)', () {
-      // Landing at 450, inside the (300, 600) interior: no edge shows ⇒ free,
-      // regardless of travel direction.
-      for (final dir in [1.0, -1.0]) {
+    test(
+        'free while inside a tall section on descent/idle (it fills the screen)',
+        () {
+      // Landing at 450, inside the (300, 600) interior: no edge shows ⇒ free
+      // on descent (dir=1) and idle (dir=0). Upward is handled separately —
+      // snap is now the default on the way up (see the UP-only tests below).
+      for (final dir in [1.0, 0.0]) {
         final target = resolveSnapTarget(
           currentPixels: 430,
           naturalLanding: 450,
@@ -61,6 +64,67 @@ void main() {
         );
         expect(target, isNull, reason: 'dir=$dir should stay free at 450');
       }
+    });
+
+    // --- Task 2: snap-by-default on the way up, fast-fling escape -----------
+
+    test('a slow upward scroll inside a tall section snaps (no longer free)',
+        () {
+      // Same landing (450) inside the (300,600) interior, but travelling UP
+      // slowly (velocity below kFastUpwardVelocity). The free-reading guard is
+      // descent/idle-only now ⇒ this re-frames onto an anchor instead of
+      // staying free. Small overshoot ⇒ pulled to the nearest point (300).
+      final target = resolveSnapTarget(
+        currentPixels: 430,
+        naturalLanding: 450,
+        velocity: -200,
+        scrollDirection: -1, // up, slow
+        frames: frames,
+      );
+      expect(target, isNotNull,
+          reason: 'slow upward should snap, not stay free');
+      expect(snapPointsOf(frames), contains(target));
+    });
+
+    test('a fast upward fling escapes free (rewind several sections)', () {
+      // Same landing inside the tall interior, but a hard upward fling
+      // (velocity ≥ kFastUpwardVelocity) ⇒ the snap steps aside so the native
+      // ballistic can rewind. The one deliberate UP-only exception.
+      final target = resolveSnapTarget(
+        currentPixels: 430,
+        naturalLanding: 450,
+        velocity: -kFastUpwardVelocity - 100,
+        scrollDirection: -1, // up, fast
+        frames: frames,
+      );
+      expect(target, isNull);
+    });
+
+    test('a fast upward fling escapes even outside any free zone', () {
+      // Lift at the finale (1200) with a fast upward fling landing far past the
+      // sections. Without the escape this would one-step to 600; with it, free.
+      final target = resolveSnapTarget(
+        currentPixels: 1200,
+        naturalLanding: -5000,
+        velocity: -kFastUpwardVelocity - 500,
+        scrollDirection: -1, // up, fast
+        frames: frames,
+      );
+      expect(target, isNull);
+    });
+
+    test('a slow upward fling below the threshold still one-steps (no escape)',
+        () {
+      // Just under kFastUpwardVelocity heading up from the finale ⇒ still
+      // snaps one frame back (600), no free escape.
+      final target = resolveSnapTarget(
+        currentPixels: 1200,
+        naturalLanding: 1200 - beyond,
+        velocity: -kFastUpwardVelocity + 1,
+        scrollDirection: -1, // up, just under the threshold
+        frames: frames,
+      );
+      expect(target, 600.0);
     });
 
     // --- One-step cap: a fling NEVER skips a section ------------------------
@@ -79,20 +143,22 @@ void main() {
       expect(target, 300.0);
     });
 
-    test('a violent fling up only recedes ONE frame (never skips)', () {
-      // Lift at the last frame (1200) with a huge upward landing past 0. Cap ⇒
-      // previous adjacent point only: 600.
+    test('a moderate fling up only recedes ONE frame (never skips)', () {
+      // Lift at the last frame (1200) with a huge upward landing past 0, but a
+      // velocity BELOW kFastUpwardVelocity (a *violent* up-fling now escapes
+      // free — see the Task 2 tests). Cap ⇒ previous adjacent point only: 600.
       final target = resolveSnapTarget(
         currentPixels: 1200,
         naturalLanding: -5000,
-        velocity: -9000,
-        scrollDirection: -1, // up
+        velocity: -300,
+        scrollDirection: -1, // up, sub-threshold
         frames: frames,
       );
       expect(target, 600.0);
     });
 
-    test('a hard fling from inside a tall section stops at its bottom (one step)',
+    test(
+        'a hard fling from inside a tall section stops at its bottom (one step)',
         () {
       // Lift inside the (300, 600) interior, huge landing past the section.
       // The cap advances to the section's own bottom frame (600), not beyond.

--- a/apps/mobile/test/features/flux_continu/widgets/section_block_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/section_block_test.dart
@@ -119,10 +119,11 @@ FeedThemeSection _sourceSection({
 }
 
 /// Finder du chevron de navigation, désormais rendu comme **icône** Phosphor
-/// (`caretRight` bold) en WidgetSpan dans le titre du banner — le glyphe texte
-/// « > » historique héritait d'une baseline décalée (cf. section_banner.dart).
+/// (`caretRight` fill — trait plein, plus épais que bold) en WidgetSpan dans le
+/// titre du banner — le glyphe texte « > » historique héritait d'une baseline
+/// décalée (cf. section_banner.dart).
 Finder _chevron() =>
-    find.byIcon(PhosphorIcons.caretRight(PhosphorIconsStyle.bold));
+    find.byIcon(PhosphorIcons.caretRight(PhosphorIconsStyle.fill));
 
 void main() {
   setUpAll(() {


### PR DESCRIPTION
## Quoi

Ajustements UI sur l'Essentiel / la Tournée (flux_continu) + carte de fin :

- **Banner de section** : chevron `caretRight` en trait plein (`fill`) plus lisible ; bouton réglages rendu **inline dans le titre** (supprime le hack `_trailingControlReserve` / `Positioned` à réserve magique de 58px).
- **« Tout lire › »** recollé à sa section ; `kSeeAllFooterHeight` 36→28 + `shrinkWrap` (corrige un tap-target fantôme de 48px qui décalait le fit).
- **Snap** : rewind rapide vers le haut (`kFastUpwardVelocity`), direction hoistée.
- **flux_continu_screen** : suppression du feedforward passage-dot / boundary-approach (~250 lignes, per-frame scan retiré du hot path) ; recompute des ancres de snap sur **layout stabilisé** (ScrollStart + changement de budget) + `kSnapTopSafety` anti-crop.
- **Carte de fin** : « Ton avis compte » (`FeedbackClosingCard`) intégré en **slot `secondary`** de `ClosingCardV18` (mode `embedded`).

## Pourquoi

Polish de lisibilité et de cadrage demandé (« titres de section plus lisibles », sections mieux cadrées à l'écran, personnalisation veille en un geste depuis le titre) ; consolidation de la fin de tournée en une seule carte.

## Comment ça a été vérifié

- [x] `flutter test test/features/flux_continu/` → **+304 verts**
- [x] `section_block_test` en isolation → vert (finder chevron `fill` aligné sur le widget)
- [x] `flutter test` (suite complète) → seuls les ~22 échecs **pré-existants** subsistent (custom_topics, digest/bookmark, feed — fichiers hors de ce diff)
- [x] `flutter analyze` sur les dossiers modifiés → clean
- [x] `/simplify` (4 revues reuse/simplification/efficacité/altitude) → clean, net simplification

## Zones à risque

`flux_continu` : mesure du fit + ancres de snap (recompute post-layout), banner (settings inline). Pas de migration ni de changement backend.