### PR TITLE
feat(veille): re-corréler le feed Veille au sujet configuré (quick wins)

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,36 +1,87 @@
-# feat(mobile): « Notif du jour » — bandeau agrégateur quotidien en tête de l'Essentiel
+# Veille — PR 1 « Quick wins » : re-corréler le feed au sujet configuré
 
-## Quoi
+Backend-only, **0 migration DB**. Chaque levier est un bouton réglable/réversible
+par constante. Motivé par l'audit du 07/07 (`.context/veille-curation-mecanique.html`,
+memory `project_veille_curation_audit_decorrelation`) : le feed Veille était
+décorrélé de l'intention (topic axis mort 97 %, kw LLM génériques = 31 % du corpus,
+seuil posé sur le composite ⇒ ~60 % hors-sujet, anti-starvation qui réadmet le bruit).
 
-Une **ligne de notification unique** en tête du feed Essentiel (sous le bandeau Lettres) : chaque jour, le Facteur met en avant une fonctionnalité peu vue, choisie selon le profil. Un seul message à la fois, **jusqu'à 3/jour** (le suivant après action ou dismiss), rotation quotidienne déterministe.
+## Commit 1 — Mécanique scoring & pool (`feed_filter.py`, `scoring_context.py`, `scoring_config.py`)
 
-Story : `docs/stories/core/23.1.notif-du-jour.md`.
+- **Constantes** : `VEILLE_PERTINENCE_GATE=20`, `VEILLE_FLOOR_MIN_KEYWORD_HITS=2`,
+  `VEILLE_BLOCK_A_PER_SOURCE_CANDIDATES=30`, `VEILLE_BLOCK_B_LANGUAGE_FILTER=True` ;
+  suppression de `VEILLE_MIN_FEED_SIZE` (anti-starvation). Seuil composite **48 inchangé**.
+- **E — plus de tokenisation des `why`** : `_tokenize_intent` + l'angle « Intention »
+  retirés. `why` reste en DB / endpoint config (badge santé inchangé).
+- **G2 — slugs non canoniques ignorés** : un `topic_id` hors des 50 slugs canoniques
+  (`SUBTOPIC_LABELS`) est neutralisé en `""` → sort du prédicat SQL, de `matched_on`
+  et de `user_subtopics` (le floor redevient honnête). Ses mots-clés survivent.
+- **B — floor durci** : un keyword-only ne qualifie que sur **≥ 2 hits distincts** ou
+  **1 hit fort** (mot-clé multi-mots, p.ex. « coupe du monde »). `_matched_axes` renvoie
+  désormais `(axes, floor_qualified)`. `matched_on` (front) inchangé.
+- **A — gate pertinence** : en plus du seuil composite, on exige pertinence normalisée
+  ≥ 20 quand la config porte un axe topic/mot-clé (le composite offre ~37-40 pts d'office
+  via source+fraîcheur+qualité). Nouveau compteur `gate_pruned_count` au log
+  `veille.feed_scored`.
+- **C — anti-starvation supprimée** : aucun candidat sous le seuil n'est réadmis
+  (feed court honnête). Revert = un bloc isolé.
+- **D — pool Bloc A équitable par source** : `row_number() OVER (PARTITION BY source_id
+  ORDER BY published_at DESC)` borne chaque source à N=30 avant le cap externe 300 — une
+  source dense n'affame plus les discrètes. `_base_query` refactoré en
+  `_apply_common_filters` (réutilisé par la sous-requête d'ids). Le point incertain du
+  plan (`apply_serein_filter` sur select non-entité) fonctionne — pas de plan B.
+- **G1 — filtre langue Bloc B** : langues des sources configurées ∪ `{fr}`,
+  `Content.language IS NULL` toléré. Bloc A non filtré. Kill-switch.
 
-## Moteur
+## Commit 2 — F : mots-clés LLM discriminants (`llm/angle_suggester.py`)
 
-- **File** : `notifDuJourQueueProvider` trie les messages éligibles par `relevance(profil) + jitter(jour, id)` (ε = 0.15, hash FNV `id#jour` → stable intra-jour, permute inter-jour pour les pertinences proches uniquement).
-- **9 messages** : 6 profil (serein, source, tournée, veille, premium, recommencer-fallback) + **3 nudges absorbés** (renudge notif 0.9, well-informed NPS 0.85 en rendu custom, géoloc 0.7) — leurs `*ShouldShowProvider` et caps existants sont réutilisés tels quels (avancés à la consommation).
-- **Day store** : `notif_du_jour_state_v1` (SharedPreferences), `{day, consumed[]}`, reset à minuit, cap 3.
-- **Rendu hifi** : surface, radius 14, ombre 0x14, carré icône 34 teinté (ocre/green/steel), DM Sans 13.5, CTA-lien + flèche, croix 30 ; repli AnimatedSize + fondu + translation 300ms, reduced-motion instantané, press scale + haptique.
+- `_SYSTEM_PROMPT` durci : noms propres / entités datées, **≥ 2 expressions multi-mots
+  par angle**, denylist explicite du vocabulaire de discours, règle d'or (« un article
+  qui contient ce mot-clé parle presque certainement de ce sujet ») ; « Pense large »
+  retiré.
+- Filtre post-parse `_filter_generic_keywords` : denylist `_GENERIC_KEYWORDS` (~65
+  unigrammes) + `FRENCH_STOP_WORDS`, jamais les multi-mots ; angle vidé → écarté ; log
+  `angle_suggester.keywords_filtered`.
+- `_fallback_angles` 8 → 3, expressions multi-mots ancrées au thème.
+- Cache TTL 24 h inchangé : d'anciennes suggestions génériques peuvent coexister ≤ 24 h
+  post-deploy.
 
-## Dépréciations (PR 1)
+## Effet produit assumé
 
-- Supprimés : `NotificationRenudgeBanner`, `WellInformedPrompt`, `GeolocPromptBanner` (widgets standalone) + leurs 3 slivers du feed.
-- `FirstImpressionSlot` réduit aux modales (`iosAddToHome`, `notifModal`) ; la carte cède aussi au bandeau Lettres (`lettresBannerVisibleThisSessionProvider`). Lettres → PR 3.
+Les feeds des configs **existantes** (kw génériques + slugs morts toujours en base) vont
+**fortement raccourcir** — 0-10 items honnêtes au lieu de dizaines majoritairement
+hors-sujet. C'est le comportement voulu. Le vrai remède (régénération des configs) est un
+agent suivant. Boutons de détente si trop agressif : `VEILLE_FLOOR_MIN_KEYWORD_HITS`
+(2→1) et `VEILLE_PERTINENCE_GATE` (20→25/0), via les logs prod
+(`floor_pruned_count` / `gate_pruned_count` / `threshold_pruned_count`).
 
-## Fix CTA (décision PO « taps propres »)
+## Harness d'audit mis à jour
 
-- Source → `RouteNames.addSource` (panneau d'ajout direct).
-- Premium → `/settings/subscriptions?add=1` : `SubscriptionsScreen` auto-ouvre la feuille d'ajout.
-- « Config » sorti de la rotation → tuile « Ma configuration » (barre de progression onboarding) dans `profile_screen.dart`.
+`scripts/evaluate_veille_curation.py` (l'outil qui a produit l'audit) est adapté à la
+nouvelle porte : `source_intents` retiré, tuple `_matched_axes` déballé, nouvelles raisons
+de rejet `floor_weak_keyword` (keyword-only sous le min de hits) et `gate_pertinence`.
 
-## Tests
+## Vérification
 
-35 nouveaux (`test/features/notif_du_jour/`) : sélecteur (déterminisme, rotation bornée à ε, fallback), éligibilité par message, day store (reset minuit, cap, idempotence), widget (anti-flash, un-à-la-fois, X → persist + suivant, cap 3, reduced motion, tap Serein in-place, NPS custom, gates). Zones impactées : 446 verts (lettres, flux_continu, well_informed, notifications, settings).
+- Suites veille + harness : **98 passed** (`test_veille_curation`, `test_veille_scoring`,
+  `test_veille_routes`, `test_angle_suggester`, `test_evaluate_veille_curation`).
+- Suite backend complète : **2034 passed**, 2 échecs pré-existants sans lien (artefacts
+  de fuseau `+02:00` sur le Postgres local, `test_notification_preferences` /
+  `test_sources_recent_items` — verts en CI UTC).
+- `ruff check` + `ruff format` OK sur tout le code modifié.
+- Nouveaux tests ciblés : floor durci (1 hit → pruned, 2 hits / multi-mots → passe),
+  gate (2 hits sans source coupés, +source passe), C (aucune réadmission), D (source
+  discrète non affamée sous cap serré), G1 (article `en` écarté, `NULL` passe, langue
+  d'une source configurée autorisée).
 
-Aucune migration / changement backend. Changelog `unreleased` ajouté (« Notif du jour »).
+## Hors périmètre (agents suivants)
 
-## Reste hors PR
+Réutilisation du brief éditorial au scoring, régénération/migration des configs existantes
+(95 slugs morts + kw génériques restent en base), dédup d'angles, preview du feed à la
+config, état vide UI mobile.
 
-- Validation on-device Android des demandes OS (renudge/géoloc) via la file.
-- Calibration relevance/ε avec le PO ; PR 3 Lettres.
+## À valider post-merge (logs prod)
+
+Mesure ex-ante non réalisée (part du corpus FR 7 j matchant ≥ 2 kw distincts de
+« Présidentielle 2027 ») : à confirmer via les logs `veille.feed_scored` en staging pour
+calibrer `VEILLE_FLOOR_MIN_KEYWORD_HITS` (2→3 si le feed reste bruité).

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Veille",
+      "summary": "La veille ne montre plus que des articles vraiment liés à ton sujet."
+    },
+    {
       "tag": "Abonnements",
       "summary": "Tes sources abonnées gardent la couverture médiatique avant d'ouvrir l'article complet, et tu peux connecter ton compte depuis la fiche de n'importe quelle source suivie."
     },

--- a/packages/api/app/services/recommendation/scoring_config.py
+++ b/packages/api/app/services/recommendation/scoring_config.py
@@ -371,18 +371,31 @@ class ScoringWeights:
     # pas un free-pass » : source-seul = 0 contribution de pertinence.
     VEILLE_SOURCE_ON_TOPIC_BONUS = 12.0
 
-    # Seuil de pertinence (score final piliers, échelle ~0-100) en-deçà duquel
-    # un article candidat est élagué du feed veille. Relevé 40→48 (Story 23.4)
-    # avec la curation v2 : source-seul frais+riche ≈ 44 (< 48, écarté en plus
-    # par le floor) ; 1 mot-clé+source ≈ 52-58 ; topic+source ≈ 62-70 ;
-    # topic+2kw+source ≈ 75-82. Point de calibration tunable via les logs prod
-    # (max_score / pass_count / floor_pruned_count / threshold_pruned_count).
+    # Seuil de pertinence (score **composite** piliers pondérés, échelle ~0-100)
+    # en-deçà duquel un article candidat est élagué du feed veille. Relevé 40→48
+    # (Story 23.4) : 1 mot-clé+source ≈ 52-58 ; topic+source ≈ 62-70 ;
+    # topic+2kw+source ≈ 75-82. Limite connue : source+fraîcheur+qualité = 60 %
+    # du poids, donc un hors-sujet frais+propre franchit le composite ; c'est le
+    # gate dédié au pilier pertinence (`VEILLE_PERTINENCE_GATE`) qui couvre ce
+    # trou. Calibration tunable via les logs prod (max_score / pass_count /
+    # floor_pruned_count / gate_pruned_count / threshold_pruned_count).
     VEILLE_RELEVANCE_THRESHOLD = 48.0
 
-    # Anti-starvation : si après scoring moins de N articles passent ET que des
-    # candidats on-axis ont été coupés par le *seuil* (jamais par le floor), on
-    # relâche le seuil d'un cran (max -8, plancher 40).
-    VEILLE_MIN_FEED_SIZE = 5
+    # Gate sur le **pilier pertinence normalisé** (0-100), appliqué en plus du
+    # seuil composite quand la config porte un axe topic/mot-clé. Exige un
+    # minimum de pertinence *thématique*, là où le composite offre ~37-40 pts
+    # d'office (source 25 % + fraîcheur 20 % + qualité 15 %) à tout article
+    # frais+propre. Calibration (pertinence = raw/160×100) : 1kw+source 18.8
+    # coupé ; 2kw seuls 16.9 coupé ; 2kw+source 24.4 passe ; 3kw+source 30
+    # passe ; topic seul 31.3 passe. Bouton de réglage (20→25) via les logs prod.
+    VEILLE_PERTINENCE_GATE = 20.0
+
+    # Floor de mots-clés : nombre de hits distincts minimum pour qu'un candidat
+    # *keyword-only* (sans topic canonique) qualifie le floor. Un hit « fort »
+    # (topic canonique OU mot-clé multi-mots, p.ex. « coupe du monde ») qualifie
+    # à lui seul. À 1, un unigramme générique (« budget », « europe ») suffisait
+    # à faire entrer un hors-sujet. Bouton de détente (2→3) via les logs prod.
+    VEILLE_FLOOR_MIN_KEYWORD_HITS = 2
 
     # Plafond du pool de candidats scorés par fetch (borne le coût ILIKE +
     # scoring sur un feed curé ; offsets au-delà renvoient vide — acceptable).
@@ -392,6 +405,13 @@ class ScoringWeights:
     # S'applique au **Bloc B « Couverture élargie »** (topics/mots-clés, sources
     # non configurées).
     VEILLE_RECENCY_HOURS = 168
+
+    # Kill-switch : restreint les langues du Bloc B « Couverture élargie » aux
+    # langues des sources configurées ∪ {fr} (Content.language NULL toléré, car
+    # beaucoup d'articles n'ont pas de langue détectée). Le Bloc A n'est jamais
+    # filtré (source choisie = langue assumée). False → comportement multilingue
+    # historique.
+    VEILLE_BLOCK_B_LANGUAGE_FILTER = True
 
     # Fenêtre de récence (heures) du **Bloc A « Tes sources »** : 30 j. Les
     # sources niche configurées ont souvent des flux RSS lents/peu fréquents —
@@ -404,6 +424,14 @@ class ScoringWeights:
     # qu'une source bavarde (flux dense) ne monopolise pas le bloc malgré la
     # fenêtre 30 j. Appliqué via `diversify()` après tri par score.
     VEILLE_SOURCE_DIVERSITY_CAP = 3
+
+    # Pool Bloc A **par source** : nombre max de candidats récents retenus par
+    # source configurée *avant* scoring (via window function
+    # `row_number() OVER (PARTITION BY source_id ...)`). Sans ça, le cap externe
+    # global `VEILLE_CANDIDATE_CAP` trié par date laisse une source dense capter
+    # tout le pool et affame les sources discrètes (flux lents). N=30 = 10× le
+    # cap de diversité final (`VEILLE_SOURCE_DIVERSITY_CAP=3`).
+    VEILLE_BLOCK_A_PER_SOURCE_CANDIDATES = 30
 
     # --- TOPIC-AWARE FEED DIVERSIFICATION (Phase 2 — Budget Neutre) ---
 

--- a/packages/api/app/services/veille/feed_filter.py
+++ b/packages/api/app/services/veille/feed_filter.py
@@ -15,7 +15,7 @@ from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 import structlog
-from sqlalchemy import exists, or_, select
+from sqlalchemy import exists, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -35,6 +35,7 @@ from app.services.recommendation.filter_presets import (
 )
 from app.services.recommendation.helpers.diversification import diversify
 from app.services.recommendation.helpers.keyword_match import matches_word_boundary
+from app.services.recommendation.pillars.pertinence import SUBTOPIC_LABELS
 from app.services.recommendation.scoring_config import ScoringWeights
 from app.services.recommendation.scoring_engine import PillarScoringEngine
 from app.services.veille.scoring_context import build_veille_scoring_context
@@ -64,14 +65,17 @@ class VeilleFilters:
     angles: list[VeilleAngle] = field(default_factory=list)
     source_ids: list[UUID] = field(default_factory=list)
     global_keywords: list[str] = field(default_factory=list)
-    # Notes d'intention texte libre (`VeilleSource.why`) par source configurée.
-    # Tokenisées en mots-clés « Intention » côté scoring_context pour affiner le
-    # tri sans nouveau code de scoring (cf. plan refonte curation, étape 6).
-    source_intents: dict[UUID, str] = field(default_factory=dict)
+    # Langues des sources configurées (`Source.language`), ∪ {fr}, pour filtrer
+    # le Bloc B « Couverture élargie » (jamais le Bloc A). Cf. G1 refonte veille.
+    source_languages: set[str] = field(default_factory=set)
 
     @property
     def topic_slugs(self) -> list[str]:
-        return [a.topic_id for a in self.angles]
+        # Filtre les slugs vides : un `topic_id` non canonique est neutralisé en
+        # "" par `load_veille_filters` (G2) — il ne doit ni entrer dans le
+        # prédicat SQL, ni compter comme axe `topic`. Sa grappe de mots-clés,
+        # elle, survit via `all_keywords`.
+        return [a.topic_id for a in self.angles if a.topic_id]
 
     @property
     def all_keywords(self) -> list[str]:
@@ -138,25 +142,34 @@ async def load_veille_filters(
         else:
             keywords_by_topic.setdefault(topic_id, []).append(keyword)
 
+    # G2 — un `topic_id` non canonique (les 95 slugs `angle-*` morts issus des
+    # suggestions LLM) est neutralisé en "" : il sort du prédicat SQL, de
+    # `matched_on` et de `user_subtopics` (le floor redevient honnête). Sa grappe
+    # de mots-clés survit (custom-topic `slug_parent=""` côté scoring_context).
+    canon = frozenset(SUBTOPIC_LABELS)
     angles = [
         VeilleAngle(
-            topic_id=topic_id,
+            topic_id=topic_id if (topic_id or "").lower().strip() in canon else "",
             label=label,
             keywords=keywords_by_topic.get(row_id, []),
         )
         for row_id, topic_id, label in topic_rows
     ]
 
+    # Jointure Source pour porter la langue des sources configurées (G1) — le
+    # Bloc B filtre les langues à `source_languages ∪ {fr}`. `why` n'est plus lu
+    # ici (tokenisation d'intention retirée, E) ; il reste servi par l'endpoint
+    # config via son propre chemin (badge santé inchangé).
     source_rows = (
         await session.execute(
-            select(VeilleSource.source_id, VeilleSource.why).where(
-                VeilleSource.veille_config_id == config.id
-            )
+            select(VeilleSource.source_id, Source.language)
+            .join(Source, Source.id == VeilleSource.source_id)
+            .where(VeilleSource.veille_config_id == config.id)
         )
     ).all()
-    source_ids = [sid for sid, _why in source_rows]
-    source_intents = {
-        sid: why.strip() for sid, why in source_rows if why and why.strip()
+    source_ids = [sid for sid, _lang in source_rows]
+    source_languages = {
+        lang.lower().strip() for _sid, lang in source_rows if lang and lang.strip()
     }
 
     return VeilleFilters(
@@ -164,7 +177,7 @@ async def load_veille_filters(
         angles=angles,
         source_ids=source_ids,
         global_keywords=global_keywords,
-        source_intents=source_intents,
+        source_languages=source_languages,
     )
 
 
@@ -222,31 +235,52 @@ def _matched_axes(
     topic_slugs: set[str],
     source_ids: set[UUID],
     keywords: list[str],
-) -> list[str]:
-    """Axes **qualifiants** sur lesquels l'article matche (exposés au front).
+) -> tuple[list[str], bool]:
+    """Axes qualifiants + drapeau `floor_qualified` (floor durci, B).
 
-    Le thème n'est plus un axe qualifiant : l'inclusion est gérée par le
-    prédicat fort + le seuil de score. On garde topic/source/keyword. Les
-    collections sont pré-calculées par l'appelant (hot path : ~CANDIDATE_CAP
-    appels par fetch).
+    Renvoie ``(axes, floor_qualified)`` :
+
+    - ``axes`` (exposés au front — sémantique ``matched_on`` **inchangée**) :
+      ``keyword`` dès **1** hit mot-entier, ``topic``/``source`` selon
+      appartenance. Le thème n'est pas un axe qualifiant (inclusion gérée par le
+      prédicat fort + le seuil). Mot-entier via ``matches_word_boundary``
+      (primitive du pilier Pertinence et du prédicat SQL ``\\m…\\M``) et non
+      sous-chaîne : sinon un mot-clé survit sur un fragment (« nets » ⊂
+      « internets »).
+    - ``floor_qualified`` (**B**) : ``True`` si l'article porte un axe ``topic``
+      **OU** un hit « fort » (mot-clé multi-mots, p.ex. « coupe du monde »)
+      **OU** ≥ ``VEILLE_FLOOR_MIN_KEYWORD_HITS`` hits **distincts**. Un unigramme
+      générique seul ne qualifie plus (fix du bruit sur les kw LLM génériques).
+      Un même mot-clé en titre+description = 1 hit (``matches_word_boundary``
+      couvre les deux champs).
+
+    Collections pré-calculées par l'appelant (hot path : ~CANDIDATE_CAP appels).
     """
     axes: list[str] = []
     if topic_slugs and content.topics and any(t in topic_slugs for t in content.topics):
         axes.append("topic")
     if source_ids and content.source_id in source_ids:
         axes.append("source")
+
+    min_hits = ScoringWeights.VEILLE_FLOOR_MIN_KEYWORD_HITS
+    hits = 0
+    strong = False
     if keywords:
         title_lower = (content.title or "").lower()
         desc_lower = (content.description or "").lower()
-        # Mot-entier (réutilise `matches_word_boundary`, déjà la primitive du
-        # pilier Pertinence et du prédicat SQL `\m…\M`) et non plus sous-chaîne :
-        # sinon un mot-clé générique survit sur un fragment (« nets » ⊂
-        # « internets ») et fait passer un article hors-sujet au-dessus du floor
-        # dans le Bloc A (où la requête par source court-circuite le prédicat
-        # SQL). Aligne l'axe `keyword` exposé sur le scoring et le prédicat.
-        if any(matches_word_boundary(kw, title_lower, desc_lower) for kw in keywords):
+        for kw in keywords:
+            if not matches_word_boundary(kw, title_lower, desc_lower):
+                continue
+            hits += 1
+            if " " in kw:  # mot-clé multi-mots = hit « fort »
+                strong = True
+            if strong or hits >= min_hits:
+                break  # qualifié (fort ou ≥ N) — inutile de continuer
+        if hits:
             axes.append("keyword")
-    return axes
+
+    floor_qualified = ("topic" in axes) or strong or hits >= min_hits
+    return axes, floor_qualified
 
 
 def _score_block(
@@ -278,13 +312,18 @@ def _score_block(
     - **Bloc B « Couverture élargie »** (`apply_floor=True`,
       `apply_threshold=True`) : comportement historique (Story 23.4) —
 
-      1. **Floor** : « la source est un boost, pas un free-pass » — tout candidat
-         dont les axes ⊆ ``{source}`` est écarté. N'agit que si un axe
-         topic/keyword existe.
-      2. **Seuil** : on garde score ≥ ``VEILLE_RELEVANCE_THRESHOLD``.
-      3. **Anti-starvation** : sous ``VEILLE_MIN_FEED_SIZE`` passants ET des
-         candidats coupés par le *seuil* (jamais le floor), on relâche d'un cran
-         (``max(threshold-8, 40)``) — scopée au bloc courant.
+      1. **Floor durci (B)** : « la source est un boost, pas un free-pass » — un
+         candidat dont les axes ⊆ ``{source}`` est écarté ; en plus, un
+         *keyword-only* ne qualifie que sur un hit fort (multi-mots) ou ≥
+         ``VEILLE_FLOOR_MIN_KEYWORD_HITS`` hits distincts (cf. `_matched_axes`).
+         N'agit que si un axe topic/keyword existe (``floor_active``).
+      2. **Gate pertinence (A)** : au-dessus du floor, on exige aussi
+         pertinence normalisée ≥ ``VEILLE_PERTINENCE_GATE`` — le seuil composite
+         seul laisse passer un hors-sujet frais+propre (source+fraîcheur+qualité
+         = 60 % du poids). Même condition d'activation que le floor.
+      3. **Seuil composite** : on garde score ≥ ``VEILLE_RELEVANCE_THRESHOLD``.
+         Plus d'anti-starvation (C) : aucun candidat sous le seuil n'est réadmis
+         — un feed court honnête vaut mieux qu'un feed rempli de bruit.
     """
     engine = PillarScoringEngine()
     # Pré-calcul hors boucle : ces dérivations sont stables sur tout le fetch.
@@ -292,41 +331,41 @@ def _score_block(
     source_ids = set(filters.source_ids)
     keywords = filters.all_keywords
     threshold = ScoringWeights.VEILLE_RELEVANCE_THRESHOLD
-    # Le floor n'a de sens que s'il existe un axe topic/keyword à côté de la
-    # source. Sans cela (config source-seule), la source est l'unique filtre.
-    floor_active = apply_floor and bool(topic_slugs or keywords)
+    gate = ScoringWeights.VEILLE_PERTINENCE_GATE
+    # Floor et gate n'ont de sens qu'avec un axe topic/keyword à côté de la
+    # source. Sans cela (config source-seule), la source est l'unique filtre :
+    # ni floor ni gate (passthrough conservé — fallback documenté).
+    has_topic_or_kw = bool(topic_slugs or keywords)
+    floor_active = apply_floor and has_topic_or_kw
+    gate_active = apply_threshold and has_topic_or_kw
 
     passing: list[tuple[Content, float, list[str]]] = []
-    # Candidats on-axis sous le seuil — réservés à l'anti-starvation.
-    below_threshold: list[tuple[Content, float, list[str]]] = []
     max_score = 0.0
     floor_pruned_count = 0
+    gate_pruned_count = 0
+    threshold_pruned_count = 0
     for content in candidates:
-        axes = _matched_axes(content, topic_slugs, source_ids, keywords)
-        if floor_active and "topic" not in axes and "keyword" not in axes:
-            # Floor : axes ⊆ {source} (ou vide) → source-seul, écarté.
+        axes, floor_qualified = _matched_axes(
+            content, topic_slugs, source_ids, keywords
+        )
+        if floor_active and not floor_qualified:
+            # Floor durci (B) : ni topic, ni hit fort, ni ≥ N hits distincts.
             floor_pruned_count += 1
             continue
         result = engine.compute_score(content, context)
+        if gate_active and result.pillar_scores.get("pertinence", 0.0) < gate:
+            # Gate pertinence (A) : composite franchi mais lien au sujet trop
+            # faible → écarté.
+            gate_pruned_count += 1
+            continue
         score = result.final_score
         if score > max_score:
             max_score = score
         if not apply_threshold or score >= threshold:
             passing.append((content, score, axes))
         else:
-            below_threshold.append((content, score, axes))
-
-    threshold_pruned_count = len(below_threshold)
-    if (
-        apply_threshold
-        and len(passing) < ScoringWeights.VEILLE_MIN_FEED_SIZE
-        and below_threshold
-    ):
-        relaxed = max(threshold - 8.0, 40.0)
-        if relaxed < threshold:
-            readmitted = [item for item in below_threshold if item[1] >= relaxed]
-            passing.extend(readmitted)
-            threshold_pruned_count -= len(readmitted)
+            # Seuil composite (C) : sous le seuil → écarté, sans réadmission.
+            threshold_pruned_count += 1
 
     _epoch = datetime.min.replace(tzinfo=UTC)
     passing.sort(
@@ -351,6 +390,7 @@ def _score_block(
         pass_count=len(passing),
         max_score=round(max_score, 1),
         floor_pruned_count=floor_pruned_count,
+        gate_pruned_count=gate_pruned_count,
         threshold_pruned_count=threshold_pruned_count,
     )
     return passing
@@ -370,13 +410,15 @@ async def fetch_veille_feed(
     ``(Content, matched_on, group)`` où ``group`` ∈ ``{"sources", "elargie"}`` :
 
     - **Bloc A « Tes sources »** (``group="sources"``) : articles des sources
-      configurées, fenêtre 30 j, scoring complet, **gate-all** (floor + seuil —
-      ajustements « released »), cap de diversité 3/source. Le floor n'agit que
-      si la config porte un axe topic/mot-clé ; une config purement source garde
-      le laisser-passer.
+      configurées, fenêtre 30 j, **pool équitable par source** (window function,
+      D — une source dense n'affame plus les discrètes), scoring complet,
+      **gate-all** (floor durci + gate pertinence + seuil), cap de diversité
+      3/source. Floor/gate n'agissent que si la config porte un axe
+      topic/mot-clé ; une config purement source garde le laisser-passer.
     - **Bloc B « Couverture élargie »** (``group="elargie"``) : articles
-      topic/mots-clés **hors** sources configurées, fenêtre 7 j, comportement
-      historique (floor + seuil + anti-starvation).
+      topic/mots-clés **hors** sources configurées, fenêtre 7 j, **filtre langue**
+      (G1 — langues des sources configurées ∪ {fr}, NULL toléré), floor durci +
+      gate pertinence + seuil (plus d'anti-starvation).
 
     Les deux blocs scorés sont concaténés (A puis B), tagués, puis paginés sur
     l'ensemble — la pagination offset/limit reste plate côté API.
@@ -406,11 +448,13 @@ async def fetch_veille_feed(
     if serein:
         serein_prefs = await load_serein_preferences(session, user_id)
 
-    def _base_query():
+    def _apply_common_filters(q):
+        """Filtres communs (exclusions user, source active, serein) applicables
+        à un select **entité `Content`** comme à une **projection `Content.id`**
+        (sous-requête de rang du Bloc A). Le join Source est requis pour
+        ``is_active`` et pour le filtre serein (``Source.theme``)."""
         q = (
-            select(Content)
-            .join(Content.source)
-            .options(selectinload(Content.source))
+            q.join(Content.source)
             .where(~exclude_user_status)
             .where(Source.is_active.is_(True))
         )
@@ -422,16 +466,45 @@ async def fetch_veille_feed(
             )
         return q
 
+    def _base_query():
+        # Select entité pour le scoring (charge Content.source en une passe).
+        return _apply_common_filters(
+            select(Content).options(selectinload(Content.source))
+        )
+
     context = await build_veille_scoring_context(session, config, filters, now)
 
-    # ─── Bloc A « Tes sources » — fenêtre 30 j, laisser-passer ───────────────
+    # ─── Bloc A « Tes sources » — fenêtre 30 j, pool équitable par source ─────
     block_a: list[tuple[Content, float, list[str]]] = []
     if filters.source_ids:
         cutoff_a = now - timedelta(hours=ScoringWeights.VEILLE_CONFIGURED_RECENCY_HOURS)
-        query_a = (
-            _base_query()
+        # Pool équitable (D) : au lieu d'un `ORDER BY published_at LIMIT 300`
+        # global (une source dense capte tout le pool et affame les discrètes),
+        # on range les candidats par source (row_number) et on retient les N
+        # plus récents de **chaque** source, puis on borne l'ensemble au cap
+        # externe. Sous-requête sur les seuls `id` (mêmes filtres communs).
+        ranked = (
+            _apply_common_filters(
+                select(
+                    Content.id.label("id"),
+                    func.row_number()
+                    .over(
+                        partition_by=Content.source_id,
+                        order_by=Content.published_at.desc(),
+                    )
+                    .label("rn"),
+                )
+            )
             .where(Content.source_id.in_(filters.source_ids))
             .where(Content.published_at >= cutoff_a)
+            .subquery()
+        )
+        per_source_ids = select(ranked.c.id).where(
+            ranked.c.rn <= ScoringWeights.VEILLE_BLOCK_A_PER_SOURCE_CANDIDATES
+        )
+        query_a = (
+            _base_query()
+            .where(Content.id.in_(per_source_ids))
             .order_by(Content.published_at.desc())
             .limit(ScoringWeights.VEILLE_CANDIDATE_CAP)
         )
@@ -463,6 +536,19 @@ async def fetch_veille_feed(
         )
         if filters.source_ids:
             query_b = query_b.where(Content.source_id.notin_(filters.source_ids))
+        if ScoringWeights.VEILLE_BLOCK_B_LANGUAGE_FILTER:
+            # Filtre langue (G1) : le Bloc B ratisse le pool global, souvent
+            # multilingue. On restreint aux langues des sources configurées
+            # ∪ {fr} ; `Content.language IS NULL` passe (permissif : beaucoup
+            # d'articles n'ont pas de langue détectée). Le Bloc A n'est jamais
+            # filtré (source choisie = langue assumée).
+            allowed_languages = filters.source_languages | {"fr"}
+            query_b = query_b.where(
+                or_(
+                    Content.language.in_(allowed_languages),
+                    Content.language.is_(None),
+                )
+            )
         query_b = query_b.order_by(Content.published_at.desc()).limit(
             ScoringWeights.VEILLE_CANDIDATE_CAP
         )

--- a/packages/api/app/services/veille/llm/angle_suggester.py
+++ b/packages/api/app/services/veille/llm/angle_suggester.py
@@ -20,11 +20,99 @@ from pydantic import BaseModel, Field, ValidationError
 
 from app.config import get_settings
 from app.services.editorial.llm_client import EditorialLLMClient
+from app.services.recommendation.french_stopwords import FRENCH_STOP_WORDS
 
 logger = structlog.get_logger()
 
 _CACHE_SIZE = 256
+# TTL 24h : après un déploiement durcissant le prompt, d'anciennes suggestions
+# génériques peuvent coexister au plus 24h avant expiration du cache in-process.
 _CACHE_TTL_SECONDS = 86400  # 24h
+
+# Denylist de mots-clés **unigrammes** de discours / d'analyse : ils matchent
+# tout et n'importe quoi (« budget », « europe »…), gonflent le corpus hors-sujet
+# et, avec le floor durci de la curation, ne qualifient de toute façon plus seuls.
+# Filtrés en post-parse (jamais les expressions multi-mots — elles discriminent).
+_GENERIC_KEYWORDS: frozenset[str] = frozenset(
+    {
+        "actualité",
+        "actualités",
+        "analyse",
+        "analyses",
+        "décryptage",
+        "enquête",
+        "enquêtes",
+        "dossier",
+        "dossiers",
+        "reportage",
+        "enjeu",
+        "enjeux",
+        "stratégie",
+        "stratégies",
+        "budget",
+        "débat",
+        "débats",
+        "controverse",
+        "polémique",
+        "tribune",
+        "initiative",
+        "initiatives",
+        "réforme",
+        "réformes",
+        "mesure",
+        "mesures",
+        "projet",
+        "projets",
+        "politique",
+        "politiques",
+        "réglementation",
+        "loi",
+        "lois",
+        "crise",
+        "crises",
+        "croissance",
+        "développement",
+        "impact",
+        "impacts",
+        "bilan",
+        "perspective",
+        "perspectives",
+        "tendance",
+        "tendances",
+        "prospective",
+        "avenir",
+        "futur",
+        "innovation",
+        "innovations",
+        "nouveau",
+        "nouveauté",
+        "nouveautés",
+        "lancement",
+        "question",
+        "questions",
+        "monde",
+        "société",
+        "économie",
+        "europe",
+        "france",
+        "international",
+        "national",
+        "secteur",
+        "secteurs",
+        "marché",
+        "marchés",
+        "acteur",
+        "acteurs",
+        "expert",
+        "experts",
+        "interview",
+        "portrait",
+        "chiffres",
+        "rapport",
+        "étude",
+        "études",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -43,7 +131,7 @@ class _LLMAngle(BaseModel):
 
 _SYSTEM_PROMPT = """Tu es un expert en curation éditoriale francophone, spécialisé en veille thématique.
 
-Tâche : pour un thème et un brief éditorial donnés, propose 8 à 12 ANGLES de veille pertinents. Chaque angle vient avec 3 à 5 mots-clés explicites qui serviront ensuite à filtrer des articles d'actualité.
+Tâche : pour un thème et un brief éditorial donnés, propose 8 à 12 ANGLES de veille pertinents. Chaque angle vient avec 3 à 5 mots-clés explicites qui serviront ensuite à FILTRER des articles d'actualité (match sur le titre / la description).
 
 Format JSON strict :
 {
@@ -56,48 +144,62 @@ Format JSON strict :
   ]
 }
 
-Contraintes :
-- 8 à 12 angles distincts (pas de redondance).
-- title : titre court (max 80 chars), explicite, complémentaire aux autres angles.
-- keywords : 3 à 5 mots ou expressions courtes (1-3 mots chacun), en français, en minuscules. Ce sont les mots qui doivent matcher dans les titres / descriptions des articles. Pense large (synonymes, variantes, noms propres pertinents) mais reste précis pour le sujet.
-- Couvre plusieurs angles complémentaires (différents axes du sujet).
+RÈGLE D'OR des mots-clés — applique ce test à CHAQUE mot-clé :
+« Un article dont le titre contient ce mot-clé parle presque certainement de ce sujet précis. »
+Si ce n'est pas vrai, le mot-clé est trop générique : jette-le.
+
+Contraintes mots-clés :
+- Privilégie les NOMS PROPRES, entités datées et termes techniques : personnes, organisations, lois, produits, événements, lieux précis (ex. « conseil constitutionnel », « jeux olympiques 2024 », « intelligence artificielle générative »).
+- AU MOINS 2 expressions multi-mots (2 à 4 mots) par angle : elles discriminent bien mieux qu'un mot isolé.
+- INTERDIT : le vocabulaire de discours / d'analyse qui matche tout et n'importe quoi — par exemple « stratégie », « budget », « analyse », « enjeux », « débat », « europe », « société », « avenir », « tendance », « réforme », « crise », « impact ». Ces mots ne disent RIEN du sujet précis.
+- 3 à 5 mots-clés par angle, en français, en minuscules.
+
+Contraintes angles :
+- 8 à 12 angles distincts (pas de redondance), complémentaires (différents axes du sujet).
+- title : titre court (max 80 chars), explicite.
 - Réponds UNIQUEMENT avec le JSON, rien d'autre."""
 
 
+def _filter_generic_keywords(keywords: list[str]) -> list[str]:
+    """Écarte les **unigrammes** de discours (denylist + stopwords FR).
+
+    Les expressions **multi-mots** sont toujours conservées : même bâties sur des
+    mots vagues, la combinaison discrimine (« coupe du monde », « conseil
+    constitutionnel »). Ordre d'origine préservé.
+    """
+    # Multi-mots (`" " in kw`) : jamais filtré — la combinaison discrimine même
+    # bâtie sur des mots vagues. Unigramme : écarté s'il est dans la denylist ou
+    # les stopwords FR. Ordre d'origine préservé.
+    return [
+        kw
+        for kw in keywords
+        if " " in kw or (kw not in _GENERIC_KEYWORDS and kw not in FRENCH_STOP_WORDS)
+    ]
+
+
 def _fallback_angles(theme_label: str) -> list[AngleSuggestion]:
-    """Angles génériques si LLM KO — couverture minimale pour ne pas bloquer le flow."""
+    """Angles de repli si le LLM est KO — peu nombreux, ancrés sur le thème.
+
+    Volontairement minimalistes et bâtis sur des **expressions multi-mots**
+    ancrées au thème (elles qualifient le floor durci comme « hit fort » et
+    survivent au filtre denylist). Ces grappes restent génériques : elles
+    produiront un feed court, voire vide — comportement dégradé **assumé** quand
+    le LLM est indisponible, préférable au bruit des anciennes grappes 100 %
+    discours (« analyse », « débat »…) qui inondaient la veille de hors-sujet.
+    """
+    label = theme_label.lower().strip()
     return [
         AngleSuggestion(
             title=f"Actualité {theme_label}",
-            keywords=[theme_label.lower(), "actualité", "nouveau"],
+            keywords=[f"actualité {label}", f"nouveauté {label}"],
         ),
         AngleSuggestion(
-            title="Analyses de fond",
-            keywords=["analyse", "enquête", "décryptage"],
+            title=f"Analyses {theme_label}",
+            keywords=[f"analyse {label}", f"enquête {label}"],
         ),
         AngleSuggestion(
-            title="Innovations et nouveautés",
-            keywords=["innovation", "nouveauté", "lancement"],
-        ),
-        AngleSuggestion(
-            title="Débats et controverses",
-            keywords=["débat", "controverse", "polémique"],
-        ),
-        AngleSuggestion(
-            title="Initiatives et bonnes pratiques",
-            keywords=["initiative", "bonne pratique", "retour d'expérience"],
-        ),
-        AngleSuggestion(
-            title="Acteurs et personnalités",
-            keywords=["interview", "portrait", "personnalité"],
-        ),
-        AngleSuggestion(
-            title="Tendances de fond",
-            keywords=["tendance", "prospective", "futur"],
-        ),
-        AngleSuggestion(
-            title="Réglementation et politique",
-            keywords=["réglementation", "loi", "politique"],
+            title=f"Débats {theme_label}",
+            keywords=[f"débat {label}", f"tribune {label}"],
         ),
     ]
 
@@ -179,14 +281,23 @@ class AngleSuggester:
         except ValidationError as exc:
             logger.warning("angle_suggester.validation_error", error=str(exc))
             return []
-        return [
-            AngleSuggestion(
-                title=a.title.strip(),
-                keywords=[k.strip().lower() for k in a.keywords if k.strip()],
-                reason=None,
+
+        result: list[AngleSuggestion] = []
+        dropped = 0
+        for a in parsed:
+            raw_kws = [k.strip().lower() for k in a.keywords if k.strip()]
+            kept = _filter_generic_keywords(raw_kws)
+            dropped += len(raw_kws) - len(kept)
+            if not kept:
+                # Angle intégralement vidé par le filtre → écarté (une grappe
+                # 100 % générique ne curerait rien d'utile).
+                continue
+            result.append(
+                AngleSuggestion(title=a.title.strip(), keywords=kept, reason=None)
             )
-            for a in parsed
-        ]
+        if dropped:
+            logger.info("angle_suggester.keywords_filtered", dropped=dropped)
+        return result
 
 
 _angle_suggester: AngleSuggester | None = None

--- a/packages/api/app/services/veille/scoring_context.py
+++ b/packages/api/app/services/veille/scoring_context.py
@@ -16,7 +16,6 @@ Aucune affinité/multiplicateur/mute en V1 — seuls ces 4 leviers pilotent le t
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -26,38 +25,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.enums import InterestState
 from app.models.user import UserProfile
-from app.services.recommendation.french_stopwords import FRENCH_STOP_WORDS
-from app.services.recommendation.scoring_config import ScoringWeights
 from app.services.recommendation.scoring_engine import ScoringContext
 
 if TYPE_CHECKING:  # éviter un import circulaire feed_filter ↔ scoring_context
     from app.services.veille.feed_filter import VeilleFilters
-
-# Longueur min d'un token d'intention (aligné sur KEYWORD_MIN_LENGTH = 4) :
-# en-deçà les mots sont trop génériques pour discriminer.
-_INTENT_MIN_TOKEN_LEN = ScoringWeights.KEYWORD_MIN_LENGTH
-_INTENT_TOKEN_RE = re.compile(r"[a-zàâäéèêëîïôöùûüÿç0-9]+", re.IGNORECASE)
-
-
-def _tokenize_intent(texts: list[str]) -> list[str]:
-    """Tokenise des notes d'intention libres en mots-clés discriminants.
-
-    Stopwords FR retirés, longueur ≥ 4, dédupliqués (ordre stable), bornés à
-    ``VEILLE_KEYWORD_CAP`` tokens — au-delà le bonus mots-clés est de toute
-    façon plafonné côté pilier Pertinence.
-    """
-    seen: set[str] = set()
-    out: list[str] = []
-    for text in texts:
-        for raw in _INTENT_TOKEN_RE.findall(text.lower()):
-            if (
-                len(raw) >= _INTENT_MIN_TOKEN_LEN
-                and raw not in FRENCH_STOP_WORDS
-                and raw not in seen
-            ):
-                seen.add(raw)
-                out.append(raw)
-    return out[: int(ScoringWeights.VEILLE_KEYWORD_CAP)]
 
 
 @dataclass(frozen=True)
@@ -126,20 +97,6 @@ async def build_veille_scoring_context(
                     k.lower().strip() for k in filters.global_keywords if k.strip()
                 ],
                 topic_name="Mots-clés",
-            )
-        )
-
-    # Notes d'intention texte libre (`why` des sources) → angle « Intention » :
-    # leurs tokens deviennent des mots-clés ordinaires qui affinent le tri via
-    # le bonus mots-clés existant (zéro nouveau code de scoring, borné par le
-    # cap). Aucun slug → ne matche que par sa grappe.
-    intent_tokens = _tokenize_intent(list(filters.source_intents.values()))
-    if intent_tokens:
-        custom_topics.append(
-            VeilleAngleTopic(
-                slug_parent="",
-                keywords=intent_tokens,
-                topic_name="Intention",
             )
         )
 

--- a/packages/api/scripts/evaluate_veille_curation.py
+++ b/packages/api/scripts/evaluate_veille_curation.py
@@ -26,8 +26,9 @@ Métriques :
   est la fuite principale.
 - **FP par chemin** (`source_only` / `keyword` / `topic` / `topic+keyword`) :
   attendu en baseline = majorité `source_only` dans le Bloc A.
-- **FN par raison** (`floor_source_only` / `below_threshold` /
-  `diversity_capped` / `not_a_candidate`).
+- **FN par raison** (`floor_source_only` / `floor_weak_keyword` /
+  `gate_pertinence` / `below_threshold` / `diversity_capped` /
+  `not_a_candidate`).
 - **Couverture d'axe** : parmi les articles `relevant`, part qui n'a qu'un axe
   mot-clé (sans topic ML) ou source-seul — quantifie le trou « nba » (topic ML
   mort) et le coût en rappel du gate-all.
@@ -172,7 +173,6 @@ class GoldConfig:
     angles: list[dict]
     global_keywords: list[str]
     sources: list[dict]
-    source_intents: dict[str, str]
     articles: list[GoldArticle]
 
 
@@ -211,11 +211,6 @@ def load_dataset(path: Path) -> list[GoldConfig]:
                 angles=list(c.get("angles") or []),
                 global_keywords=list(c.get("global_keywords") or []),
                 sources=list(c.get("sources") or []),
-                source_intents={
-                    s["source_id"]: s["why"]
-                    for s in (c.get("sources") or [])
-                    if s.get("why")
-                },
                 articles=articles,
             )
         )
@@ -238,11 +233,7 @@ def build_filters_context(config: GoldConfig):
         key: Source(
             id=key_to_uuid[key],
             name=next(
-                (
-                    s.get("name")
-                    for s in config.sources
-                    if s["source_id"] == key
-                ),
+                (s.get("name") for s in config.sources if s["source_id"] == key),
                 key,
             ),
             theme=config.theme_id,
@@ -272,9 +263,6 @@ def build_filters_context(config: GoldConfig):
         )
 
     config_source_uuids = [key_to_uuid[s["source_id"]] for s in config.sources]
-    intents_by_uuid = {
-        key_to_uuid[k]: v for k, v in config.source_intents.items()
-    }
     filters = VeilleFilters(
         theme_id=config.theme_id or None,
         angles=[
@@ -287,7 +275,6 @@ def build_filters_context(config: GoldConfig):
         ],
         source_ids=config_source_uuids,
         global_keywords=list(config.global_keywords),
-        source_intents=intents_by_uuid,
     )
 
     veille_config = VeilleConfig(
@@ -340,14 +327,27 @@ def classify_reject_reason(
     apply_floor: bool,
     apply_threshold: bool,
     floor_active: bool,
+    floor_qualified: bool,
+    gate_active: bool,
+    pertinence: float,
     threshold: float,
+    gate: float,
 ) -> str:
-    if floor_active and "topic" not in axes and "keyword" not in axes:
-        return "floor_source_only"
+    """Attribue la raison de rejet, dans l'ordre réel de la porte
+    (`_score_block`) : floor durci (B) → gate pertinence (A) → seuil composite →
+    cap de diversité. Concorde avec la décision réelle (anti-drift), sans la
+    prendre."""
+    if floor_active and not floor_qualified:
+        # Floor durci (B) : source-seul (aucun axe topic/keyword) OU keyword-only
+        # sous le minimum de hits distincts (unigramme générique isolé).
+        return "floor_weak_keyword" if "keyword" in axes else "floor_source_only"
+    if gate_active and pertinence < gate:
+        # Gate pertinence (A) : composite franchi mais lien au sujet trop faible.
+        return "gate_pertinence"
     if apply_threshold and score < threshold:
         return "below_threshold"
-    # A passé floor + seuil mais n'est pas dans le set gardé → coupé par le cap
-    # de diversité (Bloc A uniquement).
+    # A passé floor + gate + seuil mais n'est pas dans le set gardé → coupé par
+    # le cap de diversité (Bloc A uniquement).
     return "diversity_capped"
 
 
@@ -399,7 +399,9 @@ def evaluate_config(
     source_ids = set(filters.source_ids)
     keywords = filters.all_keywords
     threshold = ScoringWeights.VEILLE_RELEVANCE_THRESHOLD
-    floor_active = apply_floor and bool(topic_slugs or keywords)
+    gate = ScoringWeights.VEILLE_PERTINENCE_GATE
+    has_topic_or_kw = bool(topic_slugs or keywords)
+    floor_active = apply_floor and has_topic_or_kw
 
     # Partition par appartenance à une source configurée (= la requête SQL).
     block_a_articles: list[GoldArticle] = []
@@ -450,13 +452,19 @@ def evaluate_config(
     for a in config.articles:
         content = contents[a.id]
         block = block_of[a.id]
-        axes = _matched_axes(content, topic_slugs, source_ids, keywords)
-        raw = engine.compute_score(content, context).final_score
-        kept = content.id in kept_ids
-        block_floor_active = (
-            floor_active if block == "A" else bool(topic_slugs or keywords)
+        axes, floor_qualified = _matched_axes(
+            content, topic_slugs, source_ids, keywords
         )
+        result = engine.compute_score(content, context)
+        raw = result.final_score
+        pertinence = result.pillar_scores.get("pertinence", 0.0)
+        kept = content.id in kept_ids
+        # Le Bloc B applique toujours floor + gate + seuil ; le Bloc A suit les
+        # flags de politique (passthrough / floor / floor_threshold).
+        block_floor_active = floor_active if block == "A" else has_topic_or_kw
+        block_apply_floor = apply_floor if block == "A" else True
         block_apply_threshold = apply_threshold if block == "A" else True
+        block_gate_active = block_apply_threshold and has_topic_or_kw
         if kept:
             accept_path: str | None = classify_accept_path(axes)
             reject_reason: str | None = None
@@ -468,10 +476,14 @@ def evaluate_config(
                 reject_reason = classify_reject_reason(
                     axes,
                     raw,
-                    apply_floor=(apply_floor if block == "A" else True),
+                    apply_floor=block_apply_floor,
                     apply_threshold=block_apply_threshold,
                     floor_active=block_floor_active,
+                    floor_qualified=floor_qualified,
+                    gate_active=block_gate_active,
+                    pertinence=pertinence,
                     threshold=threshold,
+                    gate=gate,
                 )
         results.append(
             ArticleResult(
@@ -511,9 +523,7 @@ def _f1(precision: float, recall: float) -> float:
     return _safe_div(2 * precision * recall, precision + recall)
 
 
-def aggregate(
-    config_scores: list[ConfigScore], results: list[ArticleResult]
-) -> dict:
+def aggregate(config_scores: list[ConfigScore], results: list[ArticleResult]) -> dict:
     tp = sum(s.tp for s in config_scores)
     fp = sum(s.fp for s in config_scores)
     fn = sum(s.fn for s in config_scores)
@@ -551,8 +561,13 @@ def aggregate(
         "n_configs": len(config_scores),
         "n_articles": sum(s.n_articles for s in config_scores),
         "micro": {
-            "tp": tp, "fp": fp, "fn": fn, "tn": tn,
-            "precision": p, "recall": r, "f1": _f1(p, r),
+            "tp": tp,
+            "fp": fp,
+            "fn": fn,
+            "tn": tn,
+            "precision": p,
+            "recall": r,
+            "f1": _f1(p, r),
         },
         "macro": {"precision": macro_p, "recall": macro_r, "f1": macro_f1},
         "fp_by_block": dict(fp_by_block.most_common()),
@@ -570,8 +585,13 @@ def aggregate(
             {
                 "config_key": s.config_key,
                 "n_articles": s.n_articles,
-                "tp": s.tp, "fp": s.fp, "fn": s.fn, "tn": s.tn,
-                "precision": s.precision, "recall": s.recall, "f1": s.f1,
+                "tp": s.tp,
+                "fp": s.fp,
+                "fn": s.fn,
+                "tn": s.tn,
+                "precision": s.precision,
+                "recall": s.recall,
+                "f1": s.f1,
             }
             for s in config_scores
         ],
@@ -761,7 +781,9 @@ def main() -> None:
     parser.add_argument("--threshold", type=float, default=None)
     parser.add_argument("--sweep", action="store_true")
     parser.add_argument(
-        "--compare", nargs=2, metavar=("BASELINE", "AFTER"),
+        "--compare",
+        nargs=2,
+        metavar=("BASELINE", "AFTER"),
         help="2 JSON produits par ce script",
     )
     parser.add_argument("--out-json", default=None)
@@ -791,9 +813,7 @@ def main() -> None:
     out_json = Path(
         args.out_json or CONTEXT_DIR / f"veille-curation-{args.tag}-{today}.json"
     )
-    out_md = Path(
-        args.out_md or CONTEXT_DIR / f"veille-curation-{args.tag}-{today}.md"
-    )
+    out_md = Path(args.out_md or CONTEXT_DIR / f"veille-curation-{args.tag}-{today}.md")
     out_json.parent.mkdir(parents=True, exist_ok=True)
 
     payload = {

--- a/packages/api/tests/routers/test_veille_routes.py
+++ b/packages/api/tests/routers/test_veille_routes.py
@@ -70,7 +70,12 @@ async def curated_tech_source(db_session):
 
 @pytest_asyncio.fixture
 async def tech_content(db_session, curated_tech_source):
-    """3 articles tech : un matche le thème, un matche keyword 'ia', un matche les deux."""
+    """3 articles tech : un matche le thème, un matche keyword 'ia', un matche les deux.
+
+    Qualité normale (thumbnail + full) : sans anti-starvation (C), un article
+    source-seul frais mais sans image score ~43-47 (< seuil 48) et disparaîtrait ;
+    on teste la curation (floor/gate/prédicat), pas le bord du seuil composite.
+    """
     items = [
         Content(
             id=uuid4(),
@@ -83,6 +88,8 @@ async def tech_content(db_session, curated_tech_source):
             guid=f"gpt5-{uuid4()}",
             theme="tech",
             topics=["ai", "openai"],
+            thumbnail_url="https://tech.example.com/gpt5.jpg",
+            content_quality="full",
         ),
         Content(
             id=uuid4(),
@@ -95,6 +102,8 @@ async def tech_content(db_session, curated_tech_source):
             guid=f"bourse-{uuid4()}",
             theme="economy",
             topics=["markets"],
+            thumbnail_url="https://tech.example.com/bourse.jpg",
+            content_quality="full",
         ),
         Content(
             id=uuid4(),
@@ -107,6 +116,8 @@ async def tech_content(db_session, curated_tech_source):
             guid=f"velo-{uuid4()}",
             theme="society",
             topics=["mobility"],
+            thumbnail_url="https://tech.example.com/velo.jpg",
+            content_quality="full",
         ),
     ]
     db_session.add_all(items)
@@ -223,9 +234,7 @@ class TestConfigCRUD:
         payload = {
             "theme_id": "tech",
             "theme_label": "Tech",
-            "keywords": [
-                {"keyword": f"keyword-{i}", "position": i} for i in range(21)
-            ],
+            "keywords": [{"keyword": f"keyword-{i}", "position": i} for i in range(21)],
         }
         async with _client() as c:
             r = await c.post("/api/veille/config", json=payload)
@@ -253,12 +262,16 @@ class TestFavoriteIntegration:
 
     async def _favorites(self, db_session, user_id):
         rows = (
-            await db_session.execute(
-                select(UserFavoriteInterest).where(
-                    UserFavoriteInterest.user_id == user_id
+            (
+                await db_session.execute(
+                    select(UserFavoriteInterest).where(
+                        UserFavoriteInterest.user_id == user_id
+                    )
                 )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         return list(rows)
 
     async def test_post_config_auto_creates_favorite(
@@ -305,14 +318,10 @@ class TestFavoriteIntegration:
         self, auth_user, curated_tech_source, db_session
     ):
         db_session.add(
-            UserFavoriteInterest(
-                user_id=auth_user, position=0, interest_slug="tech"
-            )
+            UserFavoriteInterest(user_id=auth_user, position=0, interest_slug="tech")
         )
         db_session.add(
-            UserFavoriteInterest(
-                user_id=auth_user, position=1, interest_slug="society"
-            )
+            UserFavoriteInterest(user_id=auth_user, position=1, interest_slug="society")
         )
         await db_session.commit()
 
@@ -371,9 +380,7 @@ class TestFavoriteIntegration:
         favs = await self._favorites(db_session, auth_user)
         assert favs == []
 
-    async def test_get_config_self_heals_missing_favorite(
-        self, auth_user, db_session
-    ):
+    async def test_get_config_self_heals_missing_favorite(self, auth_user, db_session):
         """Story 23.4 : une config active orpheline (sans favori — cas proton) est
         réparée au `GET /config` (self-heal idempotent, commit dédié)."""
         cfg = VeilleConfig(
@@ -457,16 +464,18 @@ class TestFeed:
     async def test_feed_matches_keyword(
         self, auth_user, curated_tech_source, tech_content
     ):
+        # 2 mots-clés distincts (floor durci B : un keyword-only exige ≥ 2 hits
+        # distincts) — les deux matchent "Vélo électrique nouveau modèle".
         payload = {
             "theme_id": "tech",
             "theme_label": "Tech",
-            "keywords": [{"keyword": "vélo"}],
+            "keywords": [{"keyword": "vélo"}, {"keyword": "électrique"}],
         }
         async with _client() as c:
             await c.post("/api/veille/config", json=payload)
             r = await c.get("/api/veille/feed")
         items = r.json()["items"]
-        # Seul l'article "Vélo électrique" matche le keyword. GPT-5 n'entre plus
+        # Seul l'article "Vélo électrique" matche les keywords. GPT-5 n'entre plus
         # via le thème (retiré du prédicat) → 1 seul résultat (contrat inversé).
         assert len(items) == 1
         velo = items[0]
@@ -514,9 +523,7 @@ class TestFeedTwoBlocks:
             "theme_id": "tech",
             "theme_label": "Tech",
             "topics": [{"topic_id": "ai", "label": "IA", "kind": "preset"}],
-            "source_selections": [
-                {"kind": "followed", "source_id": str(source_id)}
-            ],
+            "source_selections": [{"kind": "followed", "source_id": str(source_id)}],
         }
 
     async def test_feed_exposes_group_per_item(
@@ -558,15 +565,22 @@ class TestFeedTwoBlocks:
         self, auth_user, curated_tech_source, tech_content, external_ai_content
     ):
         # Gate-all « released » : le Bloc A filtre désormais aussi les sources
-        # configurées (floor + seuil). Pour garder 3 articles on-angle dans le
-        # Bloc A, on qualifie les 3 articles de la source configurée par un axe
-        # (topic « ai » pour GPT-5, mots-clés « bourse »/« vélo » pour les deux
-        # autres) — sinon ils seraient floor-pruned comme source-seuls.
+        # configurées (floor durci + gate + seuil). Pour garder 3 articles
+        # on-angle dans le Bloc A, on qualifie les 3 articles de la source
+        # configurée par un axe : topic « ai » pour GPT-5, et **2 mots-clés
+        # distincts** pour les deux autres (« bourse »/« marchés » pour Bourse,
+        # « vélo »/« électrique » pour Vélo) — un unigramme seul serait
+        # floor-pruned depuis le durcissement du floor (B).
         payload = {
             "theme_id": "tech",
             "theme_label": "Tech",
             "topics": [{"topic_id": "ai", "label": "IA", "kind": "preset"}],
-            "keywords": [{"keyword": "bourse"}, {"keyword": "vélo"}],
+            "keywords": [
+                {"keyword": "bourse"},
+                {"keyword": "marchés"},
+                {"keyword": "vélo"},
+                {"keyword": "électrique"},
+            ],
             "source_selections": [
                 {"kind": "followed", "source_id": str(curated_tech_source.id)}
             ],
@@ -928,9 +942,7 @@ class TestResolveSourceCandidates:
 class TestOtherThemeIngestion:
     """theme_id='other' (tuile Autre) doit mapper vers theme='custom' à l'ingestion."""
 
-    async def test_other_theme_niche_source_ingestion(
-        self, auth_user, monkeypatch
-    ):
+    async def test_other_theme_niche_source_ingestion(self, auth_user, monkeypatch):
         from app.services import source_service
         from app.workers import rss_sync
 
@@ -996,9 +1008,7 @@ class TestOtherThemeIngestion:
         async def _fake_detect(self, url):
             raise ValueError("No RSS feed found")
 
-        monkeypatch.setattr(
-            source_service.SourceService, "detect_source", _fake_detect
-        )
+        monkeypatch.setattr(source_service.SourceService, "detect_source", _fake_detect)
 
         payload = {
             "theme_id": "other",
@@ -1038,9 +1048,7 @@ class TestOtherThemeIngestion:
         assert len(data["unconnected_sources"]) == 1
         assert data["unconnected_sources"][0]["client_slug"] == "niche-sans-flux"
         assert data["unconnected_sources"][0]["name"] == "Site sans flux"
-        assert (
-            data["unconnected_sources"][0]["url"] == "https://exemple-sans-rss.test"
-        )
+        assert data["unconnected_sources"][0]["url"] == "https://exemple-sans-rss.test"
         assert data["unconnected_sources"][0]["reason"]
 
 

--- a/packages/api/tests/scripts/test_evaluate_veille_curation.py
+++ b/packages/api/tests/scripts/test_evaluate_veille_curation.py
@@ -21,6 +21,7 @@ Couvre :
 
 from pathlib import Path
 
+from app.services.recommendation.scoring_config import ScoringWeights
 from app.services.veille import feed_filter
 from scripts import evaluate_veille_curation as ev
 from scripts.evaluate_veille_curation import (
@@ -79,20 +80,51 @@ def test_classify_accept_path():
 
 
 def test_classify_reject_reason():
-    common = {"apply_floor": True, "apply_threshold": True, "threshold": 48.0}
-    # axes ⊆ {source} + floor actif → source-seul écarté
+    common = {
+        "apply_floor": True,
+        "apply_threshold": True,
+        "floor_active": True,
+        "gate_active": True,
+        "threshold": 48.0,
+        "gate": ScoringWeights.VEILLE_PERTINENCE_GATE,
+    }
+    # axes ⊆ {source} + floor durci non qualifié → source-seul écarté
     assert (
-        classify_reject_reason(["source"], 60.0, floor_active=True, **common)
+        classify_reject_reason(
+            ["source"], 60.0, floor_qualified=False, pertinence=50.0, **common
+        )
         == "floor_source_only"
     )
-    # axe topic mais score sous le seuil → below_threshold
+    # keyword-only sous le minimum de hits (floor durci) → floor_weak_keyword
     assert (
-        classify_reject_reason(["topic"], 30.0, floor_active=True, **common)
+        classify_reject_reason(
+            ["source", "keyword"],
+            60.0,
+            floor_qualified=False,
+            pertinence=50.0,
+            **common,
+        )
+        == "floor_weak_keyword"
+    )
+    # qualifie le floor mais pertinence < gate → gate_pertinence
+    assert (
+        classify_reject_reason(
+            ["topic"], 60.0, floor_qualified=True, pertinence=10.0, **common
+        )
+        == "gate_pertinence"
+    )
+    # axe topic, gate OK, mais score composite sous le seuil → below_threshold
+    assert (
+        classify_reject_reason(
+            ["topic"], 30.0, floor_qualified=True, pertinence=40.0, **common
+        )
         == "below_threshold"
     )
-    # a passé floor + seuil mais pas dans le set gardé → cap de diversité
+    # a passé floor + gate + seuil mais pas dans le set gardé → cap de diversité
     assert (
-        classify_reject_reason(["topic"], 60.0, floor_active=True, **common)
+        classify_reject_reason(
+            ["topic"], 60.0, floor_qualified=True, pertinence=40.0, **common
+        )
         == "diversity_capped"
     )
 
@@ -111,7 +143,9 @@ def test_toy_passthrough_leaks_source_only_block_a_fp():
 
 def test_toy_passthrough_keeps_off_source_off_angle():
     """`off_source` (source-seul off_angle) est gardé en laisser-passer."""
-    _score, results = evaluate_config(_toy_configs()[0], apply_floor=False, apply_threshold=False)
+    _score, results = evaluate_config(
+        _toy_configs()[0], apply_floor=False, apply_threshold=False
+    )
     by_id = _by_id(results)
     assert by_id["off_source"].kept is True
     assert by_id["off_source"].accept_path == "source_only"
@@ -133,7 +167,9 @@ def test_toy_word_boundary_prunes_agentic_off_angle():
     """`off_substr` (« agentic ») : mot-entier ⇒ pas d'axe keyword ⇒ source-seul
     ⇒ floor-pruned. En sous-chaîne il aurait survécu au floor (régression Pb 3).
     """
-    _score, results = evaluate_config(_toy_configs()[0], apply_floor=True, apply_threshold=True)
+    _score, results = evaluate_config(
+        _toy_configs()[0], apply_floor=True, apply_threshold=True
+    )
     by_id = _by_id(results)
     off_substr = by_id["off_substr"]
     assert "keyword" not in off_substr.axes
@@ -146,11 +182,27 @@ def test_toy_keyword_absent_relevant_is_floor_fn():
     le coût en rappel mesuré du gate-all."""
     metrics = evaluate_dataset(_toy_configs(), "floor_threshold")
     assert metrics["fn_by_reason"].get("floor_source_only") == 1
-    _score, results = evaluate_config(_toy_configs()[0], apply_floor=True, apply_threshold=True)
+    _score, results = evaluate_config(
+        _toy_configs()[0], apply_floor=True, apply_threshold=True
+    )
     para = _by_id(results)["para"]
     assert para.gold_relevant is True
     assert para.kept is False
     assert para.reject_reason == "floor_source_only"
+
+
+def test_toy_single_unigram_keyword_is_floor_weak_keyword():
+    """`on_kw` (relevant, matche le seul mot-clé unigramme « agent ») : le floor
+    durci (B) exige ≥ 2 hits distincts ou un hit fort → il est écarté et attribué
+    `floor_weak_keyword`. C'est le coût en rappel assumé du durcissement."""
+    _score, results = evaluate_config(
+        _toy_configs()[0], apply_floor=True, apply_threshold=True
+    )
+    on_kw = _by_id(results)["on_kw"]
+    assert on_kw.gold_relevant is True
+    assert "keyword" in on_kw.axes
+    assert on_kw.kept is False
+    assert on_kw.reject_reason == "floor_weak_keyword"
 
 
 # ---------------------------------------------------------------------------
@@ -161,7 +213,9 @@ def test_toy_keyword_absent_relevant_is_floor_fn():
 def test_toy_block_b_prefilter_is_word_boundary():
     """`ext_off` (« agentic patterns », source externe) : ni topic ai ni mot-clé
     en mot-entier ⇒ jamais ramené par le prédicat Bloc B → `not_a_candidate`."""
-    _score, results = evaluate_config(_toy_configs()[0], apply_floor=True, apply_threshold=True)
+    _score, results = evaluate_config(
+        _toy_configs()[0], apply_floor=True, apply_threshold=True
+    )
     ext_off = _by_id(results)["ext_off"]
     assert ext_off.block is None
     assert ext_off.kept is False
@@ -170,7 +224,9 @@ def test_toy_block_b_prefilter_is_word_boundary():
 
 def test_toy_block_b_topic_candidate_survives():
     """`ext_on` (topic ai, source externe) entre dans le Bloc B et passe."""
-    _score, results = evaluate_config(_toy_configs()[0], apply_floor=True, apply_threshold=True)
+    _score, results = evaluate_config(
+        _toy_configs()[0], apply_floor=True, apply_threshold=True
+    )
     ext_on = _by_id(results)["ext_on"]
     assert ext_on.block == "B"
     assert ext_on.kept is True

--- a/packages/api/tests/services/test_veille_scoring.py
+++ b/packages/api/tests/services/test_veille_scoring.py
@@ -68,6 +68,9 @@ async def _add_content(
     description="",
     hours=2,
     reliability=None,
+    thumbnail_url=None,
+    content_quality=None,
+    language=None,
 ):
     c = Content(
         id=uuid4(),
@@ -80,6 +83,9 @@ async def _add_content(
         guid=str(uuid4()),
         theme=theme,
         topics=topics or [],
+        thumbnail_url=thumbnail_url,
+        content_quality=content_quality,
+        language=language,
     )
     db_session.add(c)
     await db_session.commit()
@@ -127,7 +133,9 @@ async def _make_config(
             )
 
     for sid in source_ids or []:
-        db_session.add(VeilleSource(veille_config_id=cfg.id, source_id=sid, kind="followed"))
+        db_session.add(
+            VeilleSource(veille_config_id=cfg.id, source_id=sid, kind="followed")
+        )
 
     for kpos, kw in enumerate(global_keywords or []):
         db_session.add(
@@ -155,19 +163,30 @@ async def test_theme_only_article_never_enters_pool(db_session, user, source):
 
 
 async def test_topic_outranks_keyword(db_session, user, source):
-    """Thème + topic (>) thème + mot-clé : les deux présents, topic mieux classé."""
-    await _add_content(db_session, source, title="Topic Match", topics=["ai"])
+    """Topic (>) mot-clé : les deux présents, topic mieux classé. La grappe porte
+    2 mots-clés (floor durci B : un keyword-only exige ≥ 2 hits) et les articles
+    sont de qualité normale (au-dessus du seuil composite sans anti-starvation)."""
+    await _add_content(
+        db_session,
+        source,
+        title="Topic Match",
+        topics=["ai"],
+        thumbnail_url="https://img.example.com/x.jpg",
+        content_quality="full",
+    )
     await _add_content(
         db_session,
         source,
         title="Keyword Match transformers",
         topics=["other"],
-        description="modèle transformers",
+        description="nouveau modèle transformers",
+        thumbnail_url="https://img.example.com/x.jpg",
+        content_quality="full",
     )
     await _make_config(
         db_session,
         user,
-        topics=[("ai", "IA", ["transformers"])],
+        topics=[("ai", "IA", ["transformers", "modèle"])],
     )
 
     titles, _ = await _titles(db_session, user)
@@ -176,10 +195,19 @@ async def test_topic_outranks_keyword(db_session, user, source):
     assert titles.index("Topic Match") < titles.index("Keyword Match transformers")
 
 
-async def test_source_only_and_keyword_only_present(db_session, user, source):
-    """Source-seule présente ; mot-clé-seul présent (valide le seuil)."""
+async def test_source_only_config_passthrough_present(db_session, user, source):
+    """Config purement source (floor/gate inactifs) : un article de la source
+    configurée est présent. Article de qualité normale (thumbnail + full) pour
+    dépasser franchement le seuil composite — l'anti-starvation, qui rattrapait
+    les articles source-seuls ~45-47, a été supprimée (C)."""
     await _add_content(
-        db_session, source, title="From Source", theme="economy", topics=["markets"]
+        db_session,
+        source,
+        title="From Source",
+        theme="economy",
+        topics=["markets"],
+        thumbnail_url="https://img.example.com/x.jpg",
+        content_quality="full",
     )
     await _make_config(db_session, user, source_ids=[source.id])
     titles, _ = await _titles(db_session, user)
@@ -187,6 +215,8 @@ async def test_source_only_and_keyword_only_present(db_session, user, source):
 
 
 async def test_keyword_only_present(db_session, user, source):
+    """Config mot-clés seuls : un article matchant qualifie le floor durci (B)
+    via **2 hits distincts** et reste au-dessus du gate + seuil."""
     await _add_content(
         db_session,
         source,
@@ -194,8 +224,11 @@ async def test_keyword_only_present(db_session, user, source):
         theme="society",
         topics=["mobility"],
         description="test du nouveau VAE",
+        thumbnail_url="https://img.example.com/x.jpg",
+        content_quality="full",
     )
-    await _make_config(db_session, user, global_keywords=["vélo"])
+    # 2 mots-clés distincts (floor durci exige ≥ 2 hits pour un keyword-only).
+    await _make_config(db_session, user, global_keywords=["vélo", "électrique"])
     titles, items = await _titles(db_session, user)
     assert "Vélo électrique nouveau modèle" in titles
     # items[i] = (content, axes, group) → axes en position 1.
@@ -237,9 +270,7 @@ async def test_excludes_hidden_seen_and_inactive(db_session, user, source):
     seen = await _add_content(db_session, source, title="Seen AI", topics=["ai"])
 
     db_session.add(
-        UserContentStatus(
-            user_id=user.user_id, content_id=hidden.id, is_hidden=True
-        )
+        UserContentStatus(user_id=user.user_id, content_id=hidden.id, is_hidden=True)
     )
     db_session.add(
         UserContentStatus(
@@ -286,11 +317,13 @@ async def test_pagination_over_scored_set(db_session, user, source):
     assert titles1.isdisjoint(titles2)
 
 
-# ─── Note d'intention `why` + split de récence deux blocs (refonte curation) ──
+# ─── Split de récence deux blocs (refonte curation) ──────────────────────────
 
 
-async def test_intent_why_injected_as_custom_topic(db_session, user):
-    """`build_veille_scoring_context` injecte un angle « Intention » depuis `why`."""
+async def test_why_no_longer_injected_as_custom_topic(db_session, user):
+    """E — la tokenisation des `why` est retirée : `build_veille_scoring_context`
+    ne fabrique plus d'angle « Intention », même quand des sources ont un `why`
+    (le champ `source_intents` n'existe plus sur `VeilleFilters`)."""
     sid = uuid4()
     config = VeilleConfig(
         id=uuid4(),
@@ -299,15 +332,9 @@ async def test_intent_why_injected_as_custom_topic(db_session, user):
         theme_label="Bière",
         status=VeilleStatus.ACTIVE.value,
     )
-    filters = VeilleFilters(
-        theme_id="culture",
-        source_ids=[sid],
-        source_intents={sid: "brasserie artisanale houblon"},
-    )
+    filters = VeilleFilters(theme_id="culture", source_ids=[sid])
     ctx = await build_veille_scoring_context(db_session, config, filters, _now())
-    intention = [t for t in ctx.user_custom_topics if t.topic_name == "Intention"]
-    assert len(intention) == 1
-    assert {"brasserie", "artisanale", "houblon"} <= set(intention[0].keywords)
+    assert all(t.topic_name != "Intention" for t in ctx.user_custom_topics)
 
 
 async def test_recency_split_configured_30d_external_7d(db_session, user, source):
@@ -347,3 +374,128 @@ async def test_recency_split_configured_30d_external_7d(db_session, user, source
     assert by_title.get("Configured 20d") == "sources"
     assert "External 20d" not in by_title
     assert by_title.get("External 2d") == "elargie"
+
+
+# ─── D — pool Bloc A équitable par source ────────────────────────────────────
+
+
+async def test_block_a_per_source_pool_is_fair(db_session, user, source, monkeypatch):
+    """D — une source bavarde ne rafle plus tout le pool : sous un cap externe
+    serré, les articles d'une source discrète (plus anciens, mais dans la fenêtre
+    30 j) restent visibles. Avec l'ancien `ORDER BY published_at DESC LIMIT cap`
+    **global**, les récents de la source dense les évinceraient ; le
+    `row_number() PARTITION BY source_id` borne d'abord chaque source."""
+    from app.services.recommendation.scoring_config import ScoringWeights as _SW
+
+    # Cap externe serré + 2 candidats/source pour rendre l'effet observable sans
+    # insérer des centaines d'articles (l'effet ne mord qu'au-delà du cap global).
+    monkeypatch.setattr(_SW, "VEILLE_BLOCK_A_PER_SOURCE_CANDIDATES", 2)
+    monkeypatch.setattr(_SW, "VEILLE_CANDIDATE_CAP", 3)
+
+    quiet = Source(
+        id=uuid4(),
+        name="Quiet",
+        url="https://q.example.com",
+        feed_url=f"https://q.example.com/{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="tech",
+        is_active=True,
+        is_curated=True,
+        reliability_score=ReliabilityScore.HIGH,
+    )
+    db_session.add(quiet)
+    await db_session.commit()
+
+    # Source dense : 5 articles on-topic récents (1 à 5 h).
+    for i in range(5):
+        await _add_content(
+            db_session,
+            source,
+            title=f"Dense {i}",
+            topics=["ai"],
+            hours=i + 1,
+            thumbnail_url="https://img.example.com/x.jpg",
+            content_quality="full",
+        )
+    # Source discrète : 2 articles on-topic plus anciens (100-101 h < 30 j).
+    for i in range(2):
+        await _add_content(
+            db_session,
+            quiet,
+            title=f"Quiet {i}",
+            topics=["ai"],
+            hours=100 + i,
+            thumbnail_url="https://img.example.com/x.jpg",
+            content_quality="full",
+        )
+
+    await _make_config(
+        db_session, user, topics=[("ai", "IA", [])], source_ids=[source.id, quiet.id]
+    )
+
+    titles, _ = await _titles(db_session, user)
+    # La source discrète n'est pas affamée : au moins un de ses articles passe.
+    assert any(t.startswith("Quiet") for t in titles)
+
+
+# ─── G1 — filtre langue du Bloc B ────────────────────────────────────────────
+
+
+async def _add_external_source(db_session, *, language=None):
+    s = Source(
+        id=uuid4(),
+        name=f"Ext {uuid4().hex[:6]}",
+        url=f"https://ext-{uuid4().hex}.com",
+        feed_url=f"https://ext-{uuid4().hex}.com/feed.xml",
+        type=SourceType.ARTICLE,
+        theme="tech",
+        is_active=True,
+        is_curated=True,
+        language=language,
+    )
+    db_session.add(s)
+    await db_session.commit()
+    return s
+
+
+async def test_block_b_language_filter_excludes_foreign(db_session, user, source):
+    """G1 — Bloc B : un article de langue étrangère (en) d'une source non
+    configurée est écarté ; `language=None` passe (permissif)."""
+    ext = await _add_external_source(db_session)
+    await _add_content(
+        db_session, ext, title="AI breakthrough", topics=["ai"], language="en"
+    )
+    await _add_content(
+        db_session, ext, title="Percée IA sans langue", topics=["ai"], language=None
+    )
+    # Source configurée FR (fixture `source`, language=None) → allowed = {fr}.
+    await _make_config(
+        db_session, user, topics=[("ai", "IA", [])], source_ids=[source.id]
+    )
+
+    titles, _ = await _titles(db_session, user)
+    assert "AI breakthrough" not in titles  # en → filtré
+    assert "Percée IA sans langue" in titles  # NULL → permissif
+
+
+async def test_block_b_language_filter_allows_configured_source_language(
+    db_session, user
+):
+    """G1 — une langue portée par une source **configurée** (en) est autorisée au
+    Bloc B : un article externe en anglais redevient visible."""
+    configured_en = await _add_external_source(db_session, language="en")
+    other_en = await _add_external_source(db_session, language="en")
+    await _add_content(
+        db_session,
+        other_en,
+        title="AI breakthrough abroad",
+        topics=["ai"],
+        language="en",
+    )
+    # La config déclare une source de langue en → 'en' entre dans allowed.
+    await _make_config(
+        db_session, user, topics=[("ai", "IA", [])], source_ids=[configured_en.id]
+    )
+
+    titles, _ = await _titles(db_session, user)
+    assert "AI breakthrough abroad" in titles

--- a/packages/api/tests/services/veille/test_angle_suggester.py
+++ b/packages/api/tests/services/veille/test_angle_suggester.py
@@ -116,3 +116,75 @@ async def test_suggest_angles_keywords_lowercased_and_stripped():
     suggester = AngleSuggester(llm=llm)
     angles = await suggester.suggest_angles("tech", "Tech", "")
     assert angles[0].keywords == ["majuscules", "espaces internes ok"]
+
+
+# ─── Filtre post-parse des mots-clés génériques (F) ──────────────────────────
+
+
+async def test_parse_drops_generic_unigrams_keeps_multiword():
+    """Un unigramme de discours (« stratégie », « europe ») est retiré ; une
+    expression multi-mots (« conseil constitutionnel ») et un nom propre isolé
+    (« macron ») sont conservés."""
+    llm = _mk_llm(
+        ready=True,
+        response={
+            "angles": [
+                {
+                    "title": "Vie institutionnelle",
+                    "keywords": [
+                        "stratégie",
+                        "europe",
+                        "conseil constitutionnel",
+                        "macron",
+                    ],
+                }
+            ]
+        },
+    )
+    suggester = AngleSuggester(llm=llm)
+    angles = await suggester.suggest_angles("politics", "Politique", "")
+    assert len(angles) == 1
+    assert angles[0].keywords == ["conseil constitutionnel", "macron"]
+
+
+async def test_parse_drops_angle_emptied_by_filter():
+    """Un angle dont TOUS les mots-clés sont génériques est écarté ; les autres
+    angles survivent."""
+    llm = _mk_llm(
+        ready=True,
+        response={
+            "angles": [
+                {"title": "Discours creux", "keywords": ["analyse", "enjeux", "débat"]},
+                {
+                    "title": "Sujet précis",
+                    "keywords": ["intelligence artificielle générative", "mistral ai"],
+                },
+            ]
+        },
+    )
+    suggester = AngleSuggester(llm=llm)
+    angles = await suggester.suggest_angles("tech", "Tech", "")
+    assert len(angles) == 1
+    assert angles[0].title == "Sujet précis"
+
+
+async def test_parse_drops_stopword_unigram():
+    """Un stopword FR isolé (« pour ») est retiré comme un générique."""
+    llm = _mk_llm(
+        ready=True,
+        response={"angles": [{"title": "T", "keywords": ["pour", "coupe du monde"]}]},
+    )
+    suggester = AngleSuggester(llm=llm)
+    angles = await suggester.suggest_angles("sport", "Sport", "")
+    assert angles[0].keywords == ["coupe du monde"]
+
+
+async def test_fallback_uses_multiword_keywords():
+    """Les angles de repli sont ancrés sur le thème via des expressions
+    multi-mots (survivent au floor durci + au filtre denylist)."""
+    llm = _mk_llm(ready=False, response=None)
+    suggester = AngleSuggester(llm=llm)
+    angles = await suggester.suggest_angles("tech", "Tech", "")
+    assert len(angles) >= 3
+    # Chaque mot-clé de repli est multi-mots (contient une espace).
+    assert all(" " in kw for a in angles for kw in a.keywords)

--- a/packages/api/tests/test_veille_curation.py
+++ b/packages/api/tests/test_veille_curation.py
@@ -6,9 +6,9 @@ toucher le chemin custom-topic de la Tournée (Epic 11) :
 - **Pertinence veille** (`PertinencePillar._score_custom_topics`) : barème
   escaladant (2kw > 1kw), topic > keyword, combo (topic+kw) en tête, source
   suivie conditionnée (boost on-angle only, jamais sur source-seul).
-- **Floor + seuil + anti-starvation** (`feed_filter._score_and_rank`) : la
-  source est un boost, pas un free-pass ; le seuil 48 coupe le bruit ; la
-  relâche anti-starvation ne réadmet jamais un floor-pruned.
+- **Floor durci + gate + seuil** (`feed_filter._score_and_rank`) : la source est
+  un boost, pas un free-pass ; un keyword-only exige ≥ 2 hits ou un hit fort ; le
+  seuil 48 coupe le bruit ; plus d'anti-starvation (aucune réadmission).
 - **DB end-to-end** (`fetch_veille_feed`) : un article source-seule off-angle
   est exclu du feed.
 - **Régression** : un custom topic Epic 11 (sans `is_veille`) garde le `+25` plat.
@@ -41,11 +41,13 @@ from app.services.veille.feed_filter import (
 
 
 def _score_and_rank(candidates, context, filters):
-    """Shim Bloc B (floor + seuil + anti-starvation) — comportement historique."""
+    """Shim Bloc B (floor durci + gate pertinence + seuil, sans anti-starvation)."""
     return _score_block(
         candidates, context, filters, apply_floor=True, apply_threshold=True
     )
-from app.services.veille.scoring_context import VeilleAngleTopic, _tokenize_intent
+
+
+from app.services.veille.scoring_context import VeilleAngleTopic
 
 # ─── Helpers légers pour le pilier Pertinence ────────────────────────────────
 
@@ -92,7 +94,8 @@ def test_keyword_bonus_escalates_with_distinct_matches():
     )
     assert one == pytest.approx(ScoringWeights.VEILLE_KEYWORD_BASE_BONUS)
     assert two == pytest.approx(
-        ScoringWeights.VEILLE_KEYWORD_BASE_BONUS + ScoringWeights.VEILLE_KEYWORD_INCREMENT
+        ScoringWeights.VEILLE_KEYWORD_BASE_BONUS
+        + ScoringWeights.VEILLE_KEYWORD_INCREMENT
     )
     assert two > one
 
@@ -128,7 +131,9 @@ def test_keyword_bonus_is_capped():
 
 def test_topic_beats_single_keyword():
     """Le topic canonique (+50) pèse plus qu'un mot-clé seul (+18)."""
-    topic_only = _angle_score(_Content(topics=["ai"], title="Intelligence artificielle"))
+    topic_only = _angle_score(
+        _Content(topics=["ai"], title="Intelligence artificielle")
+    )
     kw_only = _angle_score(_Content(topics=["tech"], title="Un nouveau LLM"))
     assert topic_only == pytest.approx(ScoringWeights.VEILLE_TOPIC_MATCH_BONUS)
     assert topic_only > kw_only
@@ -188,7 +193,7 @@ def test_non_veille_custom_topic_keeps_flat_bonus():
     assert score == pytest.approx(ScoringWeights.CUSTOM_TOPIC_BASE_BONUS)
 
 
-# ─── Floor + seuil + anti-starvation (`_score_and_rank`) ─────────────────────
+# ─── Floor durci + gate + seuil (`_score_and_rank`) ──────────────────────────
 
 
 def _make_source(name="Src", followed=True):
@@ -237,7 +242,9 @@ def _veille_context(followed_ids):
 def _veille_filters(source_ids):
     return VeilleFilters(
         theme_id="tech",
-        angles=[VeilleAngle(topic_id="ai", label="IA", keywords=["llm", "gpt", "agent"])],
+        angles=[
+            VeilleAngle(topic_id="ai", label="IA", keywords=["llm", "gpt", "agent"])
+        ],
         source_ids=list(source_ids),
         global_keywords=[],
     )
@@ -269,43 +276,21 @@ def test_on_topic_from_unfollowed_source_survives():
     assert {c.id for c, _s, _a in kept} == {on_topic.id}
 
 
-def test_threshold_cuts_below_floor_score():
-    """Le seuil 48 reste au-dessus du plancher anti-starvation (40)."""
-    assert ScoringWeights.VEILLE_RELEVANCE_THRESHOLD > 40.0
-
-
-def test_anti_starvation_never_readmits_floor_pruned():
-    """Sous le min feed, on relâche le seuil — mais jamais un source-seul."""
+def test_no_readmission_even_when_feed_empty():
+    """Anti-starvation supprimée (C) : même quand tout est coupé et que le feed
+    serait vide (``pass_count == 0``), aucun candidat n'est réadmis."""
     src = _make_source()
-    # 1 seul on-angle faible + plein de source-seul off-angle.
-    weak = _make_content(src, topics=["tech"], title="Un agent vaguement tech")
-    floods = [
-        _make_content(src, topics=["tech"], title=f"Bon plan #{i}", mins=40 + i)
+    # Tous source-seuls off-angle → tous floor-pruned. Aucune relâche ne les
+    # ramène (avant, l'anti-starvation aurait pu réadmettre des sous-seuil).
+    off = [
+        _make_content(src, topics=["sport"], title=f"Résultat #{i}", mins=30 + i)
         for i in range(6)
     ]
     flt = _veille_filters([src.id])
     ctx = _veille_context([src.id])
 
-    kept = _score_and_rank([weak, *floods], ctx, flt)
-    kept_ids = {c.id for c, _s, _a in kept}
-    # Aucun des articles source-seule (floods) n'est réadmis par l'anti-starvation.
-    for f in floods:
-        assert f.id not in kept_ids
-
-
-# ─── Note d'intention `why` : tokenisation ───────────────────────────────────
-
-
-def test_tokenize_intent_strips_stopwords_and_short_tokens():
-    """Stopwords FR + tokens < 4 caractères retirés ; dédup ordre stable."""
-    tokens = _tokenize_intent(["Je veux suivre la brasserie artisanale et le houblon"])
-    assert {"brasserie", "artisanale", "houblon"} <= set(tokens)
-    assert "la" not in tokens
-    assert "et" not in tokens
-
-
-def test_tokenize_intent_dedupes():
-    assert _tokenize_intent(["houblon houblon HOUBLON"]).count("houblon") == 1
+    kept = _score_and_rank(off, ctx, flt)
+    assert kept == []
 
 
 # ─── Bloc A « Tes sources » : gate-all + cap diversité ───────────────────────
@@ -325,9 +310,7 @@ def test_block_a_gates_source_only_off_angle():
     flt = _veille_filters([src.id])  # config a un topic 'ai' + des mots-clés
     ctx = _veille_context([src.id])
 
-    kept = _score_block(
-        [source_only], ctx, flt, apply_floor=True, apply_threshold=True
-    )
+    kept = _score_block([source_only], ctx, flt, apply_floor=True, apply_threshold=True)
     assert kept == []
 
 
@@ -411,6 +394,12 @@ async def _insert_content(db_session, source_id, *, topics, title) -> UUID:
             theme="tech",
             topics=topics,
             content_quality="full",
+            # Thumbnail → article de qualité « normale » (aligné sur le helper
+            # unitaire `_make_content`). Sans ça, un article source-seul frais
+            # score ~47 (< seuil 48) et n'était retenu que par l'anti-starvation
+            # (supprimée, C) : la passthrough source-seule teste alors le floor,
+            # pas le bord du seuil.
+            thumbnail_url="https://img.example.com/thumb.jpg",
         )
     )
     await db_session.commit()


### PR DESCRIPTION
# Veille — PR 1 « Quick wins » : re-corréler le feed au sujet configuré

Backend-only, **0 migration DB**. Chaque levier est un bouton réglable/réversible
par constante. Motivé par l'audit du 07/07 (`.context/veille-curation-mecanique.html`,
memory `project_veille_curation_audit_decorrelation`) : le feed Veille était
décorrélé de l'intention (topic axis mort 97 %, kw LLM génériques = 31 % du corpus,
seuil posé sur le composite ⇒ ~60 % hors-sujet, anti-starvation qui réadmet le bruit).

## Commit 1 — Mécanique scoring & pool (`feed_filter.py`, `scoring_context.py`, `scoring_config.py`)

- **Constantes** : `VEILLE_PERTINENCE_GATE=20`, `VEILLE_FLOOR_MIN_KEYWORD_HITS=2`,
  `VEILLE_BLOCK_A_PER_SOURCE_CANDIDATES=30`, `VEILLE_BLOCK_B_LANGUAGE_FILTER=True` ;
  suppression de `VEILLE_MIN_FEED_SIZE` (anti-starvation). Seuil composite **48 inchangé**.
- **E — plus de tokenisation des `why`** : `_tokenize_intent` + l'angle « Intention »
  retirés. `why` reste en DB / endpoint config (badge santé inchangé).
- **G2 — slugs non canoniques ignorés** : un `topic_id` hors des 50 slugs canoniques
  (`SUBTOPIC_LABELS`) est neutralisé en `""` → sort du prédicat SQL, de `matched_on`
  et de `user_subtopics` (le floor redevient honnête). Ses mots-clés survivent.
- **B — floor durci** : un keyword-only ne qualifie que sur **≥ 2 hits distincts** ou
  **1 hit fort** (mot-clé multi-mots, p.ex. « coupe du monde »). `_matched_axes` renvoie
  désormais `(axes, floor_qualified)`. `matched_on` (front) inchangé.
- **A — gate pertinence** : en plus du seuil composite, on exige pertinence normalisée
  ≥ 20 quand la config porte un axe topic/mot-clé (le composite offre ~37-40 pts d'office
  via source+fraîcheur+qualité). Nouveau compteur `gate_pruned_count` au log
  `veille.feed_scored`.
- **C — anti-starvation supprimée** : aucun candidat sous le seuil n'est réadmis
  (feed court honnête). Revert = un bloc isolé.
- **D — pool Bloc A équitable par source** : `row_number() OVER (PARTITION BY source_id
  ORDER BY published_at DESC)` borne chaque source à N=30 avant le cap externe 300 — une
  source dense n'affame plus les discrètes. `_base_query` refactoré en
  `_apply_common_filters` (réutilisé par la sous-requête d'ids). Le point incertain du
  plan (`apply_serein_filter` sur select non-entité) fonctionne — pas de plan B.
- **G1 — filtre langue Bloc B** : langues des sources configurées ∪ `{fr}`,
  `Content.language IS NULL` toléré. Bloc A non filtré. Kill-switch.

## Commit 2 — F : mots-clés LLM discriminants (`llm/angle_suggester.py`)

- `_SYSTEM_PROMPT` durci : noms propres / entités datées, **≥ 2 expressions multi-mots
  par angle**, denylist explicite du vocabulaire de discours, règle d'or (« un article
  qui contient ce mot-clé parle presque certainement de ce sujet ») ; « Pense large »
  retiré.
- Filtre post-parse `_filter_generic_keywords` : denylist `_GENERIC_KEYWORDS` (~65
  unigrammes) + `FRENCH_STOP_WORDS`, jamais les multi-mots ; angle vidé → écarté ; log
  `angle_suggester.keywords_filtered`.
- `_fallback_angles` 8 → 3, expressions multi-mots ancrées au thème.
- Cache TTL 24 h inchangé : d'anciennes suggestions génériques peuvent coexister ≤ 24 h
  post-deploy.

## Effet produit assumé

Les feeds des configs **existantes** (kw génériques + slugs morts toujours en base) vont
**fortement raccourcir** — 0-10 items honnêtes au lieu de dizaines majoritairement
hors-sujet. C'est le comportement voulu. Le vrai remède (régénération des configs) est un
agent suivant. Boutons de détente si trop agressif : `VEILLE_FLOOR_MIN_KEYWORD_HITS`
(2→1) et `VEILLE_PERTINENCE_GATE` (20→25/0), via les logs prod
(`floor_pruned_count` / `gate_pruned_count` / `threshold_pruned_count`).

## Harness d'audit mis à jour

`scripts/evaluate_veille_curation.py` (l'outil qui a produit l'audit) est adapté à la
nouvelle porte : `source_intents` retiré, tuple `_matched_axes` déballé, nouvelles raisons
de rejet `floor_weak_keyword` (keyword-only sous le min de hits) et `gate_pertinence`.

## Vérification

- Suites veille + harness : **98 passed** (`test_veille_curation`, `test_veille_scoring`,
  `test_veille_routes`, `test_angle_suggester`, `test_evaluate_veille_curation`).
- Suite backend complète : **2034 passed**, 2 échecs pré-existants sans lien (artefacts
  de fuseau `+02:00` sur le Postgres local, `test_notification_preferences` /
  `test_sources_recent_items` — verts en CI UTC).
- `ruff check` + `ruff format` OK sur tout le code modifié.
- Nouveaux tests ciblés : floor durci (1 hit → pruned, 2 hits / multi-mots → passe),
  gate (2 hits sans source coupés, +source passe), C (aucune réadmission), D (source
  discrète non affamée sous cap serré), G1 (article `en` écarté, `NULL` passe, langue
  d'une source configurée autorisée).

## Hors périmètre (agents suivants)

Réutilisation du brief éditorial au scoring, régénération/migration des configs existantes
(95 slugs morts + kw génériques restent en base), dédup d'angles, preview du feed à la
config, état vide UI mobile.

## À valider post-merge (logs prod)

Mesure ex-ante non réalisée (part du corpus FR 7 j matchant ≥ 2 kw distincts de
« Présidentielle 2027 ») : à confirmer via les logs `veille.feed_scored` en staging pour
calibrer `VEILLE_FLOOR_MIN_KEYWORD_HITS` (2→3 si le feed reste bruité).
