### PR TITLE
fix(mobile): configurer Firebase Android — débloque la notif du jour (root cause)

### DIFF
--- a/.github/actions/verify-google-services/action.yml
+++ b/.github/actions/verify-google-services/action.yml
@@ -1,0 +1,20 @@
+name: Verify google-services.json
+description: >-
+  Échoue tôt et lisiblement si le google-services.json du flavor manque (sinon le
+  push serait mort-né). Redondant avec le garde-fou Gradle de build.gradle.kts,
+  mais échoue plus tôt et plus lisiblement dans les logs CI, avant les étapes
+  Java/Flutter. Cf. docs/bugs/bug-notifications-stalled.md.
+inputs:
+  flavor:
+    description: "Flavor Android dont le google-services.json est requis (beta | playstore)."
+    required: true
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        f="apps/mobile/android/app/src/${{ inputs.flavor }}/google-services.json"
+        if [ ! -f "$f" ]; then
+          echo "::error::$f manquant — le push serait mort-né (Firebase non configuré)."
+          exit 1
+        fi

--- a/.github/workflows/build-aab.yml
+++ b/.github/workflows/build-aab.yml
@@ -18,6 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Verify google-services.json (playstore)
+        uses: ./.github/actions/verify-google-services
+        with:
+          flavor: playstore
+
       - name: Setup Java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -27,6 +27,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Verify google-services.json (beta)
+        uses: ./.github/actions/verify-google-services
+        with:
+          flavor: beta
+
       - name: Setup Java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -49,6 +49,11 @@ jobs:
           # écoute push:[production] et serait re-déclenché en double.
           git push origin production
 
+      - name: Verify google-services.json (beta)
+        uses: ./.github/actions/verify-google-services
+        with:
+          flavor: beta
+
       - name: Setup Java
         uses: actions/setup-java@v4
         with:

--- a/apps/mobile/android/app/build.gradle.kts
+++ b/apps/mobile/android/app/build.gradle.kts
@@ -8,14 +8,36 @@ plugins {
     id("dev.flutter.flutter-gradle-plugin")
 }
 
-// Firebase config is supplied per environment in app/src/prod and
-// app/src/staging. Keep local builds without credentials usable.
-if (
-    file("src/prod/google-services.json").exists() ||
-    file("src/staging/google-services.json").exists() ||
+// Firebase config commitée par flavor : app/src/beta (com.example.facteur.staging)
+// et app/src/playstore (facteur.app). Un google-services.json Android n'est PAS un
+// secret (identifiants publics + clé API restreinte) → commit assumé. Sans lui,
+// Firebase natif n'embarque aucune ressource `google_app_id`, donc
+// `Firebase.initializeApp()` lève une PlatformException sur CHAQUE appareil → tout
+// l'enregistrement push meurt et 100 % des users retombent sur la notif locale
+// (root cause « notif du jour morte depuis le 1er jour », cf.
+// docs/bugs/bug-notifications-stalled.md).
+val hasGoogleServices =
+    file("src/beta/google-services.json").exists() ||
+    file("src/playstore/google-services.json").exists() ||
     file("google-services.json").exists()
-) {
+
+if (hasGoogleServices) {
     apply(plugin = "com.google.gms.google-services")
+} else {
+    // Filet anti-régression : un build release/bundle (AAB Play Store, APK stable)
+    // sans google-services.json produirait une app « push mort-né ». On échoue fort
+    // et tôt plutôt que de re-livrer en silence. Les builds debug/dev restent
+    // tolérants (dev local sans credentials Firebase).
+    val isReleaseBuild = gradle.startParameter.taskNames.any {
+        it.contains("Release") || it.contains("Bundle")
+    }
+    if (isReleaseBuild) {
+        throw GradleException(
+            "google-services.json manquant — le push serait mort-né. Ajoute " +
+                "apps/mobile/android/app/src/<flavor>/google-services.json " +
+                "(src/beta pour com.example.facteur.staging, src/playstore pour facteur.app)."
+        )
+    }
 }
 
 val keystorePropertiesFile = rootProject.file("key.properties")

--- a/apps/mobile/android/app/src/beta/google-services.json
+++ b/apps/mobile/android/app/src/beta/google-services.json
@@ -1,0 +1,48 @@
+{
+  "project_info": {
+    "project_number": "843185260430",
+    "project_id": "facteur-c30dc",
+    "storage_bucket": "facteur-c30dc.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:843185260430:android:b1a8fd4cf4c4e38c8fc6df",
+        "android_client_info": {
+          "package_name": "com.example.facteur.staging"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyAonAYXZ5KaDwv8V7TjsekBxz5SiFyc4Fk"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:843185260430:android:6b6b0688940fb0f98fc6df",
+        "android_client_info": {
+          "package_name": "facteur.app"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyAonAYXZ5KaDwv8V7TjsekBxz5SiFyc4Fk"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/apps/mobile/android/app/src/playstore/google-services.json
+++ b/apps/mobile/android/app/src/playstore/google-services.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "843185260430",
+    "project_id": "facteur-c30dc",
+    "storage_bucket": "facteur-c30dc.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:843185260430:android:6b6b0688940fb0f98fc6df",
+        "android_client_info": {
+          "package_name": "facteur.app"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyAonAYXZ5KaDwv8V7TjsekBxz5SiFyc4Fk"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/apps/mobile/lib/core/services/server_push_service.dart
+++ b/apps/mobile/lib/core/services/server_push_service.dart
@@ -123,8 +123,16 @@ class ServerPushService {
       return _registerToken(token);
     } catch (e) {
       debugPrint('ServerPushService: initialization failed: $e');
+      // On capture aussi le message natif exact (tronqué) en plus du runtimeType :
+      // c'est lui qui révèle la cause racine (ex. « no default options » quand le
+      // google-services.json du flavor manque), invisible avec le seul type.
+      final detail = e.toString();
       unawaited(
-        _capturePushRegister(outcome: 'exception', reason: e.runtimeType.toString()),
+        _capturePushRegister(
+          outcome: 'exception',
+          reason: e.runtimeType.toString(),
+          error: detail.length > 300 ? detail.substring(0, 300) : detail,
+        ),
       );
       await _setRegistered(false);
       await _restoreGenericFallback();
@@ -189,6 +197,7 @@ class ServerPushService {
     required String outcome,
     int? statusCode,
     String? reason,
+    String? error,
   }) async {
     await PostHogService().capture(
       event: 'push_register',
@@ -197,6 +206,7 @@ class ServerPushService {
         'platform': Platform.isIOS ? 'ios' : 'android',
         if (statusCode != null) 'status_code': statusCode,
         if (reason != null) 'reason': reason,
+        if (error != null) 'error': error,
       },
     );
   }

--- a/docs/bugs/bug-notifications-stalled.md
+++ b/docs/bugs/bug-notifications-stalled.md
@@ -1,8 +1,102 @@
 # Bug — Notifs Android qui ne s'envoient plus
 
-**Statut** : investigation en cours.
+**Statut** : root cause PROUVÉ (2026-07) — fix repo livré, runbook ops à exécuter.
 **Plateforme** : Android.
 **Date du signal** : 2026-05-05.
+
+---
+
+## ✅ Root cause PROUVÉ (2026-07) — Firebase Android jamais configuré
+
+Le chemin push n'a **jamais** transporté un seul message : la « notif du jour » est
+cassée **depuis le premier jour sur les stores**. Les PRs #768, #848, #919, #935 ont
+toutes poli soit la **notif locale de repli**, soit l'**instrumentation** — jamais la
+cause réelle.
+
+### Preuve (pas une hypothèse)
+
+- **PostHog `push_register` (60 j)** : 376 événements, **100 % `outcome = exception`,
+  `reason = PlatformException`** (`platform = android`, 9 users). Zéro `token_null`,
+  zéro `endpoint_error` (503), zéro `registered`.
+- **DB prod (Supabase)** : `push_devices = 0`, `push_deliveries = 0`, depuis toujours.
+- **Cause** : `ServerPushService.initAndRegister()` appelle `Firebase.initializeApp()`
+  (`apps/mobile/lib/core/services/server_push_service.dart:91`) qui **lève une
+  `PlatformException` sur chaque appareil** → tout le flux meurt dans le `catch` →
+  100 % des users retombent sur la notif locale.
+  Pourquoi ça throw : `apps/mobile/android/app/build.gradle.kts` n'appliquait le
+  plugin `com.google.gms.google-services` que si un `google-services.json` existait
+  dans `src/prod/` ou `src/staging/`. Or **les vrais flavors sont `beta` et
+  `playstore`** (chemins qui ne matchent pas), **et aucun `google-services.json`
+  n'existait nulle part** → plugin silencieusement sauté → aucune ressource
+  `google_app_id` dans l'APK → Firebase natif sans options par défaut → `PlatformException`.
+
+### « Limite du Play Console ? » → Non
+
+FCM ne dépend d'aucun réglage Play Console et **ne requiert pas** d'empreinte
+SHA-1/SHA-256 (celles-ci ne servent qu'à Firebase Auth / Dynamic Links). Deux vraies
+lacunes de config, jamais satisfaites :
+1. **Firebase Console + build Android (bloqueur ACTIF)** : `facteur.app` et
+   `com.example.facteur.staging` jamais enregistrés dans un projet Firebase → aucun
+   `google-services.json` embarqué → `PlatformException`.
+2. **Railway backend (bloqueur LATENT)** : `FIREBASE_SERVICE_ACCOUNT_*` non défini →
+   `PUT /api/devices` renvoie 503 (`packages/api/app/routers/push_devices.py:43-50`)
+   et le dispatcher reste désactivé. Pas encore atteint car le client meurt avant.
+
+### Fix repo livré (PR de durcissement)
+
+- **Garde-fou Gradle corrigé + durci** (`build.gradle.kts`) : détecte les vrais
+  chemins `src/beta/` + `src/playstore/` (+ fallback `app/`), applique le plugin
+  s'ils existent, et **`throw GradleException`** sur un build release/bundle si aucun
+  `google-services.json` n'est présent → impossible de re-livrer en silence une app
+  « push morte ». Debug/dev restent tolérants.
+- **`google-services.json` commités par flavor** (`src/beta/`, `src/playstore/`) — non
+  secret pour Android. Fournis via le runbook ci-dessous.
+- **Télémétrie d'exception enrichie** (`server_push_service.dart`) : le `catch`
+  capture désormais `error: e.toString()` (tronqué ~300 car.) → le message natif exact
+  (ex. « no default options ») devient visible dans PostHog.
+- **Filet CI** dans `build-aab.yml` / `build-apk.yml` / `weekly-release.yml` : vérifie
+  la présence du `google-services.json` du flavor avant le build (échec tôt et lisible).
+
+### Runbook ops (à exécuter, hors code)
+
+**A. Firebase Console (déblocage n°1)**
+1. Ouvrir/créer le projet Firebase de Facteur.
+2. Add app → Android pour `facteur.app` → télécharger `google-services.json` →
+   `apps/mobile/android/app/src/playstore/` (commit dans la PR de durcissement).
+3. Add app → Android pour `com.example.facteur.staging` → `google-services.json` →
+   `apps/mobile/android/app/src/beta/`.
+4. FCM v1 est activé par défaut ; **aucune** empreinte SHA nécessaire pour le push.
+
+**B. Railway (déblocage n°2)**
+1. Firebase Console → Project settings → Service accounts → Generate new private key.
+2. `base64 -i service-account.json` → coller dans **`FIREBASE_SERVICE_ACCOUNT_BASE64`**
+   sur les 2 services : `api-staging-40d3` **et** `facteur-production` (même service
+   account couvre les 2 packages du même projet Firebase).
+3. Redéployer les 2 services (le dispatcher lit `_firebase_configured()` au boot).
+
+**C. Release** : merger la PR (avec les 2 JSON) → `build-aab.yml` (playstore) → Play
+Console Internal testing ; beta part automatiquement au merge sur `main`.
+
+### Vérification end-to-end
+
+1. PostHog : `registered` apparaît, `exception` s'effondre.
+2. Supabase : `select count(*) from push_devices where revoked_at is null` > 0.
+3. `PUT /api/devices` renvoie 200 (logs Railway : plus de « Push serveur non configuré »).
+4. Supabase : `push_deliveries` avec `status='sent'` > 0.
+5. Réception device (fenêtre 07:30–12:00 locale) avec bullets (`BigTextStyle` data-only).
+6. Anti-régression : renommer un `google-services.json` en local + build release → doit
+   **échouer** avec le message du garde-fou.
+
+### Gap iOS parallèle (hors périmètre immédiat)
+
+Le même schéma existe côté iOS : `Firebase.initializeApp()` a besoin de
+`GoogleService-Info.plist` + une clé APNs uploadée dans Firebase. La preuve prod est
+**Android only** (`facteur.app`). À traiter en second temps si push iOS voulu ; ne
+bloque pas la PR Android.
+
+---
+
+## Historique d'investigation (2026-05, avant preuve du root cause)
 
 ## Signal
 


### PR DESCRIPTION
## Quoi

Corrige le **root cause** de la « notif du jour » cassée **depuis le 1er jour sur les stores** : Firebase Android n'a jamais été configuré, donc le chemin push n'a **jamais** transporté un seul message (les PRs #768/#848/#919/#935 polissaient la notif locale de repli ou l'instrumentation, jamais la cause réelle).

## Pourquoi

Le plugin `com.google.gms.google-services` était gaté sur `src/prod` / `src/staging` — des flavors **inexistants** (les vrais sont `beta` et `playstore`) — et **aucun** `google-services.json` n'était commité. Résultat : plugin sauté → APK sans ressource `google_app_id` → `Firebase.initializeApp()` lève une `PlatformException` sur **chaque** appareil → tout l'enregistrement push meurt → 100 % des users retombent sur la notif locale.

**Preuve** : PostHog `push_register` (60 j) = 376 events, **100 % `outcome=exception` / `reason=PlatformException`** ; Supabase `push_devices=0`, `push_deliveries=0` depuis toujours.

## Ce que fait cette PR

- **`build.gradle.kts`** : garde-fou corrigé (`src/beta` + `src/playstore` + fallback `app/`) ; **`throw GradleException`** sur build release/bundle si aucun `google-services.json` → impossible de re-livrer en silence une app « push morte ». Debug/dev restent tolérants.
- **2 `google-services.json` commités par flavor** (projet Firebase `facteur-c30dc`) — non secret pour Android.
- **`server_push_service.dart`** : télémétrie d'exception enrichie (`error: e.toString()` tronqué 300 car.) → le message natif exact devient visible dans PostHog pour diagnostiquer les futurs échecs.
- **CI** : composite action `verify-google-services` (flavor en input) appelée par `build-aab` / `build-apk` / `weekly-release` → échec tôt et lisible avant les étapes Java/Flutter.
- **Doc** : `bug-notifications-stalled.md` mise à jour (root cause prouvé + runbook ops + gap iOS noté).

## Config ops (hors code, déjà faite)

- Firebase Console : 2 apps Android enregistrées (`facteur.app`, `com.example.facteur.staging`).
- Railway : `FIREBASE_SERVICE_ACCOUNT_BASE64` posé sur `api-staging-40d3` **et** `facteur-production` (sinon `PUT /api/devices` → 503).

## Comment ça a été vérifié

- [x] `flutter analyze` — 0 erreur/warning sur le fichier Dart modifié.
- [x] Garde-fou Gradle : `beta` + `playstore` présents → plugin appliqué, pas de throw (logique validée statiquement — pas de JDK dans Conductor, build réel en CI).
- [x] YAML des 3 workflows + composite action valides ; les 3 référencent bien la composite action après le `checkout`.
- [x] `/simplify` passé (triple check CI dédupliqué en composite action).
- [ ] Build APK/AAB release en CI (post-merge) — à surveiller.
- [ ] Vérif end-to-end post-release : PostHog `registered` apparaît, `push_devices > 0`, `push_deliveries.status='sent' > 0`.

## Zones à risque

- **CI Android** : `build-apk.yml` tourne sur `push: main` → si les `google-services.json` disparaissaient, le build beta échouerait (comportement voulu = filet).
- **iOS** : gap parallèle non traité (documenté). Preuve prod = Android only. Ne bloque pas cette PR.
- Aucune migration, aucun changement backend.
