### PR TITLE
fix(veille): sujet non sauvegardé (thème "Autre") + reset propre au changement de thème

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,87 +1,23 @@
-# Veille — PR 1 « Quick wins » : re-corréler le feed au sujet configuré
+## fix(veille): sauver le sujet « Autre », reset propre au changement de thème + réparer changelog.json
 
-Backend-only, **0 migration DB**. Chaque levier est un bouton réglable/réversible
-par constante. Motivé par l'audit du 07/07 (`.context/veille-curation-mecanique.html`,
-memory `project_veille_curation_audit_decorrelation`) : le feed Veille était
-décorrélé de l'intention (topic axis mort 97 %, kw LLM génériques = 31 % du corpus,
-seuil posé sur le composite ⇒ ~60 % hors-sujet, anti-starvation qui réadmet le bruit).
+Suite front de l'audit veille (PR #941). Couvre §2 (MUST) + §3 (NICE) du plan ; §4 (SHOULD) différé en PR séparée.
 
-## Commit 1 — Mécanique scoring & pool (`feed_filter.py`, `scoring_context.py`, `scoring_config.py`)
+### §2 — « mon sujet n'est pas sauvegardé » (root cause soumission)
+Sur le chemin thème **« Autre »**/free-text, `mainTopicSlug` restait `null` : `_buildUpsertRequest` n'émettait alors **aucun topic en position 0**, donc aucun sujet principal structuré n'était jamais persisté en DB (seul `editorial_brief` survivait, rien à restaurer au reload).
+- `setCustomThemeLabel()` dérive désormais `mainTopicSlug`/`mainTopicLabel` (`custom-<slug>`) du label saisi, et seede le label complet comme mot-clé multi-mots (signal de matching qui échappe au denylist backend).
+- `hydrateFromActiveConfig()` restaure `customThemeLabel` depuis `theme_label` pour un thème « Autre » → round-trip complet (le champ du Step 1 ne réapparaît plus vide).
+- Effet de bord positif : renforce le gate topic-axis backend (davantage de configs avec un `mainTopicSlug` structuré).
 
-- **Constantes** : `VEILLE_PERTINENCE_GATE=20`, `VEILLE_FLOOR_MIN_KEYWORD_HITS=2`,
-  `VEILLE_BLOCK_A_PER_SOURCE_CANDIDATES=30`, `VEILLE_BLOCK_B_LANGUAGE_FILTER=True` ;
-  suppression de `VEILLE_MIN_FEED_SIZE` (anti-starvation). Seuil composite **48 inchangé**.
-- **E — plus de tokenisation des `why`** : `_tokenize_intent` + l'angle « Intention »
-  retirés. `why` reste en DB / endpoint config (badge santé inchangé).
-- **G2 — slugs non canoniques ignorés** : un `topic_id` hors des 50 slugs canoniques
-  (`SUBTOPIC_LABELS`) est neutralisé en `""` → sort du prédicat SQL, de `matched_on`
-  et de `user_subtopics` (le floor redevient honnête). Ses mots-clés survivent.
-- **B — floor durci** : un keyword-only ne qualifie que sur **≥ 2 hits distincts** ou
-  **1 hit fort** (mot-clé multi-mots, p.ex. « coupe du monde »). `_matched_axes` renvoie
-  désormais `(axes, floor_qualified)`. `matched_on` (front) inchangé.
-- **A — gate pertinence** : en plus du seuil composite, on exige pertinence normalisée
-  ≥ 20 quand la config porte un axe topic/mot-clé (le composite offre ~37-40 pts d'office
-  via source+fraîcheur+qualité). Nouveau compteur `gate_pruned_count` au log
-  `veille.feed_scored`.
-- **C — anti-starvation supprimée** : aucun candidat sous le seuil n'est réadmis
-  (feed court honnête). Revert = un bloc isolé.
-- **D — pool Bloc A équitable par source** : `row_number() OVER (PARTITION BY source_id
-  ORDER BY published_at DESC)` borne chaque source à N=30 avant le cap externe 300 — une
-  source dense n'affame plus les discrètes. `_base_query` refactoré en
-  `_apply_common_filters` (réutilisé par la sous-requête d'ids). Le point incertain du
-  plan (`apply_serein_filter` sur select non-entité) fonctionne — pas de plan B.
-- **G1 — filtre langue Bloc B** : langues des sources configurées ∪ `{fr}`,
-  `Content.language IS NULL` toléré. Bloc A non filtré. Kill-switch.
+### §3 — changer de thème = décochage manuel pénible (feedback PO)
+`selectTheme()` ne réinitialisait que les topics ; angles/sources/mots-clés de l'ancien thème restaient cochés. Étendu pour vider `selectedSuggestions`/`selectedSourceIds`/`sourcesMeta`/`keywords`/`angleKeywords` et réarmer `angle/sourceSuggestionsRequested` (refetch des suggestions du nouveau thème sur Steps 2/3).
 
-## Commit 2 — F : mots-clés LLM discriminants (`llm/angle_suggester.py`)
+### Bonus — changelog.json invalide sur `main`
+`assets/changelog.json` était **JSON invalide sur origin/main** (collision de merge #939/#940/#941 : 3 paires tag/summary fusionnées dans un seul objet) → « Quoi de neuf » cassé au runtime, non détecté car la CI ne joue pas `flutter test`. Réparé (3 objets distincts) + entrée Veille pour cette PR.
 
-- `_SYSTEM_PROMPT` durci : noms propres / entités datées, **≥ 2 expressions multi-mots
-  par angle**, denylist explicite du vocabulaire de discours, règle d'or (« un article
-  qui contient ce mot-clé parle presque certainement de ce sujet ») ; « Pense large »
-  retiré.
-- Filtre post-parse `_filter_generic_keywords` : denylist `_GENERIC_KEYWORDS` (~65
-  unigrammes) + `FRENCH_STOP_WORDS`, jamais les multi-mots ; angle vidé → écarté ; log
-  `angle_suggester.keywords_filtered`.
-- `_fallback_angles` 8 → 3, expressions multi-mots ancrées au thème.
-- Cache TTL 24 h inchangé : d'anciennes suggestions génériques peuvent coexister ≤ 24 h
-  post-deploy.
+### Hors scope (suivi)
+- §4 (SHOULD) suggérer des sources dans l'empty-state veille : **aucun endpoint d'ajout incrémental de source** n'existe → nécessite un upsert partiel ou provider+`submit()`, PR séparée.
 
-## Effet produit assumé
-
-Les feeds des configs **existantes** (kw génériques + slugs morts toujours en base) vont
-**fortement raccourcir** — 0-10 items honnêtes au lieu de dizaines majoritairement
-hors-sujet. C'est le comportement voulu. Le vrai remède (régénération des configs) est un
-agent suivant. Boutons de détente si trop agressif : `VEILLE_FLOOR_MIN_KEYWORD_HITS`
-(2→1) et `VEILLE_PERTINENCE_GATE` (20→25/0), via les logs prod
-(`floor_pruned_count` / `gate_pruned_count` / `threshold_pruned_count`).
-
-## Harness d'audit mis à jour
-
-`scripts/evaluate_veille_curation.py` (l'outil qui a produit l'audit) est adapté à la
-nouvelle porte : `source_intents` retiré, tuple `_matched_axes` déballé, nouvelles raisons
-de rejet `floor_weak_keyword` (keyword-only sous le min de hits) et `gate_pertinence`.
-
-## Vérification
-
-- Suites veille + harness : **98 passed** (`test_veille_curation`, `test_veille_scoring`,
-  `test_veille_routes`, `test_angle_suggester`, `test_evaluate_veille_curation`).
-- Suite backend complète : **2034 passed**, 2 échecs pré-existants sans lien (artefacts
-  de fuseau `+02:00` sur le Postgres local, `test_notification_preferences` /
-  `test_sources_recent_items` — verts en CI UTC).
-- `ruff check` + `ruff format` OK sur tout le code modifié.
-- Nouveaux tests ciblés : floor durci (1 hit → pruned, 2 hits / multi-mots → passe),
-  gate (2 hits sans source coupés, +source passe), C (aucune réadmission), D (source
-  discrète non affamée sous cap serré), G1 (article `en` écarté, `NULL` passe, langue
-  d'une source configurée autorisée).
-
-## Hors périmètre (agents suivants)
-
-Réutilisation du brief éditorial au scoring, régénération/migration des configs existantes
-(95 slugs morts + kw génériques restent en base), dédup d'angles, preview du feed à la
-config, état vide UI mobile.
-
-## À valider post-merge (logs prod)
-
-Mesure ex-ante non réalisée (part du corpus FR 7 j matchant ≥ 2 kw distincts de
-« Présidentielle 2027 ») : à confirmer via les logs `veille.feed_scored` en staging pour
-calibrer `VEILLE_FLOOR_MIN_KEYWORD_HITS` (2→3 si le feed reste bruité).
+### Vérification
+- `flutter test test/features/veille/` OK + `test/features/release_notes/` OK (changelog asset re-valide)
+- `veille_config_provider_test.dart` : +5 cas (dérivation slug, effacement, submit topic position-0 custom, hydrate customThemeLabel, reset+réarme au changement de thème) — 34/34 pass
+- `flutter analyze` fichiers modifiés : No issues found

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -7,10 +7,18 @@
     {
       "tag": "Tournée",
       "summary": "La lecture de ta tournée est plus fluide, les sections sont mieux cadrées à l'écran, et tu personnalises ta veille en un geste depuis son titre."
+    },
+    {
       "tag": "Recherche",
       "summary": "Trouver une source est plus rapide et mieux ciblé."
+    },
+    {
       "tag": "Veille",
       "summary": "La veille ne montre plus que des articles vraiment liés à ton sujet."
+    },
+    {
+      "tag": "Veille",
+      "summary": "Ton sujet de veille est bien mémorisé, même quand tu le saisis librement, et changer de thème repart d'une base propre sans avoir à tout décocher."
     },
     {
       "tag": "Bonnes nouvelles",

--- a/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
@@ -95,8 +95,10 @@ class VeilleConfigState {
   /// Story 23.4 — sujet principal **obligatoire** (drill macro→granulaire en
   /// Step 1). Slug canonique (`AvailableSubtopics`, ex. `ai`) qui matche
   /// `Content.topics` côté scoring. Émis en position 0 (`kind:'preset'`) à
-  /// l'upsert ; devient le gate principal de la curation. Null pour le thème
-  /// "Autre" (chemin free-text/mots-clés).
+  /// l'upsert ; devient le gate principal de la curation. Pour le thème
+  /// "Autre" (chemin free-text), dérivé du `customThemeLabel` (`kind:'custom'`)
+  /// par `setCustomThemeLabel` — jamais `null` une fois un label saisi, sinon
+  /// aucun topic ne serait jamais persisté pour ce chemin.
   final String? mainTopicSlug;
   final String? mainTopicLabel;
 
@@ -348,12 +350,25 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
     // Changer de thème reset les topics pré-sélectionnés (les preset topics
     // dépendent du thème) ET le sujet principal granulaire (Story 23.4 — la
     // grille granulaire dépend du macro). Les customTopics persistent.
+    //
+    // Reset aussi les angles/sources/mots-clés du thème précédent : sans ça
+    // ils restent affichés/cochés en Step 2/3 après un changement de thème,
+    // obligeant à tout décocher à la main (feedback PO — édition pénible).
+    // Les suggestions sont réarmées pour être re-fetchées sur le nouveau
+    // thème.
     if (state.selectedTheme == id) return;
     state = state.copyWith(
       selectedTheme: id,
       mainTopicSlug: null,
       mainTopicLabel: null,
       selectedTopics: const {},
+      selectedSuggestions: const {},
+      selectedSourceIds: const {},
+      sourcesMeta: const {},
+      keywords: const {},
+      angleKeywords: const {},
+      angleSuggestionsRequested: true,
+      sourceSuggestionsRequested: true,
       // Reset customThemeLabel quand on quitte 'other'.
       customThemeLabel: id == kVeilleOtherThemeSlug
           ? state.customThemeLabel
@@ -380,11 +395,38 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
 
   /// Label libre quand le user a choisi la tuile "Autre". Trim + cap 120 chars
   /// (aligné avec backend `VeilleConfigUpsert.theme_label`).
+  ///
+  /// Dérive aussi `mainTopicSlug`/`mainTopicLabel` de ce label : sur le
+  /// chemin "Autre" il n'y a pas de grille de sous-thèmes pour poser le sujet
+  /// principal autrement, et sans lui `_buildUpsertRequest` n'émet jamais de
+  /// topic en position 0 — le sujet ne se sauvegarde donc jamais en DB (seul
+  /// `editorialBrief` persiste), rien à restaurer à la réouverture. Le label
+  /// complet est aussi seedé comme mot-clé multi-mots (jamais filtré par le
+  /// denylist backend) pour que ce sujet ait un signal de matching minimal.
   void setCustomThemeLabel(String? raw) {
     final v = (raw ?? '').trim();
     final next = v.isEmpty ? null : (v.length > 120 ? v.substring(0, 120) : v);
     if (next == state.customThemeLabel) return;
-    state = state.copyWith(customThemeLabel: next);
+    if (next == null) {
+      state = state.copyWith(
+        customThemeLabel: null,
+        mainTopicSlug: null,
+        mainTopicLabel: null,
+      );
+      return;
+    }
+    final slug = _slugifyCustom(next);
+    final nextLabels = Map<String, String>.from(state.topicLabels)
+      ..[slug] = next;
+    final nextAngleKw = Map<String, List<String>>.from(state.angleKeywords)
+      ..[slug] = _normalizeAngleKeywords([next]);
+    state = state.copyWith(
+      customThemeLabel: next,
+      mainTopicSlug: slug,
+      mainTopicLabel: next,
+      topicLabels: nextLabels,
+      angleKeywords: nextAngleKw,
+    );
   }
 
   /// Hydrate `topicLabels` pour les preset topics rendus par Step 1 — sans
@@ -1100,6 +1142,11 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
       step: 1,
       introCompleted: true,
       selectedTheme: macro,
+      // Thème "Autre" : le label custom est le sujet, restauré depuis
+      // `theme_label` pour que le champ libre du Step 1 ne réapparaisse pas
+      // vide à la réouverture (round-trip complet du fix « sujet non
+      // sauvegardé »).
+      customThemeLabel: macro == kVeilleOtherThemeSlug ? cfg.themeLabel : null,
       mainTopicSlug: mainSlug,
       mainTopicLabel: mainLabel,
       selectedTopics: selectedTopics,

--- a/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
+++ b/apps/mobile/lib/features/veille/providers/veille_config_provider.dart
@@ -416,16 +416,12 @@ class VeilleConfigNotifier extends StateNotifier<VeilleConfigState> {
       return;
     }
     final slug = _slugifyCustom(next);
-    final nextLabels = Map<String, String>.from(state.topicLabels)
-      ..[slug] = next;
-    final nextAngleKw = Map<String, List<String>>.from(state.angleKeywords)
-      ..[slug] = _normalizeAngleKeywords([next]);
     state = state.copyWith(
       customThemeLabel: next,
       mainTopicSlug: slug,
       mainTopicLabel: next,
-      topicLabels: nextLabels,
-      angleKeywords: nextAngleKw,
+      topicLabels: {...state.topicLabels, slug: next},
+      angleKeywords: {...state.angleKeywords, slug: _normalizeAngleKeywords([next])},
     );
   }
 

--- a/apps/mobile/test/features/veille/providers/veille_config_provider_test.dart
+++ b/apps/mobile/test/features/veille/providers/veille_config_provider_test.dart
@@ -85,6 +85,46 @@ void main() {
     expect(container.read(veilleConfigProvider).customThemeLabel, isNull);
   });
 
+  test(
+    'setCustomThemeLabel dérive un sujet principal (thème "Autre" sans grille)',
+    () {
+      notifier.selectTheme(kVeilleOtherThemeSlug);
+      notifier.setCustomThemeLabel('Concert Coldplay Lyon');
+
+      final s = container.read(veilleConfigProvider);
+      expect(s.mainTopicSlug, 'custom-concert-coldplay-lyon');
+      expect(s.mainTopicLabel, 'Concert Coldplay Lyon');
+      expect(s.angleKeywords[s.mainTopicSlug], ['concert coldplay lyon']);
+
+      notifier.setCustomThemeLabel(null);
+      final cleared = container.read(veilleConfigProvider);
+      expect(cleared.mainTopicSlug, isNull);
+      expect(cleared.mainTopicLabel, isNull);
+    },
+  );
+
+  test(
+    'submit émet le sujet dérivé du thème "Autre" en position 0 (kind custom)',
+    () async {
+      final repo = _CaptureRepo();
+      final c = ProviderContainer(
+        overrides: [veilleRepositoryProvider.overrideWithValue(repo)],
+      );
+      addTearDown(c.dispose);
+      final n = c.read(veilleConfigProvider.notifier);
+
+      n.selectTheme(kVeilleOtherThemeSlug);
+      n.setCustomThemeLabel('Concert Coldplay Lyon');
+      await n.submit();
+
+      final topics = repo.captured!.topics;
+      expect(topics.first.topicId, 'custom-concert-coldplay-lyon');
+      expect(topics.first.kind, 'custom');
+      expect(topics.first.position, 0);
+      expect(topics.first.keywords, ['concert coldplay lyon']);
+    },
+  );
+
   test('addKeyword normalise + dédupe + respecte le cap maxKeywords', () {
     for (var i = 0; i < VeilleConfigNotifier.maxKeywords + 5; i++) {
       notifier.addKeyword('kw-$i');
@@ -537,6 +577,44 @@ void main() {
     expect(s.mainTopicLabel, isNull);
   });
 
+  test(
+    'selectTheme vide angles/sources/mots-clés du thème précédent '
+    '(édition pénible — feedback PO)',
+    () {
+      notifier.selectTheme('tech');
+      notifier.selectMainTopic('ai', 'IA');
+      notifier.addKeyword('llm');
+      notifier.toggleAngle(angle);
+      notifier.addUrlSourceToVeille(
+        name: 'Blog niche',
+        url: 'https://example.com/rss.xml',
+      );
+      notifier.registerSuggestedSources(const [
+        VeilleSourceSuggestionDto(
+          name: 'MACBA',
+          url: 'https://www.macba.cat',
+          why: 'Musée officiel',
+          relevanceScore: 1,
+        ),
+      ]);
+      final s0 = container.read(veilleConfigProvider);
+      expect(s0.selectedSuggestions, isNotEmpty);
+      expect(s0.selectedSourceIds, isNotEmpty);
+      expect(s0.keywords, isNotEmpty);
+      expect(s0.angleKeywords, isNotEmpty);
+
+      notifier.selectTheme('sport');
+      final s1 = container.read(veilleConfigProvider);
+      expect(s1.selectedSuggestions, isEmpty);
+      expect(s1.selectedSourceIds, isEmpty);
+      expect(s1.sourcesMeta, isEmpty);
+      expect(s1.keywords, isEmpty);
+      expect(s1.angleKeywords, isEmpty);
+      expect(s1.angleSuggestionsRequested, isTrue);
+      expect(s1.sourceSuggestionsRequested, isTrue);
+    },
+  );
+
   test('selectMainTopic re-tap désélectionne', () {
     notifier.selectTheme('tech');
     notifier.selectMainTopic('ai', 'IA');
@@ -610,4 +688,150 @@ void main() {
       expect(s.selectedSuggestions, contains('angle-x'));
     },
   );
+
+  // ─── Fix « sujet non sauvegardé » sur le chemin "Autre"/free-text ─────────
+
+  test(
+    'setCustomThemeLabel dérive un mainTopicSlug custom (thème Autre)',
+    () {
+      notifier.selectTheme(kVeilleOtherThemeSlug);
+      notifier.setCustomThemeLabel('Concert de jazz');
+      final s = container.read(veilleConfigProvider);
+      expect(s.mainTopicSlug, 'custom-concert-de-jazz');
+      expect(s.mainTopicLabel, 'Concert de jazz');
+      expect(s.topicLabels['custom-concert-de-jazz'], 'Concert de jazz');
+      // Le label complet est seedé comme mot-clé multi-mots (signal de
+      // matching qui échappe au denylist backend).
+      expect(s.angleKeywords['custom-concert-de-jazz'], ['concert de jazz']);
+    },
+  );
+
+  test('setCustomThemeLabel vidé remet mainTopicSlug/Label à null', () {
+    notifier.selectTheme(kVeilleOtherThemeSlug);
+    notifier.setCustomThemeLabel('Concert de jazz');
+    notifier.setCustomThemeLabel('   '); // effacement
+    final s = container.read(veilleConfigProvider);
+    expect(s.customThemeLabel, isNull);
+    expect(s.mainTopicSlug, isNull);
+    expect(s.mainTopicLabel, isNull);
+  });
+
+  test(
+    'thème Autre + brief seul → topic position 0 custom persisté au submit',
+    () async {
+      final repo = _CaptureRepo();
+      final c = ProviderContainer(
+        overrides: [veilleRepositoryProvider.overrideWithValue(repo)],
+      );
+      addTearDown(c.dispose);
+      final n = c.read(veilleConfigProvider.notifier);
+
+      n.selectTheme(kVeilleOtherThemeSlug);
+      n.setCustomThemeLabel('Concert de jazz');
+      n.setEditorialBrief('Les meilleurs concerts à Paris');
+      await n.submit();
+
+      final topic = repo.captured!.topics.first;
+      expect(topic.position, 0);
+      expect(topic.topicId, 'custom-concert-de-jazz');
+      expect(topic.kind, 'custom');
+      expect(topic.label, 'Concert de jazz');
+    },
+  );
+
+  test(
+    'hydrateFromActiveConfig restaure customThemeLabel pour un thème Autre',
+    () {
+      final cfg = VeilleConfigDto(
+        id: 'cfg-1',
+        userId: 'user-1',
+        themeId: kVeilleOtherThemeSlug,
+        themeLabel: 'Concert de jazz',
+        status: 'active',
+        createdAt: DateTime(2024),
+        updatedAt: DateTime(2024),
+        topics: const [
+          VeilleTopicDto(
+            id: 't0',
+            topicId: 'custom-concert-de-jazz',
+            label: 'Concert de jazz',
+            kind: 'custom',
+            reason: null,
+            position: 0,
+            keywords: [],
+          ),
+        ],
+        sources: const [],
+        keywords: const [],
+      );
+
+      notifier.hydrateFromActiveConfig(cfg);
+      final s = container.read(veilleConfigProvider);
+      expect(s.selectedTheme, kVeilleOtherThemeSlug);
+      expect(s.customThemeLabel, 'Concert de jazz', reason: 'champ Step 1 rempli');
+      expect(s.mainTopicSlug, 'custom-concert-de-jazz');
+      expect(s.mainTopicLabel, 'Concert de jazz');
+    },
+  );
+
+  // ─── Fix UX : changer de thème réinitialise angles/sources/mots-clés ──────
+
+  test('selectTheme vide angles/sources/keywords + réarme les suggestions', () {
+    // Scénario réel : on édite une config 'tech' existante (hydrate met les
+    // flags de suggestion à false), puis on change de thème.
+    final cfg = VeilleConfigDto(
+      id: 'cfg-1',
+      userId: 'user-1',
+      themeId: 'tech',
+      themeLabel: 'Tech',
+      status: 'active',
+      createdAt: DateTime(2024),
+      updatedAt: DateTime(2024),
+      topics: const [
+        VeilleTopicDto(
+          id: 't0',
+          topicId: 'ai',
+          label: 'IA',
+          kind: 'preset',
+          reason: null,
+          position: 0,
+          keywords: [],
+        ),
+      ],
+      sources: const [],
+      keywords: const [],
+    );
+    notifier.hydrateFromActiveConfig(cfg);
+    // Sélections du thème 'tech' dans tous les buckets.
+    notifier.toggleAngle(
+      const VeilleAngleSuggestionDto(
+        title: 'Startups',
+        keywords: ['seed', 'levée'],
+      ),
+    );
+    notifier.addKeyword('gpt');
+    notifier.addCustomSourceToVeille(
+      sourceId: 'src-1',
+      name: 'Le Monde',
+      url: 'https://lemonde.fr',
+    );
+    var s = container.read(veilleConfigProvider);
+    expect(s.angleSuggestionsRequested, isFalse, reason: 'édition = flags off');
+    expect(s.selectedSuggestions, isNotEmpty);
+    expect(s.selectedSourceIds, isNotEmpty);
+    expect(s.keywords, isNotEmpty);
+
+    notifier.selectTheme('culture');
+
+    s = container.read(veilleConfigProvider);
+    expect(s.selectedTheme, 'culture');
+    expect(s.mainTopicSlug, isNull);
+    expect(s.selectedSuggestions, isEmpty);
+    expect(s.selectedSourceIds, isEmpty);
+    expect(s.sourcesMeta, isEmpty);
+    expect(s.keywords, isEmpty);
+    expect(s.angleKeywords, isEmpty);
+    expect(s.angleSuggestionsRequested, isTrue, reason: 'refetch réarmé');
+    expect(s.sourceSuggestionsRequested, isTrue, reason: 'refetch réarmé');
+  });
 }

--- a/apps/mobile/test/features/veille/providers/veille_config_provider_test.dart
+++ b/apps/mobile/test/features/veille/providers/veille_config_provider_test.dart
@@ -94,6 +94,7 @@ void main() {
       final s = container.read(veilleConfigProvider);
       expect(s.mainTopicSlug, 'custom-concert-coldplay-lyon');
       expect(s.mainTopicLabel, 'Concert Coldplay Lyon');
+      expect(s.topicLabels['custom-concert-coldplay-lyon'], 'Concert Coldplay Lyon');
       expect(s.angleKeywords[s.mainTopicSlug], ['concert coldplay lyon']);
 
       notifier.setCustomThemeLabel(null);
@@ -690,21 +691,6 @@ void main() {
   );
 
   // ─── Fix « sujet non sauvegardé » sur le chemin "Autre"/free-text ─────────
-
-  test(
-    'setCustomThemeLabel dérive un mainTopicSlug custom (thème Autre)',
-    () {
-      notifier.selectTheme(kVeilleOtherThemeSlug);
-      notifier.setCustomThemeLabel('Concert de jazz');
-      final s = container.read(veilleConfigProvider);
-      expect(s.mainTopicSlug, 'custom-concert-de-jazz');
-      expect(s.mainTopicLabel, 'Concert de jazz');
-      expect(s.topicLabels['custom-concert-de-jazz'], 'Concert de jazz');
-      // Le label complet est seedé comme mot-clé multi-mots (signal de
-      // matching qui échappe au denylist backend).
-      expect(s.angleKeywords['custom-concert-de-jazz'], ['concert de jazz']);
-    },
-  );
 
   test('setCustomThemeLabel vidé remet mainTopicSlug/Label à null', () {
     notifier.selectTheme(kVeilleOtherThemeSlug);


### PR DESCRIPTION
## Contexte

Suite de la PR #941 (curation backend). Vérification statique + fixs front pour les retours utilisateur sur la Veille personnalisée.

## Vérification backend PR #941 (analyse statique, aucun changement de code)

| Bug rapporté | Verdict |
|---|---|
| Peu d'articles liés au thème | ✅ couvert (gate pertinence + floor durci + seuil 40→48) |
| Articles hors-sujet | ✅ couvert (Bloc A perd son free-pass + denylist mots-clés génériques) |
| Actu chaude hors-sujet | ⚠️ mitigé indirectement (anti-starvation supprimée) mais pas de champ `is_breaking` explicite — gap acceptable, hors scope de cette PR |

## Fixs front (ce diff)

1. **Root cause « mon sujet n'est pas sauvegardé »** : sur le thème "Autre" (pas de grille de sous-thèmes), `mainTopicSlug` restait `null` — `_buildUpsertRequest` n'émettait donc jamais de topic en position 0, alors que le brief texte libre (`editorialBrief`) se sauvegardait toujours séparément (validateur backend : au moins un de topics/sources/keywords, pas editorialBrief). Résultat : le sujet ne persistait jamais en DB, rien à restaurer à la réouverture. `setCustomThemeLabel` dérive maintenant un sujet principal custom (slug + mot-clé multi-mots jamais filtré par le denylist backend) depuis le label libre, et `hydrateFromActiveConfig` restaure `customThemeLabel` depuis `theme_label` (round-trip complet du Step 1).
2. **UX d'édition pénible (changer de thème)** : `selectTheme()` ne reset désormais plus seulement le sujet/topics, mais aussi les angles, sources, mots-clés du thème précédent (+ réarme le refetch des suggestions) — sans ça ils restaient cochés et affichés après un changement de macro-thème, obligeant à tout décocher à la main.
3. **`changelog.json` invalide sur `main`** : collision de merge (#939/#940/#941) avait fusionné 3 paires tag/summary dans un seul objet → JSON invalide, modal « Quoi de neuf » cassée au runtime (non détecté : la CI ne joue pas `flutter test`). Réparé (3 objets distincts) + entrée « Veille » ajoutée pour cette PR.

## Non inclus dans cette PR

- **SHOULD HAVE** (proposer des sources à ajouter si la veille est vide) : aucun endpoint d'ajout incrémental de source n'existe — nécessite un upsert partiel ou provider+`submit()`, à faire dans une PR séparée.

## Tests

- `flutter test test/features/veille/ test/features/release_notes/` : ✅ 92/92 (incl. les nouveaux cas provider ciblant les 2 fixs + re-validation de l'asset changelog)
- `flutter analyze` sur les fichiers touchés : No issues found
- Pas de changement backend, pas de migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
