### PR TITLE
feat(media-eval): fondations (schéma, contrats, moteur d'évaluation)

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,87 +1,84 @@
-# Veille — PR 1 « Quick wins » : re-corréler le feed au sujet configuré
+# feat(media-eval): fondations (schéma, contrats, moteur d'évaluation)
 
-Backend-only, **0 migration DB**. Chaque levier est un bouton réglable/réversible
-par constante. Motivé par l'audit du 07/07 (`.context/veille-curation-mecanique.html`,
-memory `project_veille_curation_audit_decorrelation`) : le feed Veille était
-décorrélé de l'intention (topic axis mort 97 %, kw LLM génériques = 31 % du corpus,
-seuil posé sur le composite ⇒ ~60 % hors-sujet, anti-starvation qui réadmet le bruit).
+PR 1/2 du MVP pipeline d'évaluation des médias C1–C11 (story
+`docs/stories/core/media-eval.0.mvp-pipeline-evaluation.md`, plan PO validé le
+07/07/2026). Entièrement testable offline — la collecte (voie A + agents) et le
+run pilote arrivent en PR 2.
 
-## Commit 1 — Mécanique scoring & pool (`feed_filter.py`, `scoring_context.py`, `scoring_config.py`)
+## Ce que fait cette PR
 
-- **Constantes** : `VEILLE_PERTINENCE_GATE=20`, `VEILLE_FLOOR_MIN_KEYWORD_HITS=2`,
-  `VEILLE_BLOCK_A_PER_SOURCE_CANDIDATES=30`, `VEILLE_BLOCK_B_LANGUAGE_FILTER=True` ;
-  suppression de `VEILLE_MIN_FEED_SIZE` (anti-starvation). Seuil composite **48 inchangé**.
-- **E — plus de tokenisation des `why`** : `_tokenize_intent` + l'angle « Intention »
-  retirés. `why` reste en DB / endpoint config (badge santé inchangé).
-- **G2 — slugs non canoniques ignorés** : un `topic_id` hors des 50 slugs canoniques
-  (`SUBTOPIC_LABELS`) est neutralisé en `""` → sort du prédicat SQL, de `matched_on`
-  et de `user_subtopics` (le floor redevient honnête). Ses mots-clés survivent.
-- **B — floor durci** : un keyword-only ne qualifie que sur **≥ 2 hits distincts** ou
-  **1 hit fort** (mot-clé multi-mots, p.ex. « coupe du monde »). `_matched_axes` renvoie
-  désormais `(axes, floor_qualified)`. `matched_on` (front) inchangé.
-- **A — gate pertinence** : en plus du seuil composite, on exige pertinence normalisée
-  ≥ 20 quand la config porte un axe topic/mot-clé (le composite offre ~37-40 pts d'office
-  via source+fraîcheur+qualité). Nouveau compteur `gate_pruned_count` au log
-  `veille.feed_scored`.
-- **C — anti-starvation supprimée** : aucun candidat sous le seuil n'est réadmis
-  (feed court honnête). Revert = un bloc isolé.
-- **D — pool Bloc A équitable par source** : `row_number() OVER (PARTITION BY source_id
-  ORDER BY published_at DESC)` borne chaque source à N=30 avant le cap externe 300 — une
-  source dense n'affame plus les discrètes. `_base_query` refactoré en
-  `_apply_common_filters` (réutilisé par la sous-requête d'ids). Le point incertain du
-  plan (`apply_serein_filter` sur select non-entité) fonctionne — pas de plan B.
-- **G1 — filtre langue Bloc B** : langues des sources configurées ∪ `{fr}`,
-  `Content.language IS NULL` toléré. Bloc A non filtré. Kill-switch.
+### Docs source de vérité PO (`docs/media-eval/`)
+- Import de la méthodologie v1.1.1 (PDF converti) + amendements v1.2 actés
+  (raccourci JTI, pondération débunkages, temporalité, lettres A–E).
+- Import de l'architecture collecte ≠ évaluation du 07/07/2026.
+- **Rubriques évaluateur** (`rubrics/_common.md` + `C1/C5/C7/C8/C9/C11.md`) :
+  barème §4 verbatim + section « Sortie structurée » (`determinations`
+  énumérables). Lues verbatim par `build_eval_input.py` ;
+  `version_prompt` = sha256 du fichier rubrique.
 
-## Commit 2 — F : mots-clés LLM discriminants (`llm/angle_suggester.py`)
+### Schéma DB (migration `me01_media_eval_tables`, additive, RLS deny-all)
+7 tables `media_eval_*` : medias (référentiel niveau domaine), snapshots,
+corpus_articles (créée mais vide en V0), signaux (pivot ; statuts
+present/absent_verifie/partiel/bloque_acces ; dédup idempotente par
+`dedupe_key`), debunkages (qualification émetteur/gravité/suite, couple 1-1
+avec un signal C1), evaluations (score NULL si N/A, `signal_ids` cités,
+version_methodo/version_prompt), fiches (renormalisation, lettre, confiance).
+- `down_revision = ue01_user_entity_affinity` → 1 seul head. Idempotente
+  (guard `has_table` par table — la chaîne boote sur les 2 services Railway).
+  RLS pattern `sec02` (ENABLE + REVOKE anon/authenticated, aucune policy).
+- Modèles `app/models/media_eval.py` (StrEnum locaux, enums VARCHAR non natifs,
+  pattern `Source`), enregistrés dans `app/models/__init__.py`.
 
-- `_SYSTEM_PROMPT` durci : noms propres / entités datées, **≥ 2 expressions multi-mots
-  par angle**, denylist explicite du vocabulaire de discours, règle d'or (« un article
-  qui contient ce mot-clé parle presque certainement de ce sujet ») ; « Pense large »
-  retiré.
-- Filtre post-parse `_filter_generic_keywords` : denylist `_GENERIC_KEYWORDS` (~65
-  unigrammes) + `FRENCH_STOP_WORDS`, jamais les multi-mots ; angle vidé → écarté ; log
-  `angle_suggester.keywords_filtered`.
-- `_fallback_angles` 8 → 3, expressions multi-mots ancrées au thème.
-- Cache TTL 24 h inchangé : d'anciennes suggestions génériques peuvent coexister ≤ 24 h
-  post-deploy.
+### Contrats & garde-fous codés en dur (`scripts/media_eval/`)
+- `schemas.py` : `BAREMES` (100 pts), `CRITERES_VAGUE_1` (54 pts),
+  `NIVEAU_SCORES` C9/C11, `LETTRES`, registre `type_signal` figé, artefacts
+  Pydantic (Signal/Debunkage/Evaluation + enveloppes batch, GoldenSet).
+  **`derive_score(critere, determinations)`** : le score faisant foi est dérivé
+  par code, jamais choisi par le LLM (philosophie `derive_reliability`).
+  Validator dur : éval sans `signal_ids_cites` rejetée (sauf flag
+  `donnees_insuffisantes` → N/A). `poids_emetteur` des débunkages dérivé par
+  code (`arcom/justice/cdjm` = fort, fact-checkers de médias concurrents =
+  moyen, inconnu = faible).
+- `garde_fous.py` (fonctions pures) : fraîcheur 730 j (signaux événementiels
+  seulement, structurels constatés à date), fallback C1 (< 3 débunkages/2 ans),
+  raccourci JTI, corroboration (score plein sans ≥ 2 domaines sources
+  indépendants → palier inférieur + flag `corroboration_insuffisante`),
+  `bloque_acces` → `revue_requise` — jamais converti en 0.
 
-## Effet produit assumé
+### Scripts moteur (dry-run par défaut, `--apply` gardé, `--allow-prod` hors DB test)
+`seed_medias.py` (2 pilotes : cnews.fr audiovisuel, reporterre.net presse en
+ligne) · `ingest_artifacts.py` (valide en bloc puis insère — un artefact
+invalide = exit non-zéro, rien d'écrit ; idempotent) · `build_eval_input.py`
+(exports `eval_inputs/<media>_<critere>.json` + garde-fous amont) ·
+`ingest_evaluations.py` (garde-fous aval : signal_ids existants / bon média /
+bon critère, score dérivé, corroboration, statuts) · `synthese_fiche.py`
+(renormalisation sur les seuls critères évalués, lettre, confiance, fiche md +
+ligne DB) · `evaluate_golden_agreement.py` (accord vs gold : exact C9/C11,
+|Δ| ≤ 20 % du barème en continu, désaccords N/A-vs-score listés).
 
-Les feeds des configs **existantes** (kw génériques + slugs morts toujours en base) vont
-**fortement raccourcir** — 0-10 items honnêtes au lieu de dizaines majoritairement
-hors-sujet. C'est le comportement voulu. Le vrai remède (régénération des configs) est un
-agent suivant. Boutons de détente si trop agressif : `VEILLE_FLOOR_MIN_KEYWORD_HITS`
-(2→1) et `VEILLE_PERTINENCE_GATE` (20→25/0), via les logs prod
-(`floor_pruned_count` / `gate_pruned_count` / `threshold_pruned_count`).
+## Tests & vérifications
 
-## Harness d'audit mis à jour
+- **91 tests** `tests/scripts/media_eval/` (purs + DB savepoint) : contrats,
+  table `derive_score`, bornes fraîcheur 729/730/731 j, fallback 2 vs 3,
+  corroboration, JTI, `bloque_acces` jamais 0, renormalisation 0/1/3 N/A
+  (cas Reporterre max 34), bornes lettres 84.9/85, matrice confiance,
+  idempotence dedupe/évals, rejets (signal d'un autre média/critère,
+  artefact partiellement invalide → rien d'écrit), métriques gold.
+- Migration sur **DB vide** : `upgrade head` → `downgrade -1` → `upgrade head`
+  OK, exactement 1 head (`me01_media_eval_tables`).
+- Smoke E2E offline sur DB jetable : seed → ingest artefacts (5 signaux dont
+  2 couples débunkage, poids dérivés) → build_eval_input (fallback C1 déclenché
+  à 2 débunkages, 6 entrées écrites) → ingest_evaluations (3 évals, C1 N/A) →
+  synthese_fiche (10/20 → 50/100, lettre D, confiance moyenne).
+- Suite backend complète `pytest` + `ruff check`/`format` OK.
 
-`scripts/evaluate_veille_curation.py` (l'outil qui a produit l'audit) est adapté à la
-nouvelle porte : `source_intents` retiré, tuple `_matched_axes` déballé, nouvelles raisons
-de rejet `floor_weak_keyword` (keyword-only sous le min de hits) et `gate_pertinence`.
+Pas d'entrée changelog : outillage interne, aucun impact user (bypass de la
+règle 400 lignes assumé).
 
-## Vérification
+## Suite (PR 2)
 
-- Suites veille + harness : **98 passed** (`test_veille_curation`, `test_veille_scoring`,
-  `test_veille_routes`, `test_angle_suggester`, `test_evaluate_veille_curation`).
-- Suite backend complète : **2034 passed**, 2 échecs pré-existants sans lien (artefacts
-  de fuseau `+02:00` sur le Postgres local, `test_notification_preferences` /
-  `test_sources_recent_items` — verts en CI UTC).
-- `ruff check` + `ruff format` OK sur tout le code modifié.
-- Nouveaux tests ciblés : floor durci (1 hit → pruned, 2 hits / multi-mots → passe),
-  gate (2 hits sans source coupés, +source passe), C (aucune réadmission), D (source
-  discrète non affamée sous cap serré), G1 (article `en` écarté, `NULL` passe, langue
-  d'une source configurée autorisée).
-
-## Hors périmètre (agents suivants)
-
-Réutilisation du brief éditorial au scoring, régénération/migration des configs existantes
-(95 slugs morts + kw génériques restent en base), dédup d'angles, preview du feed à la
-config, état vide UI mobile.
-
-## À valider post-merge (logs prod)
-
-Mesure ex-ante non réalisée (part du corpus FR 7 j matchant ≥ 2 kw distincts de
-« Présidentielle 2027 ») : à confirmer via les logs `veille.feed_scored` en staging pour
-calibrer `VEILLE_FLOOR_MIN_KEYWORD_HITS` (2→3 si le feed reste bruité).
+Collecteurs voie A (`collect_pages_types/cdjm/jti/cppap/pappers/arcom`),
+sous-agents `.claude/agents/media-eval-*`, commande `/media-eval-run`, run
+pilote `pilote-2026-07` (CNEWS puis Reporterre) + golden set Laurin
+(`docs/media-eval/golden/gold_v0.json`) + rapport d'accord. Prérequis :
+`PAPPERS_API_TOKEN` (env locale, compte gratuit).

--- a/docs/media-eval/README.md
+++ b/docs/media-eval/README.md
@@ -1,0 +1,94 @@
+# Évaluation des médias C1–C11 — pipeline V0
+
+> Pipeline d'évaluation de la fiabilité des médias (méthodologie ouverte Facteur,
+> 100 pts, 11 critères). Ce dossier est la **source de vérité PO** des barèmes et
+> contrats donnés aux agents. V0 = 6 critères (vague 1), 2 médias pilotes.
+
+## Principe fondateur : collecte ≠ évaluation
+
+1. **Collecte** (3 voies) → produit des **signaux** horodatés, sourcés, avec
+   citation et snapshot, dans les tables `media_eval_*` (Supabase). La collecte
+   **ne note jamais**.
+   - **Voie A — CODE** : scripts déterministes (`packages/api/scripts/media_eval/collect_*.py`).
+     Écrivent directement en DB.
+   - **Voie B — AGENT** : sous-agents Claude avec accès web. N'écrivent **jamais**
+     en DB : artefacts JSON dans `.context/media_eval/<run_id>/` → validés
+     (Pydantic) puis insérés par `ingest_artifacts.py`.
+   - **Voie C — HUMAIN** : paywall, double évaluation C9/C11, golden set.
+2. **Évaluation** : 1 sous-agent par critère, **sans accès web**, qui ne lit que
+   `eval_inputs/<media>_<critere>.json` (signaux + barème verbatim) et rend un
+   JSON structuré citant des `signal_ids`. Le **score faisant foi est dérivé par
+   code** (`derive_score`) depuis des `determinations` énumérables — jamais choisi
+   librement par le LLM.
+3. **Garde-fous mécaniques codés en dur** (jamais dans les prompts) :
+   - *amont* (`build_eval_input.py`) : fraîcheur (> 730 j exclu), raccourci JTI
+     (C8 plein sans agent), déclencheur fallback C1 (< 3 débunkages / 2 ans) ;
+   - *aval* (`ingest_evaluations.py`) : signal_ids existants/bon média/bon
+     critère, corroboration (≥ 2 sources indépendantes pour un score plein,
+     sinon plafonné au palier inférieur), `bloque_acces` → `revue_requise`
+     (jamais 0), score dérivé par code.
+4. **Synthèse** (`synthese_fiche.py`) : renormalisation sur les critères
+   applicables, lettre A–E, confiance haute/moyenne/basse.
+
+## Flow d'un run
+
+```
+seed_medias.py ──────────────► media_eval_medias
+collect_*.py (voie A) ───────► signaux + snapshots (DB directe)
+agents collecteurs (voie B) ─► .context/media_eval/<run_id>/*.json
+ingest_artifacts.py ─────────► signaux + debunkages (validés Pydantic)
+build_eval_input.py ─────────► eval_inputs/<media>_<critere>.json (+ garde-fous amont)
+agents évaluateurs ──────────► evaluations_<media>_<critere>.json
+ingest_evaluations.py ───────► media_eval_evaluations (+ garde-fous aval)
+synthese_fiche.py ───────────► media_eval_fiches + fiche markdown
+evaluate_golden_agreement.py ► rapport d'accord vs golden set humain
+```
+
+## Périmètre V0 (décisions PO du 07/07/2026)
+
+- **Critères vague 1** : C1 (volet données tierces), C5, C7, C8, C9, C11 (volet
+  manifeste) — 54 pts max.
+- **Médias pilotes** : CNEWS (`cnews.fr`, audiovisuel → ARCOM applicable) et
+  Reporterre (`reporterre.net`, presse en ligne, niche → teste
+  `donnees_insuffisantes` + renormalisation avec N/A).
+- **Hors scope V0** : corpus d'articles (table créée mais vide), C2/C3/C4/C6/C10,
+  paywall, procédure contradictoire, UI/API, lien avec `sources.reliability_score`,
+  scheduling, multi-évaluateurs, SDK Anthropic.
+
+## Critères de succès V0 (verrouillés)
+
+1. **100 %** des artefacts évaluateurs passent la validation programmatique sans
+   édition manuelle.
+2. **Accord vs golden set** (exact sur niveaux C9/C11 ; |Δ| ≤ 20 % du barème sur
+   C1/C5/C7/C8) sur **≥ 4 critères / 6 par média** ; aucun désaccord N/A-vs-score
+   inexpliqué.
+3. **Reporterre** : C1 sort en N/A `donnees_insuffisantes` (pas 0) et la fiche
+   renormalise sur 34 pts.
+4. **Zéro écriture DB par agent** (par construction, vérifié en revue d'artefacts).
+
+## Contenu du dossier
+
+| Fichier | Rôle |
+|---|---|
+| `methodologie-v1.1.1.md` | Méthodologie publiée (import du PDF du 02/04/2026) |
+| `methodologie-v1.2-amendements.md` | Amendements v1.2 actés (JTI, pondération débunkages, temporalité…) |
+| `architecture-v1.2.md` | Architecture collecte/évaluation C1–C11 (import du doc du 07/07/2026) |
+| `rubrics/_common.md` | Contrat évaluateur générique + format JSON de sortie |
+| `rubrics/C{1,5,7,8,9,11}.md` | Barème §4 verbatim + sortie structurée + types de signaux |
+| `golden/gold_v0.json` | Golden set humain (Laurin) — livré en PR 2 |
+| `fiches/*.md` | Fiches générées — livrées en PR 2 |
+
+`version_prompt` d'une évaluation = **sha256 du fichier rubrique** utilisé
+(calculé par `build_eval_input.py`) : toute retouche de rubrique invalide la
+comparabilité des runs, c'est voulu.
+
+## Conventions
+
+- Fenêtre de fraîcheur des signaux événementiels V0 : **730 jours** (décision PO,
+  plus stricte que les 36 mois des amendements v1.2 — à réconcilier à la
+  publication de la v1.2 finale).
+- CNEWS chaîne TV vs site : le média évalué est **`cnews.fr`**,
+  `type_media='audiovisuel'` → signaux ARCOM applicables. Pour la presse en
+  ligne, l'absence de données ARCOM est un **N/A structurel, neutre**.
+- `media_eval_medias` est un référentiel **niveau domaine**, distinct de
+  `sources` (niveau feed). `source_ids` fait le lien applicatif futur, sans FK dure.

--- a/docs/media-eval/architecture-agentique.html
+++ b/docs/media-eval/architecture-agentique.html
@@ -1,0 +1,616 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Facteur · Architecture agentique d'évaluation des médias (C1–C11)</title>
+<style>
+  :root {
+    --ink: #1b2430;
+    --ink-soft: #48566a;
+    --line: #e3e8ef;
+    --bg: #f6f8fb;
+    --card: #ffffff;
+    --brand: #2f5fe0;
+    --brand-soft: #eaf0ff;
+    --code: #0f766e;
+    --code-soft: #e6f6f3;
+    --agent: #7c3aed;
+    --agent-soft: #f1eafe;
+    --human: #b45309;
+    --human-soft: #fdf1e0;
+    --ok: #15803d;
+    --warn: #b91c1c;
+    --shadow: 0 1px 2px rgba(16,24,40,.06), 0 8px 24px rgba(16,24,40,.05);
+  }
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    color: var(--ink);
+    background: var(--bg);
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 0 22px 96px; }
+  header.hero {
+    background: linear-gradient(135deg, #1b2a4e 0%, #2f5fe0 100%);
+    color: #fff;
+    padding: 54px 0 46px;
+    box-shadow: var(--shadow);
+  }
+  header.hero .wrap { padding-bottom: 0; }
+  .eyebrow {
+    text-transform: uppercase; letter-spacing: .14em; font-size: 12px;
+    font-weight: 700; opacity: .82; margin: 0 0 10px;
+  }
+  header.hero h1 { font-size: 34px; line-height: 1.15; margin: 0 0 14px; font-weight: 800; }
+  header.hero p.lede { font-size: 17px; max-width: 760px; margin: 0; opacity: .95; }
+  .meta-row { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 22px; }
+  .pill {
+    display: inline-flex; align-items: center; gap: 7px;
+    background: rgba(255,255,255,.14); border: 1px solid rgba(255,255,255,.22);
+    padding: 5px 12px; border-radius: 999px; font-size: 13px; font-weight: 600;
+  }
+
+  nav.toc {
+    background: var(--card); border: 1px solid var(--line); border-radius: 14px;
+    padding: 18px 22px; margin: -30px 0 40px; box-shadow: var(--shadow);
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 6px 24px;
+  }
+  nav.toc a { color: var(--ink-soft); text-decoration: none; font-size: 14px; font-weight: 600; padding: 5px 0; display: block; border-bottom: 1px solid transparent; }
+  nav.toc a:hover { color: var(--brand); }
+  nav.toc .toc-num { color: var(--brand); font-weight: 800; margin-right: 8px; }
+
+  section { margin: 0 0 52px; }
+  h2 {
+    font-size: 24px; font-weight: 800; margin: 0 0 6px; letter-spacing: -.01em;
+    display: flex; align-items: baseline; gap: 12px;
+  }
+  h2 .num {
+    font-size: 15px; font-weight: 800; color: #fff; background: var(--brand);
+    border-radius: 8px; padding: 2px 10px; letter-spacing: 0;
+  }
+  h3 { font-size: 18px; font-weight: 700; margin: 30px 0 10px; }
+  .section-lede { color: var(--ink-soft); font-size: 16px; margin: 0 0 22px; max-width: 820px; }
+  p { margin: 0 0 14px; }
+
+  .card { background: var(--card); border: 1px solid var(--line); border-radius: 14px; padding: 22px 24px; box-shadow: var(--shadow); }
+  .grid { display: grid; gap: 18px; }
+  .grid-2 { grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); }
+  .grid-3 { grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
+
+  /* Voie badges */
+  .badge { display: inline-flex; align-items: center; gap: 6px; font-weight: 700; font-size: 12px; padding: 3px 9px; border-radius: 6px; white-space: nowrap; }
+  .b-code  { color: var(--code);  background: var(--code-soft); }
+  .b-agent { color: var(--agent); background: var(--agent-soft); }
+  .b-human { color: var(--human); background: var(--human-soft); }
+  .dot { width: 9px; height: 9px; border-radius: 50%; display: inline-block; }
+  .d-code { background: var(--code); } .d-agent { background: var(--agent); } .d-human { background: var(--human); }
+
+  /* Pipeline */
+  .pipeline { display: flex; flex-direction: column; gap: 0; }
+  .stage {
+    display: grid; grid-template-columns: 46px 1fr; gap: 16px; align-items: stretch;
+    position: relative;
+  }
+  .stage .rail { display: flex; flex-direction: column; align-items: center; }
+  .stage .knob {
+    width: 34px; height: 34px; border-radius: 50%; background: var(--brand); color: #fff;
+    display: grid; place-items: center; font-weight: 800; font-size: 15px; flex: 0 0 auto; z-index: 1;
+  }
+  .stage .line { width: 2px; flex: 1; background: var(--line); }
+  .stage .body { padding: 0 0 20px; }
+  .stage .body h4 { margin: 4px 0 4px; font-size: 16px; }
+  .stage .body p { margin: 0; color: var(--ink-soft); font-size: 14.5px; }
+  .stage .body code { font-size: 12.5px; }
+  .stage.collecte .knob { background: var(--code); }
+  .stage.eval .knob { background: var(--agent); }
+  .stage.store .knob { background: #334155; }
+
+  code, .mono { font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace; font-size: 13px; background: #f1f4f8; padding: 1px 6px; border-radius: 5px; color: #223; }
+  .arrow { color: var(--ink-soft); }
+
+  table { width: 100%; border-collapse: collapse; font-size: 14px; margin: 8px 0 0; }
+  th, td { text-align: left; padding: 9px 12px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  th { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--ink-soft); font-weight: 700; }
+  tbody tr:last-child td { border-bottom: none; }
+
+  /* Criterion cards */
+  .crit { border-top: 4px solid var(--brand); }
+  .crit .crit-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 14px; margin-bottom: 4px; }
+  .crit .crit-title { font-size: 17px; font-weight: 800; margin: 0; }
+  .crit .crit-sub { color: var(--ink-soft); font-size: 13px; margin: 2px 0 0; }
+  .crit .pts { font-size: 13px; font-weight: 800; color: var(--brand); background: var(--brand-soft); border-radius: 8px; padding: 4px 10px; white-space: nowrap; }
+  .crit.pilier-rigueur { border-top-color: #2f5fe0; }
+  .crit.pilier-transparence { border-top-color: #0f766e; }
+  .crit.pilier-independance { border-top-color: #7c3aed; }
+  .det-table td:last-child { font-weight: 700; text-align: right; white-space: nowrap; }
+  .flag-2eval { font-size: 11px; font-weight: 800; color: var(--human); background: var(--human-soft); border-radius: 5px; padding: 2px 7px; }
+
+  .callout { border-left: 4px solid var(--brand); background: var(--brand-soft); border-radius: 0 10px 10px 0; padding: 14px 18px; margin: 18px 0; }
+  .callout.warn { border-left-color: var(--warn); background: #fdeceb; }
+  .callout.ok { border-left-color: var(--ok); background: #eaf6ee; }
+  .callout strong { color: var(--ink); }
+
+  ul.clean { margin: 6px 0 0; padding-left: 20px; }
+  ul.clean li { margin: 5px 0; }
+
+  .split-note { font-size: 13px; color: var(--ink-soft); }
+  .legend { display: flex; flex-wrap: wrap; gap: 16px; margin: 4px 0 26px; font-size: 13.5px; }
+  .legend span { display: inline-flex; align-items: center; gap: 7px; font-weight: 600; color: var(--ink-soft); }
+
+  footer { border-top: 1px solid var(--line); padding: 26px 0; color: var(--ink-soft); font-size: 13px; text-align: center; }
+  a.link { color: var(--brand); text-decoration: none; font-weight: 600; }
+  a.link:hover { text-decoration: underline; }
+
+  @media (max-width: 620px) {
+    header.hero h1 { font-size: 27px; }
+    h2 { font-size: 21px; }
+  }
+</style>
+</head>
+<body>
+
+<header class="hero">
+  <div class="wrap">
+    <p class="eyebrow">Facteur · Méthodologie ouverte v1.2</p>
+    <h1>Architecture agentique d'évaluation des médias</h1>
+    <p class="lede">Comment Facteur évalue la fiabilité d'un média sur 11 critères (100 points) grâce à un pipeline qui sépare strictement la <strong>collecte de signaux</strong> de leur <strong>évaluation par des sous-agents</strong>, avec un score toujours dérivé par code, jamais choisi librement par un modèle.</p>
+    <div class="meta-row">
+      <span class="pill">Vague 1 · 6 critères · 54 pts</span>
+      <span class="pill">3 voies de collecte</span>
+      <span class="pill">1 sous-agent par critère</span>
+      <span class="pill">Score dérivé par code</span>
+      <span class="pill">Calibré sur golden set humain</span>
+    </div>
+  </div>
+</header>
+
+<div class="wrap">
+
+  <nav class="toc">
+    <a href="#principe"><span class="toc-num">1</span>Le principe fondateur</a>
+    <a href="#macro"><span class="toc-num">2</span>Pipeline macro</a>
+    <a href="#voies"><span class="toc-num">3</span>Les 3 voies de collecte</a>
+    <a href="#store"><span class="toc-num">4</span>Le data store</a>
+    <a href="#harness"><span class="toc-num">5</span>Le harness évaluateur</a>
+    <a href="#gardefous"><span class="toc-num">6</span>Garde-fous codés en dur</a>
+    <a href="#criteres"><span class="toc-num">7</span>Vue par critère (vague 1)</a>
+    <a href="#calibration"><span class="toc-num">8</span>Calibration &amp; confiance</a>
+    <a href="#perimetre"><span class="toc-num">9</span>Périmètre V0 &amp; phasage</a>
+  </nav>
+
+  <div class="legend">
+    <span><span class="dot d-code"></span> Voie CODE : déterministe</span>
+    <span><span class="dot d-agent"></span> Voie AGENT : jugement</span>
+    <span><span class="dot d-human"></span> Voie HUMAIN : inaccessible &amp; contradictoire</span>
+  </div>
+
+  <!-- 1 -->
+  <section id="principe">
+    <h2><span class="num">1</span> Le principe fondateur : collecte ≠ évaluation</h2>
+    <p class="section-lede">Deux phases, un data store entre les deux. La collecte produit des observations factuelles, la collecte <strong>ne note jamais</strong>. L'évaluation lit uniquement ces observations, l'évaluation <strong>ne collecte jamais</strong>.</p>
+    <div class="grid grid-2">
+      <div class="card">
+        <h3 style="margin-top:0;">Phase COLLECTE</h3>
+        <p class="split-note">Produit des <strong>signaux</strong> : observations factuelles avec source, URL, date, citation et capture horodatée (snapshot). Chère (fetch, navigation, lecture) donc tourne <strong>une fois</strong>.</p>
+        <ul class="clean split-note">
+          <li>Statuts distincts : <code>present</code>, <code>absent_verifie</code>, <code>partiel</code>, <code>bloque_acces</code>.</li>
+          <li>« Absence vérifiée » et « bloqué » sont tracés, pas confondus avec un échec.</li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3 style="margin-top:0;">Phase ÉVALUATION</h3>
+        <p class="split-note">Un sous-agent par critère, <strong>sans accès web</strong>, ne lit que les signaux d'un couple (média, critère) + le barème verbatim. Bon marché (lecture de JSON) donc peut tourner <strong>N fois</strong>.</p>
+        <ul class="clean split-note">
+          <li>Rend des <strong>déterminations énumérables</strong>, jamais un score chiffré.</li>
+          <li>Chaque affirmation cite des <code>signal_ids</code> précis.</li>
+        </ul>
+      </div>
+    </div>
+    <div class="callout">
+      <strong>Quatre garanties alignées sur la méthodo :</strong> reproductibilité (re-noter sans re-collecter, indispensable au contradictoire), traçabilité (chaque point cite ses signaux), auditabilité du non-collecté (absence vérifiée vs accès bloqué), coût maîtrisé (collecte une fois, évaluation N fois).
+    </div>
+  </section>
+
+  <!-- 2 -->
+  <section id="macro">
+    <h2><span class="num">2</span> Le pipeline macro</h2>
+    <p class="section-lede">Le flux complet d'un run, du référentiel média à la fiche publiée. Les agents collecteurs et les agents évaluateurs sont des rôles <strong>distincts</strong> : jamais le même agent cherche et note.</p>
+    <div class="card">
+      <div class="pipeline">
+        <div class="stage store">
+          <div class="rail"><div class="knob">1</div><div class="line"></div></div>
+          <div class="body">
+            <h4>Référentiel média <span class="badge b-code"><span class="dot d-code"></span> CODE</span></h4>
+            <p><code>seed_medias.py</code> → domaine, type (presse en ligne / audiovisuel), volume/jour, paywall. Conditionne échantillons et routage.</p>
+          </div>
+        </div>
+        <div class="stage collecte">
+          <div class="rail"><div class="knob">2</div><div class="line"></div></div>
+          <div class="body">
+            <h4>Collecte, 3 voies en parallèle <span class="badge b-code"><span class="dot d-code"></span> CODE</span> <span class="badge b-agent"><span class="dot d-agent"></span> AGENT</span> <span class="badge b-human"><span class="dot d-human"></span> HUMAIN</span></h4>
+            <p>Voie A : <code>collect_*.py</code> écrit en DB. Voie B : agents Claude → artefacts JSON dans <code>.context/media_eval/&lt;run_id&gt;/</code>, jamais d'écriture DB directe. Voie C : humain (paywall, golden set). Sortie unique : des signaux horodatés + snapshots. Zéro notation.</p>
+          </div>
+        </div>
+        <div class="stage store">
+          <div class="rail"><div class="knob">3</div><div class="line"></div></div>
+          <div class="body">
+            <h4>Ingestion &amp; data store <span class="badge b-code"><span class="dot d-code"></span> CODE</span></h4>
+            <p><code>ingest_artifacts.py</code> valide les artefacts agents (Pydantic strict) puis insère signaux + débunkages. Rejet en bloc si un artefact est invalide : rien n'est écrit.</p>
+          </div>
+        </div>
+        <div class="stage store">
+          <div class="rail"><div class="knob">4</div><div class="line"></div></div>
+          <div class="body">
+            <h4>Construction de l'entrée d'évaluation <span class="badge b-code"><span class="dot d-code"></span> CODE</span></h4>
+            <p><code>build_eval_input.py</code> → <code>eval_inputs/&lt;media&gt;_&lt;critere&gt;.json</code> : signaux + barème verbatim. Applique les garde-fous <strong>amont</strong> (fraîcheur, raccourci JTI, déclencheur fallback C1) et calcule <code>version_prompt</code> = sha256 de la rubrique.</p>
+          </div>
+        </div>
+        <div class="stage eval">
+          <div class="rail"><div class="knob">5</div><div class="line"></div></div>
+          <div class="body">
+            <h4>Évaluation par sous-agents <span class="badge b-agent"><span class="dot d-agent"></span> AGENT</span></h4>
+            <p>1 agent par critère, sans accès web → <code>evaluations_&lt;media&gt;_&lt;critere&gt;.json</code> : déterminations + justification + <code>signal_ids_cites</code>. Aucun score chiffré.</p>
+          </div>
+        </div>
+        <div class="stage store">
+          <div class="rail"><div class="knob">6</div><div class="line"></div></div>
+          <div class="body">
+            <h4>Ingestion des évaluations <span class="badge b-code"><span class="dot d-code"></span> CODE</span></h4>
+            <p><code>ingest_evaluations.py</code> applique les garde-fous <strong>aval</strong> (signal_ids valides / bon média / bon critère, corroboration, <code>bloque_acces</code> → revue) puis <strong>dérive le score par code</strong>.</p>
+          </div>
+        </div>
+        <div class="stage store">
+          <div class="rail"><div class="knob">7</div><div class="line"></div></div>
+          <div class="body">
+            <h4>Synthèse de la fiche <span class="badge b-code"><span class="dot d-code"></span> CODE</span></h4>
+            <p><code>synthese_fiche.py</code> renormalise sur les critères applicables (règle de trois), attribue la lettre A–E et le niveau de confiance (haute / moyenne / basse).</p>
+          </div>
+        </div>
+        <div class="stage store">
+          <div class="rail"><div class="knob">8</div></div>
+          <div class="body">
+            <h4>Mesure d'accord vs golden set <span class="badge b-human"><span class="dot d-human"></span> HUMAIN</span> <span class="badge b-code"><span class="dot d-code"></span> CODE</span></h4>
+            <p><code>evaluate_golden_agreement.py</code> compare la sortie du harness à la notation humaine de référence. On ne publie rien tant que l'accord n'est pas stable.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 3 -->
+  <section id="voies">
+    <h2><span class="num">3</span> Les trois voies de collecte</h2>
+    <p class="section-lede">Règle de routage : le code pour le déterministe, l'agent pour le jugement, l'humain pour l'inaccessible et le contradictoire. Un signal descend toujours au niveau le plus bas (le moins cher) capable de le produire de façon fiable.</p>
+    <div class="grid grid-3">
+      <div class="card" style="border-top:4px solid var(--code);">
+        <p style="margin:0 0 8px;"><span class="badge b-code"><span class="dot d-code"></span> VOIE A · CODE</span></p>
+        <p class="split-note" style="margin-bottom:10px;">Scripts + edge functions planifiables. Déterministe, répétable, quasi gratuit.</p>
+        <ul class="clean split-note">
+          <li>Crawl structurel (mentions légales, chartes, corrections, publicité) + snapshots.</li>
+          <li>Registres : Pappers, CPPAP, JTI, avis CDJM.</li>
+          <li>Constitution du corpus (échantillonnage stratifié documenté).</li>
+          <li>Pré-métriques d'articles (bylines, labels, liens).</li>
+        </ul>
+      </div>
+      <div class="card" style="border-top:4px solid var(--agent);">
+        <p style="margin:0 0 8px;"><span class="badge b-agent"><span class="dot d-agent"></span> VOIE B · AGENT</span></p>
+        <p class="split-note" style="margin-bottom:10px;">Sous-agents Claude avec accès web (dont fetch navigateur). Lecture, recherche ouverte, qualification. <strong>N'écrivent jamais en DB.</strong></p>
+        <ul class="clean split-note">
+          <li>Recherche ouverte : débunkages, condamnations, départs, déclarations.</li>
+          <li>Qualification : pondérer un débunkage, juger une charte.</li>
+          <li>Analyse de corpus (vague 2) : sourçage, cadrage, diversité.</li>
+          <li>Extraction structurée (page « Qui sommes-nous » → données).</li>
+        </ul>
+      </div>
+      <div class="card" style="border-top:4px solid var(--human);">
+        <p style="margin:0 0 8px;"><span class="badge b-human"><span class="dot d-human"></span> VOIE C · HUMAIN</span></p>
+        <p class="split-note" style="margin-bottom:10px;">Rare et ciblé : là où ni le code ni l'agent ne peuvent aller, ou là où la méthodo exige un regard second.</p>
+        <ul class="clean split-note">
+          <li>Corpus paywallé (copie manuelle déposée, puis analyse en voie B).</li>
+          <li>Double évaluation C9 / C11, divergences documentées.</li>
+          <li>Contreseing du fallback C1 avant entrée au score.</li>
+          <li>Golden set de calibration.</li>
+        </ul>
+      </div>
+    </div>
+    <div class="callout">
+      <strong>Répartition observée sur les ~40 signaux de la grille :</strong> environ <strong>40 % collectables par code</strong>, <strong>45 % par agents</strong>, <strong>15 % exigent l'humain</strong>. Le point de rupture identifié au batch-test #1 (27/06/2026) n'est pas l'intelligence mais l'<strong>accès</strong> (blocklist, paywalls) et la <strong>disponibilité</strong> (zéro donnée tierce sur les médias de niche). L'accès est donc traité comme une propriété du signal (statut dédié), pas comme un échec de collecte.
+    </div>
+  </section>
+
+  <!-- 4 -->
+  <section id="store">
+    <h2><span class="num">4</span> Le data store (tables <code>media_eval_*</code>)</h2>
+    <p class="section-lede">Tout ce que la fiche publiée doit contenir (source, URL, date, citation) est un champ obligatoire dès la collecte, pas une reconstruction a posteriori. RLS deny-all sur toutes les tables (outillage interne).</p>
+    <div class="card" style="padding-top:8px;">
+      <table>
+        <thead><tr><th>Table</th><th>Grain</th><th>Rôle</th></tr></thead>
+        <tbody>
+          <tr><td><code>medias</code></td><td>domaine / média</td><td>Référentiel : type presse en ligne / audiovisuel, volume/jour, paywall, rubriques d'opinion. Distinct de <code>sources</code> (grain feed RSS de l'app live).</td></tr>
+          <tr><td><code>snapshots</code></td><td>page</td><td>Capture horodatée + hash d'une page type (mentions légales, charte, corrections). Preuve, gère les incohérences internes.</td></tr>
+          <tr><td><code>corpus_articles</code></td><td>article</td><td>Échantillon délibéré et figé (stratifié rubrique × mois), texte stable, pré-métriques. Vide en V0.</td></tr>
+          <tr><td><code>signaux</code></td><td>observation</td><td><strong>La table pivot.</strong> media_id, critere, type_signal, statut, valeur (jsonb + citation), voie, collecteur, source_urls, snapshot_id, sources_consultees.</td></tr>
+          <tr><td><code>debunkages</code></td><td>débunkage</td><td>emetteur + <code>poids_emetteur</code> (dérivé par code), gravité, suite donnée. Alimente le signal C1.</td></tr>
+          <tr><td><code>evaluations</code></td><td>(média, critère)</td><td>score, niveau, justification, signal_ids cités, évaluateur (agent / humain), version_methodo, version_prompt, evalue_at.</td></tr>
+          <tr><td><code>fiches</code></td><td>média</td><td>score brut, score renormalisé, lettre, critères N/A, confiance, statut (brouillon / contradictoire / publiée).</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p class="split-note" style="margin-top:14px;"><strong>Articulation avec l'app.</strong> <code>media_eval_*</code> est le système d'audit versionné ; les colonnes plates de <code>sources</code> (<code>reliability_score</code>…) sont un cache applicatif. À terme, les fiches pourront <em>alimenter</em> ces colonnes par projection. Ce n'est pas un doublon : un média = N sources.</p>
+  </section>
+
+  <!-- 5 -->
+  <section id="harness">
+    <h2><span class="num">5</span> Le harness d'évaluation par sous-agents</h2>
+    <p class="section-lede">Un contrat d'entrée / sortie strict, verrouillé par validation programmatique. L'agent produit du jugement énumérable ; le code produit le score.</p>
+    <div class="grid grid-2">
+      <div class="card">
+        <h3 style="margin-top:0;">Entrée</h3>
+        <ul class="clean split-note">
+          <li>Les signaux du data store pour un couple (média, critère).</li>
+          <li>Le barème §4 du critère, lu <strong>verbatim</strong>.</li>
+          <li>D'éventuels <code>pre_flags</code> posés par les garde-fous amont.</li>
+          <li><strong>Aucun accès web, fichier ou base.</strong> Signal manquant → l'agent le dit, il ne va pas le chercher.</li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3 style="margin-top:0;">Sortie</h3>
+        <p class="split-note" style="margin-bottom:8px;">JSON structuré <code>evaluations_&lt;media&gt;_&lt;critere&gt;.json</code> :</p>
+        <ul class="clean split-note">
+          <li><code>determinations</code> : valeurs énumérées par la rubrique (rien d'autre).</li>
+          <li><code>justification</code> : 2 à 6 phrases, chacune adossée à des signal_ids.</li>
+          <li><code>signal_ids_cites</code> : <strong>non vide</strong>, sauf N/A.</li>
+          <li><code>flags</code> : dans le contrat uniquement.</li>
+          <li><strong>Pas de champ <code>score</code></strong> : rejet à la validation.</li>
+        </ul>
+      </div>
+    </div>
+    <h3>Les flags autorisés et leur effet (appliqué par code)</h3>
+    <div class="card" style="padding-top:8px;">
+      <table>
+        <thead><tr><th>Flag</th><th>Sens</th><th>Effet</th></tr></thead>
+        <tbody>
+          <tr><td><code>donnees_insuffisantes</code></td><td>Signaux insuffisants pour appliquer le barème</td><td>Critère <strong>N/A</strong>, exclu de la renormalisation</td></tr>
+          <tr><td><code>signaux_contradictoires</code></td><td>Les signaux se contredisent</td><td>Score partiel + justification ; confiance dégradée</td></tr>
+          <tr><td><code>bloque_acces</code></td><td>Seuls signaux pertinents = accès bloqué</td><td><strong>Revue requise</strong>, jamais converti en 0</td></tr>
+          <tr><td><code>revue_humaine_requise</code></td><td>Cas limite signalé par l'agent</td><td>Confiance <strong>basse</strong> sur la fiche</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="callout ok">
+      <strong>Le score faisant foi est dérivé par code</strong> (<code>derive_score</code>), depuis les <code>determinations</code> énumérables, jamais choisi librement par le modèle. Même philosophie que <code>derive_reliability</code> pour les sources. La validation Pydantic rejette en bloc un artefact non conforme : le rejet devient un feedback loop, pas un piège.
+    </div>
+  </section>
+
+  <!-- 6 -->
+  <section id="gardefous">
+    <h2><span class="num">6</span> Les garde-fous, codés en dur (jamais dans les prompts)</h2>
+    <p class="section-lede">Toute règle mécanique de la méthodo sort du prompt et devient une validation programmatique. Deux moments : <strong>amont</strong> (avant l'agent, dans <code>build_eval_input.py</code>) et <strong>aval</strong> (après l'agent, dans <code>ingest_evaluations.py</code>).</p>
+    <div class="grid grid-2">
+      <div class="card">
+        <h3 style="margin-top:0;">Amont · <code>build_eval_input.py</code></h3>
+        <ul class="clean split-note">
+          <li><strong>Fraîcheur</strong> : signal événementiel &gt; 730 jours → exclu (N/A automatique).</li>
+          <li><strong>Raccourci JTI</strong> : certification valide → C8 plein, sans passage par l'agent.</li>
+          <li><strong>Déclencheur fallback C1</strong> : &lt; 3 débunkages / 2 ans → pre_flag <code>fallback_c1_declenche</code>.</li>
+          <li><strong>Neutralité ARCOM</strong> : presse en ligne → signaux ARCOM exclus (N/A structurel neutre).</li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3 style="margin-top:0;">Aval · <code>ingest_evaluations.py</code></h3>
+        <ul class="clean split-note">
+          <li><strong>Intégrité des citations</strong> : chaque signal_id doit exister, bon média, bon critère.</li>
+          <li><strong>Corroboration</strong> : ≥ 2 sources indépendantes pour un score plein, sinon plafonné au palier inférieur.</li>
+          <li><strong>Bloqué ≠ zéro</strong> : <code>bloque_acces</code> → revue requise, jamais 0.</li>
+          <li><strong>Score dérivé</strong> par code depuis les déterminations.</li>
+        </ul>
+      </div>
+    </div>
+    <p class="split-note" style="margin-top:14px;"><strong>Synthèse (pur calcul)</strong> : renormalisation sur 100 (règle de trois sur les critères évaluables), lettre A–E, niveau de confiance HAUTE / MOYENNE / BASSE. Une confiance BASSE n'est pas publiable.</p>
+  </section>
+
+  <!-- 7 -->
+  <section id="criteres">
+    <h2><span class="num">7</span> Vue par critère : vague 1 (54 pts)</h2>
+    <p class="section-lede">Chaque critère a son sous-agent, son barème verbatim, ses types de signaux attendus et ses déterminations énumérables. L'agent choisit une détermination ; le code en dérive le score.</p>
+
+    <div class="grid grid-2">
+
+      <!-- C1 -->
+      <div class="card crit pilier-rigueur">
+        <div class="crit-head">
+          <div>
+            <p class="crit-title">C1 · Véracité et exactitude</p>
+            <p class="crit-sub">Pilier Rigueur · échelle continue · volet données tierces (V0)</p>
+          </div>
+          <span class="pts">20 pts</span>
+        </div>
+        <p class="split-note" style="margin:10px 0 6px;">Voies dominantes : <span class="badge b-code"><span class="dot d-code"></span> CODE</span> <span class="badge b-agent"><span class="dot d-agent"></span> AGENT</span> <span class="badge b-human"><span class="dot d-human"></span> HUMAIN</span> (fallback)</p>
+        <p class="split-note" style="margin:0 0 8px;"><strong>Signaux :</strong> débunkage, sanction_arcom, condamnation_justice, avis_cdjm. Chaque débunkage pondéré par émetteur / gravité / suite donnée (poids dérivé par code).</p>
+        <table class="det-table">
+          <thead><tr><th>determination · profil_veracite</th><th>Score</th></tr></thead>
+          <tbody>
+            <tr><td>aucun_signal_negatif</td><td>20</td></tr>
+            <tr><td>problemes_mineurs_corriges</td><td>15</td></tr>
+            <tr><td>problemes_mixtes</td><td>10</td></tr>
+            <tr><td>problemes_significatifs</td><td>5</td></tr>
+            <tr><td>fabrication_ou_refus_non_corrige</td><td>0</td></tr>
+          </tbody>
+        </table>
+        <p class="split-note" style="margin:10px 0 0;">Critère radicalement asymétrique : médias exposés = données abondantes ; médias de niche = zéro (fallback = voie principale, non instruit en V0 → N/A).</p>
+      </div>
+
+      <!-- C5 -->
+      <div class="card crit pilier-transparence">
+        <div class="crit-head">
+          <div>
+            <p class="crit-title">C5 · Transparence propriété &amp; financement</p>
+            <p class="crit-sub">Pilier Transparence · échelle continue</p>
+          </div>
+          <span class="pts">10 pts</span>
+        </div>
+        <p class="split-note" style="margin:10px 0 6px;">Voies dominantes : <span class="badge b-code"><span class="dot d-code"></span> CODE</span> <span class="badge b-agent"><span class="dot d-agent"></span> AGENT</span></p>
+        <p class="split-note" style="margin:0 0 8px;"><strong>Signaux :</strong> mentions_legales, identification_proprietaire, structure_actionnariat, enregistrement_cppap, transparence_financement.</p>
+        <table class="det-table">
+          <thead><tr><th>determination · profil_signaux</th><th>Score</th></tr></thead>
+          <tbody>
+            <tr><td>positifs_majoritaires</td><td>10</td></tr>
+            <tr><td>mixtes</td><td>5</td></tr>
+            <tr><td>negatifs</td><td>0</td></tr>
+          </tbody>
+        </table>
+        <p class="split-note" style="margin:10px 0 0;">Disponible et homogène sur tous les médias testés, petits inclus. Fondation fiable à scorer en premier.</p>
+      </div>
+
+      <!-- C7 -->
+      <div class="card crit pilier-transparence">
+        <div class="crit-head">
+          <div>
+            <p class="crit-title">C7 · Séparation éditorial / publicité</p>
+            <p class="crit-sub">Pilier Transparence · échelle continue</p>
+          </div>
+          <span class="pts">4 pts</span>
+        </div>
+        <p class="split-note" style="margin:10px 0 6px;">Voies dominantes : <span class="badge b-code"><span class="dot d-code"></span> CODE</span> <span class="badge b-agent"><span class="dot d-agent"></span> AGENT</span></p>
+        <p class="split-note" style="margin:0 0 8px;"><strong>Signaux :</strong> marquage_contenu_sponsorise, regie_pub_identifiee, politique_publicitaire. Le native advertising non labellisé se voit (jugement visuel), ne se regexe pas.</p>
+        <table class="det-table">
+          <thead><tr><th>determination · profil_signaux</th><th>Score</th></tr></thead>
+          <tbody>
+            <tr><td>positifs_majoritaires</td><td>4</td></tr>
+            <tr><td>mixtes</td><td>2</td></tr>
+            <tr><td>negatifs</td><td>0</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- C8 -->
+      <div class="card crit pilier-transparence">
+        <div class="crit-head">
+          <div>
+            <p class="crit-title">C8 · Engagement déontologique formel</p>
+            <p class="crit-sub">Pilier Transparence · échelle continue</p>
+          </div>
+          <span class="pts">4 pts</span>
+        </div>
+        <p class="split-note" style="margin:10px 0 6px;">Voies dominantes : <span class="badge b-code"><span class="dot d-code"></span> CODE</span> <span class="badge b-agent"><span class="dot d-agent"></span> AGENT</span></p>
+        <p class="split-note" style="margin:0 0 8px;"><strong>Signaux :</strong> charte_deontologique, adhesion_cdjm, certification_jti, reference_charte_externe.</p>
+        <table class="det-table">
+          <thead><tr><th>determination · profil_signaux</th><th>Score</th></tr></thead>
+          <tbody>
+            <tr><td>positifs_majoritaires</td><td>4</td></tr>
+            <tr><td>mixtes</td><td>2</td></tr>
+            <tr><td>negatifs</td><td>0</td></tr>
+          </tbody>
+        </table>
+        <div class="callout" style="margin:12px 0 0; padding:10px 14px;"><span class="split-note"><strong>Raccourci JTI :</strong> certification valide = 4/4 sans examen de l'agent. Le seul critère de la grille avec un raccourci automatique.</span></div>
+      </div>
+
+      <!-- C9 -->
+      <div class="card crit pilier-independance">
+        <div class="crit-head">
+          <div>
+            <p class="crit-title">C9 · Indépendance éditoriale <span class="flag-2eval">⚑ double éval</span></p>
+            <p class="crit-sub">Pilier Indépendance · 3 niveaux</p>
+          </div>
+          <span class="pts">10 pts</span>
+        </div>
+        <p class="split-note" style="margin:10px 0 6px;">Voies dominantes : <span class="badge b-agent"><span class="dot d-agent"></span> AGENT</span> <span class="badge b-human"><span class="dot d-human"></span> HUMAIN</span></p>
+        <p class="split-note" style="margin:0 0 8px;"><strong>Signaux :</strong> charte_independance, societe_journalistes, independance_capital, intervention_actionnaire (négatif), statuts_redaction. « Partiel » vs « complet » = une question de clauses (droit de veto, agrément), pas de présence.</p>
+        <table class="det-table">
+          <thead><tr><th>determination · niveau</th><th>Score</th></tr></thead>
+          <tbody>
+            <tr><td>0 · Absent</td><td>0</td></tr>
+            <tr><td>1 · Partiel</td><td>5</td></tr>
+            <tr><td>2 · Complet</td><td>10</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- C11 -->
+      <div class="card crit pilier-transparence">
+        <div class="crit-head">
+          <div>
+            <p class="crit-title">C11 · Transparence du positionnement <span class="flag-2eval">⚑ double éval</span></p>
+            <p class="crit-sub">Pilier Transparence · 3 niveaux · volet manifeste (V0)</p>
+          </div>
+          <span class="pts">6 pts</span>
+        </div>
+        <p class="split-note" style="margin:10px 0 6px;">Voies dominantes : <span class="badge b-code"><span class="dot d-code"></span> CODE</span> <span class="badge b-agent"><span class="dot d-agent"></span> AGENT</span></p>
+        <p class="split-note" style="margin:0 0 8px;"><strong>Signaux :</strong> manifeste_positionnement, ligne_editoriale_publiee, auto_description_orientation, rubriques_opinion_identifiees. On évalue la <em>transparence</em> du positionnement, jamais sa nature politique.</p>
+        <table class="det-table">
+          <thead><tr><th>determination · niveau</th><th>Score</th></tr></thead>
+          <tbody>
+            <tr><td>0 · Opaque</td><td>0</td></tr>
+            <tr><td>1 · Partiel</td><td>3</td></tr>
+            <tr><td>2 · Transparent</td><td>6</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+    </div>
+    <p class="split-note" style="margin-top:18px;">Hors vague 1 : C2, C3, C4, C6, C10 sont article-dépendants (vague 2), plus C1 (fallback) et C11 (volet cadrage). Ils dépendent du corpus + d'un fetch navigateur + d'une stratégie paywall.</p>
+  </section>
+
+  <!-- 8 -->
+  <section id="calibration">
+    <h2><span class="num">8</span> Calibration &amp; confiance</h2>
+    <p class="section-lede">On ne fait pas confiance au harness par principe : on le mesure contre un golden set humain avant toute évaluation en série.</p>
+    <div class="grid grid-2">
+      <div class="card">
+        <h3 style="margin-top:0;">Golden set</h3>
+        <p class="split-note">Notation humaine de référence (Laurin), critère par critère. Chaque version du harness (prompt ou modèle) est mesurée contre ce set : accord exact sur les échelles à 3 niveaux (C9, C11), écart toléré sur les échelles continues.</p>
+      </div>
+      <div class="card">
+        <h3 style="margin-top:0;">Puis QA en continu</h3>
+        <p class="split-note">Une fois l'accord stable : QA humaine en échantillonnage (1 fiche sur N revue intégralement) + double évaluation systématique C9 / C11. Rien n'est publié tant que l'accord agent/humain n'est pas stable.</p>
+      </div>
+    </div>
+    <div class="callout ok">
+      <strong>Critères de succès V0 :</strong> 100 % des artefacts évaluateurs passent la validation sans édition manuelle · accord vs golden sur ≥ 4 critères / 6 par média · Reporterre sort C1 en N/A <code>donnees_insuffisantes</code> (pas 0) et renormalise sur 34 pts · <strong>zéro écriture DB par agent</strong> (par construction).
+    </div>
+  </section>
+
+  <!-- 9 -->
+  <section id="perimetre">
+    <h2><span class="num">9</span> Périmètre V0 &amp; phasage</h2>
+    <div class="grid grid-2">
+      <div class="card">
+        <h3 style="margin-top:0;">Vague 1 : le socle structurel</h3>
+        <p class="split-note">Scorable dès maintenant : C5, C7, C8, C9, C11 (manifeste) + C1 (données tierces). Collecte code + agents sur pages du média et registres ouverts. Homogène sur tous les médias, petits inclus. Budget : ~25-30 appels d'outils web et 5-10 min d'agent par média.</p>
+        <p class="split-note" style="margin-bottom:0;"><strong>Médias pilotes :</strong> CNEWS (audiovisuel, ARCOM applicable) et Reporterre (presse en ligne de niche, teste <code>donnees_insuffisantes</code> + renormalisation avec N/A).</p>
+      </div>
+      <div class="card">
+        <h3 style="margin-top:0;">Vague 2 : les critères article-dépendants</h3>
+        <p class="split-note">C2, C4, C6, C10 + C1 (fallback) + C11 (cadrage). Prérequis : fetch navigateur + stratégie paywall + échantillonneur stratifié. À lancer sur 2-3 médias pilotes avant d'industrialiser.</p>
+        <p class="split-note" style="margin-bottom:0;"><strong>Hors scope V0 :</strong> corpus d'articles (table créée, vide), paywall, procédure contradictoire, UI/API, lien avec <code>sources.reliability_score</code>, scheduling, multi-évaluateurs, SDK Anthropic.</p>
+      </div>
+    </div>
+    <h3>Sept arbitrages par défaut (réversibles, à valider en revue méthodo)</h3>
+    <div class="card" style="padding-top:8px;">
+      <table>
+        <thead><tr><th>Cas limite</th><th>Choix par défaut</th></tr></thead>
+        <tbody>
+          <tr><td>C1 sur médias à faible empreinte</td><td>Fallback (5 articles) = voie par défaut, déclenchée si &lt; 3 débunkages / 2 ans.</td></tr>
+          <tr><td>Biais ARCOM (audiovisuel sur-instruit)</td><td>Absence ARCOM pour la presse en ligne = N/A structurel neutre.</td></tr>
+          <tr><td>« Bloqué » ≠ « absent »</td><td>Statut <code>bloque_acces</code> natif, jamais converti en 0.</td></tr>
+          <tr><td>Médias à fort paywall</td><td>Cascade : compte de test → reproductions tierces → collecte manuelle.</td></tr>
+          <tr><td>NewsGuard / Societe.com faibles</td><td>NewsGuard retiré ; Pappers officialisé (API, gratuit).</td></tr>
+          <tr><td>Auto-déclaratif des petits médias</td><td>Accepté pour la transparence : la présence vérifiable du document vaut preuve.</td></tr>
+          <tr><td>Prérequis technique non négociable</td><td>Fetch navigateur obligatoire (fetch simple aveugle sur ~40 % du panel).</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <footer>
+    <p>Source de vérité : <a class="link" href="README.md">docs/media-eval/README.md</a> · <a class="link" href="architecture-v1.2.md">architecture-v1.2.md</a> · <a class="link" href="rubrics/_common.md">rubrics/_common.md</a> · <code>packages/api/scripts/media_eval/</code></p>
+    <p>Facteur · Méthodologie ouverte v1.2 · Document de synthèse pour toute personne rejoignant le projet.</p>
+  </footer>
+
+</div>
+</body>
+</html>

--- a/docs/media-eval/architecture-v1.2.md
+++ b/docs/media-eval/architecture-v1.2.md
@@ -1,0 +1,313 @@
+# Architecture de collecte & d'évaluation — critères C1 à C11
+
+> **Import** : conversion markdown de
+> `FACTEUR_architecture-collecte-evaluation_C1-C11_2026-07-07.html` (v1.0 du
+> 07/07/2026). Fondé sur : méthodologie ouverte v1.2 (§4 grille, §5 protocole) et
+> batch-test #1 disponibilité des données (27/06/2026). Les choix marqués
+> « arbitrage n° » sont des défauts réversibles, à valider en revue méthodo.
+
+*Rapport d'opérationnalisation · 7 juillet 2026 · Périmètre : la grille de
+notation uniquement (Annexes A/B/C hors scope V1) · Ancré sur la stack Facteur
+(Supabase · scripts · sous-agents Claude)*
+
+**L'essentiel.** L'architecture repose sur deux principes : (1) séparer
+strictement la collecte de l'évaluation — la collecte produit des signaux bruts,
+horodatés et sourcés dans Supabase ; l'évaluation (sous-agents) ne lit que ce
+data store, jamais le web — et (2) router chaque signal vers l'une de trois
+voies : CODE pour tout ce qui est déterministe, AGENT pour tout ce qui demande
+lecture et jugement, HUMAIN pour l'inaccessible (paywall) et le contradictoire
+(double évaluation, calibration). Sur les ~40 signaux de la grille : environ
+40 % sont collectables par code, 45 % par agents, 15 % exigent l'humain.
+
+## 1. Principe fondateur : collecte ≠ évaluation
+
+La méthodo l'exige déjà implicitement (§5.1 : traçabilité, reproductibilité,
+contestabilité). L'architecture le rend physique : deux phases, un data store
+entre les deux.
+
+**La phase de collecte ne note jamais.** Elle produit des signaux : des
+observations factuelles avec source, URL, date, citation et capture (snapshot).
+**La phase d'évaluation ne collecte jamais** : les sous-agents évaluateurs
+reçoivent les signaux d'un média pour un critère, appliquent le barème du §4, et
+rendent un score justifié qui cite les signaux utilisés.
+
+Quatre garanties directement alignées sur la méthodo :
+
+- **Reproductibilité** — on peut re-noter (nouvelle version du barème, nouveau
+  modèle, contre-expertise) sans re-collecter. Indispensable pour le processus
+  contradictoire (§6) : si un média conteste, on rejoue l'évaluation sur les
+  mêmes données.
+- **Traçabilité** — chaque point attribué pointe vers des `signal_id` précis,
+  eux-mêmes liés à des snapshots horodatés. La fiche publiée (§5.5.1) se génère
+  mécaniquement.
+- **Auditabilité du non-collecté** — le data store enregistre aussi ce qui a été
+  cherché sans être trouvé (« absence vérifiée ») et ce qui n'a pas pu être
+  atteint (« bloqué accès »). Deux statuts différents, deux effets différents sur
+  la note.
+- **Coût maîtrisé** — la collecte (chère : fetch, navigation, lecture) tourne une
+  fois ; l'évaluation (bon marché : lecture de JSON) peut tourner N fois.
+
+## 2. Les trois voies de collecte
+
+**Règle de routage** : le code pour le déterministe, l'agent pour le jugement,
+l'humain pour l'inaccessible et le contradictoire. Un signal descend toujours au
+niveau le plus bas (le moins cher) capable de le produire de façon fiable.
+
+### VOIE A — CODE
+
+Scripts + edge functions Supabase, planifiables (cron). Déterministe, répétable,
+quasi gratuit.
+
+- **Crawl structurel** : détection et snapshot des pages types (mentions légales,
+  à propos, chartes, corrections, publicité) via chemins connus + sitemap.
+- **Registres structurés** : API Pappers (propriété, comptes), liste CPPAP,
+  registre JTI, liste des membres et avis CDJM (cdjm.org, scrapable).
+- **Constitution du corpus** : échantillonnage stratifié rubrique × mois sur 90
+  jours (§5.4) via sitemap/RSS — sélection aléatoire scriptée, donc documentée et
+  rejouable.
+- **Pré-métriques d'articles** : bylines, labels (« Tribune », « Sponsorisé »),
+  liens sortants, patterns (« selon… », « Mise à jour »), dates.
+
+### VOIE B — AGENT
+
+Sous-agents Claude spécialisés, avec accès web (dont fetch navigateur). Lecture,
+recherche ouverte, qualification.
+
+- **Recherche ouverte** : débunkages, condamnations judiciaires, départs de
+  journalistes, déclarations de dirigeants, couverture du propriétaire.
+- **Qualification** : pondérer chaque débunkage (émetteur / gravité / suite
+  donnée, §4.1 C1), juger la qualité d'une charte (clauses contraignantes ou
+  déclaratives ?).
+- **Analyse de corpus** : sourçage (C2), info/opinion (C4), diversité des
+  perspectives (C10), cadrage (C11) — article par article, avec grille fermée.
+- **Extraction structurée** : transformer une page « Qui sommes-nous » en données
+  actionnariales normalisées.
+
+### VOIE C — HUMAIN
+
+Rare et ciblé : là où ni le code ni l'agent ne peuvent aller, ou là où la méthodo
+exige un regard second.
+
+- **Corpus paywallé** : copie manuelle d'articles inaccessibles déposée dans le
+  corpus store — une fois déposé, l'analyse redevient voie B.
+- **Double évaluation C9 / C11 (⚑ méthodo)** : second évaluateur humain,
+  divergences documentées.
+- **Validation du fallback C1** : les recoupements de véracité faits par agent
+  sont contresignés avant d'entrer au score.
+- **Golden set de calibration** : notation humaine de référence pour mesurer
+  l'accord agent/humain avant de faire confiance au harness.
+
+**Pourquoi ce routage est robuste** : le batch-test #1 (27/06) a montré que le
+point de rupture n'est pas l'intelligence mais l'accès (blocklist
+lemonde.fr/mediapart.fr, paywalls) et la disponibilité (zéro donnée tierce sur
+les médias de niche). L'architecture traite donc l'accès comme une propriété du
+signal (statut dédié) et non comme un échec de collecte.
+
+## 3. Pipeline global
+
+1. **Référentiel** — fiche média : domaine, volume/jour, type de paywall,
+   audiovisuel ou presse en ligne. Conditionne échantillons (§5.4) et routage.
+2. **Collecte** — 3 voies en parallèle. Sortie unique : des signaux horodatés +
+   snapshots. Zéro notation.
+3. **Data store** — Supabase. Signaux, corpus, débunkages, snapshots. Statuts :
+   présent / absent vérifié / partiel / bloqué accès.
+4. **Évaluation** — 1 sous-agent par critère, sans accès web. Barème §4 + règles
+   codées (corroboration, N/A, fraîcheur).
+5. **Synthèse & QA** — score renormalisé, lettre, niveau de confiance
+   (§5.3-É3). Double éval C9/C11, QA humaine par échantillon.
+6. **Restitution** — fiche détaillée (§5.5.1) générée depuis les signaux cités +
+   carte média. Puis contradictoire (§6).
+
+## 4. Mapping critère par critère (extraits vague 1)
+
+### C1 — Véracité et exactitude (20 pts · continue · Rigueur)
+
+| Signal (méthodo §4.1) | Voie | Brique concrète |
+|---|---|---|
+| Recensement des débunkages (5 fact-checkers IFCN + avis CDJM) | CODE + AGENT | Scripts de recherche ciblée par domaine sur chaque fact-checker + scrape des avis CDJM (indexés par média) → l'agent trie les faux positifs et remplit la table debunkages. |
+| Qualification de chaque débunkage : émetteur / gravité / suite donnée | AGENT | Grille fermée de la méthodo (3 dimensions × modalités) appliquée par l'agent à chaque entrée — le calcul de pondération devient ensuite du code pur. |
+| Condamnations judiciaires (diffamation, fausses nouvelles) | AGENT | Recherche Légifrance + presse juridique ; chaque trouvaille exige la décision source (pas un article seul, règle §5.2). |
+| Décisions ARCOM (médias audiovisuels uniquement) | CODE | Base des décisions ARCOM, filtrable par éditeur. Presse en ligne → signal marqué « N/A structurel », neutre (arbitrage n°2). |
+| Fallback : vérification manuelle de 5 articles factuels si < 3 débunkages / 2 ans | AGENT + HUMAIN | Déclenchement automatique (règle codée sur la table debunkages). L'agent recoupe les affirmations clés auprès de sources primaires ; l'humain contresigne avant entrée au score. |
+
+*Point d'attention batch* : critère radicalement asymétrique. Médias exposés
+(CNEWS, Le Monde) = données tierces abondantes ; médias de niche (Reporterre,
+Next) = zéro. Pour eux, le fallback n'est pas l'exception mais la voie
+principale — à budgéter comme telle.
+
+### C5 — Transparence de la propriété et du financement (10 pts · continue · Transparence)
+
+| Signal | Voie | Brique concrète |
+|---|---|---|
+| Page « Qui sommes-nous » / structure actionnariale affichée | CODE + AGENT | Crawl + snapshot ; l'agent extrait la structure déclarée en données normalisées. |
+| Mentions légales complètes (forme juridique, capital, immatriculation) | CODE | Crawl /mentions-legales + vérification de complétude par champs attendus (checklist codable). |
+| Croisement registres : Pappers (propriété, comptes), CPPAP (reconnaissance presse) | CODE | API Pappers (officialisé, remplace Societe.com — arbitrage n°6) + liste CPPAP publiée. Le croisement déclaré vs registre est documenté hors score. |
+| Sources de financement décrites, rapports financiers, déclaration de conflits d'intérêts | AGENT | Lecture des pages À propos / transparence financière ; recherche du rapport annuel. |
+
+*Verdict batch* : ✅ disponible et homogène sur les 5 médias testés, petits
+inclus. Fondation fiable de la V1 — à scorer en premier.
+
+### C7 — Séparation contenu éditorial / publicité (4 pts · continue · Transparence)
+
+| Signal | Voie | Brique concrète |
+|---|---|---|
+| Mentions « Contenu sponsorisé / partenaire / publi-reportage » sur les contenus payés | CODE | Détection des labels types sur le site et le corpus. |
+| Absence de native advertising non labellisé ; séparation visuelle claire | AGENT | Jugement visuel (captures navigateur) : un contenu payé maquetté comme un article se voit, ne se regexe pas. |
+| Politique publicitaire publiée (page « Publicité » / « Régie ») | CODE + AGENT | Crawl + lecture de substance. |
+
+*Verdict batch* : ✅ quasi homogène (4 ✅, 1 🟡). Scorable en V1 sans friction.
+
+### C8 — Engagement déontologique formel (4 pts · continue · Transparence)
+
+| Signal | Voie | Brique concrète |
+|---|---|---|
+| Charte éditoriale / déontologique publique | CODE + AGENT | Crawl + snapshot ; l'agent vérifie la substance (engagements réels vs page marketing). |
+| Adhésion CDJM | CODE | Liste des membres sur cdjm.org — lookup direct. |
+| Certification JTI en cours de validité | CODE | Registre JTI. Règle codable en dur : JTI valide = score plein C8, sans examen complémentaire (§4.2) — le seul critère de la grille avec un raccourci automatique. |
+| Médiateur, comité d'éthique, processus de réclamation | AGENT | Recherche sur site + ours. |
+
+*Verdict batch* : solide. Beaucoup d'auto-déclaratif chez les petits médias :
+assumé en V1 — la présence vérifiable du document vaut preuve (arbitrage n°7).
+
+### C9 — Indépendance éditoriale (10 pts · 3 niveaux 0/5/10 · Indépendance · ⚑ double évaluation)
+
+| Signal | Voie | Brique concrète |
+|---|---|---|
+| Charte d'indépendance, société de journalistes, gouvernance rédactionnelle | AGENT | Lecture qualifiante : la différence entre « partiel » (charte déclarative) et « complet » (droit de veto, droit d'agrément) est une question de clauses, pas de présence — cœur du prompt évaluateur. |
+| Couverture observable de sujets touchant le propriétaire ⚑ | AGENT | Recherche site-spécifique après résolution de la propriété via C5/Pappers. Non abouti au batch #1 — à instruire en priorité au batch #2. |
+| Signaux négatifs : avis CDJM d'ingérence, départs documentés de journalistes | AGENT | Corpus CDJM (déjà collecté pour C1) + recherche presse professionnelle (avec corroboration §5.2). |
+| Double évaluation (fortement recommandée) | HUMAIN | Second évaluateur humain sur les mêmes signaux ; divergences documentées dans la fiche. |
+
+*Verdict batch* : ✅ 4/5 médias documentés. L'échelle à 3 niveaux réduit la
+surface de subjectivité : l'agent propose un niveau + justification, l'humain
+tranche en cas de doute.
+
+### C11 — Transparence du positionnement éditorial (6 pts · 3 niveaux 0/3/6 · Transparence · ⚑ double évaluation recommandée)
+
+| Signal | Voie | Brique concrète |
+|---|---|---|
+| Ligne éditoriale / manifeste explicite sur le site | CODE + AGENT | Crawl (pages « Manifeste », « Notre projet »…) ; l'agent juge la lisibilité pour un lecteur lambda — c'est le barème (opaque / partiel / transparent), pas le contenu politique (qui relève de l'Annexe B, hors V1). |
+| Déclarations publiques des dirigeants éditoriaux | AGENT | Recherche interviews / tribunes des dirigeants. |
+| Cohérence : analyse de cadrage sur 5 articles du corpus C10 | AGENT | Le cadrage observé correspond-il au positionnement affiché ? Vague 2. |
+| Double évaluation recommandée | HUMAIN | Même mécanisme que C9. |
+
+*Verdict batch* : ✅ bien documenté. La partie structurelle (manifeste) est
+scorable en vague 1 ; la partie cohérence (cadrage) suit le corpus C10 en
+vague 2.
+
+*(C2, C3, C4, C6, C10 : article-dépendants, vague 2 — cf. document source pour
+le mapping complet.)*
+
+## 5. Modèle de données (Supabase)
+
+Sept tables (`media_eval_*`). Le principe : tout ce que la fiche d'évaluation
+(§5.5.1) doit publier — source, URL, date, citation — est un champ obligatoire
+dès la collecte, pas une reconstruction a posteriori.
+
+- **medias** — id, nom, domaine ; type presse en ligne / audiovisuel (conditionne
+  la neutralité ARCOM) ; volume_articles_jour (tailles d'échantillon §5.4) ;
+  paywall (routage voie C) ; rubriques_opinion (où vivent les tribunes, pour C4).
+- **snapshots** — media_id, url, type_page (mentions_legales / charte /
+  corrections / publicite / a_propos…) ; contenu, hash, capture_at (preuve
+  horodatée — gère aussi les incohérences internes, arbitrage n°7) ; mode_acces.
+- **corpus_articles** — media_id, url, titre, date_pub, rubrique, strate_mois
+  (stratification §5.4 documentée) ; texte ; mode_acquisition ; pre_metriques
+  jsonb (voie A).
+- **signaux** (la table pivot) — media_id, critere, type_signal ; statut
+  present / absent_verifie / partiel / bloque_acces (la distinction clé,
+  arbitrage n°3) ; valeur jsonb (observation factuelle + citation) ; voie,
+  collecteur ; source_urls[], snapshot_id, collecte_at ; sources_consultees[]
+  (si rien trouvé : la preuve qu'on a cherché, §5.3-É1).
+- **debunkages** — media_id, url, date, resume ; emetteur, poids_emetteur
+  (CDJM / IFCN tiers = plein ; concurrent direct = réduit) ; gravite
+  (matérielle / trompeuse / fabrication) ; suite_donnee (corrigé / sans
+  réaction / refus documenté).
+- **evaluations** — media_id, critere, score, niveau ; justification,
+  signal_ids[] (chaque point cite ses signaux — traçabilité §5.1) ; evaluateur
+  (agent:<version> / humain:<nom> — permet la double éval C9/C11) ;
+  version_methodo, version_prompt, evalue_at (re-notation comparable dans le
+  temps).
+- **fiches** — media_id, score_brut, score_renormalise, lettre ; criteres_na[],
+  confiance HAUTE / MOYENNE / BASSE (règle §5.3-É3 — BASSE = non publiable) ;
+  statut brouillon / contradictoire (§6) / publiée.
+
+## 6. Le harness d'évaluation par sous-agents
+
+Un sous-agent par critère, avec un contrat d'entrée/sortie strict. Les agents
+collecteurs (voie B) et les agents évaluateurs sont des rôles distincts — jamais
+le même agent qui cherche et qui note.
+
+**Le contrat évaluateur**
+
+- **Entrée** : les signaux du data store pour (média, critère) + le barème §4 du
+  critère + les pré-métriques du corpus. Aucun accès web. Si un signal manque,
+  l'agent le dit — il ne va pas le chercher.
+- **Sortie** : JSON structuré `{ critere, score, niveau, justification,
+  signal_ids_cites[], flags[] }`. Un score sans signal_ids est rejeté par
+  validation.
+- **Flags** : `donnees_insuffisantes` (→ N/A), `signaux_contradictoires`
+  (→ score partiel + justification), `bloque_acces` (→ « non évaluable pour
+  cause d'accès », jamais converti en 0), `revue_humaine_requise`.
+
+**Les garde-fous de la méthodo, codés en dur (pas confiés au LLM)**
+
+Tout ce qui est une règle mécanique du §5.3 sort du prompt et devient une
+validation programmatique :
+
+- **Corroboration (§5.2)** : ≥ 2 sources indépendantes pour un score plein ;
+  aucun critère fondé sur une seule source externe → check sur les source_urls
+  des signaux cités.
+- **Fraîcheur** : données > 2 ans → N/A automatique.
+- **Déclencheur fallback C1** : < 3 débunkages sur 2 ans dans debunkages → tâche
+  de vérification manuelle créée automatiquement.
+- **Raccourci JTI** : certification valide → C8 plein, sans passage par l'agent.
+- **Synthèse** : renormalisation sur 100 (règle de trois sur les critères
+  évaluables), lettre A–E, niveau de confiance HAUTE / MOYENNE / BASSE — pur
+  calcul.
+- **Neutralité ARCOM** : média de presse en ligne → les signaux ARCOM sont
+  exclus du comparatif inter-médias (N/A structurel).
+
+**Calibration avant confiance**
+
+Avant d'évaluer en série : constituer un golden set noté à la main critère par
+critère. Chaque version du harness (prompt ou modèle) est mesurée contre ce
+set : accord exact sur les critères à 3 niveaux (C9, C10, C11), écart toléré sur
+les échelles continues. On ne publie rien tant que l'accord agent/humain n'est
+pas stable. Ensuite, la QA humaine passe en échantillonnage (1 fiche sur N revue
+intégralement) + double évaluation systématique C9/C11.
+
+## 7. Cas limites & arbitrages par défaut
+
+| # | Arbitrage | Choix par défaut intégré |
+|---|---|---|
+| 1 | C1 sur les médias à faible empreinte | Fallback (5 articles) = voie par défaut, déclenchée automatiquement si < 3 débunkages / 2 ans. Pondération émetteur/gravité/suite portée par la table debunkages. |
+| 2 | Biais ARCOM (audiovisuel sur-instruit) | Absence de données ARCOM pour la presse en ligne = N/A structurel, neutre. Codé dans le référentiel média (type). |
+| 3 | « Bloqué » ≠ « absent » | Statut `bloque_acces` natif dans la table signaux. Jamais converti en score 0 ; affiché « non évaluable pour cause d'accès » dans la fiche. |
+| 4 | Médias à fort paywall | Cascade : ① compte abonné de test → ② reproductions tierces (avis CDJM, décisions de justice) en proxy → ③ collecte manuelle humaine en dernier recours. Le mode_acquisition reste tracé. |
+| 5 | Barème C3 (politique vs pratiques) | Les deux familles de signaux sont collectées et valorisées. Le délai ≤ 48 h devient optionnel, jamais bloquant. |
+| 6 | NewsGuard / Societe.com faibles en pratique | NewsGuard retiré du protocole opérationnel. Pappers officialisé comme registre propriété/comptes (API, gratuit). |
+| 7 | Auto-déclaratif des petits médias | Accepté pour la transparence (C8, C11) : la présence vérifiable du document vaut preuve. Incohérences internes gérées par snapshots horodatés + hash. |
+
+**Prérequis technique non négociable** : le fetch simple est aveugle sur
+lemonde.fr et mediapart.fr (blocklist) et sur les sites à rendu JavaScript. Les
+agents collecteurs doivent disposer d'un fetch navigateur, sinon ~40 % du panel
+reste invisible sur les critères article-dépendants.
+
+## 8. Phasage & budget
+
+**Vague 1 — scorable dès maintenant (le socle structurel)** : C5 · C7 · C8 · C9
+· C11 (partie manifeste) + C1 (volet données tierces). Collecte code + agents
+sur pages du média et registres ouverts. Homogène sur tous les médias, petits
+inclus (validé au batch #1). Budget observé : ~25–30 appels d'outils web et
+5–10 min d'agent par média.
+
+**Vague 2 — dépend du corpus (les critères article-dépendants)** : C2 · C4 · C6
+· C10 + C1 (fallback) + C11 (volet cadrage). Prérequis : fetch navigateur +
+stratégie paywall + échantillonneur §5.4. À lancer sur 2–3 médias pilotes avant
+d'industrialiser.
+
+**Ordre de mise en route** : ① 7 tables Supabase + référentiel médias ; ②
+scripts voie A du socle (crawl structurel, Pappers, CPPAP, CDJM, JTI) ; ③ agents
+collecteurs voie B du socle ; ④ golden set (notation humaine vague 1) ; ⑤
+sous-agents évaluateurs vague 1 + garde-fous codés → mesure d'accord contre le
+golden set ; ⑥ échantillonneur §5.4 + stratégie paywall → vague 2.

--- a/docs/media-eval/methodologie-v1.1.1.md
+++ b/docs/media-eval/methodologie-v1.1.1.md
@@ -1,0 +1,426 @@
+# Méthodologie d'évaluation de la fiabilité des médias d'information francophones
+
+> **Import** : conversion markdown du PDF `methodologie_evaluation_medias_v1.1.1.pdf`
+> (2 avril 2026). Le texte des sections normatives (§4 grille, §5 protocole) est
+> repris **verbatim** — c'est la référence des rubriques `rubrics/`. Les
+> amendements v1.2 actés sont dans `methodologie-v1.2-amendements.md`.
+
+**Version** : 1.1.1 · **Date** : 2 avril 2026 · **Statut** : Document de référence — soumis à revues externes
+**Licence** : libre accès (licence libre), réutilisable, modifiable et adaptable sans restriction.
+
+## 1. Introduction et objectifs
+
+Cette méthodologie propose un cadre reproductible et transparent pour évaluer la
+fiabilité des médias d'information francophones. Elle repose sur la synthèse de
+référentiels déontologiques internationalement reconnus et vise à documenter, de
+manière factuelle et structurée, le respect par un média de normes
+professionnelles établies.
+
+L'évaluation porte spécifiquement sur les pratiques éditoriales et
+informationnelles observables : vérification des faits, sourçage, transparence de
+la propriété, distinction information/opinion, correction des erreurs, et
+indépendance rédactionnelle. Elle ne juge ni la ligne éditoriale, ni les choix de
+sujets traités, ni les opinions exprimées.
+
+La méthodologie poursuit trois objectifs :
+
+- **Documenter** — fournir aux lecteurs, chercheurs et institutions des données
+  structurées et justifiées sur les pratiques déontologiques des sources
+  d'information francophones.
+- **Responsabiliser** — inciter les médias à respecter les standards
+  déontologiques reconnus par la profession, en rendant visibles les pratiques
+  observées.
+- **Servir de référence ouverte** — proposer un protocole applicable par des
+  chercheurs en sciences de l'information, des organismes de déontologie, des
+  organisations de fact-checking, ou tout évaluateur indépendant.
+
+Le protocole est conçu pour être applicable aussi bien par un évaluateur humain
+que par un outil d'aide à l'évaluation.
+
+## 2. Périmètre et limites de l'évaluation
+
+### 2.1. Ce que cette méthodologie couvre
+
+La méthodologie évalue le degré de conformité d'un média d'information (à date,
+principalement francophone) à un ensemble de bonnes pratiques journalistiques
+reconnues, réparties en trois dimensions :
+
+- **La rigueur informationnelle** : respect des faits, qualité du sourçage,
+  correction des erreurs, distinction entre information et opinion.
+- **La transparence** : clarté sur la propriété, le financement, l'identité des
+  auteurs, la séparation contenu éditorial/publicitaire, et les engagements
+  déontologiques formels.
+- **L'indépendance éditoriale et le pluralisme** : protection de la rédaction
+  contre les pressions extérieures et représentation équilibrée des perspectives
+  sur les sujets controversés.
+
+### 2.2. Non-couvert par cette méthodologie
+
+La qualité littéraire, la pertinence des choix éditoriaux, l'orientation
+politique ou idéologique, la recherche de « vérité » sur un plan philosophique,
+ou l'exhaustivité des couvertures thématiques.
+
+Cette méthodologie ne prétend en aucun cas correspondre à un label de vérité
+absolue (un score élevé indique de bonnes pratiques, pas l'absence d'erreur), ni
+un classement de la « meilleure » information. Elle n'a également aucune vocation
+à s'associer à tout outil de censure ou de labellisation politique, ni à des
+évaluations en temps réel.
+
+### 2.3. Choix normatifs et limites épistémologiques
+
+**Ce que cette méthodologie valorise** : la transparence du positionnement
+éditorial (car elle permet au lecteur d'interpréter l'information de façon
+éclairée), le pluralisme des perspectives (car il limite le risque de
+désinformation systématique), et la traçabilité des sources (car elle conditionne
+la vérifiabilité). Ces choix sont conformes aux chartes de Munich et FIJ, mais il
+s'agit bien de choix subjectifs et spécifiques à notre cadre de travail, pas de
+faits neutres.
+
+**Limites structurelles** : mesure de l'impact réel de l'information sur les
+croyances des lecteurs ; la sélection de sujets opérée par le média — les
+critères C10 et C11 mesurent la pluralité et la transparence sur les sujets
+couverts, pas le choix de ne pas couvrir certains sujets. Elle ne différencie pas
+non plus correction visible (fact-checking « ex post ») et vérification avant
+publication (fact-checking « ex ante »).
+
+**Absence de neutralité substantive** : la méthodologie aspire à une application
+identique quel que soit le média évalué (objectivité procédurale). Elle ne
+prétend pas être neutre dans ses priorités (transparence, pluralisme, sourçage)
+ni dans ses hypothèses normatives.
+
+## 3. Référentiels fondateurs
+
+Chaque critère s'appuie sur au moins deux référentiels indépendants.
+
+### 3.1. Chartes déontologiques professionnelles
+
+| Référentiel | Portée | Année | Source |
+|---|---|---|---|
+| Déclaration des devoirs et droits des journalistes (Charte de Munich) | Européenne | 1971 | cfdt-journalistes.fr |
+| Charte d'éthique mondiale des journalistes (FIJ) | Internationale (187 syndicats, 146 pays) | 2019 | ifj.org |
+| Charte d'éthique professionnelle des journalistes (SNJ) | France | 1918/2011 | Référencée par le CDJM |
+
+### 3.2. Organismes d'évaluation et de certification
+
+| Organisme | Approche | Périmètre |
+|---|---|---|
+| CDJM (France) | Traitement de saisines selon les trois chartes ci-dessus ; structure tripartite (journalistes, éditeurs, public) | Cas individuels |
+| JTI / RSF | Certification sur 130+ critères de processus organisationnels (norme ISO) ; 2 400+ médias, 127 pays | Transparence organisationnelle |
+| NewsGuard | 9 critères pondérés, score 0-100 ; 35 000+ sites évalués par des analystes | Fiabilité du contenu et transparence |
+| Ad Fontes Media | Double axe fiabilité × biais politique ; panel d'analystes de sensibilités diverses | Articles individuels (principalement US) |
+| MBFC | 4 catégories pondérées ; forte corrélation avec NewsGuard (r = 0,81) | Fiabilité et biais (large couverture) |
+
+### 3.3. Sources exclues et justification
+
+| Source | Raison de l'exclusion |
+|---|---|
+| Décodex (Le Monde) | Critères non publiés ; absence de méthodologie reproductible ; auto-évaluation partielle |
+| Classement RSF de la liberté de la presse | Évalue des cadres nationaux, non des médias individuels |
+| Acrimed | Critique médiatique documentée, mais positionnement militant revendiqué, incompatible avec l'exigence de neutralité méthodologique |
+
+## 4. Grille de critères
+
+La grille comporte onze critères répartis en trois axes, pour un total de
+**100 points** : rigueur informationnelle (50 pts), transparence (30 pts),
+indépendance et pluralisme (20 pts). Cette répartition est un paramètre
+configurable (documenter et justifier toute modification).
+
+### Tableau récapitulatif
+
+**Axe 1 — Rigueur informationnelle (50 pts)**
+
+| # | Critère | Pts | Échelle | Échantillon requis |
+|---|---|---|---|---|
+| C1 | Véracité et exactitude | 20 | Continue | Fact-checkers + 5 articles si données insuffisantes |
+| C2 | Sourçage et vérification | 15 | Continue | 20–40 articles informatifs (selon volume) |
+| C3 | Correction des erreurs | 10 | Continue | Site du média (pages corrections, errata) |
+| C4 | Distinction information / opinion d'auteur | 5 | Continue | 15–25 articles mixtes (info + opinion) |
+
+**Axe 2 — Transparence (30 pts)**
+
+| # | Critère | Pts | Échelle | Échantillon requis |
+|---|---|---|---|---|
+| C5 | Transparence propriété et financement | 10 | Continue | Site du média + registres (Societe.com, CPPAP) |
+| C6 | Identification des auteurs | 6 | Continue | Même échantillon que C2 |
+| C7 | Séparation contenu / publicité | 4 | Continue | Site du média (navigation générale) |
+| C8 | Engagement déontologique formel | 4 | Continue | Site du média + CDJM, JTI |
+| C11 | Transparence du positionnement éditorial | 6 | 3 niveaux | Analyse de cadrage sur 5 articles de C10 |
+
+**Axe 3 — Indépendance et pluralisme (20 pts)**
+
+| # | Critère | Pts | Échelle | Échantillon requis |
+|---|---|---|---|---|
+| C9 | Indépendance éditoriale | 10 | 3 niveaux | Chartes, registres, couverture propriétaire |
+| C10 | Diversité des perspectives | 10 | 3 niveaux | 10–20 articles controversés (≥ 3 thématiques) |
+
+**Total : 100 points**
+
+### 4.1. Axe 1 : Rigueur informationnelle (50 points)
+
+**C1. Véracité et exactitude (20 points)**
+*Définition* : Le média ne publie pas de manière répétée des informations fausses
+ou significativement trompeuses.
+
+*Signaux observables* :
+- Nombre de vérifications négatives (débunkages) publiées par des fact-checkers accrédités IFCN
+- Décisions, mises en demeure ou sanctions de l'ARCOM
+- Ratio entre les corrections publiées et les erreurs identifiées par des tiers
+- Condamnations judiciaires pour diffamation ou publication de fausses nouvelles
+- Refus documenté de corriger une erreur signalée par un fact-checker ou un tiers
+
+**C2. Sourçage et vérification (15 points)**
+*Définition* : Le média cite ses sources de manière régulière, les croise lorsque
+nécessaire, et distingue les faits établis des allégations ou hypothèses.
+
+*Signaux observables* :
+- Présence de sources nommées dans les articles informatifs
+- Usage du conditionnel ou de formulations prudentes pour les informations non confirmées
+- Nombre moyen de sources indépendantes par article factuel (objectif : ≥ 2)
+- Attribution claire des citations directes
+
+**C3. Correction des erreurs (10 points)**
+*Définition* : Le média dispose d'un processus identifiable pour corriger ses
+erreurs de manière visible et dans un délai raisonnable.
+
+*Signaux observables* :
+- Existence et accessibilité d'une page dédiée aux corrections ou errata
+- Mentions explicites « Correction », « Mise à jour », « Erratum » dans les articles modifiés
+- Existence d'un formulaire ou d'un canal de signalement d'erreur accessible au public
+- Délai observable entre signalement et correction (indicatif : ≤ 48 h)
+
+**C4. Distinction information / opinion (5 points)**
+*Définition* : Le média distingue clairement le contenu factuel du contenu
+d'opinion d'auteur (tribunes, éditoriaux, chroniques signées).
+
+*Signaux observables* :
+- Labellisation explicite des contenus d'opinion d'auteur
+- Absence de termes de jugement non attribués dans les articles informatifs
+- Distinction graphique ou visuelle entre contenu informatif et contenu d'opinion
+
+### 4.2. Axe 2 : Transparence (30 points)
+
+**C5. Transparence de la propriété et du financement (10 points)**
+*Définition* : Le média indique clairement qui le possède, le finance, quels sont
+les éventuels conflits d'intérêts, et comment il génère ses revenus.
+
+*Signaux observables* :
+- Page « Qui sommes-nous » indiquant la structure actionnariale
+- Mentions légales complètes
+- Description des sources de financement
+- Publication de rapports financiers ou résumé annuel
+- Déclaration relative aux conflits d'intérêts
+- Appartenance à un groupe média identifiable
+
+**C6. Identification des auteurs (6 points)**
+*Définition* : Les articles publiés sont signés par un auteur identifiable,
+disposant d'une biographie ou d'un profil accessible.
+
+*Signaux observables* :
+- Articles informatifs systématiquement signés
+- Présence de pages biographiques ou de profils pour les journalistes réguliers
+- Indication du statut de l'auteur
+
+**C7. Séparation contenu éditorial / publicité (4 points)**
+*Définition* : Le contenu commandité, sponsorisé ou publicitaire est clairement
+identifié et séparé du contenu éditorial.
+
+*Signaux observables* :
+- Mention explicite « Contenu sponsorisé », « Publi-reportage », « Contenu partenaire »
+- Absence de native advertising non labellisé
+- Séparation visuelle claire
+- Politique publicitaire publiée
+
+**C8. Engagement déontologique formel (4 points)**
+*Définition* : Le média adhère à des instances de régulation professionnelle ou
+dispose d'une charte éditoriale publique documentant ses engagements.
+
+*Signaux observables* :
+- Publication d'une charte éditoriale ou déontologique accessible au public
+- Adhésion au CDJM, certification JTI
+- Présence d'un médiateur, d'un comité d'éthique ou d'un processus de réclamation
+- Règlement intérieur ou charte d'auto-régulation
+
+**C11. Transparence et cohérence du positionnement éditorial (6 points)**
+*Définition* : Le média rend explicite sa grille de lecture et son positionnement
+éditorial, permettant au lecteur de situer l'information dans son contexte de
+production.
+
+*Niveaux d'évaluation* :
+
+| Niveau | Score | Signaux requis |
+|---|---|---|
+| Opaque | 0 | Aucune indication du positionnement éditorial |
+| Partiel | 3 | Positionnement implicitement identifiable mais non formalisé |
+| Transparent | 6 | Positionnement explicité ; cohérence observable |
+
+### 4.3. Axe 3 : Indépendance éditoriale et pluralisme (20 points)
+
+**C9. Indépendance éditoriale (10 points)**
+*Définition* : La rédaction dispose de garanties formelles et vérifiables
+d'indépendance vis-à-vis du propriétaire, des annonceurs ou de tout intérêt
+extérieur.
+
+*Niveaux d'évaluation* :
+
+| Niveau | Score | Signaux requis |
+|---|---|---|
+| Absent | 0 | Aucune garantie documentée d'indépendance |
+| Partiel | 5 | Charte d'indépendance existante mais sans mécanismes contraignants |
+| Complet | 10 | Charte d'indépendance formelle ; société de journalistes ; gouvernance |
+
+**C10. Diversité des perspectives (10 points)**
+*Définition* : Sur les sujets de controverse ou d'importance publique, le média
+présente plusieurs points de vue significatifs et les traite avec équité.
+
+*Niveaux d'évaluation* :
+
+| Niveau | Score | Signaux requis |
+|---|---|---|
+| Absent | 0 | Absence systématique de contradicteurs |
+| Partiel | 5 | Présence occasionnelle de contradicteurs ; traitement inégal |
+| Complet | 10 | Contradicteurs systématiquement sollicités ; espace équitable |
+
+## 5. Protocole d'évaluation
+
+### 5.1. Principes directeurs
+
+L'évaluation repose sur l'observation de signaux factuels, non sur le jugement
+personnel de l'évaluateur.
+
+- **Traçabilité** : chaque point attribué ou retiré est justifié par un signal
+  observable cité (source, date, lien).
+- **Neutralité** : tous les médias sont traités selon le même protocole, quelle
+  que soit leur ligne éditoriale.
+- **Transparence** : la fiche d'évaluation complète est publiée, permettant à
+  tout tiers de reproduire et contester la notation.
+
+**Règles absolues** : Jamais de notation « au sentiment ». Si les données sont
+insuffisantes, le critère est marqué **N/A** (ni présomption positive, ni
+négative).
+
+### 5.2. Sources autorisées
+
+**Sources directes** : pages « À propos », « Qui sommes-nous », « Mentions
+légales » ; charte éditoriale, déontologique, d'indépendance ; page de
+corrections ou d'errata ; page « Publicité » ou « Régie ».
+
+**Registres institutionnels** : CDJM (cdjm.org), ARCOM (arcom.fr), JTI
+(journalismtrustinitiative.org), Registre du Commerce / Societe.com / Pappers,
+CPPAP.
+
+**Organismes de fact-checking** : AFP Factuel, Les Décodeurs (Le Monde),
+CheckNews (Libération), Factuel (France Info), 20 Minutes Fake Off.
+
+**Sources exclues** : rumeurs, blogs non vérifiés ; évaluations par des
+concurrents non documentées ; connaissances personnelles ou opinion publique ;
+MBFC et Ground.News (transparence insuffisante).
+
+### 5.3. Étapes de l'évaluation
+
+**Étape 1 — Collecte.** Pour chaque critère : identifier les signaux à observer ;
+consulter les sources autorisées ; enregistrer chaque signal avec : source, URL
+exacte, date, citation factuelle.
+
+**Étape 2 — Notation.**
+- Signaux positifs majoritaires (≥ 2 sources indépendantes) → score plein
+- Signaux mixtes → score partiel (50 % du maximum)
+- Signaux négatifs → score 0
+- Données insuffisantes → N/A (exclu du calcul total)
+
+**Étape 3 — Synthèse.** Calculer le score total ; déterminer le niveau de
+confiance global (HAUTE / MOYENNE / BASSE) ; identifier les axes de force et de
+faiblesse.
+
+**Étape 4 — Processus contradictoire.** Avant publication, le média évalué est
+contacté (voir section 6).
+
+### 5.4. Protocole d'échantillonnage
+
+**Période de référence** : 90 jours glissants à compter de la date de début de
+l'évaluation.
+
+| Volume du média | Taille de l'échantillon |
+|---|---|
+| < 10 articles/jour | 5 articles factuels |
+| 10–50 articles/jour | 5-10 articles |
+| > 50 articles/jour | 15-20 articles |
+
+**Stratification** : répartition proportionnelle entre les principales rubriques
+du média et sur les 3 mois de la fenêtre. **Mode de sélection** : sélection
+aléatoire au sein de chaque strate (rubrique × mois).
+
+## 6. Processus contradictoire et droit de réponse
+
+Toute évaluation est communiquée au média concerné avant publication.
+Modalités : notification écrite de la fiche complète ; délai de réponse de 21
+jours calendaires ; réponses recevables (correction de données factuelles,
+documents complémentaires, clarifications, contestation méthodologique
+argumentée) ; intégration des données nouvelles vérifiables ; publication avec
+mention du processus contradictoire. Procédure d'appel : réexamen par un
+évaluateur différent ; note de désaccord du média annexable.
+
+## 7. Limites connues et perspectives d'amélioration
+
+**Limites v1.1.1** : biais de disponibilité (médias mieux dotés mécaniquement
+mieux documentés) ; pas de vérification exhaustive ; dépendance aux
+fact-checkers (aucun organisme → C1 = N/A) ; subjectivité résiduelle (C9, C10) ;
+absence de pondération temporelle ; couverture géographique inégale.
+
+**Améliorations envisagées** : pondération temporelle, augmentation de
+l'échantillon, évaluation longitudinale, évaluation par rubrique,
+inter-évaluation, extension géographique.
+
+## 8. Gouvernance et processus de révision
+
+Révisions mineures : équipe d'évaluation (changelog). Révisions substantielles :
+avis consultatif du comité externe (2-3 chercheurs SIC, 1-2 représentants
+fact-checking IFCN, 1 représentant CDJM ou équivalent, 1 représentant syndical de
+journalistes ; réunion annuelle ; non constitué à la date de publication).
+Contributions ouvertes à toute personne ou organisation.
+
+## 9. Glossaire
+
+- **Biais** — Inclinaison systématique, consciente ou non, vers une perspective
+  donnée. La méthodologie n'évalue pas le biais idéologique, mais les mécanismes
+  de protection mis en place pour en limiter les effets.
+- **Débunkage** — Constat publié par un organisme de fact-checking accrédité,
+  indiquant qu'une affirmation diffusée par le média est fausse, trompeuse ou
+  hors contexte.
+- **Analyse de cadrage** — Examen structuré de la manière dont un article traite
+  un sujet : experts cités, termes employés, perspectives représentées ou
+  absentes, ton appliqué.
+- **Fact-checking** — Processus de vérification d'informations auprès de sources
+  primaires, conduit avant ou après publication.
+- **Fiabilité** — Propriété d'une source qui respecte régulièrement les bonnes
+  pratiques journalistiques. Ne signifie pas absence totale d'erreur.
+- **Indépendance éditoriale** — Situation où les décisions de la rédaction ne
+  sont pas subordonnées aux intérêts financiers, politiques ou commerciaux du
+  propriétaire.
+- **Native advertising** — Contenu publicitaire conçu pour imiter la forme du
+  contenu éditorial, créant risque de confusion.
+- **Positionnement éditorial** — Ensemble des choix reflétant la grille de
+  lecture d'un média. La méthodologie évalue sa transparence, pas sa nature.
+- **Pluralisme** — Représentation de plusieurs points de vue significatifs dans
+  le média.
+- **Processus contradictoire** — Procédure par laquelle une entité évaluée est
+  informée des conclusions avant publication et dispose d'un droit de réponse.
+- **Sourçage** — Pratique d'identifier, vérifier et citer les origines des
+  informations, permettant au lecteur d'évaluer la crédibilité.
+- **Reproductibilité** — Capacité d'un second évaluateur, avec les mêmes sources,
+  à obtenir un score comparable (± 10 %).
+- **Signal observable** — Élément factuel, documenté et vérifiable, indicateur
+  pour l'évaluation d'un critère.
+
+## 10. Historique des versions
+
+| Version | Date | Changements principaux |
+|---|---|---|
+| 1.0 | 1er avril 2026 | Conception initiale : 10 critères, 3 axes, protocole d'évaluation |
+| 1.1 | 2 avril 2026 | Refonte structurelle : gouvernance, glossaire, C11 ajouté |
+| 1.1.1 | 2 avril 2026 | Suite aux revues externes : C1/C4/C9/C11 renforcés, protocole d'échantillonnage amélioré |
+
+## 11. À propos
+
+Méthodologie conçue dans le cadre du projet Facteur (Slow Medias), rédigée par
+Laurin Boujon, mise à disposition sous licence libre. Contact :
+boujon.laurin@gmail.com.

--- a/docs/media-eval/methodologie-v1.2-amendements.md
+++ b/docs/media-eval/methodologie-v1.2-amendements.md
@@ -1,0 +1,100 @@
+# Méthodologie v1.2 — Amendements actés (extraits opérationnels)
+
+> **Import** : extraits de `FACTEUR_methodo-v1.2_reponses-commentaires_2026-07-02.md`
+> (revue des 48 commentaires ouverts sur la v1.1.1). Seuls les amendements
+> **nécessaires à la pipeline V0** sont repris ici, verbatim. Le document complet
+> reste la référence pour la publication de la v1.2 finale.
+> `version_methodo` des évaluations V0 = **`v1.2`** (grille §4 inchangée pour les
+> critères vague 1, amendements ci-dessous inclus).
+
+## 1. Certification JTI = score plein direct (C8)
+
+> À l'inverse, une **certification JTI obtenue et en cours de validité** (audit
+> tiers sur 130+ critères de processus) vaut à elle seule score plein sur C8,
+> sans examen complémentaire : elle constitue le signal formel le plus exigeant
+> actuellement disponible.
+
+→ Codé en dur dans `build_eval_input.py` (raccourci `code:jti_shortcut`, pas
+d'agent évaluateur pour C8 dans ce cas).
+
+## 2. Pondération des vérifications négatives (C1)
+
+> **Pondération des vérifications négatives.** Toutes les vérifications
+> négatives n'ont pas le même poids. Chaque débunkage recensé est qualifié selon
+> trois dimensions, documentées dans la fiche :
+>
+> | Dimension | Modalités | Effet sur l'évaluation |
+> | --- | --- | --- |
+> | **Émetteur** | Avis CDJM ou fact-checker IFCN tiers (poids plein) / rubrique de fact-checking d'un média concurrent direct (poids réduit, conflit d'intérêts potentiel documenté) | Pondération du signal |
+> | **Gravité** | Erreur matérielle corrigeable (date, chiffre) / information substantiellement trompeuse / fabrication ou désinformation caractérisée | Gradation croissante |
+> | **Suite donnée** | Correction publiée par le média (atténuant) / absence de réaction / refus documenté de corriger (aggravant, cf. signal existant) | Modulation |
+>
+> Une accumulation de débunkages de faible gravité corrigés rapidement ne peut à
+> elle seule justifier un score nul ; à l'inverse, un unique cas de fabrication
+> non corrigée le peut.
+
+→ Portée par la table `media_eval_debunkages` (`poids_emetteur` **dérivé par
+code**, `gravite`, `suite_donnee`) et par la grille de `determinations` de la
+rubrique C1.
+
+## 3. Confiance par critère
+
+> Attribuer à chaque critère un **indice de confiance** (Haute / Moyenne /
+> Basse) selon la densité des signaux : Haute = ≥ 2 sources indépendantes
+> convergentes ; Moyenne = signaux corroborés mais peu nombreux, ou partiellement
+> datés ; Basse = signal unique corroboré a minima, ou signaux mixtes. Cet indice
+> figure dans la fiche et ne modifie pas le score : il qualifie sa robustesse.
+
+## 4. Corroboration — cas limite
+
+> **Cas limite.** Lorsqu'un signal pertinent n'est corroborable par aucune
+> seconde source (paywall, archives inaccessibles, média peu documenté), il n'est
+> pas utilisé pour la notation : le critère est évalué sur les seuls signaux
+> corroborés ou, à défaut, marqué N/A. L'impossibilité de corroboration est
+> consignée dans la fiche (sources consultées et réserves).
+
+→ Garde-fou aval `ingest_evaluations.py` : score plein avec < 2 sources
+indépendantes → plafonné au palier inférieur + flag `corroboration_insuffisante`.
+
+## 5. Bornes temporelles des signaux hors-échantillon
+
+> - **Signaux structurels positifs** (charte publiée, société de journalistes,
+>   page corrections) : constatés à la date de l'évaluation, sans limite
+>   d'ancienneté — c'est leur existence actuelle qui compte.
+> - **Signaux événementiels** (débunkage, avis CDJM, correction, départ de
+>   journalistes) : pris en compte sur une fenêtre maximale avant la date de
+>   début de l'évaluation. Au-delà, ils sont mentionnés à titre descriptif dans
+>   la fiche mais ne fondent aucune notation.
+
+⚠️ **Divergence V0 assumée** : les amendements v1.2 proposent une fenêtre
+événementielle de **36 mois** ; la décision PO du 07/07/2026 verrouille
+**730 jours** pour le V0 (`FRAICHEUR_MAX_JOURS = 730`, cohérent avec le
+déclencheur fallback C1 « < 3 débunkages / 2 ans » de l'architecture). À
+réconcilier à la publication de la v1.2 finale.
+
+## 6. Statut de l'ARCOM
+
+Les amendements v1.2 proposent le **retrait de l'ARCOM** du document
+méthodologique (registre d'État, asymétrie TV/presse). La décision PO du
+07/07/2026 pour le V0 **conserve `sanction_arcom`** dans le registre des signaux
+C1, avec le garde-fou d'asymétrie de l'architecture (arbitrage n°2) : pour un
+média `type_media != audiovisuel`, l'absence de données ARCOM est un **N/A
+structurel, neutre** — le collecteur s'auto-désactive. À réconcilier à la
+publication de la v1.2 finale.
+
+## 7. Échelle des lettres (§4.4.1 v1.2)
+
+La v1.2 introduit une note synthétique **A à E**, d'« Excellent » à « Faible »,
+appliquée au score renormalisé sur 100 :
+
+| Lettre | Seuil (score renormalisé ≥) |
+|---|---|
+| A | 85 |
+| B | 70 |
+| C | 55 |
+| D | 40 |
+| E | 0 |
+
+⚠️ Seuils repris de la décision PO du plan V0 (le §4.4.1 complet n'est pas dans
+le PDF v1.1.1) — **à confirmer à l'import de la v1.2 finale** (`LETTRES` dans
+`scripts/media_eval/schemas.py`).

--- a/docs/media-eval/rubrics/C1.md
+++ b/docs/media-eval/rubrics/C1.md
@@ -1,0 +1,71 @@
+# C1 — Véracité et exactitude (20 points · échelle continue · Rigueur)
+
+> Périmètre V0 : **volet données tierces uniquement** (débunkages, sanctions,
+> condamnations, avis CDJM). Le fallback « vérification manuelle de 5 articles »
+> (déclenché par code si < 3 débunkages / 2 ans, pre_flag
+> `fallback_c1_declenche`) n'est **pas instruit en V0** : dans ce cas, rends
+> `donnees_insuffisantes` → N/A.
+
+## Barème (méthodo §4.1, verbatim)
+
+**Définition** : Le média ne publie pas de manière répétée des informations
+fausses ou significativement trompeuses.
+
+**Signaux observables** :
+- Nombre de vérifications négatives (débunkages) publiées par des fact-checkers accrédités IFCN
+- Décisions, mises en demeure ou sanctions de l'ARCOM
+- Ratio entre les corrections publiées et les erreurs identifiées par des tiers
+- Condamnations judiciaires pour diffamation ou publication de fausses nouvelles
+- Refus documenté de corriger une erreur signalée par un fact-checker ou un tiers
+
+**Pondération des vérifications négatives (amendement v1.2, verbatim)** :
+Toutes les vérifications négatives n'ont pas le même poids. Chaque débunkage
+recensé est qualifié selon trois dimensions, documentées dans la fiche :
+
+| Dimension | Modalités | Effet sur l'évaluation |
+| --- | --- | --- |
+| **Émetteur** | Avis CDJM ou fact-checker IFCN tiers (poids plein) / rubrique de fact-checking d'un média concurrent direct (poids réduit, conflit d'intérêts potentiel documenté) | Pondération du signal |
+| **Gravité** | Erreur matérielle corrigeable (date, chiffre) / information substantiellement trompeuse / fabrication ou désinformation caractérisée | Gradation croissante |
+| **Suite donnée** | Correction publiée par le média (atténuant) / absence de réaction / refus documenté de corriger (aggravant) | Modulation |
+
+Une accumulation de débunkages de faible gravité corrigés rapidement ne peut à
+elle seule justifier un score nul ; à l'inverse, un unique cas de fabrication
+non corrigée le peut.
+
+## Types de signaux attendus en entrée
+
+| `type_signal` | Contenu de `valeur` |
+|---|---|
+| `debunkage` | url, emetteur, `poids_emetteur` (dérivé par code), `gravite` (mineure/significative/grave), `suite_donnee`, `publie_at`, resume |
+| `sanction_arcom` | décision, date, montant/portée (médias audiovisuels uniquement — pour la presse en ligne l'absence est un N/A structurel neutre, jamais un signal négatif) |
+| `condamnation_justice` | juridiction, date, motif (diffamation / fausses nouvelles), référence de la décision |
+| `avis_cdjm` | numéro d'avis, date, verdict (fondé / non fondé), griefs |
+
+Les signaux événementiels de plus de 2 ans ont déjà été exclus par code : tout
+ce que tu reçois est dans la fenêtre.
+
+## Comment déterminer le profil
+
+1. Considère uniquement les signaux `present` (et `partiel`, avec prudence).
+   Pondère chaque signal négatif par `poids_emetteur` (fort > moyen > faible),
+   `gravite` et `suite_donnee` — la grille v1.2 ci-dessus.
+2. Un avis CDJM « non fondé » ou un débunkage retiré n'est pas un signal négatif.
+3. `aucun_signal_negatif` exige des signaux montrant qu'on a **cherché** (des
+   `absent_verifie` documentés) — pas simplement une entrée vide. Si l'entrée est
+   vide ou si `fallback_c1_declenche` est posé : `donnees_insuffisantes`.
+
+## Sortie structurée
+
+`determinations` :
+
+```json
+{ "profil_veracite": "<une des 5 valeurs>" }
+```
+
+| `profil_veracite` | Définition | Score dérivé (code) |
+|---|---|---|
+| `aucun_signal_negatif` | Recherche documentée, aucun signal négatif pondéré retenu | 20 |
+| `problemes_mineurs_corriges` | Débunkages de faible gravité, corrections publiées, pas de récidive caractérisée | 15 |
+| `problemes_mixtes` | Signaux négatifs réels mais compensés (gravité moyenne, suites données inégales) | 10 |
+| `problemes_significatifs` | Signaux négatifs répétés de gravité significative, émetteurs à poids fort, suites insuffisantes | 5 |
+| `fabrication_ou_refus_non_corrige` | Fabrication / désinformation caractérisée, ou refus documenté de corriger | 0 |

--- a/docs/media-eval/rubrics/C11.md
+++ b/docs/media-eval/rubrics/C11.md
@@ -1,0 +1,58 @@
+# C11 — Transparence du positionnement éditorial (6 points · 3 niveaux · Transparence · ⚑ double évaluation recommandée)
+
+> Périmètre V0 : **volet manifeste uniquement** (partie structurelle). Le volet
+> cohérence (analyse de cadrage sur 5 articles du corpus C10) est en vague 2.
+> Tu évalues la **transparence** du positionnement, jamais sa nature politique.
+
+## Barème (méthodo §4.2, verbatim)
+
+**Définition** : Le média rend explicite sa grille de lecture et son
+positionnement éditorial, permettant au lecteur de situer l'information dans son
+contexte de production.
+
+**Niveaux d'évaluation** :
+
+| Niveau | Score | Signaux requis |
+|---|---|---|
+| Opaque | 0 | Aucune indication du positionnement éditorial |
+| Partiel | 3 | Positionnement implicitement identifiable mais non formalisé |
+| Transparent | 6 | Positionnement explicité ; cohérence observable |
+
+## Types de signaux attendus en entrée
+
+| `type_signal` | Contenu de `valeur` |
+|---|---|
+| `manifeste_positionnement` | manifeste / « Notre projet » publié : url, ce qu'il explicite |
+| `ligne_editoriale_publiee` | ligne éditoriale formalisée sur le site (charte, page À propos) |
+| `auto_description_orientation` | auto-description publique de l'orientation (déclarations de dirigeants, interviews, tribunes) |
+| `rubriques_opinion_identifiees` | rubriques d'opinion clairement identifiées et séparées (structure du site) |
+
+## Comment déterminer le niveau
+
+- **Transparent (2)** : le positionnement est **explicité par le média
+  lui-même**, lisible pour un lecteur lambda (manifeste, ligne éditoriale
+  assumée : « média écologiste », « regard libéral »…).
+- **Partiel (1)** : le positionnement est identifiable implicitement (choix de
+  rubriques, auto-descriptions éparses, déclarations de dirigeants) mais jamais
+  formalisé pour le lecteur.
+- **Opaque (0)** : aucune indication — y compris le cas du média qui se dit
+  « neutre » sans aucun élément permettant de situer sa grille de lecture,
+  alors que des signaux montrent le contraire.
+- Se déclarer « sans étiquette » **et l'assumer explicitement** est un
+  positionnement transparent ; ne rien dire n'en est pas un.
+- V0 (volet manifeste) : la « cohérence observable » du niveau 2 s'apprécie sur
+  les seuls signaux structurels fournis — pas d'analyse de cadrage.
+
+## Sortie structurée
+
+`determinations` :
+
+```json
+{ "niveau": 0 | 1 | 2 }
+```
+
+| `niveau` | Libellé barème | Score dérivé (code) |
+|---|---|---|
+| 0 | Opaque | 0 |
+| 1 | Partiel | 3 |
+| 2 | Transparent | 6 |

--- a/docs/media-eval/rubrics/C5.md
+++ b/docs/media-eval/rubrics/C5.md
@@ -1,0 +1,56 @@
+# C5 — Transparence de la propriété et du financement (10 points · échelle continue · Transparence)
+
+## Barème (méthodo §4.2, verbatim)
+
+**Définition** : Le média indique clairement qui le possède, le finance, quels
+sont les éventuels conflits d'intérêts, et comment il génère ses revenus.
+
+**Signaux observables** :
+- Page « Qui sommes-nous » indiquant la structure actionnariale
+- Mentions légales complètes
+- Description des sources de financement
+- Publication de rapports financiers ou résumé annuel
+- Déclaration relative aux conflits d'intérêts
+- Appartenance à un groupe média identifiable
+
+**Notation (méthodo §5.3 Étape 2, verbatim)** :
+- Signaux positifs majoritaires (≥ 2 sources indépendantes) → score plein
+- Signaux mixtes → score partiel (50 % du maximum)
+- Signaux négatifs → score 0
+- Données insuffisantes → N/A (exclu du calcul total)
+
+## Types de signaux attendus en entrée
+
+| `type_signal` | Contenu de `valeur` |
+|---|---|
+| `mentions_legales` | complétude observée (forme juridique, capital, immatriculation, directeur de publication), url |
+| `identification_proprietaire` | propriétaire / groupe déclaré, où et comment |
+| `structure_actionnariat` | structure décrite (déclarée par le média et/ou registre Pappers) |
+| `enregistrement_cppap` | numéro et validité de l'enregistrement CPPAP |
+| `transparence_financement` | sources de revenus décrites, rapport financier, déclaration de conflits d'intérêts |
+
+## Comment déterminer le profil
+
+- `positifs_majoritaires` : l'essentiel des signaux ci-dessus est `present` et
+  convergent — le lecteur peut savoir qui possède et finance le média.
+- `mixtes` : transparence partielle (ex. mentions légales complètes mais
+  actionnariat flou, ou financement décrit sans structure de propriété), ou
+  signaux `partiel` dominants.
+- `negatifs` : opacité caractérisée — signaux `absent_verifie` sur l'essentiel
+  (pas de mentions légales exploitables, propriétaire non identifiable).
+- Ignore les signaux `bloque_acces` pour trancher ; s'il ne reste rien d'autre,
+  pose le flag `bloque_acces`.
+
+## Sortie structurée
+
+`determinations` :
+
+```json
+{ "profil_signaux": "<positifs_majoritaires | mixtes | negatifs>" }
+```
+
+| `profil_signaux` | Score dérivé (code) |
+|---|---|
+| `positifs_majoritaires` | 10 |
+| `mixtes` | 5 |
+| `negatifs` | 0 |

--- a/docs/media-eval/rubrics/C7.md
+++ b/docs/media-eval/rubrics/C7.md
@@ -1,0 +1,52 @@
+# C7 — Séparation contenu éditorial / publicité (4 points · échelle continue · Transparence)
+
+## Barème (méthodo §4.2, verbatim)
+
+**Définition** : Le contenu commandité, sponsorisé ou publicitaire est
+clairement identifié et séparé du contenu éditorial.
+
+**Signaux observables** :
+- Mention explicite « Contenu sponsorisé », « Publi-reportage », « Contenu partenaire »
+- Absence de native advertising non labellisé
+- Séparation visuelle claire
+- Politique publicitaire publiée
+
+**Notation (méthodo §5.3 Étape 2, verbatim)** :
+- Signaux positifs majoritaires (≥ 2 sources indépendantes) → score plein
+- Signaux mixtes → score partiel (50 % du maximum)
+- Signaux négatifs → score 0
+- Données insuffisantes → N/A (exclu du calcul total)
+
+## Types de signaux attendus en entrée
+
+| `type_signal` | Contenu de `valeur` |
+|---|---|
+| `marquage_contenu_sponsorise` | labels observés (« Sponsorisé », « Partenaire »…), exemples, ou native advertising non labellisé constaté (signal négatif) |
+| `regie_pub_identifiee` | régie publicitaire identifiable (page, ours, mentions) |
+| `politique_publicitaire` | page « Publicité » / « Régie » publiée et sa substance |
+
+## Comment déterminer le profil
+
+- `positifs_majoritaires` : marquage explicite observé et cohérent, pas de
+  native advertising non labellisé constaté.
+- `mixtes` : marquage présent mais inconstant, ou politique publicitaire absente
+  alors que le marquage existe (et inversement).
+- `negatifs` : contenus payés non séparés du contenu éditorial (native
+  advertising non labellisé constaté et documenté).
+- Un média **sans publicité** (ex. financé par dons) qui l'affiche clairement
+  relève de `positifs_majoritaires` : la séparation est structurellement
+  garantie et transparente.
+
+## Sortie structurée
+
+`determinations` :
+
+```json
+{ "profil_signaux": "<positifs_majoritaires | mixtes | negatifs>" }
+```
+
+| `profil_signaux` | Score dérivé (code) |
+|---|---|
+| `positifs_majoritaires` | 4 |
+| `mixtes` | 2 |
+| `negatifs` | 0 |

--- a/docs/media-eval/rubrics/C8.md
+++ b/docs/media-eval/rubrics/C8.md
@@ -1,0 +1,58 @@
+# C8 — Engagement déontologique formel (4 points · échelle continue · Transparence)
+
+> **Raccourci JTI (codé en dur, amendement v1.2)** : une certification JTI en
+> cours de validité vaut score plein C8 **sans passage par l'agent**
+> (`evaluateur='code:jti_shortcut'`). Si tu reçois cette entrée, c'est qu'aucune
+> certification JTI valide n'a été trouvée — évalue sur les autres signaux.
+
+## Barème (méthodo §4.2, verbatim)
+
+**Définition** : Le média adhère à des instances de régulation professionnelle
+ou dispose d'une charte éditoriale publique documentant ses engagements.
+
+**Signaux observables** :
+- Publication d'une charte éditoriale ou déontologique accessible au public
+- Adhésion au CDJM, certification JTI
+- Présence d'un médiateur, d'un comité d'éthique ou d'un processus de réclamation
+- Règlement intérieur ou charte d'auto-régulation
+
+**Notation (méthodo §5.3 Étape 2, verbatim)** :
+- Signaux positifs majoritaires (≥ 2 sources indépendantes) → score plein
+- Signaux mixtes → score partiel (50 % du maximum)
+- Signaux négatifs → score 0
+- Données insuffisantes → N/A (exclu du calcul total)
+
+## Types de signaux attendus en entrée
+
+| `type_signal` | Contenu de `valeur` |
+|---|---|
+| `charte_deontologique` | charte publiée : url, substance (engagements réels vs page marketing) |
+| `adhesion_cdjm` | présence dans la liste des membres CDJM (lookup registre) |
+| `certification_jti` | certification JTI et validité (si présent et valide, le raccourci a déjà scoré — cf. encadré) |
+| `reference_charte_externe` | référence formelle à une charte externe (Munich, SNJ, FIJ), médiateur, processus de réclamation |
+
+## Comment déterminer le profil
+
+- `positifs_majoritaires` : engagement formel documenté (charte publique
+  substantielle, et/ou adhésion CDJM, et/ou référence formelle à une charte
+  externe avec processus identifiable).
+- `mixtes` : engagement partiel — charte déclarative sans substance, référence
+  vague à la déontologie, pas d'instance ni de processus.
+- `negatifs` : aucune trace d'engagement après recherche documentée
+  (`absent_verifie` sur l'ensemble des types).
+- L'auto-déclaratif vérifiable **vaut preuve** (arbitrage architecture n°7) : la
+  présence publique du document suffit, tu n'exiges pas une validation tierce.
+
+## Sortie structurée
+
+`determinations` :
+
+```json
+{ "profil_signaux": "<positifs_majoritaires | mixtes | negatifs>" }
+```
+
+| `profil_signaux` | Score dérivé (code) |
+|---|---|
+| `positifs_majoritaires` | 4 |
+| `mixtes` | 2 |
+| `negatifs` | 0 |

--- a/docs/media-eval/rubrics/C9.md
+++ b/docs/media-eval/rubrics/C9.md
@@ -1,0 +1,54 @@
+# C9 — Indépendance éditoriale (10 points · 3 niveaux · Indépendance · ⚑ double évaluation)
+
+> Critère à **double évaluation** (méthodo) : en V0, le golden set humain de
+> Laurin fait office de seconde évaluation. Pose `revue_humaine_requise` au
+> moindre doute entre deux niveaux.
+
+## Barème (méthodo §4.3, verbatim)
+
+**Définition** : La rédaction dispose de garanties formelles et vérifiables
+d'indépendance vis-à-vis du propriétaire, des annonceurs ou de tout intérêt
+extérieur.
+
+**Niveaux d'évaluation** :
+
+| Niveau | Score | Signaux requis |
+|---|---|---|
+| Absent | 0 | Aucune garantie documentée d'indépendance |
+| Partiel | 5 | Charte d'indépendance existante mais sans mécanismes contraignants |
+| Complet | 10 | Charte d'indépendance formelle ; société de journalistes ; gouvernance |
+
+## Types de signaux attendus en entrée
+
+| `type_signal` | Contenu de `valeur` |
+|---|---|
+| `charte_independance` | charte publiée : url, clauses (déclaratives vs contraignantes : droit de veto, droit d'agrément…) |
+| `societe_journalistes` | existence d'une société de journalistes / de rédacteurs, prérogatives |
+| `independance_capital` | structure de capital protectrice (actionnariat salarié/lecteurs, fonds de dotation, absence d'annonceurs…) |
+| `intervention_actionnaire` | signal **négatif** : intervention documentée du propriétaire dans la ligne (avis CDJM d'ingérence, départs documentés de journalistes) |
+| `statuts_redaction` | statuts / gouvernance rédactionnelle formalisée (comité éditorial, indépendance statutaire) |
+
+## Comment déterminer le niveau
+
+- La différence entre **partiel** (1) et **complet** (2) est une question de
+  **clauses**, pas de présence : une charte purement déclarative sans mécanisme
+  contraignant (veto, agrément, société de journalistes dotée de droits) reste
+  au niveau 1.
+- Un `intervention_actionnaire` documenté et corroboré **dégrade** : des
+  garanties formelles contredites par la pratique ne sont pas des garanties.
+- Niveau 0 : rien de documenté après recherche (`absent_verifie`) — pas
+  simplement une entrée pauvre. Entrée vide → `donnees_insuffisantes`.
+
+## Sortie structurée
+
+`determinations` :
+
+```json
+{ "niveau": 0 | 1 | 2 }
+```
+
+| `niveau` | Libellé barème | Score dérivé (code) |
+|---|---|---|
+| 0 | Absent | 0 |
+| 1 | Partiel | 5 |
+| 2 | Complet | 10 |

--- a/docs/media-eval/rubrics/_common.md
+++ b/docs/media-eval/rubrics/_common.md
@@ -1,0 +1,81 @@
+# Contrat évaluateur — commun à tous les critères
+
+> **Source de vérité PO.** Ce fichier + la rubrique du critère (`C<k>.md`) sont
+> lus **verbatim** par l'agent évaluateur via `eval_inputs/<media>_<critere>.json`
+> (générés par `build_eval_input.py`). Aucune règle mécanique ici : les
+> garde-fous (corroboration, fraîcheur, fallback, raccourci JTI, `bloque_acces`)
+> sont codés en dur dans les scripts — pas dans les prompts.
+
+## Ton rôle
+
+Tu es un **évaluateur** de la méthodologie Facteur (v1.2). Tu reçois, pour UN
+média et UN critère :
+
+- le **barème verbatim** du critère (section « Barème » de la rubrique) ;
+- la liste des **signaux** collectés (observations factuelles horodatées, avec
+  statut, valeur, citation, sources) ;
+- d'éventuels **pre_flags** posés par les garde-fous amont.
+
+Tu n'as **aucun accès web, fichier ou base de données**. Tu ne lis que l'entrée
+JSON. Si un signal manque, tu le dis (flag), tu ne vas jamais le chercher.
+
+## Règles absolues
+
+1. **Jamais de notation « au sentiment »** (méthodo §5.1). Chaque affirmation de
+   ta justification cite un ou plusieurs `signal_ids`. Tu ne choisis **pas** de
+   score chiffré : tu produis des **`determinations`** énumérables (définies par
+   la rubrique) ; le score faisant foi est dérivé par code.
+2. **Statuts des signaux** — ils n'ont pas le même sens :
+   - `present` : le signal a été observé (citation + sources à l'appui) ;
+   - `absent_verifie` : cherché selon un protocole documenté
+     (`sources_consultees`) et **non trouvé** — c'est une information négative
+     utilisable ;
+   - `partiel` : observé mais incomplet ;
+   - `bloque_acces` : **non atteint** (paywall, blocage technique). Ce n'est PAS
+     une absence : ne jamais le traiter comme un signal négatif.
+3. **Données insuffisantes → N/A** (ni présomption positive, ni négative). Si
+   les signaux ne permettent pas d'appliquer le barème, pose le flag
+   `donnees_insuffisantes` et n'invente rien.
+4. Un média n'est jamais pénalisé pour sa ligne éditoriale : tu évalues des
+   **pratiques observables**, pas des opinions.
+
+## Flags autorisés
+
+| Flag | Sens | Effet (appliqué par code) |
+|---|---|---|
+| `donnees_insuffisantes` | Signaux insuffisants pour appliquer le barème | Critère `non_applicable` (N/A), exclu de la renormalisation |
+| `signaux_contradictoires` | Les signaux se contredisent entre eux | Score partiel + justification obligatoire ; confiance dégradée |
+| `bloque_acces` | Les seuls signaux pertinents sont `bloque_acces` | Critère `revue_requise` — jamais converti en 0 |
+| `revue_humaine_requise` | Cas limite, tu recommandes un regard humain | Confiance `basse` sur la fiche |
+
+## Sortie structurée (format JSON)
+
+Ta sortie est un fichier `evaluations_<media>_<critere>.json` :
+
+```json
+{
+  "run_id": "<repris de l'entrée>",
+  "agent": "agent:media-eval-evaluateur@v1",
+  "genere_at": "<ISO 8601 UTC>",
+  "version_prompt": "<repris verbatim de l'entrée (sha256 de la rubrique)>",
+  "items": [
+    {
+      "media_domaine": "<domaine>",
+      "critere": "<Ck>",
+      "determinations": { "...": "selon la section « Sortie structurée » de la rubrique" },
+      "justification": "2 à 6 phrases factuelles, chacune adossée à des signal_ids",
+      "signal_ids_cites": ["<uuid>", "..."],
+      "flags": []
+    }
+  ]
+}
+```
+
+Contraintes de validation (rejet programmatique sinon) :
+
+- `signal_ids_cites` **non vide**, sauf si `donnees_insuffisantes` est posé ;
+- chaque `signal_id` cité doit exister, appartenir au bon média ET au bon
+  critère ;
+- `determinations` doit respecter exactement les valeurs énumérées par la
+  rubrique (rien d'autre) ;
+- pas de champ `score` : le score est dérivé par code.

--- a/docs/stories/core/media-eval.0.mvp-pipeline-evaluation.md
+++ b/docs/stories/core/media-eval.0.mvp-pipeline-evaluation.md
@@ -1,0 +1,71 @@
+# Story media-eval.0 — MVP (V0) pipeline d'évaluation des médias C1–C11
+
+## Statut
+
+- **Type** : Feature (outillage interne, rien de user-visible — pas d'entrée changelog)
+- **PR 1** : `feat(media-eval): fondations (schéma, contrats, moteur d'évaluation)` — en cours
+- **PR 2** : `feat(media-eval): collecte vague 1 + orchestration + run pilote` — à suivre
+- **Plan validé PO** : 07/07/2026 (cf. `.context/attachments` plan MVP)
+
+## Contexte
+
+Facteur note des médias français sur 11 critères (méthodologie ouverte v1.2, 100 pts).
+Architecture cible (doc du 07/07/2026, importé dans `docs/media-eval/architecture-v1.2.md`) :
+
+- **collecte ≠ évaluation**, séparées par un data store Supabase (signaux horodatés + snapshots) ;
+- **3 voies de collecte** : CODE (déterministe) / AGENT (jugement + web) / HUMAIN ;
+- évaluateurs **sans accès web**, qui citent des `signal_ids` ;
+- garde-fous mécaniques **codés en dur** (jamais dans les prompts).
+
+Le V0 teste la pipeline de bout en bout sur un périmètre resserré, avec mesure
+d'accord contre un golden set humain (Laurin).
+
+## Décisions PO actées (07/07/2026)
+
+- Data store = **DB Supabase prod** (partagée main/production) via migration Alembic
+  **additive**, tables préfixées `media_eval_*`, **RLS deny-all**.
+- Périmètre = critères **vague 1** : C1 (volet données tierces), C5, C7, C8, C9,
+  C11 (volet manifeste) — 54 pts max.
+- **2 médias pilotes** : CNEWS (`cnews.fr`, exposé, audiovisuel → ARCOM applicable)
+  + Reporterre (`reporterre.net`, niche, presse en ligne → teste
+  `donnees_insuffisantes` et la renormalisation avec N/A).
+- Runtime = **sous-agents Claude Code** (pas de SDK). Les agents n'écrivent
+  **jamais** en DB : artefacts JSON dans `.context/media_eval/` → scripts Python
+  valident (Pydantic) puis insèrent. Les scripts voie A écrivent directement en DB.
+- La fenêtre de fraîcheur V0 est **730 jours** (décision PO du plan, plus stricte
+  que les 36 mois proposés dans les amendements v1.2 — à réconcilier à la
+  publication de la méthodo v1.2 finale).
+
+## Tasks PR 1
+
+- [x] Import docs méthodo dans `docs/media-eval/` (README, méthodo, architecture, rubriques C1/C5/C7/C8/C9/C11 + `_common.md`)
+- [x] Migration Alembic `me01_media_eval_tables` (7 tables, idempotente, RLS deny-all)
+- [x] Modèles `app/models/media_eval.py` + enregistrement `app/models/__init__.py`
+- [x] Contrats & constantes `scripts/media_eval/schemas.py` (Pydantic v2, `derive_score`, registre `type_signal`)
+- [x] Garde-fous purs `scripts/media_eval/garde_fous.py` (fraîcheur, fallback C1, corroboration, raccourci JTI, `bloque_acces`)
+- [x] Scripts moteur : `seed_medias.py`, `ingest_artifacts.py`, `build_eval_input.py`, `ingest_evaluations.py`, `synthese_fiche.py`, `evaluate_golden_agreement.py`
+- [x] Tests `tests/scripts/media_eval/` + fixtures
+- [x] Vérif E2E : migration DB vide (up/down/up), suite pytest, smoke dry-run/apply sur DB test
+
+## Tasks PR 2 (à venir)
+
+- [ ] Collecteurs voie A : `collect_pages_types.py`, `collect_cdjm.py`, `collect_jti.py`, `collect_cppap.py`, `collect_pappers.py`, `collect_arcom.py`
+- [ ] Sous-agents `.claude/agents/media-eval-*.md` + commande `.claude/commands/media-eval-run.md`
+- [ ] Run pilote `pilote-2026-07` (CNEWS puis Reporterre) + golden set + rapport d'accord
+
+## Fichiers modifiés (PR 1)
+
+- `docs/media-eval/` (nouveau) : README, méthodo, architecture, `rubrics/`
+- `packages/api/alembic/versions/me01_media_eval_tables.py` (nouveau)
+- `packages/api/app/models/media_eval.py` (nouveau) + `app/models/__init__.py`
+- `packages/api/scripts/media_eval/` (nouveau) : `__init__.py`, `schemas.py`, `garde_fous.py`, `seed_medias.py`, `ingest_artifacts.py`, `build_eval_input.py`, `ingest_evaluations.py`, `synthese_fiche.py`, `evaluate_golden_agreement.py`
+- `packages/api/tests/scripts/media_eval/` (nouveau) + `tests/scripts/fixtures/media_eval/`
+
+## Critères de succès V0 (verrouillés)
+
+1. 100 % des artefacts évaluateurs passent la validation programmatique sans édition manuelle.
+2. Accord (exact sur niveaux C9/C11 ; |Δ| ≤ 20 % du barème sur C1/C5/C7/C8) sur
+   ≥ 4 critères/6 par média ; aucun désaccord N/A-vs-score inexpliqué.
+3. Reporterre : C1 sort en N/A `donnees_insuffisantes` (pas 0) et la fiche
+   renormalise sur 34 pts.
+4. Zéro écriture DB par agent (par construction, vérifié en revue d'artefacts).

--- a/packages/api/alembic/versions/me01_media_eval_tables.py
+++ b/packages/api/alembic/versions/me01_media_eval_tables.py
@@ -1,8 +1,14 @@
-"""media eval — 7 tables du pipeline d'évaluation des médias C1–C11.
+"""media eval — 9 tables du pipeline d'évaluation des médias C1–C11.
 
 Data store collecte ≠ évaluation (cf. docs/media-eval/architecture-v1.2.md) :
-référentiel médias, snapshots, corpus (vide en V0), signaux (pivot),
-débunkages qualifiés, évaluations, fiches.
+runs (l'entité batch — date de référence, périmètre, statut), référentiel
+médias, snapshots, corpus (vide en V0), signaux (pivot), débunkages qualifiés,
+évaluations, fiches, notes de collecte (observations libres des collecteurs,
+hors registre des signaux).
+
+Tout enregistrement daté porte un ``run_id`` FK vers ``media_eval_runs`` :
+un batch est isolable, daté (``date_reference`` pilote la fenêtre de
+fraîcheur) et supprimable en cascade.
 
 Additive pure (CREATE TABLE uniquement) → sûre en expand-contract sur la DB
 partagée staging/prod : le backend prod (ancien code) ignore les tables
@@ -20,15 +26,16 @@ from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from alembic import op
 
 revision: str = "me01_media_eval_tables"
-down_revision: str | None = "ue01_user_entity_affinity"
+down_revision: str | None = "cv01_source_coverage_themes"
 branch_labels: str | None = None
 depends_on: str | None = None
 
 _CRITERE_CHECK = "critere IN ({})".format(", ".join(f"'C{i}'" for i in range(1, 12)))
 
-# Ordre de création (les FK imposent medias puis snapshots puis signaux…).
+# Ordre de création (les FK imposent runs+medias puis snapshots puis signaux…).
 # downgrade() droppe en ordre inverse.
 _TABLES = (
+    "media_eval_runs",
     "media_eval_medias",
     "media_eval_snapshots",
     "media_eval_corpus_articles",
@@ -36,6 +43,7 @@ _TABLES = (
     "media_eval_debunkages",
     "media_eval_evaluations",
     "media_eval_fiches",
+    "media_eval_notes_collecte",
 )
 
 
@@ -53,9 +61,39 @@ def _media_fk() -> sa.Column:
     return sa.Column("media_id", PGUUID(as_uuid=True), nullable=False)
 
 
+def _run_fk() -> sa.Column:
+    return sa.Column("run_id", sa.String(length=50), nullable=False)
+
+
 def upgrade() -> None:
     bind = op.get_bind()
     inspector = sa.inspect(bind)
+
+    if not inspector.has_table("media_eval_runs"):
+        op.create_table(
+            "media_eval_runs",
+            sa.Column("run_id", sa.String(length=50), primary_key=True),
+            sa.Column("libelle", sa.Text(), nullable=True),
+            sa.Column("version_methodo", sa.String(length=20), nullable=False),
+            # Date de référence du batch : pilote la fenêtre de fraîcheur
+            # (build_eval_input) → un run rejoué plus tard reste identique.
+            sa.Column("date_reference", sa.Date(), nullable=False),
+            sa.Column("perimetre", JSONB(), nullable=True),
+            sa.Column(
+                "statut",
+                sa.String(length=30),
+                nullable=False,
+                server_default="en_cours",
+            ),
+            sa.Column("notes", sa.Text(), nullable=True),
+            sa.Column(
+                "cree_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("now()"),
+                nullable=False,
+            ),
+            sa.Column("clos_at", sa.DateTime(timezone=True), nullable=True),
+        )
 
     if not inspector.has_table("media_eval_medias"):
         op.create_table(
@@ -82,6 +120,7 @@ def upgrade() -> None:
             "media_eval_snapshots",
             _uuid_pk(),
             _media_fk(),
+            _run_fk(),
             sa.Column("url", sa.Text(), nullable=False),
             sa.Column("type_page", sa.String(length=30), nullable=False),
             sa.Column("contenu", sa.Text(), nullable=True),
@@ -102,6 +141,9 @@ def upgrade() -> None:
             sa.ForeignKeyConstraint(
                 ["media_id"], ["media_eval_medias.id"], ondelete="CASCADE"
             ),
+            sa.ForeignKeyConstraint(
+                ["run_id"], ["media_eval_runs.run_id"], ondelete="CASCADE"
+            ),
         )
         op.create_index(
             "ix_media_eval_snapshots_media_id", "media_eval_snapshots", ["media_id"]
@@ -112,6 +154,7 @@ def upgrade() -> None:
             "media_eval_corpus_articles",
             _uuid_pk(),
             _media_fk(),
+            _run_fk(),
             sa.Column("url", sa.Text(), nullable=False),
             sa.Column("titre", sa.Text(), nullable=True),
             sa.Column("date_pub", sa.Date(), nullable=True),
@@ -128,8 +171,14 @@ def upgrade() -> None:
             sa.ForeignKeyConstraint(
                 ["media_id"], ["media_eval_medias.id"], ondelete="CASCADE"
             ),
+            sa.ForeignKeyConstraint(
+                ["run_id"], ["media_eval_runs.run_id"], ondelete="CASCADE"
+            ),
             sa.UniqueConstraint(
-                "media_id", "url", name="uq_media_eval_corpus_media_url"
+                "media_id",
+                "run_id",
+                "url",
+                name="uq_media_eval_corpus_media_run_url",
             ),
         )
 
@@ -150,19 +199,35 @@ def upgrade() -> None:
             ),
             sa.Column("sources_consultees", ARRAY(sa.Text()), nullable=True),
             sa.Column("snapshot_id", PGUUID(as_uuid=True), nullable=True),
-            sa.Column("run_id", sa.String(length=50), nullable=False),
+            _run_fk(),
             sa.Column("dedupe_key", sa.String(length=64), nullable=False),
+            # collecte_at = moment réel de collecte (genere_at de l'artefact) ;
+            # ingere_at = moment d'écriture DB. version_prompt_collecteur =
+            # sha256 du prompt de l'agent collecteur (enveloppe voie B).
             sa.Column(
                 "collecte_at",
                 sa.DateTime(timezone=True),
                 server_default=sa.text("now()"),
                 nullable=False,
             ),
+            sa.Column(
+                "ingere_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("now()"),
+                nullable=False,
+            ),
+            sa.Column(
+                "version_prompt_collecteur", sa.String(length=64), nullable=True
+            ),
+            sa.Column("note_collecteur", sa.Text(), nullable=True),
             sa.ForeignKeyConstraint(
                 ["media_id"], ["media_eval_medias.id"], ondelete="CASCADE"
             ),
             sa.ForeignKeyConstraint(
                 ["snapshot_id"], ["media_eval_snapshots.id"], ondelete="SET NULL"
+            ),
+            sa.ForeignKeyConstraint(
+                ["run_id"], ["media_eval_runs.run_id"], ondelete="CASCADE"
             ),
             sa.CheckConstraint(_CRITERE_CHECK, name="ck_media_eval_signaux_critere"),
             sa.UniqueConstraint(
@@ -230,7 +295,7 @@ def upgrade() -> None:
             sa.Column("evaluateur", sa.String(length=100), nullable=False),
             sa.Column("version_methodo", sa.String(length=20), nullable=False),
             sa.Column("version_prompt", sa.String(length=64), nullable=False),
-            sa.Column("run_id", sa.String(length=50), nullable=False),
+            _run_fk(),
             sa.Column(
                 "evalue_at",
                 sa.DateTime(timezone=True),
@@ -239,6 +304,9 @@ def upgrade() -> None:
             ),
             sa.ForeignKeyConstraint(
                 ["media_id"], ["media_eval_medias.id"], ondelete="CASCADE"
+            ),
+            sa.ForeignKeyConstraint(
+                ["run_id"], ["media_eval_runs.run_id"], ondelete="CASCADE"
             ),
             sa.CheckConstraint(
                 _CRITERE_CHECK, name="ck_media_eval_evaluations_critere"
@@ -261,7 +329,7 @@ def upgrade() -> None:
             "media_eval_fiches",
             _uuid_pk(),
             _media_fk(),
-            sa.Column("run_id", sa.String(length=50), nullable=False),
+            _run_fk(),
             sa.Column("score_brut", sa.Float(), nullable=False),
             sa.Column("score_max_applicable", sa.Float(), nullable=False),
             sa.Column("score_renormalise", sa.Float(), nullable=False),
@@ -292,8 +360,48 @@ def upgrade() -> None:
             sa.ForeignKeyConstraint(
                 ["media_id"], ["media_eval_medias.id"], ondelete="CASCADE"
             ),
+            sa.ForeignKeyConstraint(
+                ["run_id"], ["media_eval_runs.run_id"], ondelete="CASCADE"
+            ),
             sa.UniqueConstraint(
                 "media_id", "run_id", name="uq_media_eval_fiches_media_run"
+            ),
+        )
+
+    if not inspector.has_table("media_eval_notes_collecte"):
+        op.create_table(
+            "media_eval_notes_collecte",
+            _uuid_pk(),
+            _run_fk(),
+            # media_id/critere nullables : une note peut être globale au run,
+            # propre à un média, ou propre à un (média, critère).
+            sa.Column("media_id", PGUUID(as_uuid=True), nullable=True),
+            sa.Column("critere", sa.String(length=3), nullable=True),
+            sa.Column("type_note", sa.String(length=30), nullable=False),
+            sa.Column("contenu", sa.Text(), nullable=False),
+            sa.Column(
+                "source_urls", ARRAY(sa.Text()), nullable=False, server_default="{}"
+            ),
+            sa.Column("collecteur", sa.String(length=100), nullable=False),
+            sa.Column("dedupe_key", sa.String(length=64), nullable=False),
+            sa.Column(
+                "cree_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("now()"),
+                nullable=False,
+            ),
+            sa.ForeignKeyConstraint(
+                ["run_id"], ["media_eval_runs.run_id"], ondelete="CASCADE"
+            ),
+            sa.ForeignKeyConstraint(
+                ["media_id"], ["media_eval_medias.id"], ondelete="CASCADE"
+            ),
+            sa.CheckConstraint(
+                f"critere IS NULL OR {_CRITERE_CHECK}",
+                name="ck_media_eval_notes_critere",
+            ),
+            sa.UniqueConstraint(
+                "run_id", "dedupe_key", name="uq_media_eval_notes_run_dedupe"
             ),
         )
 

--- a/packages/api/alembic/versions/me01_media_eval_tables.py
+++ b/packages/api/alembic/versions/me01_media_eval_tables.py
@@ -1,0 +1,311 @@
+"""media eval — 7 tables du pipeline d'évaluation des médias C1–C11.
+
+Data store collecte ≠ évaluation (cf. docs/media-eval/architecture-v1.2.md) :
+référentiel médias, snapshots, corpus (vide en V0), signaux (pivot),
+débunkages qualifiés, évaluations, fiches.
+
+Additive pure (CREATE TABLE uniquement) → sûre en expand-contract sur la DB
+partagée staging/prod : le backend prod (ancien code) ignore les tables
+jusqu'au passage hebdo. Idempotente (no-op table par table si déjà créée —
+la chaîne boote sur les DEUX services Railway).
+
+RLS deny-all en fin d'upgrade (pattern sec02) : tables backend-only, aucune
+policy — ENABLE ROW LEVEL SECURITY + REVOKE ALL FROM anon, authenticated.
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+
+from alembic import op
+
+revision: str = "me01_media_eval_tables"
+down_revision: str | None = "ue01_user_entity_affinity"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+_CRITERE_CHECK = "critere IN ({})".format(", ".join(f"'C{i}'" for i in range(1, 12)))
+
+# Ordre de création (les FK imposent medias puis snapshots puis signaux…).
+# downgrade() droppe en ordre inverse.
+_TABLES = (
+    "media_eval_medias",
+    "media_eval_snapshots",
+    "media_eval_corpus_articles",
+    "media_eval_signaux",
+    "media_eval_debunkages",
+    "media_eval_evaluations",
+    "media_eval_fiches",
+)
+
+
+def _uuid_pk() -> sa.Column:
+    return sa.Column(
+        "id",
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        server_default=sa.text("gen_random_uuid()"),
+        nullable=False,
+    )
+
+
+def _media_fk() -> sa.Column:
+    return sa.Column("media_id", PGUUID(as_uuid=True), nullable=False)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if not inspector.has_table("media_eval_medias"):
+        op.create_table(
+            "media_eval_medias",
+            _uuid_pk(),
+            sa.Column("nom", sa.String(length=200), nullable=False),
+            sa.Column("domaine", sa.String(length=255), nullable=False),
+            sa.Column("type_media", sa.String(length=30), nullable=False),
+            sa.Column("paywall", sa.Boolean(), nullable=False, server_default="false"),
+            sa.Column("rubriques_opinion", ARRAY(sa.Text()), nullable=True),
+            sa.Column("volume_articles_jour", sa.Integer(), nullable=True),
+            sa.Column("source_ids", ARRAY(PGUUID(as_uuid=True)), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("now()"),
+                nullable=False,
+            ),
+            sa.UniqueConstraint("domaine", name="uq_media_eval_medias_domaine"),
+        )
+
+    if not inspector.has_table("media_eval_snapshots"):
+        op.create_table(
+            "media_eval_snapshots",
+            _uuid_pk(),
+            _media_fk(),
+            sa.Column("url", sa.Text(), nullable=False),
+            sa.Column("type_page", sa.String(length=30), nullable=False),
+            sa.Column("contenu", sa.Text(), nullable=True),
+            sa.Column("hash", sa.String(length=64), nullable=True),
+            sa.Column("http_status", sa.Integer(), nullable=True),
+            sa.Column(
+                "mode_acces",
+                sa.String(length=30),
+                nullable=False,
+                server_default="libre",
+            ),
+            sa.Column(
+                "capture_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("now()"),
+                nullable=False,
+            ),
+            sa.ForeignKeyConstraint(
+                ["media_id"], ["media_eval_medias.id"], ondelete="CASCADE"
+            ),
+        )
+        op.create_index(
+            "ix_media_eval_snapshots_media_id", "media_eval_snapshots", ["media_id"]
+        )
+
+    if not inspector.has_table("media_eval_corpus_articles"):
+        op.create_table(
+            "media_eval_corpus_articles",
+            _uuid_pk(),
+            _media_fk(),
+            sa.Column("url", sa.Text(), nullable=False),
+            sa.Column("titre", sa.Text(), nullable=True),
+            sa.Column("date_pub", sa.Date(), nullable=True),
+            sa.Column("rubrique", sa.String(length=100), nullable=True),
+            sa.Column("texte", sa.Text(), nullable=True),
+            sa.Column("mode_acquisition", sa.String(length=30), nullable=True),
+            sa.Column("pre_metriques", JSONB(), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("now()"),
+                nullable=False,
+            ),
+            sa.ForeignKeyConstraint(
+                ["media_id"], ["media_eval_medias.id"], ondelete="CASCADE"
+            ),
+            sa.UniqueConstraint(
+                "media_id", "url", name="uq_media_eval_corpus_media_url"
+            ),
+        )
+
+    if not inspector.has_table("media_eval_signaux"):
+        op.create_table(
+            "media_eval_signaux",
+            _uuid_pk(),
+            _media_fk(),
+            sa.Column("critere", sa.String(length=3), nullable=False),
+            sa.Column("type_signal", sa.String(length=50), nullable=False),
+            sa.Column("statut", sa.String(length=30), nullable=False),
+            sa.Column("valeur", JSONB(), nullable=True),
+            sa.Column("citation", sa.Text(), nullable=True),
+            sa.Column("voie", sa.String(length=30), nullable=False),
+            sa.Column("collecteur", sa.String(length=100), nullable=False),
+            sa.Column(
+                "source_urls", ARRAY(sa.Text()), nullable=False, server_default="{}"
+            ),
+            sa.Column("sources_consultees", ARRAY(sa.Text()), nullable=True),
+            sa.Column("snapshot_id", PGUUID(as_uuid=True), nullable=True),
+            sa.Column("run_id", sa.String(length=50), nullable=False),
+            sa.Column("dedupe_key", sa.String(length=64), nullable=False),
+            sa.Column(
+                "collecte_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("now()"),
+                nullable=False,
+            ),
+            sa.ForeignKeyConstraint(
+                ["media_id"], ["media_eval_medias.id"], ondelete="CASCADE"
+            ),
+            sa.ForeignKeyConstraint(
+                ["snapshot_id"], ["media_eval_snapshots.id"], ondelete="SET NULL"
+            ),
+            sa.CheckConstraint(_CRITERE_CHECK, name="ck_media_eval_signaux_critere"),
+            sa.UniqueConstraint(
+                "media_id",
+                "run_id",
+                "dedupe_key",
+                name="uq_media_eval_signaux_media_run_dedupe",
+            ),
+        )
+        op.create_index(
+            "ix_media_eval_signaux_media_critere",
+            "media_eval_signaux",
+            ["media_id", "critere"],
+        )
+        op.create_index(
+            "ix_media_eval_signaux_run_id", "media_eval_signaux", ["run_id"]
+        )
+
+    if not inspector.has_table("media_eval_debunkages"):
+        op.create_table(
+            "media_eval_debunkages",
+            _uuid_pk(),
+            _media_fk(),
+            sa.Column("signal_id", PGUUID(as_uuid=True), nullable=False),
+            sa.Column("url_debunkage", sa.Text(), nullable=False),
+            sa.Column("emetteur", sa.String(length=100), nullable=False),
+            sa.Column("poids_emetteur", sa.String(length=30), nullable=False),
+            sa.Column("gravite", sa.String(length=30), nullable=False),
+            sa.Column("suite_donnee", sa.String(length=30), nullable=False),
+            sa.Column("resume", sa.Text(), nullable=True),
+            sa.Column("publie_at", sa.Date(), nullable=False),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("now()"),
+                nullable=False,
+            ),
+            sa.ForeignKeyConstraint(
+                ["media_id"], ["media_eval_medias.id"], ondelete="CASCADE"
+            ),
+            sa.ForeignKeyConstraint(
+                ["signal_id"], ["media_eval_signaux.id"], ondelete="CASCADE"
+            ),
+            sa.UniqueConstraint("signal_id", name="uq_media_eval_debunkages_signal"),
+        )
+
+    if not inspector.has_table("media_eval_evaluations"):
+        op.create_table(
+            "media_eval_evaluations",
+            _uuid_pk(),
+            _media_fk(),
+            sa.Column("critere", sa.String(length=3), nullable=False),
+            sa.Column("score", sa.Float(), nullable=True),
+            sa.Column("score_max", sa.Float(), nullable=False),
+            sa.Column("niveau", sa.Integer(), nullable=True),
+            sa.Column("statut", sa.String(length=30), nullable=False),
+            sa.Column("justification", sa.Text(), nullable=False),
+            sa.Column(
+                "signal_ids",
+                ARRAY(PGUUID(as_uuid=True)),
+                nullable=False,
+                server_default="{}",
+            ),
+            sa.Column("flags", ARRAY(sa.Text()), nullable=False, server_default="{}"),
+            sa.Column("evaluateur", sa.String(length=100), nullable=False),
+            sa.Column("version_methodo", sa.String(length=20), nullable=False),
+            sa.Column("version_prompt", sa.String(length=64), nullable=False),
+            sa.Column("run_id", sa.String(length=50), nullable=False),
+            sa.Column(
+                "evalue_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("now()"),
+                nullable=False,
+            ),
+            sa.ForeignKeyConstraint(
+                ["media_id"], ["media_eval_medias.id"], ondelete="CASCADE"
+            ),
+            sa.CheckConstraint(
+                _CRITERE_CHECK, name="ck_media_eval_evaluations_critere"
+            ),
+            sa.CheckConstraint(
+                "niveau IS NULL OR (niveau >= 0 AND niveau <= 2)",
+                name="ck_media_eval_evaluations_niveau",
+            ),
+            sa.UniqueConstraint(
+                "media_id",
+                "critere",
+                "evaluateur",
+                "run_id",
+                name="uq_media_eval_evaluations_media_critere_eval_run",
+            ),
+        )
+
+    if not inspector.has_table("media_eval_fiches"):
+        op.create_table(
+            "media_eval_fiches",
+            _uuid_pk(),
+            _media_fk(),
+            sa.Column("run_id", sa.String(length=50), nullable=False),
+            sa.Column("score_brut", sa.Float(), nullable=False),
+            sa.Column("score_max_applicable", sa.Float(), nullable=False),
+            sa.Column("score_renormalise", sa.Float(), nullable=False),
+            sa.Column("lettre", sa.String(length=1), nullable=False),
+            sa.Column(
+                "criteres_evalues",
+                ARRAY(sa.Text()),
+                nullable=False,
+                server_default="{}",
+            ),
+            sa.Column(
+                "criteres_na", ARRAY(sa.Text()), nullable=False, server_default="{}"
+            ),
+            sa.Column("confiance", sa.String(length=30), nullable=False),
+            sa.Column(
+                "statut",
+                sa.String(length=30),
+                nullable=False,
+                server_default="brouillon",
+            ),
+            sa.Column("detail", JSONB(), nullable=True),
+            sa.Column(
+                "genere_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("now()"),
+                nullable=False,
+            ),
+            sa.ForeignKeyConstraint(
+                ["media_id"], ["media_eval_medias.id"], ondelete="CASCADE"
+            ),
+            sa.UniqueConstraint(
+                "media_id", "run_id", name="uq_media_eval_fiches_media_run"
+            ),
+        )
+
+    # RLS deny-all (pattern sec02) : backend-only, aucune policy. Idempotent.
+    for table in _TABLES:
+        op.execute(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY")
+        op.execute(f"REVOKE ALL ON TABLE {table} FROM anon, authenticated")
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    for table in reversed(_TABLES):
+        if inspector.has_table(table):
+            op.drop_table(table)

--- a/packages/api/app/models/__init__.py
+++ b/packages/api/app/models/__init__.py
@@ -19,6 +19,15 @@ from app.models.grille_game_state import GrilleGameState
 from app.models.grille_puzzle import GrillePuzzle
 from app.models.host_feed_resolution import HostFeedResolution
 from app.models.learning import UserEntityAffinity, UserEntityPreference
+from app.models.media_eval import (
+    MediaEvalCorpusArticle,
+    MediaEvalDebunkage,
+    MediaEvalEvaluation,
+    MediaEvalFiche,
+    MediaEvalMedia,
+    MediaEvalSignal,
+    MediaEvalSnapshot,
+)
 from app.models.perspective_analysis import PerspectiveAnalysis
 from app.models.progress import TopicQuiz, UserTopicProgress
 from app.models.push_notification import PushDelivery, PushDevice
@@ -132,4 +141,12 @@ __all__ = [
     # User Feedback System (Epic 13)
     "DigestSentiment",
     "FeedbackInvite",
+    # Évaluation des médias C1-C11 (media-eval.0)
+    "MediaEvalMedia",
+    "MediaEvalSnapshot",
+    "MediaEvalCorpusArticle",
+    "MediaEvalSignal",
+    "MediaEvalDebunkage",
+    "MediaEvalEvaluation",
+    "MediaEvalFiche",
 ]

--- a/packages/api/app/models/media_eval.py
+++ b/packages/api/app/models/media_eval.py
@@ -1,0 +1,405 @@
+"""Modèles évaluation des médias C1–C11 (méthodologie ouverte v1.2).
+
+Data store du pipeline collecte ≠ évaluation (cf. docs/media-eval/) : les
+collecteurs écrivent des signaux horodatés + snapshots, les évaluateurs (sans
+accès web) citent des ``signal_ids``, la synthèse produit une fiche. Tables
+préfixées ``media_eval_*``, RLS deny-all (migration ``me01``), backend-only.
+
+``media_eval_medias`` est un référentiel **niveau domaine**, distinct de
+``sources`` (niveau feed) : ``source_ids`` fait le lien applicatif futur sans
+FK dure.
+"""
+
+import uuid
+from datetime import date, datetime
+from enum import StrEnum
+from uuid import UUID
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Date,
+    DateTime,
+    Enum,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+_CRITERES_VALIDES = tuple(f"C{i}" for i in range(1, 12))
+_CRITERE_CHECK = "critere IN ({})".format(
+    ", ".join(f"'{c}'" for c in _CRITERES_VALIDES)
+)
+
+
+class TypeMedia(StrEnum):
+    PRESSE_EN_LIGNE = "presse_en_ligne"
+    PRESSE_ECRITE = "presse_ecrite"
+    AUDIOVISUEL = "audiovisuel"
+
+
+class TypePage(StrEnum):
+    MENTIONS_LEGALES = "mentions_legales"
+    A_PROPOS = "a_propos"
+    CHARTE = "charte"
+    OURS_EQUIPE = "ours_equipe"
+    DONS_FINANCEMENT = "dons_financement"
+    LIGNE_EDITORIALE = "ligne_editoriale"
+    REGIE_PUB = "regie_pub"
+    AUTRE = "autre"
+
+
+class ModeAcces(StrEnum):
+    LIBRE = "libre"
+    PAYWALL = "paywall"
+    BLOQUE = "bloque"
+
+
+class StatutSignal(StrEnum):
+    """La distinction clé (arbitrage n°3) : bloqué ≠ absent."""
+
+    PRESENT = "present"
+    ABSENT_VERIFIE = "absent_verifie"
+    PARTIEL = "partiel"
+    BLOQUE_ACCES = "bloque_acces"
+
+
+class VoieCollecte(StrEnum):
+    CODE = "code"
+    AGENT = "agent"
+    HUMAIN = "humain"
+
+
+class PoidsEmetteur(StrEnum):
+    FORT = "fort"
+    MOYEN = "moyen"
+    FAIBLE = "faible"
+
+
+class GraviteDebunkage(StrEnum):
+    MINEURE = "mineure"
+    SIGNIFICATIVE = "significative"
+    GRAVE = "grave"
+
+
+class SuiteDonnee(StrEnum):
+    CORRECTION_PUBLIEE = "correction_publiee"
+    RETRAIT = "retrait"
+    AUCUNE = "aucune"
+    CONTESTATION = "contestation"
+    INCONNUE = "inconnue"
+
+
+class StatutEvaluation(StrEnum):
+    EVALUEE = "evaluee"
+    NON_APPLICABLE = "non_applicable"
+    REVUE_REQUISE = "revue_requise"
+
+
+class ConfianceFiche(StrEnum):
+    HAUTE = "haute"
+    MOYENNE = "moyenne"
+    BASSE = "basse"
+
+
+class StatutFiche(StrEnum):
+    BROUILLON = "brouillon"
+    VALIDEE = "validee"
+    PUBLIEE = "publiee"
+
+
+def _str_enum(enum_cls: type[StrEnum], length: int = 30) -> Enum:
+    """Enum stocké VARCHAR (pas de type Postgres natif), pattern Source."""
+    return Enum(
+        enum_cls,
+        values_callable=lambda x: [e.value for e in x],
+        native_enum=False,
+        length=length,
+    )
+
+
+class MediaEvalMedia(Base):
+    """Référentiel des médias évalués (niveau domaine, étape 0 du pipeline)."""
+
+    __tablename__ = "media_eval_medias"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    nom: Mapped[str] = mapped_column(String(200), nullable=False)
+    domaine: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    type_media: Mapped[TypeMedia] = mapped_column(_str_enum(TypeMedia), nullable=False)
+    paywall: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+    rubriques_opinion: Mapped[list[str] | None] = mapped_column(
+        ARRAY(Text), nullable=True
+    )
+    volume_articles_jour: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # Lien applicatif futur vers sources (niveau feed) — volontairement sans FK.
+    source_ids: Mapped[list[UUID] | None] = mapped_column(
+        ARRAY(PGUUID(as_uuid=True)), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+
+
+class MediaEvalSnapshot(Base):
+    """Capture horodatée d'une page type — la preuve derrière un signal."""
+
+    __tablename__ = "media_eval_snapshots"
+    __table_args__ = (Index("ix_media_eval_snapshots_media_id", "media_id"),)
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    media_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("media_eval_medias.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    url: Mapped[str] = mapped_column(Text, nullable=False)
+    type_page: Mapped[TypePage] = mapped_column(_str_enum(TypePage), nullable=False)
+    contenu: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    http_status: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    mode_acces: Mapped[ModeAcces] = mapped_column(
+        _str_enum(ModeAcces),
+        nullable=False,
+        default=ModeAcces.LIBRE,
+        server_default=ModeAcces.LIBRE.value,
+    )
+    capture_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+
+
+class MediaEvalCorpusArticle(Base):
+    """Corpus d'articles échantillonnés (§5.4) — créée mais vide en V0."""
+
+    __tablename__ = "media_eval_corpus_articles"
+    __table_args__ = (
+        UniqueConstraint("media_id", "url", name="uq_media_eval_corpus_media_url"),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    media_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("media_eval_medias.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    url: Mapped[str] = mapped_column(Text, nullable=False)
+    titre: Mapped[str | None] = mapped_column(Text, nullable=True)
+    date_pub: Mapped[date | None] = mapped_column(Date, nullable=True)
+    rubrique: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    texte: Mapped[str | None] = mapped_column(Text, nullable=True)
+    mode_acquisition: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    pre_metriques: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+
+
+class MediaEvalSignal(Base):
+    """La table pivot : une observation factuelle, sourcée, jamais un score."""
+
+    __tablename__ = "media_eval_signaux"
+    __table_args__ = (
+        CheckConstraint(_CRITERE_CHECK, name="ck_media_eval_signaux_critere"),
+        UniqueConstraint(
+            "media_id",
+            "run_id",
+            "dedupe_key",
+            name="uq_media_eval_signaux_media_run_dedupe",
+        ),
+        Index("ix_media_eval_signaux_media_critere", "media_id", "critere"),
+        Index("ix_media_eval_signaux_run_id", "run_id"),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    media_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("media_eval_medias.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    critere: Mapped[str] = mapped_column(String(3), nullable=False)
+    type_signal: Mapped[str] = mapped_column(String(50), nullable=False)
+    statut: Mapped[StatutSignal] = mapped_column(
+        _str_enum(StatutSignal), nullable=False
+    )
+    valeur: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    citation: Mapped[str | None] = mapped_column(Text, nullable=True)
+    voie: Mapped[VoieCollecte] = mapped_column(_str_enum(VoieCollecte), nullable=False)
+    # Ex. "code:collect_cdjm@v1", "agent:media-eval-collecteur-debunkages@v1".
+    collecteur: Mapped[str] = mapped_column(String(100), nullable=False)
+    source_urls: Mapped[list[str]] = mapped_column(
+        ARRAY(Text), nullable=False, default=list, server_default="{}"
+    )
+    # Preuve de recherche pour les statuts absent_verifie (§5.3-É1).
+    sources_consultees: Mapped[list[str] | None] = mapped_column(
+        ARRAY(Text), nullable=True
+    )
+    snapshot_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("media_eval_snapshots.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    run_id: Mapped[str] = mapped_column(String(50), nullable=False)
+    # sha256 canonique calculé par code → ré-ingestion idempotente.
+    dedupe_key: Mapped[str] = mapped_column(String(64), nullable=False)
+    collecte_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+
+
+class MediaEvalDebunkage(Base):
+    """Vérification négative qualifiée (C1, pondération v1.2).
+
+    Chaque débunkage est aussi un signal C1 (``signal_id`` unique NOT NULL) :
+    le contrat évaluateur reste uniforme, la table porte la qualification.
+    """
+
+    __tablename__ = "media_eval_debunkages"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    media_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("media_eval_medias.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    signal_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("media_eval_signaux.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    )
+    url_debunkage: Mapped[str] = mapped_column(Text, nullable=False)
+    emetteur: Mapped[str] = mapped_column(String(100), nullable=False)
+    # Dérivé par code (POIDS_EMETTEUR), jamais choisi par l'agent.
+    poids_emetteur: Mapped[PoidsEmetteur] = mapped_column(
+        _str_enum(PoidsEmetteur), nullable=False
+    )
+    gravite: Mapped[GraviteDebunkage] = mapped_column(
+        _str_enum(GraviteDebunkage), nullable=False
+    )
+    suite_donnee: Mapped[SuiteDonnee] = mapped_column(
+        _str_enum(SuiteDonnee), nullable=False
+    )
+    resume: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Requis pour la fenêtre de fraîcheur (2 ans).
+    publie_at: Mapped[date] = mapped_column(Date, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+
+
+class MediaEvalEvaluation(Base):
+    """Évaluation d'un critère : score dérivé par code, signaux cités."""
+
+    __tablename__ = "media_eval_evaluations"
+    __table_args__ = (
+        CheckConstraint(_CRITERE_CHECK, name="ck_media_eval_evaluations_critere"),
+        CheckConstraint(
+            "niveau IS NULL OR (niveau >= 0 AND niveau <= 2)",
+            name="ck_media_eval_evaluations_niveau",
+        ),
+        UniqueConstraint(
+            "media_id",
+            "critere",
+            "evaluateur",
+            "run_id",
+            name="uq_media_eval_evaluations_media_critere_eval_run",
+        ),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    media_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("media_eval_medias.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    critere: Mapped[str] = mapped_column(String(3), nullable=False)
+    # NULL si non_applicable / revue_requise (jamais 0 par défaut).
+    score: Mapped[float | None] = mapped_column(Float, nullable=True)
+    score_max: Mapped[float] = mapped_column(Float, nullable=False)
+    # Niveau 0-2 pour les critères à 3 niveaux (C9, C11), NULL sinon.
+    niveau: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    statut: Mapped[StatutEvaluation] = mapped_column(
+        _str_enum(StatutEvaluation), nullable=False
+    )
+    justification: Mapped[str] = mapped_column(Text, nullable=False)
+    signal_ids: Mapped[list[UUID]] = mapped_column(
+        ARRAY(PGUUID(as_uuid=True)), nullable=False, default=list, server_default="{}"
+    )
+    flags: Mapped[list[str]] = mapped_column(
+        ARRAY(Text), nullable=False, default=list, server_default="{}"
+    )
+    # "agent:media-eval-evaluateur@v1" / "humain:laurin" / "code:jti_shortcut".
+    evaluateur: Mapped[str] = mapped_column(String(100), nullable=False)
+    version_methodo: Mapped[str] = mapped_column(String(20), nullable=False)
+    # sha256 du fichier rubrique utilisé (build_eval_input).
+    version_prompt: Mapped[str] = mapped_column(String(64), nullable=False)
+    run_id: Mapped[str] = mapped_column(String(50), nullable=False)
+    evalue_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+
+
+class MediaEvalFiche(Base):
+    """Synthèse par (média, run) : renormalisation, lettre, confiance."""
+
+    __tablename__ = "media_eval_fiches"
+    __table_args__ = (
+        UniqueConstraint("media_id", "run_id", name="uq_media_eval_fiches_media_run"),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    media_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("media_eval_medias.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    run_id: Mapped[str] = mapped_column(String(50), nullable=False)
+    score_brut: Mapped[float] = mapped_column(Float, nullable=False)
+    score_max_applicable: Mapped[float] = mapped_column(Float, nullable=False)
+    score_renormalise: Mapped[float] = mapped_column(Float, nullable=False)
+    lettre: Mapped[str] = mapped_column(String(1), nullable=False)
+    criteres_evalues: Mapped[list[str]] = mapped_column(
+        ARRAY(Text), nullable=False, default=list, server_default="{}"
+    )
+    criteres_na: Mapped[list[str]] = mapped_column(
+        ARRAY(Text), nullable=False, default=list, server_default="{}"
+    )
+    confiance: Mapped[ConfianceFiche] = mapped_column(
+        _str_enum(ConfianceFiche), nullable=False
+    )
+    statut: Mapped[StatutFiche] = mapped_column(
+        _str_enum(StatutFiche),
+        nullable=False,
+        default=StatutFiche.BROUILLON,
+        server_default=StatutFiche.BROUILLON.value,
+    )
+    detail: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    genere_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )

--- a/packages/api/app/models/media_eval.py
+++ b/packages/api/app/models/media_eval.py
@@ -5,6 +5,10 @@ collecteurs écrivent des signaux horodatés + snapshots, les évaluateurs (sans
 accès web) citent des ``signal_ids``, la synthèse produit une fiche. Tables
 préfixées ``media_eval_*``, RLS deny-all (migration ``me01``), backend-only.
 
+``media_eval_runs`` est l'entité batch : tout enregistrement daté porte un
+``run_id`` FK — un run est isolable, daté (``date_reference`` pilote la
+fenêtre de fraîcheur, jamais ``now()``) et supprimable en cascade.
+
 ``media_eval_medias`` est un référentiel **niveau domaine**, distinct de
 ``sources`` (niveau feed) : ``source_ids`` fait le lien applicatif futur sans
 FK dure.
@@ -117,6 +121,24 @@ class StatutFiche(StrEnum):
     PUBLIEE = "publiee"
 
 
+class StatutRun(StrEnum):
+    EN_COURS = "en_cours"
+    CLOS = "clos"
+
+
+class TypeNoteCollecte(StrEnum):
+    """Notes libres des collecteurs — hors registre des signaux.
+
+    ``amelioration_protocole`` : revue humaine uniquement (faire évoluer
+    ``TYPE_SIGNAUX``) ; les deux autres sont injectées aux évaluateurs comme
+    contexte non-citable (pas de signal_id → ne peut fonder aucun score).
+    """
+
+    AMELIORATION_PROTOCOLE = "amelioration_protocole"
+    CONTEXTE_MEDIA = "contexte_media"
+    DONNEE_NON_STRUCTUREE = "donnee_non_structuree"
+
+
 def _str_enum(enum_cls: type[StrEnum], length: int = 30) -> Enum:
     """Enum stocké VARCHAR (pas de type Postgres natif), pattern Source."""
     return Enum(
@@ -124,6 +146,34 @@ def _str_enum(enum_cls: type[StrEnum], length: int = 30) -> Enum:
         values_callable=lambda x: [e.value for e in x],
         native_enum=False,
         length=length,
+    )
+
+
+class MediaEvalRun(Base):
+    """L'entité batch : un cycle de collecte + évaluation nommé et daté."""
+
+    __tablename__ = "media_eval_runs"
+
+    run_id: Mapped[str] = mapped_column(String(50), primary_key=True)
+    libelle: Mapped[str | None] = mapped_column(Text, nullable=True)
+    version_methodo: Mapped[str] = mapped_column(String(20), nullable=False)
+    # Pilote la fenêtre de fraîcheur (build_eval_input) : un run rejoué plus
+    # tard produit exactement les mêmes entrées évaluateur.
+    date_reference: Mapped[date] = mapped_column(Date, nullable=False)
+    # {"medias": [...], "criteres": [...]} — périmètre prévu du batch.
+    perimetre: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    statut: Mapped[StatutRun] = mapped_column(
+        _str_enum(StatutRun),
+        nullable=False,
+        default=StatutRun.EN_COURS,
+        server_default=StatutRun.EN_COURS.value,
+    )
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    cree_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+    clos_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
     )
 
 
@@ -168,6 +218,11 @@ class MediaEvalSnapshot(Base):
         ForeignKey("media_eval_medias.id", ondelete="CASCADE"),
         nullable=False,
     )
+    run_id: Mapped[str] = mapped_column(
+        String(50),
+        ForeignKey("media_eval_runs.run_id", ondelete="CASCADE"),
+        nullable=False,
+    )
     url: Mapped[str] = mapped_column(Text, nullable=False)
     type_page: Mapped[TypePage] = mapped_column(_str_enum(TypePage), nullable=False)
     contenu: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -189,7 +244,9 @@ class MediaEvalCorpusArticle(Base):
 
     __tablename__ = "media_eval_corpus_articles"
     __table_args__ = (
-        UniqueConstraint("media_id", "url", name="uq_media_eval_corpus_media_url"),
+        UniqueConstraint(
+            "media_id", "run_id", "url", name="uq_media_eval_corpus_media_run_url"
+        ),
     )
 
     id: Mapped[UUID] = mapped_column(
@@ -198,6 +255,11 @@ class MediaEvalCorpusArticle(Base):
     media_id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
         ForeignKey("media_eval_medias.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    run_id: Mapped[str] = mapped_column(
+        String(50),
+        ForeignKey("media_eval_runs.run_id", ondelete="CASCADE"),
         nullable=False,
     )
     url: Mapped[str] = mapped_column(Text, nullable=False)
@@ -258,12 +320,26 @@ class MediaEvalSignal(Base):
         ForeignKey("media_eval_snapshots.id", ondelete="SET NULL"),
         nullable=True,
     )
-    run_id: Mapped[str] = mapped_column(String(50), nullable=False)
+    run_id: Mapped[str] = mapped_column(
+        String(50),
+        ForeignKey("media_eval_runs.run_id", ondelete="CASCADE"),
+        nullable=False,
+    )
     # sha256 canonique calculé par code → ré-ingestion idempotente.
     dedupe_key: Mapped[str] = mapped_column(String(64), nullable=False)
+    # Moment réel de collecte (genere_at de l'artefact voie B) ≠ ingere_at
+    # (écriture DB). version_prompt_collecteur = sha256 du prompt collecteur.
     collecte_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=datetime.utcnow
     )
+    ingere_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+    version_prompt_collecteur: Mapped[str | None] = mapped_column(
+        String(64), nullable=True
+    )
+    # Contexte libre propre au signal — jamais un signal en soi.
+    note_collecteur: Mapped[str | None] = mapped_column(Text, nullable=True)
 
 
 class MediaEvalDebunkage(Base):
@@ -357,7 +433,11 @@ class MediaEvalEvaluation(Base):
     version_methodo: Mapped[str] = mapped_column(String(20), nullable=False)
     # sha256 du fichier rubrique utilisé (build_eval_input).
     version_prompt: Mapped[str] = mapped_column(String(64), nullable=False)
-    run_id: Mapped[str] = mapped_column(String(50), nullable=False)
+    run_id: Mapped[str] = mapped_column(
+        String(50),
+        ForeignKey("media_eval_runs.run_id", ondelete="CASCADE"),
+        nullable=False,
+    )
     evalue_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=datetime.utcnow
     )

--- a/packages/api/scripts/media_eval/build_eval_input.py
+++ b/packages/api/scripts/media_eval/build_eval_input.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Export des entrées évaluateur `eval_inputs/<media>_<critere>.json`.
+
+Pour chaque critère vague 1 : signaux du data store (média, run) + barème
+**verbatim** (rubrique `docs/media-eval/rubrics/C<k>.md`) + contrat commun
+(`_common.md`). ``version_prompt`` = sha256 du fichier rubrique.
+
+Garde-fous **amont** (codés en dur, `scripts/media_eval/garde_fous.py`) :
+- **fraîcheur** : signaux événementiels > 730 j exclus (journalisés) ;
+- **raccourci JTI** : certification valide → écrit directement l'éval C8
+  pleine (``evaluateur='code:jti_shortcut'``), pas d'agent ; l'entrée C8
+  n'est pas générée ;
+- **fallback C1** : < 3 débunkages / 2 ans → ``pre_flags:
+  ["fallback_c1_declenche"]`` (l'évaluateur rendra N/A en V0).
+
+Les fichiers d'entrée sont toujours écrits (pas une mutation DB) ; seule
+l'éval JTI passe par ``--apply`` (+ ``--allow-prod`` hors DB test).
+
+Usage :
+    cd packages/api
+    python3 scripts/media_eval/build_eval_input.py --media cnews.fr --run-id pilote-2026-07
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import sys
+from datetime import UTC, date, datetime
+from pathlib import Path
+from uuid import UUID
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from sqlalchemy import select
+
+from app.config import get_settings
+from app.database import async_session_maker, engine
+from app.models.media_eval import (
+    MediaEvalDebunkage,
+    MediaEvalEvaluation,
+    MediaEvalSignal,
+    StatutEvaluation,
+)
+from scripts.cleanup_orphan_sources import _is_test_db
+from scripts.media_eval.garde_fous import (
+    detecter_jti_valide,
+    fallback_c1_requis,
+    filtrer_fraicheur,
+)
+from scripts.media_eval.ingest_artifacts import IngestError, resoudre_media
+from scripts.media_eval.schemas import (
+    BAREMES,
+    CRITERES_VAGUE_1,
+    FLAG_FALLBACK_C1,
+    VERSION_METHODO,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+RUBRICS_DIR = _REPO_ROOT / "docs" / "media-eval" / "rubrics"
+DEFAULT_OUT_ROOT = _REPO_ROOT / ".context" / "media_eval"
+
+
+def rubrique_path(critere: str) -> Path:
+    return RUBRICS_DIR / f"{critere}.md"
+
+
+def version_prompt(critere: str) -> str:
+    """sha256 du fichier rubrique — toute retouche invalide la comparabilité."""
+    return hashlib.sha256(rubrique_path(critere).read_bytes()).hexdigest()
+
+
+def serialiser_signal(signal: MediaEvalSignal) -> dict:
+    return {
+        "id": str(signal.id),
+        "type_signal": signal.type_signal,
+        "statut": signal.statut.value
+        if hasattr(signal.statut, "value")
+        else signal.statut,
+        "valeur": signal.valeur,
+        "citation": signal.citation,
+        "source_urls": list(signal.source_urls or []),
+        "sources_consultees": list(signal.sources_consultees or []),
+        "voie": signal.voie.value if hasattr(signal.voie, "value") else signal.voie,
+        "collecte_at": signal.collecte_at.isoformat() if signal.collecte_at else None,
+    }
+
+
+def construire_eval_input(
+    media: dict,
+    critere: str,
+    signaux: list[dict],
+    *,
+    run_id: str,
+    bareme_verbatim: str,
+    contrat_commun: str,
+    version_prompt_sha: str,
+    pre_flags: list[str],
+) -> dict:
+    """Payload lu par l'agent évaluateur — pur, testable sans DB."""
+    return {
+        "media": media,
+        "critere": critere,
+        "run_id": run_id,
+        "version_methodo": VERSION_METHODO,
+        "version_prompt": version_prompt_sha,
+        "score_max": BAREMES[critere],
+        "contrat_commun": contrat_commun,
+        "bareme_verbatim": bareme_verbatim,
+        "pre_flags": pre_flags,
+        "signaux": signaux,
+    }
+
+
+async def _signaux_du_critere(session, media_id, run_id: str, critere: str):
+    rows = await session.execute(
+        select(MediaEvalSignal)
+        .where(
+            MediaEvalSignal.media_id == media_id,
+            MediaEvalSignal.run_id == run_id,
+            MediaEvalSignal.critere == critere,
+        )
+        .order_by(MediaEvalSignal.collecte_at)
+    )
+    return list(rows.scalars())
+
+
+async def _nb_debunkages_frais(
+    session, media_id, run_id: str, aujourd_hui: date
+) -> int:
+    rows = await session.execute(
+        select(MediaEvalDebunkage.publie_at)
+        .join(MediaEvalSignal, MediaEvalSignal.id == MediaEvalDebunkage.signal_id)
+        .where(
+            MediaEvalDebunkage.media_id == media_id,
+            MediaEvalSignal.run_id == run_id,
+        )
+    )
+    return sum(1 for (publie_at,) in rows if (aujourd_hui - publie_at).days <= 730)
+
+
+async def ecrire_eval_jti(
+    session, media_id, run_id: str, signal_jti: dict
+) -> MediaEvalEvaluation:
+    """Raccourci JTI : éval C8 pleine écrite par code, sans agent."""
+    evaluation = MediaEvalEvaluation(
+        media_id=media_id,
+        critere="C8",
+        score=float(BAREMES["C8"]),
+        score_max=float(BAREMES["C8"]),
+        statut=StatutEvaluation.EVALUEE,
+        justification=(
+            "Certification JTI en cours de validité (raccourci automatique "
+            "v1.2 : score plein C8 sans examen complémentaire)."
+        ),
+        signal_ids=[UUID(signal_jti["id"])],
+        flags=[],
+        evaluateur="code:jti_shortcut",
+        version_methodo=VERSION_METHODO,
+        version_prompt=version_prompt("C8"),
+        run_id=run_id,
+    )
+    session.add(evaluation)
+    return evaluation
+
+
+async def run(
+    domaine: str,
+    run_id: str,
+    out_root: Path,
+    apply: bool,
+    allow_prod: bool,
+) -> int:
+    settings = get_settings()
+    db_url = settings.database_url or ""
+    is_test = _is_test_db(db_url)
+    print(
+        f"DB cible : {db_url.split('@')[-1] if '@' in db_url else db_url}  (test={is_test})"
+    )
+    if apply and not is_test and not allow_prod:
+        print("\nABORT : --apply contre une DB non-test sans --allow-prod (gated PO).")
+        return 2
+
+    aujourd_hui = datetime.now(UTC).date()
+    contrat_commun = (RUBRICS_DIR / "_common.md").read_text()
+    out_dir = out_root / run_id / "eval_inputs"
+
+    async with async_session_maker() as session:
+        try:
+            media = await resoudre_media(session, domaine)
+            media_dict = {
+                "nom": media.nom,
+                "domaine": media.domaine,
+                "type_media": media.type_media.value
+                if hasattr(media.type_media, "value")
+                else media.type_media,
+            }
+
+            nb_debunkages = await _nb_debunkages_frais(
+                session, media.id, run_id, aujourd_hui
+            )
+            ecrits: list[Path] = []
+            jti_applique = False
+
+            for critere in CRITERES_VAGUE_1:
+                rows = await _signaux_du_critere(session, media.id, run_id, critere)
+                signaux = [serialiser_signal(s) for s in rows]
+                frais, exclus = filtrer_fraicheur(signaux, aujourd_hui)
+                for s in exclus:
+                    print(
+                        f"  ! {critere}: signal {s['type_signal']} exclu "
+                        f"(fraîcheur > 730 j ou date manquante)"
+                    )
+
+                if critere == "C8":
+                    signal_jti = detecter_jti_valide(frais)
+                    if signal_jti is not None:
+                        print(
+                            "  ★ C8: certification JTI valide → raccourci "
+                            "code:jti_shortcut (pas d'agent)"
+                        )
+                        if apply:
+                            await ecrire_eval_jti(session, media.id, run_id, signal_jti)
+                            jti_applique = True
+                        else:
+                            print("    (dry-run — éval C8 non écrite)")
+                        continue  # pas d'entrée évaluateur pour C8
+
+                pre_flags: list[str] = []
+                if critere == "C1" and fallback_c1_requis(nb_debunkages):
+                    pre_flags.append(FLAG_FALLBACK_C1)
+                    print(
+                        f"  ⚑ C1: fallback déclenché ({nb_debunkages} débunkage(s) "
+                        "frais < 3) — l'évaluateur rendra N/A en V0"
+                    )
+
+                payload = construire_eval_input(
+                    media_dict,
+                    critere,
+                    frais,
+                    run_id=run_id,
+                    bareme_verbatim=rubrique_path(critere).read_text(),
+                    contrat_commun=contrat_commun,
+                    version_prompt_sha=version_prompt(critere),
+                    pre_flags=pre_flags,
+                )
+                out_dir.mkdir(parents=True, exist_ok=True)
+                out_path = out_dir / f"{media.domaine.replace('.', '_')}_{critere}.json"
+                out_path.write_text(
+                    json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+                )
+                ecrits.append(out_path)
+                affiche = (
+                    out_path.relative_to(_REPO_ROOT)
+                    if out_path.is_relative_to(_REPO_ROOT)
+                    else out_path
+                )
+                print(f"  → {affiche} ({len(frais)} signaux)")
+
+            if jti_applique:
+                await session.commit()
+                print("APPLIQUÉ : éval C8 (code:jti_shortcut) écrite.")
+            else:
+                await session.rollback()
+            print(f"Entrées évaluateur écrites : {len(ecrits)}")
+            return 0
+        except IngestError as exc:
+            await session.rollback()
+            print(f"REJET : {exc}")
+            return 1
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await engine.dispose()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--media", required=True, help="domaine (ex. cnews.fr)")
+    parser.add_argument("--run-id", required=True, help="ex. pilote-2026-07")
+    parser.add_argument(
+        "--out-root",
+        type=Path,
+        default=DEFAULT_OUT_ROOT,
+        help="racine des artefacts (défaut .context/media_eval)",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="écrit l'éval C8 du raccourci JTI en DB (défaut: dry-run)",
+    )
+    parser.add_argument(
+        "--allow-prod", action="store_true", help="autorise --apply en prod"
+    )
+    args = parser.parse_args()
+    sys.exit(
+        asyncio.run(
+            run(
+                args.media,
+                args.run_id,
+                args.out_root,
+                apply=args.apply,
+                allow_prod=args.allow_prod,
+            )
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/scripts/media_eval/evaluate_golden_agreement.py
+++ b/packages/api/scripts/media_eval/evaluate_golden_agreement.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Accord évaluations agents vs golden set humain — benchmark V0.
+
+Calqué sur `scripts/evaluate_source_evaluations.py` : charge le gold
+(`docs/media-eval/golden/gold_v0.json`, notation Laurin) + un export
+d'évaluations générées (même schéma `GoldenSet`), mesure l'accord, écrit
+json + md dans `.context/`.
+
+Métriques (critères de succès V0 §2) :
+- C9 / C11 : accord **exact** sur le niveau ;
+- C1 / C5 / C7 / C8 : accord si **|Δ| ≤ 20 % du barème** du critère ;
+- désaccords **N/A-vs-score** listés à part (aucun ne doit rester inexpliqué) ;
+- MAE sur les paires scorées des deux côtés.
+
+Usage :
+    cd packages/api
+    python3 scripts/media_eval/evaluate_golden_agreement.py \
+        --gold ../../docs/media-eval/golden/gold_v0.json \
+        --generated .context/media_eval/pilote-2026-07/evaluations_export.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.media_eval.schemas import (
+    BAREMES,
+    CRITERES_NIVEAUX,
+    GoldenEntry,
+    GoldenSet,
+)
+
+TOLERANCE_CONTINUE = 0.20  # |Δ| ≤ 20 % du barème (critère de succès V0)
+
+
+def _paire_accord(gold: GoldenEntry, gen: GoldenEntry) -> dict:
+    """Compare une paire (média, critère). Pur, testable."""
+    critere = gold.critere
+    resultat: dict = {
+        "media": gold.media_domaine,
+        "critere": critere,
+        "gold_statut": gold.statut,
+        "gen_statut": gen.statut,
+        "gold_score": gold.score,
+        "gen_score": gen.score,
+        "gold_niveau": gold.niveau,
+        "gen_niveau": gen.niveau,
+    }
+    if (gold.statut == "evaluee") != (gen.statut == "evaluee"):
+        resultat |= {"accord": False, "type_desaccord": "na_vs_score", "delta": None}
+        return resultat
+    if gold.statut != "evaluee":
+        # N/A ou revue_requise des deux côtés : accord si même statut.
+        accord = gold.statut == gen.statut
+        resultat |= {
+            "accord": accord,
+            "type_desaccord": None if accord else "statut",
+            "delta": None,
+        }
+        return resultat
+    if critere in CRITERES_NIVEAUX:
+        accord = gold.niveau == gen.niveau
+        resultat |= {
+            "accord": accord,
+            "type_desaccord": None if accord else "niveau",
+            "delta": abs((gold.score or 0) - (gen.score or 0)),
+        }
+        return resultat
+    delta = abs((gold.score or 0) - (gen.score or 0))
+    accord = delta <= TOLERANCE_CONTINUE * BAREMES[critere]
+    resultat |= {
+        "accord": accord,
+        "type_desaccord": None if accord else "score",
+        "delta": delta,
+    }
+    return resultat
+
+
+def evaluate(gold: GoldenSet, generated: GoldenSet) -> dict:
+    gen_par_cle = {(e.media_domaine, e.critere): e for e in generated.entries}
+    paires = [
+        (g, gen_par_cle[(g.media_domaine, g.critere)])
+        for g in gold.entries
+        if (g.media_domaine, g.critere) in gen_par_cle
+    ]
+    if not paires:
+        return {"n": 0, "error": "aucune paire gold/généré"}
+
+    resultats = [_paire_accord(g, gen) for g, gen in paires]
+    par_media: dict[str, dict] = {}
+    for r in resultats:
+        stats = par_media.setdefault(r["media"], {"accords": 0, "total": 0})
+        stats["total"] += 1
+        stats["accords"] += int(r["accord"])
+
+    deltas = [r["delta"] for r in resultats if r["delta"] is not None]
+    desaccords = sorted(
+        (r for r in resultats if not r["accord"]),
+        key=lambda r: (r["type_desaccord"] != "na_vs_score", -(r["delta"] or 0)),
+    )
+    return {
+        "n": len(resultats),
+        "accord_global": round(sum(r["accord"] for r in resultats) / len(resultats), 3),
+        "par_media": {
+            m: f"{s['accords']}/{s['total']}" for m, s in sorted(par_media.items())
+        },
+        "na_vs_score": sum(
+            1 for r in resultats if r["type_desaccord"] == "na_vs_score"
+        ),
+        "mae_scores": round(sum(deltas) / len(deltas), 2) if deltas else None,
+        "desaccords": desaccords,
+    }
+
+
+def render_md(report: dict) -> str:
+    if report.get("n", 0) == 0:
+        return f"# Accord media-eval vs gold\n\n{report.get('error', 'vide')}\n"
+    lignes = [
+        "# Accord évaluations agents vs golden set",
+        "",
+        f"- Paires évaluées : **{report['n']}**",
+        f"- Accord global : **{report['accord_global']:.0%}**"
+        f" (cible V0 : ≥ 4 critères / 6 par média)",
+        f"- Par média : {report['par_media']}",
+        f"- Désaccords N/A-vs-score : **{report['na_vs_score']}** (cible : 0 inexpliqué)",
+        f"- MAE scores : {report['mae_scores']}",
+        "",
+        f"## Désaccords ({len(report['desaccords'])})",
+        "",
+        "| Média | Critère | Type | Gold | Généré | Δ |",
+        "|---|---|---|---|---|--:|",
+    ]
+    for d in report["desaccords"]:
+        gold = (
+            f"niv {d['gold_niveau']}"
+            if d["gold_niveau"] is not None
+            else (
+                d["gold_score"] if d["gold_statut"] == "evaluee" else d["gold_statut"]
+            )
+        )
+        gen = (
+            f"niv {d['gen_niveau']}"
+            if d["gen_niveau"] is not None
+            else (d["gen_score"] if d["gen_statut"] == "evaluee" else d["gen_statut"])
+        )
+        lignes.append(
+            f"| {d['media']} | {d['critere']} | {d['type_desaccord']} | "
+            f"{gold} | {gen} | {d['delta'] if d['delta'] is not None else '-'} |"
+        )
+    return "\n".join(lignes) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--gold", type=Path, required=True, help="gold_v0.json")
+    parser.add_argument(
+        "--generated",
+        type=Path,
+        required=True,
+        help="export évals générées (même schéma)",
+    )
+    args = parser.parse_args()
+
+    gold = GoldenSet.model_validate_json(args.gold.read_text())
+    generated = GoldenSet.model_validate_json(args.generated.read_text())
+    report = evaluate(gold, generated)
+
+    ts = datetime.now(UTC).strftime("%Y%m%d")
+    ctx = Path(__file__).resolve().parents[4] / ".context"
+    ctx.mkdir(parents=True, exist_ok=True)
+    (ctx / f"media-eval-accord-{ts}.json").write_text(
+        json.dumps(report, indent=2, ensure_ascii=False)
+    )
+    (ctx / f"media-eval-accord-{ts}.md").write_text(render_md(report))
+    print(render_md(report))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/scripts/media_eval/garde_fous.py
+++ b/packages/api/scripts/media_eval/garde_fous.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Garde-fous mécaniques de la méthodo v1.2 — fonctions pures, codées en dur.
+
+Jamais dans les prompts (architecture §6). Amont (`build_eval_input.py`) :
+fraîcheur, raccourci JTI, déclencheur fallback C1. Aval
+(`ingest_evaluations.py`) : corroboration, `bloque_acces` jamais 0, dérivation
+du statut. Toutes les fonctions travaillent sur des dicts sérialisés (signaux)
+pour être testables sans DB.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from urllib.parse import urlparse
+
+from app.models.media_eval import StatutEvaluation, StatutSignal
+from scripts.media_eval.schemas import (
+    BAREMES,
+    CORROBORATION_MIN_SOURCES,
+    FALLBACK_C1_MIN_DEBUNKAGES,
+    FLAG_CORROBORATION,
+    FRAICHEUR_MAX_JOURS,
+    TYPES_EVENEMENTIELS,
+    palier_inferieur,
+)
+
+# --------------------------------------------------------------------------- #
+# Amont — fraîcheur (v1.2 §5.4 : événementiel borné, structurel constaté à date)
+# --------------------------------------------------------------------------- #
+
+
+def date_evenement(signal: dict) -> date | None:
+    """Date de l'événement porté par un signal événementiel (C1)."""
+    valeur = signal.get("valeur") or {}
+    brut = valeur.get("publie_at") or valeur.get("date")
+    if brut is None:
+        return None
+    if isinstance(brut, date):
+        return brut
+    return date.fromisoformat(str(brut)[:10])
+
+
+def est_frais(signal: dict, aujourd_hui: date) -> bool:
+    """True si le signal peut fonder une notation à la date donnée.
+
+    Les signaux structurels (chartes, registres…) sont constatés à date, sans
+    limite d'ancienneté. Les signaux événementiels (types C1) doivent dater de
+    moins de ``FRAICHEUR_MAX_JOURS`` ; sans date exploitable ils sont exclus
+    (ils ne peuvent pas prouver leur fraîcheur).
+    """
+    if signal.get("type_signal") not in TYPES_EVENEMENTIELS:
+        return True
+    quand = date_evenement(signal)
+    if quand is None:
+        return False
+    return (aujourd_hui - quand).days <= FRAICHEUR_MAX_JOURS
+
+
+def filtrer_fraicheur(
+    signaux: list[dict], aujourd_hui: date
+) -> tuple[list[dict], list[dict]]:
+    """Sépare (frais, exclus) — les exclus sont journalisés, jamais notés."""
+    frais = [s for s in signaux if est_frais(s, aujourd_hui)]
+    exclus = [s for s in signaux if not est_frais(s, aujourd_hui)]
+    return frais, exclus
+
+
+def fallback_c1_requis(nb_debunkages_frais: int) -> bool:
+    """< 3 débunkages / 2 ans → vérification manuelle (N/A en V0)."""
+    return nb_debunkages_frais < FALLBACK_C1_MIN_DEBUNKAGES
+
+
+def detecter_jti_valide(signaux_c8: list[dict]) -> dict | None:
+    """Raccourci JTI (v1.2) : certification présente et en cours de validité.
+
+    Retourne le signal déclencheur, ou None. La validité est portée par
+    ``valeur.en_cours_de_validite`` (renseignée par le collecteur registre).
+    """
+    for signal in signaux_c8:
+        if (
+            signal.get("type_signal") == "certification_jti"
+            and signal.get("statut") == StatutSignal.PRESENT.value
+            and (signal.get("valeur") or {}).get("en_cours_de_validite") is True
+        ):
+            return signal
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Aval — corroboration (§5.2) + bloque_acces jamais 0 (arbitrage n°3)
+# --------------------------------------------------------------------------- #
+
+
+def _domaine_enregistrable(url: str) -> str | None:
+    netloc = urlparse(url).netloc.lower().removeprefix("www.")
+    return netloc or None
+
+
+def compter_sources_independantes(signaux_cites: list[dict]) -> int:
+    """Nombre de domaines distincts parmi les source_urls des signaux cités."""
+    domaines = {
+        d
+        for s in signaux_cites
+        for u in (s.get("source_urls") or [])
+        if (d := _domaine_enregistrable(u))
+    }
+    return len(domaines)
+
+
+def appliquer_corroboration(
+    critere: str, score: float, signaux_cites: list[dict]
+) -> tuple[float, list[str]]:
+    """Score plein sans ≥ 2 sources indépendantes → palier inférieur + flag."""
+    if score < BAREMES[critere]:
+        return score, []
+    if compter_sources_independantes(signaux_cites) >= CORROBORATION_MIN_SOURCES:
+        return score, []
+    return palier_inferieur(critere, score), [FLAG_CORROBORATION]
+
+
+def statut_evaluation(flags: list[str], signaux_cites: list[dict]) -> str:
+    """Statut dérivé — `bloque_acces` n'est JAMAIS converti en 0.
+
+    - flag ``donnees_insuffisantes`` → ``non_applicable`` (N/A, score NULL) ;
+    - flag ``bloque_acces``, ou uniquement des signaux cités ``bloque_acces``
+      → ``revue_requise`` (« non évaluable pour cause d'accès », score NULL) ;
+    - sinon → ``evaluee``.
+    """
+    if "donnees_insuffisantes" in flags:
+        return StatutEvaluation.NON_APPLICABLE.value
+    if "bloque_acces" in flags:
+        return StatutEvaluation.REVUE_REQUISE.value
+    if signaux_cites and all(
+        s.get("statut") == StatutSignal.BLOQUE_ACCES.value for s in signaux_cites
+    ):
+        return StatutEvaluation.REVUE_REQUISE.value
+    return StatutEvaluation.EVALUEE.value

--- a/packages/api/scripts/media_eval/ingest_artifacts.py
+++ b/packages/api/scripts/media_eval/ingest_artifacts.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Ingestion des artefacts des agents collecteurs (voie B) — SANS LLM.
+
+Les agents n'écrivent jamais en DB : ils déposent des JSON dans
+``.context/media_eval/<run_id>/``. Ce script valide (Pydantic,
+`scripts/media_eval/schemas.py`) puis insère :
+
+- ``SignalBatchArtifact`` → lignes `media_eval_signaux` ;
+- ``DebunkageBatchArtifact`` → couples signal C1 + `media_eval_debunkages`
+  (``poids_emetteur`` dérivé par code, jamais par l'agent).
+
+Idempotent par ``dedupe_key`` (sha256 canonique calculé ici) : ré-ingérer le
+même artefact ne crée rien. Un artefact invalide est rejeté en bloc (exit
+non-zéro, rien d'écrit). **Dry-run par défaut**, ``--apply`` gardé.
+
+Usage :
+    cd packages/api
+    python3 scripts/media_eval/ingest_artifacts.py --artifact <fichier.json>
+    python3 scripts/media_eval/ingest_artifacts.py --artifact <dossier/> --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from uuid import UUID
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from sqlalchemy import select
+
+from app.config import get_settings
+from app.database import async_session_maker, engine
+from app.models.media_eval import (
+    MediaEvalDebunkage,
+    MediaEvalMedia,
+    MediaEvalSignal,
+    StatutSignal,
+    VoieCollecte,
+)
+from scripts.cleanup_orphan_sources import _is_test_db
+from scripts.media_eval.schemas import (
+    DebunkageArtifact,
+    DebunkageBatchArtifact,
+    SignalArtifact,
+    SignalBatchArtifact,
+)
+
+
+class IngestError(Exception):
+    """Artefact invalide — rien ne doit être écrit."""
+
+
+@dataclass
+class IngestResult:
+    inseres: int = 0
+    doublons: int = 0
+    details: list[str] = field(default_factory=list)
+
+
+def charger_artifact(path: Path) -> SignalBatchArtifact | DebunkageBatchArtifact:
+    """Valide un fichier artefact (type inféré du contenu des items)."""
+    data = json.loads(path.read_text())
+    items = data.get("items") or []
+    if items and "url_debunkage" in items[0]:
+        return DebunkageBatchArtifact.model_validate(data)
+    return SignalBatchArtifact.model_validate(data)
+
+
+def dedupe_key_signal(item: SignalArtifact) -> str:
+    ancre = item.source_urls[0] if item.source_urls else (item.citation or "")
+    brut = f"{item.critere}|{item.type_signal}|{item.statut}|{ancre}"
+    return hashlib.sha256(brut.encode()).hexdigest()
+
+
+def dedupe_key_debunkage(item: DebunkageArtifact) -> str:
+    brut = f"C1|{item.type_signal}|{item.url_debunkage}|{item.publie_at.isoformat()}"
+    return hashlib.sha256(brut.encode()).hexdigest()
+
+
+async def resoudre_media(session, domaine: str) -> MediaEvalMedia:
+    media = (
+        await session.execute(
+            select(MediaEvalMedia).where(MediaEvalMedia.domaine == domaine)
+        )
+    ).scalar_one_or_none()
+    if media is None:
+        raise IngestError(
+            f"média inconnu : {domaine!r} (lancer seed_medias.py d'abord)"
+        )
+    return media
+
+
+async def _dedupe_existants(session, media_id: UUID, run_id: str) -> set[str]:
+    rows = await session.execute(
+        select(MediaEvalSignal.dedupe_key).where(
+            MediaEvalSignal.media_id == media_id,
+            MediaEvalSignal.run_id == run_id,
+        )
+    )
+    return {r[0] for r in rows}
+
+
+async def inserer_signaux(session, batch: SignalBatchArtifact) -> IngestResult:
+    """Insère les signaux d'un batch — sans commit (l'appelant décide)."""
+    result = IngestResult()
+    deja_vus: dict[UUID, set[str]] = {}
+    for item in batch.items:
+        media = await resoudre_media(session, item.media_domaine)
+        if media.id not in deja_vus:
+            deja_vus[media.id] = await _dedupe_existants(
+                session, media.id, batch.run_id
+            )
+        key = dedupe_key_signal(item)
+        if key in deja_vus[media.id]:
+            result.doublons += 1
+            continue
+        deja_vus[media.id].add(key)
+        session.add(
+            MediaEvalSignal(
+                media_id=media.id,
+                critere=item.critere,
+                type_signal=item.type_signal,
+                statut=StatutSignal(item.statut),
+                valeur=item.valeur,
+                citation=item.citation,
+                voie=VoieCollecte.AGENT,
+                collecteur=batch.agent,
+                source_urls=item.source_urls,
+                sources_consultees=item.sources_consultees or None,
+                run_id=batch.run_id,
+                dedupe_key=key,
+            )
+        )
+        result.inseres += 1
+        result.details.append(
+            f"signal {item.critere}/{item.type_signal} ({item.statut})"
+        )
+    return result
+
+
+async def inserer_debunkages(session, batch: DebunkageBatchArtifact) -> IngestResult:
+    """Insère les couples signal C1 + débunkage — sans commit."""
+    result = IngestResult()
+    deja_vus: dict[UUID, set[str]] = {}
+    for item in batch.items:
+        media = await resoudre_media(session, item.media_domaine)
+        if media.id not in deja_vus:
+            deja_vus[media.id] = await _dedupe_existants(
+                session, media.id, batch.run_id
+            )
+        key = dedupe_key_debunkage(item)
+        if key in deja_vus[media.id]:
+            result.doublons += 1
+            continue
+        deja_vus[media.id].add(key)
+        poids = item.poids_emetteur()  # dérivé par code, jamais par l'agent
+        signal = MediaEvalSignal(
+            media_id=media.id,
+            critere="C1",
+            type_signal=item.type_signal,
+            statut=StatutSignal.PRESENT,
+            valeur={
+                "url": item.url_debunkage,
+                "emetteur": item.emetteur,
+                "poids_emetteur": poids,
+                "gravite": item.gravite,
+                "suite_donnee": item.suite_donnee,
+                "publie_at": item.publie_at.isoformat(),
+                "resume": item.resume,
+            },
+            citation=item.citation or item.resume,
+            voie=VoieCollecte.AGENT,
+            collecteur=batch.agent,
+            source_urls=item.source_urls,
+            sources_consultees=item.sources_consultees or None,
+            run_id=batch.run_id,
+            dedupe_key=key,
+        )
+        session.add(signal)
+        await session.flush()  # signal.id requis pour le couple
+        session.add(
+            MediaEvalDebunkage(
+                media_id=media.id,
+                signal_id=signal.id,
+                url_debunkage=item.url_debunkage,
+                emetteur=item.emetteur,
+                poids_emetteur=poids,
+                gravite=item.gravite,
+                suite_donnee=item.suite_donnee,
+                resume=item.resume,
+                publie_at=item.publie_at,
+            )
+        )
+        result.inseres += 1
+        result.details.append(
+            f"debunkage {item.emetteur} ({item.gravite}, poids={poids})"
+        )
+    return result
+
+
+async def ingester(session, paths: list[Path]) -> IngestResult:
+    """Valide TOUS les artefacts avant d'insérer quoi que ce soit."""
+    batches = [charger_artifact(p) for p in paths]  # lève avant toute écriture
+    total = IngestResult()
+    for batch in batches:
+        if isinstance(batch, DebunkageBatchArtifact):
+            partiel = await inserer_debunkages(session, batch)
+        else:
+            partiel = await inserer_signaux(session, batch)
+        total.inseres += partiel.inseres
+        total.doublons += partiel.doublons
+        total.details.extend(partiel.details)
+    return total
+
+
+def _collecter_paths(artifact: Path) -> list[Path]:
+    if artifact.is_dir():
+        paths = sorted(
+            p
+            for p in artifact.glob("*.json")
+            if p.name.startswith(("signaux", "debunkages"))
+        )
+        if not paths:
+            raise IngestError(f"aucun artefact signaux_*/debunkages_* dans {artifact}")
+        return paths
+    return [artifact]
+
+
+async def run(artifact: Path, apply: bool, allow_prod: bool) -> int:
+    settings = get_settings()
+    db_url = settings.database_url or ""
+    is_test = _is_test_db(db_url)
+    print(
+        f"DB cible : {db_url.split('@')[-1] if '@' in db_url else db_url}  (test={is_test})"
+    )
+    if apply and not is_test and not allow_prod:
+        print("\nABORT : --apply contre une DB non-test sans --allow-prod (gated PO).")
+        return 2
+
+    try:
+        paths = _collecter_paths(artifact)
+    except IngestError as exc:
+        print(f"REJET : {exc}")
+        return 1
+
+    async with async_session_maker() as session:
+        try:
+            result = await ingester(session, paths)
+            for ligne in result.details:
+                print(f"  + {ligne}")
+            print(
+                f"Artefacts : {len(paths)} | à insérer : {result.inseres} | "
+                f"doublons ignorés : {result.doublons}"
+            )
+            if not apply:
+                await session.rollback()
+                print("(dry-run — aucune mutation. Relance avec --apply.)")
+                return 0
+            await session.commit()
+            print(f"APPLIQUÉ : {result.inseres} lignes insérées.")
+            return 0
+        except IngestError as exc:
+            await session.rollback()
+            print(f"REJET : {exc} — rien n'a été écrit.")
+            return 1
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await engine.dispose()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        required=True,
+        help="fichier artefact JSON ou dossier (signaux_*.json / debunkages_*.json)",
+    )
+    parser.add_argument(
+        "--apply", action="store_true", help="exécute (défaut: dry-run)"
+    )
+    parser.add_argument(
+        "--allow-prod", action="store_true", help="autorise --apply en prod"
+    )
+    args = parser.parse_args()
+    sys.exit(
+        asyncio.run(run(args.artifact, apply=args.apply, allow_prod=args.allow_prod))
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/scripts/media_eval/ingest_evaluations.py
+++ b/packages/api/scripts/media_eval/ingest_evaluations.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Ingestion des sorties évaluateurs — garde-fous aval, SANS LLM.
+
+Valide les artefacts ``evaluations_*.json`` (`EvaluationBatchArtifact`) puis
+applique les règles mécaniques AVANT toute écriture :
+
+- chaque ``signal_id`` cité doit **exister**, appartenir au **bon média** et
+  au **bon critère** — sinon rejet de l'artefact (exit non-zéro, rien d'écrit) ;
+- le **score faisant foi est dérivé par code** (`derive_score`) depuis les
+  ``determinations`` — jamais lu depuis l'artefact ;
+- **corroboration** (§5.2) : score plein avec < 2 sources indépendantes →
+  plafonné au palier inférieur + flag ``corroboration_insuffisante`` ;
+- ``bloque_acces`` seul → statut ``revue_requise``, score NULL — **jamais 0** ;
+- ``donnees_insuffisantes`` → ``non_applicable``, score NULL.
+
+Idempotent : une éval existante (media, critère, évaluateur, run) est ignorée.
+**Dry-run par défaut**, ``--apply`` gardé (``--allow-prod`` hors DB test).
+
+Usage :
+    cd packages/api
+    python3 scripts/media_eval/ingest_evaluations.py --artifact <fichier|dossier> [--apply]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from uuid import UUID
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from sqlalchemy import select
+
+from app.config import get_settings
+from app.database import async_session_maker, engine
+from app.models.media_eval import (
+    MediaEvalEvaluation,
+    MediaEvalSignal,
+    StatutEvaluation,
+)
+from scripts.cleanup_orphan_sources import _is_test_db
+from scripts.media_eval.build_eval_input import serialiser_signal
+from scripts.media_eval.garde_fous import (
+    appliquer_corroboration,
+    statut_evaluation,
+)
+from scripts.media_eval.ingest_artifacts import IngestError, resoudre_media
+from scripts.media_eval.schemas import (
+    BAREMES,
+    VERSION_METHODO,
+    EvaluationBatchArtifact,
+    EvaluationOutput,
+)
+
+
+@dataclass
+class EvaluationPreparee:
+    """Ligne prête à insérer, après garde-fous aval — pur, testable."""
+
+    statut: str
+    score: float | None
+    niveau: int | None
+    flags: list[str] = field(default_factory=list)
+
+
+def preparer_evaluation(
+    item: EvaluationOutput, signaux_cites: list[dict]
+) -> EvaluationPreparee:
+    """Applique les garde-fous aval à une sortie évaluateur validée."""
+    statut = statut_evaluation(item.flags, signaux_cites)
+    if statut != StatutEvaluation.EVALUEE.value:
+        # N/A ou revue_requise : score NULL — jamais 0 (arbitrage n°3).
+        return EvaluationPreparee(
+            statut=statut, score=None, niveau=None, flags=list(item.flags)
+        )
+    score, niveau = item.score_derive()
+    score, flags_corro = appliquer_corroboration(item.critere, score, signaux_cites)
+    return EvaluationPreparee(
+        statut=statut,
+        score=score,
+        niveau=niveau,
+        flags=list(item.flags) + flags_corro,
+    )
+
+
+async def _signaux_cites(session, item: EvaluationOutput, media_id) -> list[dict]:
+    """Charge et contrôle les signaux cités — lève IngestError sinon."""
+    ids = [UUID(s) for s in item.signal_ids_cites]
+    if not ids:
+        return []
+    rows = await session.execute(
+        select(MediaEvalSignal).where(MediaEvalSignal.id.in_(ids))
+    )
+    signaux = {s.id: s for s in rows.scalars()}
+    for signal_id in ids:
+        signal = signaux.get(signal_id)
+        if signal is None:
+            raise IngestError(
+                f"{item.critere}/{item.media_domaine}: signal cité inexistant {signal_id}"
+            )
+        if signal.media_id != media_id:
+            raise IngestError(
+                f"{item.critere}/{item.media_domaine}: signal {signal_id} "
+                "appartient à un autre média"
+            )
+        if signal.critere != item.critere:
+            raise IngestError(
+                f"{item.critere}/{item.media_domaine}: signal {signal_id} "
+                f"appartient au critère {signal.critere}"
+            )
+    return [serialiser_signal(signaux[i]) for i in ids]
+
+
+async def ingester_evaluations(
+    session, batch: EvaluationBatchArtifact
+) -> tuple[int, int]:
+    """Valide TOUT le batch puis insère. Retourne (insérées, ignorées)."""
+    preparees: list[tuple[EvaluationOutput, EvaluationPreparee, UUID]] = []
+    for item in batch.items:
+        media = await resoudre_media(session, item.media_domaine)
+        signaux_cites = await _signaux_cites(session, item, media.id)
+        preparees.append((item, preparer_evaluation(item, signaux_cites), media.id))
+
+    inserees, ignorees = 0, 0
+    for item, prep, media_id in preparees:
+        existante = (
+            await session.execute(
+                select(MediaEvalEvaluation.id).where(
+                    MediaEvalEvaluation.media_id == media_id,
+                    MediaEvalEvaluation.critere == item.critere,
+                    MediaEvalEvaluation.evaluateur == batch.agent,
+                    MediaEvalEvaluation.run_id == batch.run_id,
+                )
+            )
+        ).scalar_one_or_none()
+        if existante is not None:
+            ignorees += 1
+            continue
+        session.add(
+            MediaEvalEvaluation(
+                media_id=media_id,
+                critere=item.critere,
+                score=prep.score,
+                score_max=float(BAREMES[item.critere]),
+                niveau=prep.niveau,
+                statut=StatutEvaluation(prep.statut),
+                justification=item.justification,
+                signal_ids=[UUID(s) for s in item.signal_ids_cites],
+                flags=prep.flags,
+                evaluateur=batch.agent,
+                version_methodo=VERSION_METHODO,
+                version_prompt=batch.version_prompt or "",
+                run_id=batch.run_id,
+            )
+        )
+        inserees += 1
+    return inserees, ignorees
+
+
+def _collecter_paths(artifact: Path) -> list[Path]:
+    if artifact.is_dir():
+        paths = sorted(artifact.glob("evaluations_*.json"))
+        if not paths:
+            raise IngestError(f"aucun artefact evaluations_*.json dans {artifact}")
+        return paths
+    return [artifact]
+
+
+async def run(artifact: Path, apply: bool, allow_prod: bool) -> int:
+    settings = get_settings()
+    db_url = settings.database_url or ""
+    is_test = _is_test_db(db_url)
+    print(
+        f"DB cible : {db_url.split('@')[-1] if '@' in db_url else db_url}  (test={is_test})"
+    )
+    if apply and not is_test and not allow_prod:
+        print("\nABORT : --apply contre une DB non-test sans --allow-prod (gated PO).")
+        return 2
+
+    try:
+        paths = _collecter_paths(artifact)
+        batches = [
+            EvaluationBatchArtifact.model_validate(json.loads(p.read_text()))
+            for p in paths
+        ]
+    except IngestError as exc:
+        print(f"REJET : {exc}")
+        return 1
+
+    async with async_session_maker() as session:
+        try:
+            total_ins, total_ign = 0, 0
+            for batch in batches:
+                ins, ign = await ingester_evaluations(session, batch)
+                total_ins += ins
+                total_ign += ign
+            print(
+                f"Artefacts : {len(paths)} | à insérer : {total_ins} | "
+                f"déjà présentes (ignorées) : {total_ign}"
+            )
+            if not apply:
+                await session.rollback()
+                print("(dry-run — aucune mutation. Relance avec --apply.)")
+                return 0
+            await session.commit()
+            print(f"APPLIQUÉ : {total_ins} évaluations écrites.")
+            return 0
+        except IngestError as exc:
+            await session.rollback()
+            print(f"REJET : {exc} — rien n'a été écrit.")
+            return 1
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await engine.dispose()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        required=True,
+        help="fichier evaluations_*.json ou dossier",
+    )
+    parser.add_argument(
+        "--apply", action="store_true", help="exécute (défaut: dry-run)"
+    )
+    parser.add_argument(
+        "--allow-prod", action="store_true", help="autorise --apply en prod"
+    )
+    args = parser.parse_args()
+    sys.exit(
+        asyncio.run(run(args.artifact, apply=args.apply, allow_prod=args.allow_prod))
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/scripts/media_eval/schemas.py
+++ b/packages/api/scripts/media_eval/schemas.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Contrats Pydantic + constantes du pipeline media-eval (C1–C11).
+
+Source de vérité **codée en dur** des règles mécaniques de la méthodo v1.2
+(cf. docs/media-eval/) : barèmes, registre des types de signaux, dérivation du
+score depuis les `determinations` de l'évaluateur, dérivation du poids
+émetteur des débunkages. Rien de tout cela n'est confié aux prompts — même
+philosophie que `derive_reliability` dans `scripts/source_eval_schema.py`.
+
+Les artefacts JSON produits par les agents (voie B + évaluateurs) sont validés
+ici AVANT toute écriture DB (`ingest_artifacts.py`, `ingest_evaluations.py`) :
+un artefact invalide est rejeté en bloc, rien n'est écrit.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from app.models.media_eval import (
+    GraviteDebunkage,
+    PoidsEmetteur,
+    StatutSignal,
+    SuiteDonnee,
+)
+
+VERSION_METHODO = "v1.2"
+
+# --------------------------------------------------------------------------- #
+# Barèmes (méthodo §4, verbatim) — jamais dans les prompts.
+# --------------------------------------------------------------------------- #
+BAREMES: dict[str, int] = {
+    "C1": 20,
+    "C2": 15,
+    "C3": 10,
+    "C4": 5,
+    "C5": 10,
+    "C6": 6,
+    "C7": 4,
+    "C8": 4,
+    "C9": 10,
+    "C10": 10,
+    "C11": 6,
+}  # total 100
+assert sum(BAREMES.values()) == 100
+
+CRITERES_VAGUE_1: tuple[str, ...] = ("C1", "C5", "C7", "C8", "C9", "C11")  # 54 pts
+CRITERES_NIVEAUX: tuple[str, ...] = ("C9", "C11")  # échelles à 3 niveaux en vague 1
+
+# Scores par niveau (méthodo §4.2/§4.3, verbatim).
+NIVEAU_SCORES: dict[str, dict[int, int]] = {
+    "C9": {0: 0, 1: 5, 2: 10},
+    "C11": {0: 0, 1: 3, 2: 6},
+}
+
+# Lettres A–E sur le score renormalisé /100 (méthodo §4.4.1 — seuils PO,
+# à confirmer à l'import de la v1.2 finale).
+LETTRES: list[tuple[int, str]] = [(85, "A"), (70, "B"), (55, "C"), (40, "D"), (0, "E")]
+
+# Garde-fous mécaniques (architecture §6).
+FRAICHEUR_MAX_JOURS = 730
+FALLBACK_C1_MIN_DEBUNKAGES = 3
+CORROBORATION_MIN_SOURCES = 2
+
+# Échelle de scores possibles par critère (vague 1) : sert au plafonnement
+# « palier inférieur » du garde-fou de corroboration.
+PALIERS: dict[str, tuple[int, ...]] = {
+    "C1": (0, 5, 10, 15, 20),
+    "C5": (0, 5, 10),
+    "C7": (0, 2, 4),
+    "C8": (0, 2, 4),
+    "C9": (0, 5, 10),
+    "C11": (0, 3, 6),
+}
+
+# Pondération des émetteurs de débunkages (amendement v1.2 C1) — dérivée par
+# code depuis l'émetteur normalisé, jamais choisie par l'agent. Les rubriques
+# de fact-checking de médias concurrents directs = poids réduit (conflit
+# d'intérêts potentiel documenté). Émetteur inconnu -> `faible`.
+POIDS_EMETTEUR: dict[str, str] = {
+    "arcom": PoidsEmetteur.FORT.value,
+    "justice": PoidsEmetteur.FORT.value,
+    "cdjm": PoidsEmetteur.FORT.value,
+    "afp_factuel": PoidsEmetteur.MOYEN.value,
+    "les_decodeurs": PoidsEmetteur.MOYEN.value,
+    "checknews": PoidsEmetteur.MOYEN.value,
+    "factuel_franceinfo": PoidsEmetteur.MOYEN.value,
+    "fake_off": PoidsEmetteur.MOYEN.value,
+}
+POIDS_EMETTEUR_DEFAUT = PoidsEmetteur.FAIBLE.value
+
+
+def derive_poids_emetteur(emetteur: str) -> str:
+    """Poids d'un émetteur de débunkage (clé normalisée snake_case)."""
+    return POIDS_EMETTEUR.get(emetteur.strip().lower(), POIDS_EMETTEUR_DEFAUT)
+
+
+# --------------------------------------------------------------------------- #
+# Registre des types de signaux (vague 1, figé).
+# --------------------------------------------------------------------------- #
+TYPE_SIGNAUX: dict[str, tuple[str, ...]] = {
+    "C1": ("debunkage", "sanction_arcom", "condamnation_justice", "avis_cdjm"),
+    "C5": (
+        "mentions_legales",
+        "identification_proprietaire",
+        "structure_actionnariat",
+        "enregistrement_cppap",
+        "transparence_financement",
+    ),
+    "C7": (
+        "marquage_contenu_sponsorise",
+        "regie_pub_identifiee",
+        "politique_publicitaire",
+    ),
+    "C8": (
+        "charte_deontologique",
+        "adhesion_cdjm",
+        "certification_jti",
+        "reference_charte_externe",
+    ),
+    "C9": (
+        "charte_independance",
+        "societe_journalistes",
+        "independance_capital",
+        "intervention_actionnaire",
+        "statuts_redaction",
+    ),
+    "C11": (
+        "manifeste_positionnement",
+        "ligne_editoriale_publiee",
+        "auto_description_orientation",
+        "rubriques_opinion_identifiees",
+    ),
+}
+
+# Types de signaux « événementiels » (fenêtre de fraîcheur 730 j) vs
+# « structurels » (constatés à date, sans limite d'ancienneté) — v1.2 §5.4.
+TYPES_EVENEMENTIELS: frozenset[str] = frozenset(TYPE_SIGNAUX["C1"])
+
+# --------------------------------------------------------------------------- #
+# Flags évaluateur (contrat `_common.md`) + flags posés par code.
+# --------------------------------------------------------------------------- #
+FLAGS_EVALUATEUR: frozenset[str] = frozenset(
+    {
+        "donnees_insuffisantes",
+        "signaux_contradictoires",
+        "bloque_acces",
+        "revue_humaine_requise",
+    }
+)
+FLAG_CORROBORATION = "corroboration_insuffisante"  # posé par code (aval)
+FLAG_FALLBACK_C1 = "fallback_c1_declenche"  # posé par code (amont)
+
+# Déterminations énumérables par critère (rubriques `docs/media-eval/rubrics/`).
+C1_PROFILS: dict[str, int] = {
+    "aucun_signal_negatif": 20,
+    "problemes_mineurs_corriges": 15,
+    "problemes_mixtes": 10,
+    "problemes_significatifs": 5,
+    "fabrication_ou_refus_non_corrige": 0,
+}
+# Notation méthodo §5.3-É2 (continue) : plein / 50 % / 0.
+PROFILS_SIGNAUX: tuple[str, ...] = ("positifs_majoritaires", "mixtes", "negatifs")
+
+
+def derive_score(critere: str, determinations: dict) -> tuple[float, int | None]:
+    """Score faisant foi, dérivé par code depuis les `determinations`.
+
+    Retourne ``(score, niveau)`` — ``niveau`` renseigné pour C9/C11, None
+    sinon. Lève ``ValueError`` si les déterminations ne respectent pas la
+    rubrique (mêmes règles que la validation `EvaluationOutput`).
+    """
+    if critere in CRITERES_NIVEAUX:
+        niveau = determinations.get("niveau")
+        if niveau not in (0, 1, 2):
+            raise ValueError(f"{critere}: niveau invalide {niveau!r} (attendu 0|1|2)")
+        return float(NIVEAU_SCORES[critere][niveau]), niveau
+    if critere == "C1":
+        profil = determinations.get("profil_veracite")
+        if profil not in C1_PROFILS:
+            raise ValueError(f"C1: profil_veracite invalide {profil!r}")
+        return float(C1_PROFILS[profil]), None
+    if critere in ("C5", "C7", "C8"):
+        profil = determinations.get("profil_signaux")
+        if profil not in PROFILS_SIGNAUX:
+            raise ValueError(f"{critere}: profil_signaux invalide {profil!r}")
+        plein = float(BAREMES[critere])
+        return {"positifs_majoritaires": plein, "mixtes": plein / 2, "negatifs": 0.0}[
+            profil
+        ], None
+    raise ValueError(f"critère hors vague 1 : {critere!r}")
+
+
+def palier_inferieur(critere: str, score: float) -> float:
+    """Palier immédiatement inférieur au score (garde-fou corroboration)."""
+    paliers = PALIERS[critere]
+    inferieurs = [p for p in paliers if p < score]
+    return float(inferieurs[-1]) if inferieurs else 0.0
+
+
+# --------------------------------------------------------------------------- #
+# Artefacts voie B (collecteurs) — validés avant insertion.
+# --------------------------------------------------------------------------- #
+_STATUTS_SANS_SOURCE = {
+    StatutSignal.ABSENT_VERIFIE.value,
+    StatutSignal.BLOQUE_ACCES.value,
+}
+
+
+class SignalArtifact(BaseModel):
+    """Un signal proposé par un agent collecteur (jamais écrit tel quel)."""
+
+    media_domaine: str
+    critere: str
+    type_signal: str
+    statut: str
+    valeur: dict | None = None
+    citation: str | None = None
+    source_urls: list[str] = Field(default_factory=list)
+    sources_consultees: list[str] = Field(default_factory=list)
+
+    @field_validator("statut")
+    @classmethod
+    def _statut_valide(cls, v: str) -> str:
+        if v not in {s.value for s in StatutSignal}:
+            raise ValueError(f"statut hors enum: {v!r}")
+        return v
+
+    @model_validator(mode="after")
+    def _coherence(self) -> SignalArtifact:
+        registre = TYPE_SIGNAUX.get(self.critere)
+        if registre is None:
+            raise ValueError(f"critère hors vague 1 : {self.critere!r}")
+        if self.type_signal not in registre:
+            raise ValueError(
+                f"type_signal {self.type_signal!r} hors registre {self.critere}"
+            )
+        if self.statut not in _STATUTS_SANS_SOURCE and not self.source_urls:
+            raise ValueError(
+                f"source_urls vide interdit pour statut {self.statut!r} "
+                "(exigé sauf absent_verifie / bloque_acces)"
+            )
+        if (
+            self.statut == StatutSignal.ABSENT_VERIFIE.value
+            and not self.sources_consultees
+        ):
+            raise ValueError(
+                "absent_verifie exige sources_consultees (preuve de recherche)"
+            )
+        return self
+
+
+class DebunkageArtifact(BaseModel):
+    """Un débunkage qualifié par un agent (C1).
+
+    ``poids_emetteur`` est **dérivé par code** (`derive_poids_emetteur`) —
+    toute valeur fournie par l'agent est ignorée. L'ingestion crée le couple
+    débunkage + signal C1 (contrat évaluateur uniforme).
+    """
+
+    media_domaine: str
+    type_signal: str = "debunkage"
+    url_debunkage: str
+    emetteur: str
+    gravite: str
+    suite_donnee: str
+    publie_at: date
+    resume: str | None = None
+    citation: str | None = None
+    source_urls: list[str] = Field(min_length=1)
+    sources_consultees: list[str] = Field(default_factory=list)
+
+    @field_validator("type_signal")
+    @classmethod
+    def _type_c1(cls, v: str) -> str:
+        if v not in TYPE_SIGNAUX["C1"]:
+            raise ValueError(f"type_signal {v!r} hors registre C1")
+        return v
+
+    @field_validator("gravite")
+    @classmethod
+    def _gravite_valide(cls, v: str) -> str:
+        if v not in {g.value for g in GraviteDebunkage}:
+            raise ValueError(f"gravite hors enum: {v!r}")
+        return v
+
+    @field_validator("suite_donnee")
+    @classmethod
+    def _suite_valide(cls, v: str) -> str:
+        if v not in {s.value for s in SuiteDonnee}:
+            raise ValueError(f"suite_donnee hors enum: {v!r}")
+        return v
+
+    def poids_emetteur(self) -> str:
+        return derive_poids_emetteur(self.emetteur)
+
+
+# --------------------------------------------------------------------------- #
+# Sortie évaluateur — score dérivé par code, signal_ids obligatoires.
+# --------------------------------------------------------------------------- #
+class EvaluationOutput(BaseModel):
+    """Sortie d'un agent évaluateur pour (média, critère)."""
+
+    media_domaine: str
+    critere: str
+    determinations: dict = Field(default_factory=dict)
+    justification: str
+    signal_ids_cites: list[str] = Field(default_factory=list)
+    flags: list[str] = Field(default_factory=list)
+
+    @field_validator("flags")
+    @classmethod
+    def _flags_valides(cls, v: list[str]) -> list[str]:
+        inconnus = set(v) - FLAGS_EVALUATEUR
+        if inconnus:
+            raise ValueError(f"flags hors contrat: {sorted(inconnus)}")
+        return v
+
+    @model_validator(mode="after")
+    def _coherence(self) -> EvaluationOutput:
+        if self.critere not in CRITERES_VAGUE_1:
+            raise ValueError(f"critère hors vague 1 : {self.critere!r}")
+        if self.est_non_applicable():
+            return self  # N/A : pas de déterminations ni de signaux exigés
+        # Validator dur : un score sans signaux cités est rejeté.
+        if not self.signal_ids_cites:
+            raise ValueError(
+                "signal_ids_cites vide sans flag donnees_insuffisantes : rejet"
+            )
+        derive_score(self.critere, self.determinations)  # lève si invalide
+        return self
+
+    def est_non_applicable(self) -> bool:
+        return "donnees_insuffisantes" in self.flags
+
+    def score_derive(self) -> tuple[float, int | None]:
+        """Score faisant foi (avant garde-fous aval)."""
+        return derive_score(self.critere, self.determinations)
+
+
+# --------------------------------------------------------------------------- #
+# Enveloppes d'artefacts + golden set.
+# --------------------------------------------------------------------------- #
+class _BatchArtifact(BaseModel):
+    run_id: str
+    agent: str
+    genere_at: datetime
+    version_prompt: str | None = None
+
+
+class SignalBatchArtifact(_BatchArtifact):
+    items: list[SignalArtifact]
+
+
+class DebunkageBatchArtifact(_BatchArtifact):
+    items: list[DebunkageArtifact]
+
+
+class EvaluationBatchArtifact(_BatchArtifact):
+    items: list[EvaluationOutput]
+
+
+class GoldenEntry(BaseModel):
+    """Une notation humaine de référence pour (média, critère)."""
+
+    media_domaine: str
+    critere: str
+    statut: str  # evaluee | non_applicable | revue_requise
+    score: float | None = None
+    niveau: int | None = None
+    commentaire: str | None = None
+
+    @model_validator(mode="after")
+    def _coherence(self) -> GoldenEntry:
+        if self.critere not in CRITERES_VAGUE_1:
+            raise ValueError(f"critère hors vague 1 : {self.critere!r}")
+        if self.statut == "evaluee":
+            if self.score is None:
+                raise ValueError("statut evaluee exige un score")
+            if self.critere in CRITERES_NIVEAUX and self.niveau not in (0, 1, 2):
+                raise ValueError(f"{self.critere}: niveau 0|1|2 requis dans le gold")
+        return self
+
+
+class GoldenSet(BaseModel):
+    """`docs/media-eval/golden/gold_v0.json` — notation Laurin."""
+
+    version_methodo: str = VERSION_METHODO
+    notateur: str = "humain:laurin"
+    note_at: datetime | None = None
+    entries: list[GoldenEntry]

--- a/packages/api/scripts/media_eval/seed_medias.py
+++ b/packages/api/scripts/media_eval/seed_medias.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Seed du référentiel `media_eval_medias` — 2 médias pilotes V0.
+
+Upsert par ``domaine`` (insert si absent, update des champs référentiel
+sinon). **Dry-run par défaut**, ``--apply`` gardé (``--allow-prod`` requis
+hors DB test — pattern `apply_source_evaluations.py`). Idempotent.
+
+Usage :
+    cd packages/api
+    python3 scripts/media_eval/seed_medias.py                    # dry-run
+    python3 scripts/media_eval/seed_medias.py --apply            # DB test
+    python3 scripts/media_eval/seed_medias.py --apply --allow-prod
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from sqlalchemy import select
+
+from app.config import get_settings
+from app.database import async_session_maker, engine
+from app.models.media_eval import MediaEvalMedia, TypeMedia
+from scripts.cleanup_orphan_sources import _is_test_db
+
+# Référentiel V0 (décisions PO 07/07/2026). Convention CNEWS : le média évalué
+# est le domaine cnews.fr, type audiovisuel → signaux ARCOM applicables.
+MEDIAS_PILOTES: list[dict] = [
+    {
+        "nom": "CNEWS",
+        "domaine": "cnews.fr",
+        "type_media": TypeMedia.AUDIOVISUEL,
+        "paywall": False,
+        "rubriques_opinion": ["opinions"],
+        "volume_articles_jour": 80,
+    },
+    {
+        "nom": "Reporterre",
+        "domaine": "reporterre.net",
+        "type_media": TypeMedia.PRESSE_EN_LIGNE,
+        "paywall": False,
+        "rubriques_opinion": ["tribunes", "chroniques"],
+        "volume_articles_jour": 12,
+    },
+]
+
+_CHAMPS = (
+    "nom",
+    "type_media",
+    "paywall",
+    "rubriques_opinion",
+    "volume_articles_jour",
+)
+
+
+async def seed(session, medias: list[dict]) -> tuple[list[str], list[str]]:
+    """Upsert par domaine. Retourne (créés, mis à jour) — sans commit."""
+    crees: list[str] = []
+    maj: list[str] = []
+    for spec in medias:
+        existant = (
+            await session.execute(
+                select(MediaEvalMedia).where(MediaEvalMedia.domaine == spec["domaine"])
+            )
+        ).scalar_one_or_none()
+        if existant is None:
+            session.add(MediaEvalMedia(**spec))
+            crees.append(spec["domaine"])
+            continue
+        change = False
+        for champ in _CHAMPS:
+            if getattr(existant, champ) != spec[champ]:
+                setattr(existant, champ, spec[champ])
+                change = True
+        if change:
+            maj.append(spec["domaine"])
+    return crees, maj
+
+
+async def run(apply: bool, allow_prod: bool) -> int:
+    settings = get_settings()
+    db_url = settings.database_url or ""
+    is_test = _is_test_db(db_url)
+    print(
+        f"DB cible : {db_url.split('@')[-1] if '@' in db_url else db_url}  (test={is_test})"
+    )
+    if apply and not is_test and not allow_prod:
+        print("\nABORT : --apply contre une DB non-test sans --allow-prod (gated PO).")
+        return 2
+
+    async with async_session_maker() as session:
+        try:
+            crees, maj = await seed(session, MEDIAS_PILOTES)
+            print(f"À créer : {crees or '-'} | à mettre à jour : {maj or '-'}")
+            if not apply:
+                await session.rollback()
+                print("(dry-run — aucune mutation. Relance avec --apply.)")
+                return 0
+            await session.commit()
+            print(f"APPLIQUÉ : {len(crees)} créés, {len(maj)} mis à jour.")
+            return 0
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await engine.dispose()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply", action="store_true", help="exécute (défaut: dry-run)"
+    )
+    parser.add_argument(
+        "--allow-prod", action="store_true", help="autorise --apply en prod"
+    )
+    args = parser.parse_args()
+    sys.exit(asyncio.run(run(apply=args.apply, allow_prod=args.allow_prod)))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/scripts/media_eval/synthese_fiche.py
+++ b/packages/api/scripts/media_eval/synthese_fiche.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Synthèse de la fiche média — pur calcul (architecture §6), SANS LLM.
+
+Depuis les évaluations d'un (média, run) :
+- ``score_renormalise = score_brut / score_max_applicable × 100`` où
+  ``score_max_applicable = Σ BAREMES[critères vague 1 évalués]`` (les N/A et
+  ``revue_requise`` sont exclus du dénominateur — CNEWS : 54 ; Reporterre si
+  C1 N/A : 34) ;
+- lettre A–E (`LETTRES`) ;
+- confiance : ``haute`` = 0 N/A et 0 flag bloquant ; ``moyenne`` = ≤ 2 N/A ou
+  ``signaux_contradictoires`` ; ``basse`` = > 2 N/A ou ``revue_humaine_requise``
+  (ou critère en ``revue_requise``).
+
+Sortie : ligne `media_eval_fiches` (upsert par (media, run), ``--apply``
+gardé) + fiche markdown. **Dry-run par défaut.**
+
+Usage :
+    cd packages/api
+    python3 scripts/media_eval/synthese_fiche.py --media cnews.fr --run-id pilote-2026-07
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from sqlalchemy import select
+
+from app.config import get_settings
+from app.database import async_session_maker, engine
+from app.models.media_eval import (
+    ConfianceFiche,
+    MediaEvalEvaluation,
+    MediaEvalFiche,
+    StatutEvaluation,
+)
+from scripts.cleanup_orphan_sources import _is_test_db
+from scripts.media_eval.ingest_artifacts import IngestError, resoudre_media
+from scripts.media_eval.schemas import BAREMES, CRITERES_VAGUE_1, LETTRES
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+DEFAULT_FICHES_DIR = _REPO_ROOT / "docs" / "media-eval" / "fiches"
+
+_FLAGS_BLOQUANTS = {
+    "signaux_contradictoires",
+    "corroboration_insuffisante",
+    "revue_humaine_requise",
+    "bloque_acces",
+}
+
+
+def lettre_pour(score_renormalise: float) -> str:
+    for seuil, lettre in LETTRES:
+        if score_renormalise >= seuil:
+            return lettre
+    return LETTRES[-1][1]
+
+
+def _meilleure_par_critere(evaluations: list[dict]) -> dict[str, dict]:
+    """Une éval par critère : le raccourci code: prime sur l'agent."""
+    par_critere: dict[str, dict] = {}
+    for ev in evaluations:
+        critere = ev["critere"]
+        actuel = par_critere.get(critere)
+        if actuel is None or (
+            str(ev.get("evaluateur", "")).startswith("code:")
+            and not str(actuel.get("evaluateur", "")).startswith("code:")
+        ):
+            par_critere[critere] = ev
+    return par_critere
+
+
+def compute_fiche(evaluations: list[dict]) -> dict:
+    """Calcule la fiche — pur, testable sans DB.
+
+    ``evaluations`` : dicts {critere, statut, score, flags, evaluateur, niveau}.
+    """
+    par_critere = _meilleure_par_critere(evaluations)
+
+    criteres_evalues, criteres_na, criteres_revue = [], [], []
+    flags_toutes: set[str] = set()
+    score_brut = 0.0
+    for critere in CRITERES_VAGUE_1:
+        ev = par_critere.get(critere)
+        if ev is None:
+            continue
+        flags_toutes.update(ev.get("flags") or [])
+        statut = ev["statut"]
+        if statut == StatutEvaluation.EVALUEE.value:
+            criteres_evalues.append(critere)
+            score_brut += float(ev["score"])
+        elif statut == StatutEvaluation.NON_APPLICABLE.value:
+            criteres_na.append(critere)
+        else:
+            criteres_revue.append(critere)
+
+    score_max_applicable = float(sum(BAREMES[c] for c in criteres_evalues))
+    score_renormalise = (
+        round(score_brut / score_max_applicable * 100, 1)
+        if score_max_applicable
+        else 0.0
+    )
+
+    n_na = len(criteres_na)
+    if n_na > 2 or "revue_humaine_requise" in flags_toutes or criteres_revue:
+        confiance = ConfianceFiche.BASSE.value
+    elif n_na == 0 and not (flags_toutes & _FLAGS_BLOQUANTS):
+        confiance = ConfianceFiche.HAUTE.value
+    else:
+        confiance = ConfianceFiche.MOYENNE.value
+
+    return {
+        "score_brut": score_brut,
+        "score_max_applicable": score_max_applicable,
+        "score_renormalise": score_renormalise,
+        "lettre": lettre_pour(score_renormalise),
+        "criteres_evalues": criteres_evalues,
+        "criteres_na": criteres_na,
+        "criteres_revue_requise": criteres_revue,
+        "confiance": confiance,
+        "detail": {
+            c: {
+                "statut": ev["statut"],
+                "score": ev.get("score"),
+                "score_max": BAREMES[c],
+                "niveau": ev.get("niveau"),
+                "flags": list(ev.get("flags") or []),
+                "evaluateur": ev.get("evaluateur"),
+            }
+            for c, ev in sorted(par_critere.items())
+        },
+    }
+
+
+def render_fiche_md(media: dict, run_id: str, fiche: dict) -> str:
+    lignes = [
+        f"# Fiche d'évaluation — {media['nom']} ({media['domaine']})",
+        "",
+        f"- Run : `{run_id}` · généré le {datetime.now(UTC).date().isoformat()}",
+        f"- **Score : {fiche['score_brut']:g} / {fiche['score_max_applicable']:g}"
+        f" → {fiche['score_renormalise']:g}/100 · lettre {fiche['lettre']}**",
+        f"- Confiance : **{fiche['confiance']}**",
+        f"- Critères évalués : {', '.join(fiche['criteres_evalues']) or 'aucun'}"
+        f" · N/A : {', '.join(fiche['criteres_na']) or 'aucun'}"
+        f" · revue requise : {', '.join(fiche['criteres_revue_requise']) or 'aucun'}",
+        "",
+        "| Critère | Statut | Score | Niveau | Flags | Évaluateur |",
+        "|---|---|---|---|---|---|",
+    ]
+    for critere, det in fiche["detail"].items():
+        score = (
+            "N/A" if det["score"] is None else f"{det['score']:g}/{det['score_max']}"
+        )
+        lignes.append(
+            f"| {critere} | {det['statut']} | {score} | "
+            f"{det['niveau'] if det['niveau'] is not None else '-'} | "
+            f"{', '.join(det['flags']) or '-'} | {det['evaluateur'] or '-'} |"
+        )
+    lignes.append("")
+    return "\n".join(lignes)
+
+
+async def run(
+    domaine: str,
+    run_id: str,
+    out_dir: Path,
+    apply: bool,
+    allow_prod: bool,
+) -> int:
+    settings = get_settings()
+    db_url = settings.database_url or ""
+    is_test = _is_test_db(db_url)
+    print(
+        f"DB cible : {db_url.split('@')[-1] if '@' in db_url else db_url}  (test={is_test})"
+    )
+    if apply and not is_test and not allow_prod:
+        print("\nABORT : --apply contre une DB non-test sans --allow-prod (gated PO).")
+        return 2
+
+    async with async_session_maker() as session:
+        try:
+            media = await resoudre_media(session, domaine)
+            rows = await session.execute(
+                select(MediaEvalEvaluation).where(
+                    MediaEvalEvaluation.media_id == media.id,
+                    MediaEvalEvaluation.run_id == run_id,
+                )
+            )
+            evaluations = [
+                {
+                    "critere": ev.critere,
+                    "statut": ev.statut.value
+                    if hasattr(ev.statut, "value")
+                    else ev.statut,
+                    "score": ev.score,
+                    "niveau": ev.niveau,
+                    "flags": list(ev.flags or []),
+                    "evaluateur": ev.evaluateur,
+                }
+                for ev in rows.scalars()
+            ]
+            if not evaluations:
+                print(f"REJET : aucune évaluation pour {domaine} / {run_id}.")
+                return 1
+
+            fiche = compute_fiche(evaluations)
+            media_dict = {"nom": media.nom, "domaine": media.domaine}
+            print(json.dumps(fiche, indent=2, ensure_ascii=False))
+
+            out_dir.mkdir(parents=True, exist_ok=True)
+            md_path = out_dir / f"{media.domaine.replace('.', '_')}_{run_id}.md"
+            md_path.write_text(render_fiche_md(media_dict, run_id, fiche))
+            print(f"Fiche markdown : {md_path}")
+
+            if not apply:
+                await session.rollback()
+                print("(dry-run — ligne media_eval_fiches non écrite. --apply.)")
+                return 0
+
+            existante = (
+                await session.execute(
+                    select(MediaEvalFiche).where(
+                        MediaEvalFiche.media_id == media.id,
+                        MediaEvalFiche.run_id == run_id,
+                    )
+                )
+            ).scalar_one_or_none()
+            valeurs = {
+                "score_brut": fiche["score_brut"],
+                "score_max_applicable": fiche["score_max_applicable"],
+                "score_renormalise": fiche["score_renormalise"],
+                "lettre": fiche["lettre"],
+                "criteres_evalues": fiche["criteres_evalues"],
+                "criteres_na": fiche["criteres_na"],
+                "confiance": ConfianceFiche(fiche["confiance"]),
+                "detail": fiche["detail"],
+            }
+            if existante is None:
+                session.add(MediaEvalFiche(media_id=media.id, run_id=run_id, **valeurs))
+            else:
+                for champ, valeur in valeurs.items():
+                    setattr(existante, champ, valeur)
+            await session.commit()
+            print("APPLIQUÉ : fiche écrite (media_eval_fiches).")
+            return 0
+        except IngestError as exc:
+            await session.rollback()
+            print(f"REJET : {exc}")
+            return 1
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await engine.dispose()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--media", required=True, help="domaine (ex. cnews.fr)")
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=DEFAULT_FICHES_DIR,
+        help="dossier des fiches markdown (défaut docs/media-eval/fiches)",
+    )
+    parser.add_argument(
+        "--apply", action="store_true", help="exécute (défaut: dry-run)"
+    )
+    parser.add_argument(
+        "--allow-prod", action="store_true", help="autorise --apply en prod"
+    )
+    args = parser.parse_args()
+    sys.exit(
+        asyncio.run(
+            run(
+                args.media,
+                args.run_id,
+                args.out_dir,
+                apply=args.apply,
+                allow_prod=args.allow_prod,
+            )
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/tests/scripts/fixtures/media_eval/debunkages_cnews.json
+++ b/packages/api/tests/scripts/fixtures/media_eval/debunkages_cnews.json
@@ -1,0 +1,37 @@
+{
+  "run_id": "run-test",
+  "agent": "agent:media-eval-collecteur-debunkages@v1",
+  "genere_at": "2026-07-08T10:00:00Z",
+  "version_prompt": null,
+  "items": [
+    {
+      "media_domaine": "cnews.fr",
+      "type_signal": "sanction_arcom",
+      "url_debunkage": "https://www.arcom.fr/decision-cnews-2025-042",
+      "emetteur": "arcom",
+      "gravite": "significative",
+      "suite_donnee": "contestation",
+      "publie_at": "2025-11-12",
+      "resume": "Sanction de 20 000 EUR pour manquement au pluralisme, confirmée par le Conseil d'Etat.",
+      "citation": "L'ARCOM sanctionne la chaîne CNEWS…",
+      "source_urls": [
+        "https://www.arcom.fr/decision-cnews-2025-042",
+        "https://www.conseil-etat.fr/decision-2026-011"
+      ],
+      "sources_consultees": []
+    },
+    {
+      "media_domaine": "cnews.fr",
+      "type_signal": "avis_cdjm",
+      "url_debunkage": "https://cdjm.org/avis/26-014",
+      "emetteur": "cdjm",
+      "gravite": "mineure",
+      "suite_donnee": "aucune",
+      "publie_at": "2026-02-03",
+      "resume": "Avis fondé : chiffre erroné non attribué dans un bandeau.",
+      "citation": "Le CDJM déclare la saisine fondée…",
+      "source_urls": ["https://cdjm.org/avis/26-014"],
+      "sources_consultees": []
+    }
+  ]
+}

--- a/packages/api/tests/scripts/fixtures/media_eval/generated_mini.json
+++ b/packages/api/tests/scripts/fixtures/media_eval/generated_mini.json
@@ -1,0 +1,13 @@
+{
+  "version_methodo": "v1.2",
+  "notateur": "agent:media-eval-evaluateur@v1",
+  "note_at": "2026-07-08T12:00:00Z",
+  "entries": [
+    {"media_domaine": "cnews.fr", "critere": "C1", "statut": "evaluee", "score": 9},
+    {"media_domaine": "cnews.fr", "critere": "C5", "statut": "evaluee", "score": 10},
+    {"media_domaine": "cnews.fr", "critere": "C9", "statut": "evaluee", "score": 5, "niveau": 1},
+    {"media_domaine": "cnews.fr", "critere": "C11", "statut": "evaluee", "score": 3, "niveau": 1},
+    {"media_domaine": "reporterre.net", "critere": "C1", "statut": "evaluee", "score": 20},
+    {"media_domaine": "reporterre.net", "critere": "C9", "statut": "evaluee", "score": 10, "niveau": 2}
+  ]
+}

--- a/packages/api/tests/scripts/fixtures/media_eval/gold_mini.json
+++ b/packages/api/tests/scripts/fixtures/media_eval/gold_mini.json
@@ -1,0 +1,13 @@
+{
+  "version_methodo": "v1.2",
+  "notateur": "humain:laurin",
+  "note_at": "2026-07-08T09:00:00Z",
+  "entries": [
+    {"media_domaine": "cnews.fr", "critere": "C1", "statut": "evaluee", "score": 5},
+    {"media_domaine": "cnews.fr", "critere": "C5", "statut": "evaluee", "score": 10},
+    {"media_domaine": "cnews.fr", "critere": "C9", "statut": "evaluee", "score": 0, "niveau": 0},
+    {"media_domaine": "cnews.fr", "critere": "C11", "statut": "evaluee", "score": 3, "niveau": 1},
+    {"media_domaine": "reporterre.net", "critere": "C1", "statut": "non_applicable"},
+    {"media_domaine": "reporterre.net", "critere": "C9", "statut": "evaluee", "score": 10, "niveau": 2}
+  ]
+}

--- a/packages/api/tests/scripts/fixtures/media_eval/signaux_cnews.json
+++ b/packages/api/tests/scripts/fixtures/media_eval/signaux_cnews.json
@@ -1,0 +1,42 @@
+{
+  "run_id": "run-test",
+  "agent": "agent:media-eval-collecteur-gouvernance@v1",
+  "genere_at": "2026-07-08T10:00:00Z",
+  "version_prompt": null,
+  "items": [
+    {
+      "media_domaine": "cnews.fr",
+      "critere": "C5",
+      "type_signal": "mentions_legales",
+      "statut": "present",
+      "valeur": {"complet": true, "forme_juridique": "SAS", "url": "https://www.cnews.fr/mentions-legales"},
+      "citation": "CNEWS est édité par la Société d'Exploitation d'un Service d'Information (SESI), SAS au capital de…",
+      "source_urls": ["https://www.cnews.fr/mentions-legales"],
+      "sources_consultees": []
+    },
+    {
+      "media_domaine": "cnews.fr",
+      "critere": "C5",
+      "type_signal": "structure_actionnariat",
+      "statut": "present",
+      "valeur": {"groupe": "Canal+ / Vivendi", "source": "pappers"},
+      "citation": "SESI, détenue par le Groupe Canal+.",
+      "source_urls": ["https://www.pappers.fr/entreprise/sesi"],
+      "sources_consultees": []
+    },
+    {
+      "media_domaine": "cnews.fr",
+      "critere": "C9",
+      "type_signal": "charte_independance",
+      "statut": "absent_verifie",
+      "valeur": null,
+      "citation": null,
+      "source_urls": [],
+      "sources_consultees": [
+        "https://www.cnews.fr/mentions-legales",
+        "https://www.cnews.fr/qui-sommes-nous",
+        "https://www.google.com/search?q=charte+independance+cnews"
+      ]
+    }
+  ]
+}

--- a/packages/api/tests/scripts/media_eval/test_evaluate_golden_agreement.py
+++ b/packages/api/tests/scripts/media_eval/test_evaluate_golden_agreement.py
@@ -1,0 +1,66 @@
+"""Tests du benchmark d'accord vs golden set (evaluate_golden_agreement.py).
+
+Mini-fixtures : 6 paires couvrant accord continu (|Δ| ≤ 20 % du barème),
+désaccord de niveau (C9), désaccord N/A-vs-score, et accords exacts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.media_eval.evaluate_golden_agreement import evaluate, render_md
+from scripts.media_eval.schemas import GoldenSet
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "media_eval"
+
+
+def _charger() -> tuple[GoldenSet, GoldenSet]:
+    gold = GoldenSet.model_validate_json((FIXTURES / "gold_mini.json").read_text())
+    generated = GoldenSet.model_validate_json(
+        (FIXTURES / "generated_mini.json").read_text()
+    )
+    return gold, generated
+
+
+class TestEvaluate:
+    def test_metriques(self):
+        gold, generated = _charger()
+        report = evaluate(gold, generated)
+
+        assert report["n"] == 6
+        # Accords : C1 cnews (Δ4 ≤ 4), C5 cnews, C11 cnews, C9 reporterre.
+        assert report["accord_global"] == round(4 / 6, 3)
+        assert report["par_media"] == {"cnews.fr": "3/4", "reporterre.net": "1/2"}
+        # Reporterre C1 : gold N/A vs généré scoré -> désaccord critique.
+        assert report["na_vs_score"] == 1
+        # MAE sur les paires scorées des deux côtés : [4, 0, 5, 0, 0] -> 1.8.
+        assert report["mae_scores"] == 1.8
+
+    def test_desaccords_tries_na_dabord(self):
+        gold, generated = _charger()
+        report = evaluate(gold, generated)
+        types = [d["type_desaccord"] for d in report["desaccords"]]
+        assert types == ["na_vs_score", "niveau"]
+
+    def test_niveau_exact_exige_c9(self):
+        # C9 cnews : même si Δ score (5) serait toléré en continu, le
+        # niveau 0 vs 1 est un désaccord (accord exact exigé).
+        gold, generated = _charger()
+        report = evaluate(gold, generated)
+        c9 = next(
+            d
+            for d in report["desaccords"]
+            if d["critere"] == "C9" and d["media"] == "cnews.fr"
+        )
+        assert c9["type_desaccord"] == "niveau"
+
+    def test_gold_vide(self):
+        gold, generated = _charger()
+        report = evaluate(GoldenSet(entries=[]), generated)
+        assert report["n"] == 0
+
+    def test_render_md(self):
+        gold, generated = _charger()
+        md = render_md(evaluate(gold, generated))
+        assert "na_vs_score" in md
+        assert "reporterre.net" in md

--- a/packages/api/tests/scripts/media_eval/test_garde_fous.py
+++ b/packages/api/tests/scripts/media_eval/test_garde_fous.py
@@ -1,0 +1,161 @@
+"""Tests purs des garde-fous mécaniques (scripts/media_eval/garde_fous.py).
+
+Couvre : fraîcheur 729/731 j ; fallback C1 à 2 vs 3 débunkages ; corroboration
+1 source → plafonné + flag ; raccourci JTI ; `bloque_acces` jamais 0.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from scripts.media_eval.garde_fous import (
+    appliquer_corroboration,
+    compter_sources_independantes,
+    detecter_jti_valide,
+    est_frais,
+    fallback_c1_requis,
+    filtrer_fraicheur,
+    statut_evaluation,
+)
+from scripts.media_eval.schemas import FLAG_CORROBORATION
+
+AUJOURD_HUI = date(2026, 7, 8)
+
+
+def signal_evenementiel(jours: int, **kw) -> dict:
+    base = {
+        "type_signal": "debunkage",
+        "statut": "present",
+        "valeur": {"publie_at": (AUJOURD_HUI - timedelta(days=jours)).isoformat()},
+        "source_urls": ["https://cdjm.org/avis/1"],
+    }
+    base.update(kw)
+    return base
+
+
+class TestFraicheur:
+    def test_729_jours_frais(self):
+        assert est_frais(signal_evenementiel(729), AUJOURD_HUI)
+
+    def test_730_jours_limite_incluse(self):
+        assert est_frais(signal_evenementiel(730), AUJOURD_HUI)
+
+    def test_731_jours_exclu(self):
+        assert not est_frais(signal_evenementiel(731), AUJOURD_HUI)
+
+    def test_structurel_sans_limite(self):
+        charte = {
+            "type_signal": "charte_independance",
+            "statut": "present",
+            "valeur": {"publie_at": "2008-01-01"},
+        }
+        assert est_frais(charte, AUJOURD_HUI)
+
+    def test_evenementiel_sans_date_exclu(self):
+        assert not est_frais(
+            {"type_signal": "sanction_arcom", "valeur": {}}, AUJOURD_HUI
+        )
+
+    def test_filtre(self):
+        frais, exclus = filtrer_fraicheur(
+            [signal_evenementiel(10), signal_evenementiel(800)], AUJOURD_HUI
+        )
+        assert len(frais) == 1 and len(exclus) == 1
+
+
+class TestFallbackC1:
+    def test_2_debunkages_declenche(self):
+        assert fallback_c1_requis(2)
+
+    def test_3_debunkages_ne_declenche_pas(self):
+        assert not fallback_c1_requis(3)
+
+
+class TestCorroboration:
+    def test_score_plein_1_source_plafonne(self):
+        cites = [
+            {"source_urls": ["https://cnews.fr/a", "https://www.cnews.fr/b"]}
+        ]  # www. déduit -> 1 seul domaine
+        score, flags = appliquer_corroboration("C5", 10.0, cites)
+        assert score == 5.0
+        assert flags == [FLAG_CORROBORATION]
+
+    def test_score_plein_2_sources_intact(self):
+        cites = [
+            {"source_urls": ["https://cnews.fr/mentions"]},
+            {"source_urls": ["https://pappers.fr/entreprise/sesi"]},
+        ]
+        score, flags = appliquer_corroboration("C5", 10.0, cites)
+        assert score == 10.0 and flags == []
+
+    def test_score_partiel_jamais_plafonne(self):
+        cites = [{"source_urls": ["https://cnews.fr/mentions"]}]
+        score, flags = appliquer_corroboration("C5", 5.0, cites)
+        assert score == 5.0 and flags == []
+
+    def test_compteur_domaines(self):
+        assert (
+            compter_sources_independantes(
+                [
+                    {"source_urls": ["https://www.arcom.fr/d1", "https://arcom.fr/d2"]},
+                    {"source_urls": ["https://conseil-etat.fr/x"]},
+                ]
+            )
+            == 2
+        )
+
+
+class TestRaccourciJTI:
+    def test_certification_valide_detectee(self):
+        signal = {
+            "id": "abc",
+            "type_signal": "certification_jti",
+            "statut": "present",
+            "valeur": {"en_cours_de_validite": True},
+        }
+        assert detecter_jti_valide([signal]) is signal
+
+    def test_certification_expiree_ignoree(self):
+        assert (
+            detecter_jti_valide(
+                [
+                    {
+                        "type_signal": "certification_jti",
+                        "statut": "present",
+                        "valeur": {"en_cours_de_validite": False},
+                    }
+                ]
+            )
+            is None
+        )
+
+    def test_absence_ignoree(self):
+        assert (
+            detecter_jti_valide(
+                [
+                    {
+                        "type_signal": "certification_jti",
+                        "statut": "absent_verifie",
+                        "valeur": {"en_cours_de_validite": True},
+                    },
+                    {"type_signal": "charte_deontologique", "statut": "present"},
+                ]
+            )
+            is None
+        )
+
+
+class TestStatutEvaluation:
+    def test_donnees_insuffisantes_na(self):
+        assert statut_evaluation(["donnees_insuffisantes"], []) == "non_applicable"
+
+    def test_flag_bloque_acces_revue(self):
+        assert statut_evaluation(["bloque_acces"], []) == "revue_requise"
+
+    def test_signaux_tous_bloques_revue_jamais_zero(self):
+        cites = [{"statut": "bloque_acces"}, {"statut": "bloque_acces"}]
+        assert statut_evaluation([], cites) == "revue_requise"
+
+    def test_signaux_mixtes_evaluee(self):
+        cites = [{"statut": "bloque_acces"}, {"statut": "present"}]
+        assert statut_evaluation([], cites) == "evaluee"

--- a/packages/api/tests/scripts/media_eval/test_ingest_artifacts.py
+++ b/packages/api/tests/scripts/media_eval/test_ingest_artifacts.py
@@ -1,0 +1,148 @@
+"""Tests DB de l'ingestion d'artefacts collecteurs (ingest_artifacts.py).
+
+Couvre : domaine inconnu → erreur ; idempotence par dedupe_key ; couple
+signal C1 + débunkage avec poids dérivé par code ; dry-run (rollback) n'écrit
+rien. Fixtures savepoint du conftest (`db_session`).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from sqlalchemy import func, select
+
+from app.models.media_eval import (
+    MediaEvalDebunkage,
+    MediaEvalMedia,
+    MediaEvalSignal,
+    TypeMedia,
+)
+from scripts.media_eval.ingest_artifacts import (
+    IngestError,
+    charger_artifact,
+    ingester,
+    inserer_debunkages,
+    inserer_signaux,
+)
+from scripts.media_eval.schemas import DebunkageBatchArtifact, SignalBatchArtifact
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "media_eval"
+
+
+@pytest.fixture
+async def media_cnews(db_session) -> MediaEvalMedia:
+    media = MediaEvalMedia(
+        nom="CNEWS", domaine="cnews.fr", type_media=TypeMedia.AUDIOVISUEL
+    )
+    db_session.add(media)
+    await db_session.commit()
+    return media
+
+
+def _signaux_batch() -> SignalBatchArtifact:
+    return SignalBatchArtifact.model_validate(
+        json.loads((FIXTURES / "signaux_cnews.json").read_text())
+    )
+
+
+def _debunkages_batch() -> DebunkageBatchArtifact:
+    return DebunkageBatchArtifact.model_validate(
+        json.loads((FIXTURES / "debunkages_cnews.json").read_text())
+    )
+
+
+async def _count(db_session, model) -> int:
+    return (await db_session.execute(select(func.count()).select_from(model))).scalar()
+
+
+class TestChargerArtifact:
+    def test_detection_type(self):
+        assert isinstance(
+            charger_artifact(FIXTURES / "signaux_cnews.json"), SignalBatchArtifact
+        )
+        assert isinstance(
+            charger_artifact(FIXTURES / "debunkages_cnews.json"),
+            DebunkageBatchArtifact,
+        )
+
+
+class TestInsererSignaux:
+    async def test_domaine_inconnu_erreur(self, db_session, media_cnews):
+        batch = _signaux_batch()
+        batch.items[0].media_domaine = "inconnu.fr"
+        with pytest.raises(IngestError, match="média inconnu"):
+            await inserer_signaux(db_session, batch)
+
+    async def test_insertion_et_idempotence(self, db_session, media_cnews):
+        batch = _signaux_batch()
+        premier = await inserer_signaux(db_session, batch)
+        await db_session.commit()
+        assert premier.inseres == 3 and premier.doublons == 0
+        assert await _count(db_session, MediaEvalSignal) == 3
+
+        second = await inserer_signaux(db_session, batch)
+        await db_session.commit()
+        assert second.inseres == 0 and second.doublons == 3
+        assert await _count(db_session, MediaEvalSignal) == 3
+
+    async def test_champs_conserves(self, db_session, media_cnews):
+        await inserer_signaux(db_session, _signaux_batch())
+        await db_session.commit()
+        absent = (
+            await db_session.execute(
+                select(MediaEvalSignal).where(
+                    MediaEvalSignal.statut == "absent_verifie"
+                )
+            )
+        ).scalar_one()
+        assert absent.critere == "C9"
+        assert absent.sources_consultees  # preuve de recherche conservée
+        assert absent.collecteur == "agent:media-eval-collecteur-gouvernance@v1"
+        assert absent.run_id == "run-test"
+
+
+class TestInsererDebunkages:
+    async def test_couple_signal_debunkage(self, db_session, media_cnews):
+        result = await inserer_debunkages(db_session, _debunkages_batch())
+        await db_session.commit()
+        assert result.inseres == 2
+        assert await _count(db_session, MediaEvalSignal) == 2
+        assert await _count(db_session, MediaEvalDebunkage) == 2
+
+        arcom = (
+            await db_session.execute(
+                select(MediaEvalDebunkage).where(MediaEvalDebunkage.emetteur == "arcom")
+            )
+        ).scalar_one()
+        # Poids dérivé par code, pas fourni par l'agent.
+        assert arcom.poids_emetteur == "fort"
+        signal = (
+            await db_session.execute(
+                select(MediaEvalSignal).where(MediaEvalSignal.id == arcom.signal_id)
+            )
+        ).scalar_one()
+        assert signal.critere == "C1"
+        assert signal.type_signal == "sanction_arcom"
+        assert signal.valeur["poids_emetteur"] == "fort"
+
+    async def test_idempotence(self, db_session, media_cnews):
+        await inserer_debunkages(db_session, _debunkages_batch())
+        await db_session.commit()
+        second = await inserer_debunkages(db_session, _debunkages_batch())
+        await db_session.commit()
+        assert second.inseres == 0 and second.doublons == 2
+        assert await _count(db_session, MediaEvalDebunkage) == 2
+
+
+class TestDryRun:
+    async def test_rollback_n_ecrit_rien(self, db_session, media_cnews):
+        result = await ingester(
+            db_session,
+            [FIXTURES / "signaux_cnews.json", FIXTURES / "debunkages_cnews.json"],
+        )
+        assert result.inseres == 5
+        await db_session.rollback()  # équivalent du dry-run CLI
+        assert await _count(db_session, MediaEvalSignal) == 0
+        assert await _count(db_session, MediaEvalDebunkage) == 0

--- a/packages/api/tests/scripts/media_eval/test_ingest_evaluations.py
+++ b/packages/api/tests/scripts/media_eval/test_ingest_evaluations.py
@@ -1,0 +1,283 @@
+"""Tests DB de l'ingestion des évaluations (ingest_evaluations.py).
+
+Couvre : rejet d'un signal_id inexistant / d'un autre média / d'un autre
+critère ; score dérivé par code ; corroboration plafonnée ; `bloque_acces` →
+`revue_requise` (jamais 0) ; N/A ; idempotence ; dry-run n'écrit rien.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import func, select
+
+from app.models.media_eval import (
+    MediaEvalEvaluation,
+    MediaEvalMedia,
+    MediaEvalSignal,
+    StatutSignal,
+    TypeMedia,
+    VoieCollecte,
+)
+from scripts.media_eval.ingest_artifacts import IngestError
+from scripts.media_eval.ingest_evaluations import (
+    ingester_evaluations,
+    preparer_evaluation,
+)
+from scripts.media_eval.schemas import (
+    EvaluationBatchArtifact,
+    EvaluationOutput,
+)
+
+RUN_ID = "run-test"
+
+
+@pytest.fixture
+async def media_cnews(db_session) -> MediaEvalMedia:
+    media = MediaEvalMedia(
+        nom="CNEWS", domaine="cnews.fr", type_media=TypeMedia.AUDIOVISUEL
+    )
+    db_session.add(media)
+    await db_session.commit()
+    return media
+
+
+@pytest.fixture
+async def media_reporterre(db_session) -> MediaEvalMedia:
+    media = MediaEvalMedia(
+        nom="Reporterre", domaine="reporterre.net", type_media=TypeMedia.PRESSE_EN_LIGNE
+    )
+    db_session.add(media)
+    await db_session.commit()
+    return media
+
+
+async def make_signal(
+    db_session,
+    media: MediaEvalMedia,
+    critere: str = "C5",
+    type_signal: str = "mentions_legales",
+    statut: StatutSignal = StatutSignal.PRESENT,
+    source_urls: list[str] | None = None,
+    dedupe_suffix: str = "",
+) -> MediaEvalSignal:
+    signal = MediaEvalSignal(
+        media_id=media.id,
+        critere=critere,
+        type_signal=type_signal,
+        statut=statut,
+        valeur={},
+        voie=VoieCollecte.AGENT,
+        collecteur="agent:test",
+        source_urls=source_urls or [f"https://{media.domaine}/page"],
+        run_id=RUN_ID,
+        dedupe_key=f"k-{critere}-{type_signal}-{dedupe_suffix}",
+    )
+    db_session.add(signal)
+    await db_session.commit()
+    return signal
+
+
+def make_batch(*items: dict) -> EvaluationBatchArtifact:
+    return EvaluationBatchArtifact(
+        run_id=RUN_ID,
+        agent="agent:media-eval-evaluateur@v1",
+        genere_at=datetime.now(UTC),
+        version_prompt="sha-test",
+        items=[EvaluationOutput.model_validate(i) for i in items],
+    )
+
+
+def item_c5(signal_ids: list[str], **kw) -> dict:
+    base = {
+        "media_domaine": "cnews.fr",
+        "critere": "C5",
+        "determinations": {"profil_signaux": "mixtes"},
+        "justification": "Transparence partielle.",
+        "signal_ids_cites": signal_ids,
+        "flags": [],
+    }
+    base.update(kw)
+    return base
+
+
+class TestGardeFousAval:
+    async def test_signal_inexistant_rejet(self, db_session, media_cnews):
+        batch = make_batch(item_c5(["00000000-0000-0000-0000-00000000dead"]))
+        with pytest.raises(IngestError, match="inexistant"):
+            await ingester_evaluations(db_session, batch)
+
+    async def test_signal_autre_media_rejet(
+        self, db_session, media_cnews, media_reporterre
+    ):
+        etranger = await make_signal(db_session, media_reporterre)
+        batch = make_batch(item_c5([str(etranger.id)]))
+        with pytest.raises(IngestError, match="autre média"):
+            await ingester_evaluations(db_session, batch)
+
+    async def test_signal_autre_critere_rejet(self, db_session, media_cnews):
+        c9 = await make_signal(
+            db_session, media_cnews, critere="C9", type_signal="charte_independance"
+        )
+        batch = make_batch(item_c5([str(c9.id)]))
+        with pytest.raises(IngestError, match="critère C9"):
+            await ingester_evaluations(db_session, batch)
+
+    async def test_rejet_ne_laisse_rien(self, db_session, media_cnews):
+        ok = await make_signal(db_session, media_cnews)
+        batch = make_batch(
+            item_c5([str(ok.id)]),
+            item_c5(["00000000-0000-0000-0000-00000000dead"]),
+        )
+        with pytest.raises(IngestError):
+            await ingester_evaluations(db_session, batch)
+        await db_session.rollback()
+        n = (
+            await db_session.execute(
+                select(func.count()).select_from(MediaEvalEvaluation)
+            )
+        ).scalar()
+        assert n == 0
+
+
+class TestScoreDeriveEtCorroboration:
+    async def test_score_derive_par_code(self, db_session, media_cnews):
+        s1 = await make_signal(db_session, media_cnews, dedupe_suffix="1")
+        batch = make_batch(item_c5([str(s1.id)]))
+        ins, _ = await ingester_evaluations(db_session, batch)
+        await db_session.commit()
+        assert ins == 1
+        ev = (await db_session.execute(select(MediaEvalEvaluation))).scalar_one()
+        assert ev.score == 5.0  # mixtes -> 50 % de 10, dérivé par code
+        assert ev.statut == "evaluee"
+        assert ev.score_max == 10.0
+
+    async def test_corroboration_plafonne_score_plein(self, db_session, media_cnews):
+        # 1 seul domaine source -> score plein 10 plafonné à 5 + flag.
+        s1 = await make_signal(
+            db_session,
+            media_cnews,
+            source_urls=["https://cnews.fr/mentions-legales"],
+            dedupe_suffix="1",
+        )
+        batch = make_batch(
+            item_c5(
+                [str(s1.id)],
+                determinations={"profil_signaux": "positifs_majoritaires"},
+            )
+        )
+        await ingester_evaluations(db_session, batch)
+        await db_session.commit()
+        ev = (await db_session.execute(select(MediaEvalEvaluation))).scalar_one()
+        assert ev.score == 5.0
+        assert "corroboration_insuffisante" in ev.flags
+
+    async def test_score_plein_corrobore_intact(self, db_session, media_cnews):
+        s1 = await make_signal(
+            db_session,
+            media_cnews,
+            source_urls=["https://cnews.fr/mentions-legales"],
+            dedupe_suffix="1",
+        )
+        s2 = await make_signal(
+            db_session,
+            media_cnews,
+            type_signal="structure_actionnariat",
+            source_urls=["https://pappers.fr/entreprise/sesi"],
+            dedupe_suffix="2",
+        )
+        batch = make_batch(
+            item_c5(
+                [str(s1.id), str(s2.id)],
+                determinations={"profil_signaux": "positifs_majoritaires"},
+            )
+        )
+        await ingester_evaluations(db_session, batch)
+        await db_session.commit()
+        ev = (await db_session.execute(select(MediaEvalEvaluation))).scalar_one()
+        assert ev.score == 10.0
+        assert ev.flags == []
+
+
+class TestStatuts:
+    async def test_bloque_acces_revue_requise_jamais_zero(
+        self, db_session, media_cnews
+    ):
+        bloque = await make_signal(
+            db_session,
+            media_cnews,
+            statut=StatutSignal.BLOQUE_ACCES,
+            dedupe_suffix="b",
+        )
+        batch = make_batch(item_c5([str(bloque.id)]))
+        await ingester_evaluations(db_session, batch)
+        await db_session.commit()
+        ev = (await db_session.execute(select(MediaEvalEvaluation))).scalar_one()
+        assert ev.statut == "revue_requise"
+        assert ev.score is None  # jamais 0
+
+    async def test_donnees_insuffisantes_na(self, db_session, media_cnews):
+        batch = make_batch(
+            {
+                "media_domaine": "cnews.fr",
+                "critere": "C1",
+                "determinations": {},
+                "justification": "Fallback déclenché, pas de corpus en V0.",
+                "signal_ids_cites": [],
+                "flags": ["donnees_insuffisantes"],
+            }
+        )
+        await ingester_evaluations(db_session, batch)
+        await db_session.commit()
+        ev = (await db_session.execute(select(MediaEvalEvaluation))).scalar_one()
+        assert ev.statut == "non_applicable"
+        assert ev.score is None
+
+    async def test_niveau_persiste_c9(self, db_session, media_cnews):
+        s = await make_signal(
+            db_session,
+            media_cnews,
+            critere="C9",
+            type_signal="charte_independance",
+            dedupe_suffix="9",
+        )
+        batch = make_batch(
+            {
+                "media_domaine": "cnews.fr",
+                "critere": "C9",
+                "determinations": {"niveau": 1},
+                "justification": "Charte déclarative sans mécanisme contraignant.",
+                "signal_ids_cites": [str(s.id)],
+                "flags": ["revue_humaine_requise"],
+            }
+        )
+        await ingester_evaluations(db_session, batch)
+        await db_session.commit()
+        ev = (await db_session.execute(select(MediaEvalEvaluation))).scalar_one()
+        assert (ev.score, ev.niveau) == (5.0, 1)
+        assert "revue_humaine_requise" in ev.flags
+
+
+class TestIdempotence:
+    async def test_reingestion_ignoree(self, db_session, media_cnews):
+        s1 = await make_signal(db_session, media_cnews, dedupe_suffix="1")
+        batch = make_batch(item_c5([str(s1.id)]))
+        ins1, ign1 = await ingester_evaluations(db_session, batch)
+        await db_session.commit()
+        ins2, ign2 = await ingester_evaluations(db_session, batch)
+        await db_session.commit()
+        assert (ins1, ign1) == (1, 0)
+        assert (ins2, ign2) == (0, 1)
+
+
+class TestPreparerEvaluation:
+    def test_pur_sans_db(self):
+        item = EvaluationOutput.model_validate(
+            item_c5(["3f0a5b1e-0000-0000-0000-000000000001"])
+        )
+        prep = preparer_evaluation(
+            item, [{"statut": "present", "source_urls": ["https://cnews.fr/a"]}]
+        )
+        assert prep.statut == "evaluee"
+        assert prep.score == 5.0

--- a/packages/api/tests/scripts/media_eval/test_schemas.py
+++ b/packages/api/tests/scripts/media_eval/test_schemas.py
@@ -1,0 +1,216 @@
+"""Tests purs des contrats Pydantic media-eval (scripts/media_eval/schemas.py).
+
+Couvre : rejet d'un score sans signal_ids ; type_signal hors registre ;
+niveau requis C9/C11 ; table de cas `derive_score` ; dérivation du poids
+émetteur ; publie_at manquant sur un débunkage.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from scripts.media_eval.schemas import (
+    BAREMES,
+    CRITERES_VAGUE_1,
+    DebunkageArtifact,
+    EvaluationOutput,
+    SignalArtifact,
+    derive_poids_emetteur,
+    derive_score,
+    palier_inferieur,
+)
+
+
+def make_eval(**kw) -> dict:
+    base = {
+        "media_domaine": "cnews.fr",
+        "critere": "C5",
+        "determinations": {"profil_signaux": "positifs_majoritaires"},
+        "justification": "Mentions légales complètes [signal:a].",
+        "signal_ids_cites": ["3f0a5b1e-0000-0000-0000-000000000001"],
+        "flags": [],
+    }
+    base.update(kw)
+    return base
+
+
+class TestEvaluationOutput:
+    def test_score_sans_signal_ids_rejete(self):
+        with pytest.raises(ValidationError, match="signal_ids_cites vide"):
+            EvaluationOutput.model_validate(make_eval(signal_ids_cites=[]))
+
+    def test_na_sans_signal_ids_accepte(self):
+        ev = EvaluationOutput.model_validate(
+            make_eval(
+                signal_ids_cites=[],
+                determinations={},
+                flags=["donnees_insuffisantes"],
+            )
+        )
+        assert ev.est_non_applicable()
+
+    def test_flag_hors_contrat_rejete(self):
+        with pytest.raises(ValidationError, match="flags hors contrat"):
+            EvaluationOutput.model_validate(make_eval(flags=["score_bonus"]))
+
+    def test_critere_hors_vague_1_rejete(self):
+        with pytest.raises(ValidationError, match="hors vague 1"):
+            EvaluationOutput.model_validate(make_eval(critere="C2"))
+
+    def test_niveau_requis_c9(self):
+        with pytest.raises(ValidationError, match="niveau invalide"):
+            EvaluationOutput.model_validate(
+                make_eval(critere="C9", determinations={"profil_signaux": "mixtes"})
+            )
+
+    def test_niveau_hors_bornes_c11(self):
+        with pytest.raises(ValidationError, match="niveau invalide"):
+            EvaluationOutput.model_validate(
+                make_eval(critere="C11", determinations={"niveau": 3})
+            )
+
+    def test_determination_valide_c9(self):
+        ev = EvaluationOutput.model_validate(
+            make_eval(critere="C9", determinations={"niveau": 1})
+        )
+        assert ev.score_derive() == (5.0, 1)
+
+
+class TestDeriveScore:
+    @pytest.mark.parametrize(
+        ("critere", "determinations", "attendu"),
+        [
+            ("C1", {"profil_veracite": "aucun_signal_negatif"}, (20.0, None)),
+            ("C1", {"profil_veracite": "problemes_mineurs_corriges"}, (15.0, None)),
+            ("C1", {"profil_veracite": "problemes_mixtes"}, (10.0, None)),
+            ("C1", {"profil_veracite": "problemes_significatifs"}, (5.0, None)),
+            (
+                "C1",
+                {"profil_veracite": "fabrication_ou_refus_non_corrige"},
+                (0.0, None),
+            ),
+            ("C5", {"profil_signaux": "positifs_majoritaires"}, (10.0, None)),
+            ("C5", {"profil_signaux": "mixtes"}, (5.0, None)),
+            ("C7", {"profil_signaux": "mixtes"}, (2.0, None)),
+            ("C7", {"profil_signaux": "negatifs"}, (0.0, None)),
+            ("C8", {"profil_signaux": "positifs_majoritaires"}, (4.0, None)),
+            ("C9", {"niveau": 0}, (0.0, 0)),
+            ("C9", {"niveau": 2}, (10.0, 2)),
+            ("C11", {"niveau": 1}, (3.0, 1)),
+            ("C11", {"niveau": 2}, (6.0, 2)),
+        ],
+    )
+    def test_table(self, critere, determinations, attendu):
+        assert derive_score(critere, determinations) == attendu
+
+    def test_profil_c1_invalide(self):
+        with pytest.raises(ValueError, match="profil_veracite invalide"):
+            derive_score("C1", {"profil_veracite": "correct"})
+
+    def test_critere_vague_2_refuse(self):
+        with pytest.raises(ValueError, match="hors vague 1"):
+            derive_score("C10", {"niveau": 1})
+
+    def test_vague_1_couverte(self):
+        # Chaque critère vague 1 a une dérivation définie.
+        exemples = {
+            "C1": {"profil_veracite": "problemes_mixtes"},
+            "C5": {"profil_signaux": "mixtes"},
+            "C7": {"profil_signaux": "mixtes"},
+            "C8": {"profil_signaux": "mixtes"},
+            "C9": {"niveau": 1},
+            "C11": {"niveau": 1},
+        }
+        for critere in CRITERES_VAGUE_1:
+            score, _ = derive_score(critere, exemples[critere])
+            assert 0 <= score <= BAREMES[critere]
+
+
+class TestPalierInferieur:
+    @pytest.mark.parametrize(
+        ("critere", "score", "attendu"),
+        [
+            ("C1", 20, 15.0),
+            ("C5", 10, 5.0),
+            ("C7", 4, 2.0),
+            ("C9", 10, 5.0),
+            ("C11", 6, 3.0),
+            ("C1", 0, 0.0),
+        ],
+    )
+    def test_paliers(self, critere, score, attendu):
+        assert palier_inferieur(critere, score) == attendu
+
+
+class TestPoidsEmetteur:
+    def test_derivation(self):
+        assert derive_poids_emetteur("cdjm") == "fort"
+        assert derive_poids_emetteur("ARCOM") == "fort"
+        assert derive_poids_emetteur("afp_factuel") == "moyen"
+        assert derive_poids_emetteur("blog-inconnu") == "faible"
+
+
+class TestSignalArtifact:
+    def make(self, **kw) -> dict:
+        base = {
+            "media_domaine": "reporterre.net",
+            "critere": "C11",
+            "type_signal": "manifeste_positionnement",
+            "statut": "present",
+            "source_urls": ["https://reporterre.net/notre-projet"],
+        }
+        base.update(kw)
+        return base
+
+    def test_type_signal_hors_registre(self):
+        with pytest.raises(ValidationError, match="hors registre"):
+            SignalArtifact.model_validate(self.make(type_signal="charte_independance"))
+
+    def test_present_sans_source_rejete(self):
+        with pytest.raises(ValidationError, match="source_urls vide"):
+            SignalArtifact.model_validate(self.make(source_urls=[]))
+
+    def test_absent_verifie_exige_sources_consultees(self):
+        with pytest.raises(ValidationError, match="sources_consultees"):
+            SignalArtifact.model_validate(
+                self.make(statut="absent_verifie", source_urls=[])
+            )
+        ok = SignalArtifact.model_validate(
+            self.make(
+                statut="absent_verifie",
+                source_urls=[],
+                sources_consultees=["https://reporterre.net/plan-du-site"],
+            )
+        )
+        assert ok.statut == "absent_verifie"
+
+
+class TestDebunkageArtifact:
+    def make(self, **kw) -> dict:
+        base = {
+            "media_domaine": "cnews.fr",
+            "url_debunkage": "https://cdjm.org/avis/26-014",
+            "emetteur": "cdjm",
+            "gravite": "mineure",
+            "suite_donnee": "aucune",
+            "publie_at": "2026-02-03",
+            "source_urls": ["https://cdjm.org/avis/26-014"],
+        }
+        base.update(kw)
+        return base
+
+    def test_publie_at_manquant_rejete(self):
+        artefact = self.make()
+        del artefact["publie_at"]
+        with pytest.raises(ValidationError):
+            DebunkageArtifact.model_validate(artefact)
+
+    def test_poids_derive_ignore_agent(self):
+        # Même si l'agent fournissait un poids, seul le dérivé fait foi.
+        deb = DebunkageArtifact.model_validate(self.make())
+        assert deb.poids_emetteur() == "fort"
+
+    def test_gravite_hors_enum(self):
+        with pytest.raises(ValidationError, match="gravite hors enum"):
+            DebunkageArtifact.model_validate(self.make(gravite="catastrophique"))

--- a/packages/api/tests/scripts/media_eval/test_synthese_fiche.py
+++ b/packages/api/tests/scripts/media_eval/test_synthese_fiche.py
@@ -1,0 +1,135 @@
+"""Tests purs de la synthèse de fiche (scripts/media_eval/synthese_fiche.py).
+
+Couvre : renormalisation 0/1/3 N/A ; bornes des lettres (84.9 → B, 85 → A) ;
+matrice de confiance ; cas Reporterre simulé (C1 N/A → max 34).
+"""
+
+from __future__ import annotations
+
+from scripts.media_eval.synthese_fiche import compute_fiche, lettre_pour
+
+
+def make_eval(critere: str, score: float | None, statut: str = "evaluee", **kw) -> dict:
+    base = {
+        "critere": critere,
+        "statut": statut,
+        "score": score,
+        "niveau": None,
+        "flags": [],
+        "evaluateur": "agent:media-eval-evaluateur@v1",
+    }
+    base.update(kw)
+    return base
+
+
+def evals_completes(**overrides) -> list[dict]:
+    """6 critères vague 1 évalués au max (54 pts)."""
+    scores = {"C1": 20.0, "C5": 10.0, "C7": 4.0, "C8": 4.0, "C9": 10.0, "C11": 6.0}
+    return [overrides.get(c, make_eval(c, s)) for c, s in scores.items()]
+
+
+class TestLettres:
+    def test_bornes(self):
+        assert lettre_pour(85.0) == "A"
+        assert lettre_pour(84.9) == "B"
+        assert lettre_pour(70.0) == "B"
+        assert lettre_pour(69.9) == "C"
+        assert lettre_pour(55.0) == "C"
+        assert lettre_pour(40.0) == "D"
+        assert lettre_pour(39.9) == "E"
+        assert lettre_pour(0.0) == "E"
+
+
+class TestRenormalisation:
+    def test_zero_na_max_54(self):
+        fiche = compute_fiche(evals_completes())
+        assert fiche["score_max_applicable"] == 54.0
+        assert fiche["score_brut"] == 54.0
+        assert fiche["score_renormalise"] == 100.0
+        assert fiche["lettre"] == "A"
+        assert fiche["confiance"] == "haute"
+
+    def test_un_na_reporterre_max_34(self):
+        # Cas Reporterre : C1 N/A (donnees_insuffisantes) → renormalise sur 34.
+        fiche = compute_fiche(
+            evals_completes(
+                C1=make_eval(
+                    "C1",
+                    None,
+                    statut="non_applicable",
+                    flags=["donnees_insuffisantes"],
+                )
+            )
+        )
+        assert fiche["score_max_applicable"] == 34.0
+        assert fiche["criteres_na"] == ["C1"]
+        assert fiche["score_renormalise"] == 100.0
+        assert fiche["confiance"] == "moyenne"  # 1 N/A -> plus haute
+
+    def test_trois_na_confiance_basse(self):
+        fiche = compute_fiche(
+            evals_completes(
+                C1=make_eval("C1", None, statut="non_applicable"),
+                C7=make_eval("C7", None, statut="non_applicable"),
+                C8=make_eval("C8", None, statut="non_applicable"),
+            )
+        )
+        assert fiche["score_max_applicable"] == 26.0
+        assert fiche["confiance"] == "basse"
+
+    def test_score_partiel(self):
+        fiche = compute_fiche(
+            evals_completes(
+                C1=make_eval("C1", 10.0),
+                C9=make_eval("C9", 5.0, niveau=1),
+            )
+        )
+        assert fiche["score_brut"] == 39.0
+        assert fiche["score_renormalise"] == 72.2  # 39/54
+        assert fiche["lettre"] == "B"
+
+    def test_aucune_evaluee(self):
+        fiche = compute_fiche([make_eval("C1", None, statut="non_applicable")])
+        assert fiche["score_max_applicable"] == 0.0
+        assert fiche["score_renormalise"] == 0.0
+        assert fiche["lettre"] == "E"
+
+
+class TestConfiance:
+    def test_signaux_contradictoires_moyenne(self):
+        fiche = compute_fiche(
+            evals_completes(C5=make_eval("C5", 5.0, flags=["signaux_contradictoires"]))
+        )
+        assert fiche["confiance"] == "moyenne"
+
+    def test_corroboration_insuffisante_moyenne(self):
+        fiche = compute_fiche(
+            evals_completes(
+                C8=make_eval("C8", 2.0, flags=["corroboration_insuffisante"])
+            )
+        )
+        assert fiche["confiance"] == "moyenne"
+
+    def test_revue_humaine_requise_basse(self):
+        fiche = compute_fiche(
+            evals_completes(C9=make_eval("C9", 5.0, flags=["revue_humaine_requise"]))
+        )
+        assert fiche["confiance"] == "basse"
+
+    def test_critere_revue_requise_basse_et_exclu_du_max(self):
+        fiche = compute_fiche(
+            evals_completes(
+                C7=make_eval("C7", None, statut="revue_requise", flags=["bloque_acces"])
+            )
+        )
+        assert fiche["criteres_revue_requise"] == ["C7"]
+        assert fiche["score_max_applicable"] == 50.0
+        assert fiche["confiance"] == "basse"
+
+
+class TestPreferenceEvaluateur:
+    def test_code_prime_sur_agent(self):
+        fiche = compute_fiche(
+            evals_completes() + [make_eval("C8", 4.0, evaluateur="code:jti_shortcut")]
+        )
+        assert fiche["detail"]["C8"]["evaluateur"] == "code:jti_shortcut"


### PR DESCRIPTION
# feat(media-eval): fondations (schéma, contrats, moteur d'évaluation)

PR 1/2 du MVP pipeline d'évaluation des médias C1–C11 (story
`docs/stories/core/media-eval.0.mvp-pipeline-evaluation.md`, plan PO validé le
07/07/2026). Entièrement testable offline — la collecte (voie A + agents) et le
run pilote arrivent en PR 2.

## Ce que fait cette PR

### Docs source de vérité PO (`docs/media-eval/`)
- Import de la méthodologie v1.1.1 (PDF converti) + amendements v1.2 actés
  (raccourci JTI, pondération débunkages, temporalité, lettres A–E).
- Import de l'architecture collecte ≠ évaluation du 07/07/2026.
- **Rubriques évaluateur** (`rubrics/_common.md` + `C1/C5/C7/C8/C9/C11.md`) :
  barème §4 verbatim + section « Sortie structurée » (`determinations`
  énumérables). Lues verbatim par `build_eval_input.py` ;
  `version_prompt` = sha256 du fichier rubrique.

### Schéma DB (migration `me01_media_eval_tables`, additive, RLS deny-all)
7 tables `media_eval_*` : medias (référentiel niveau domaine), snapshots,
corpus_articles (créée mais vide en V0), signaux (pivot ; statuts
present/absent_verifie/partiel/bloque_acces ; dédup idempotente par
`dedupe_key`), debunkages (qualification émetteur/gravité/suite, couple 1-1
avec un signal C1), evaluations (score NULL si N/A, `signal_ids` cités,
version_methodo/version_prompt), fiches (renormalisation, lettre, confiance).
- `down_revision = ue01_user_entity_affinity` → 1 seul head. Idempotente
  (guard `has_table` par table — la chaîne boote sur les 2 services Railway).
  RLS pattern `sec02` (ENABLE + REVOKE anon/authenticated, aucune policy).
- Modèles `app/models/media_eval.py` (StrEnum locaux, enums VARCHAR non natifs,
  pattern `Source`), enregistrés dans `app/models/__init__.py`.

### Contrats & garde-fous codés en dur (`scripts/media_eval/`)
- `schemas.py` : `BAREMES` (100 pts), `CRITERES_VAGUE_1` (54 pts),
  `NIVEAU_SCORES` C9/C11, `LETTRES`, registre `type_signal` figé, artefacts
  Pydantic (Signal/Debunkage/Evaluation + enveloppes batch, GoldenSet).
  **`derive_score(critere, determinations)`** : le score faisant foi est dérivé
  par code, jamais choisi par le LLM (philosophie `derive_reliability`).
  Validator dur : éval sans `signal_ids_cites` rejetée (sauf flag
  `donnees_insuffisantes` → N/A). `poids_emetteur` des débunkages dérivé par
  code (`arcom/justice/cdjm` = fort, fact-checkers de médias concurrents =
  moyen, inconnu = faible).
- `garde_fous.py` (fonctions pures) : fraîcheur 730 j (signaux événementiels
  seulement, structurels constatés à date), fallback C1 (< 3 débunkages/2 ans),
  raccourci JTI, corroboration (score plein sans ≥ 2 domaines sources
  indépendants → palier inférieur + flag `corroboration_insuffisante`),
  `bloque_acces` → `revue_requise` — jamais converti en 0.

### Scripts moteur (dry-run par défaut, `--apply` gardé, `--allow-prod` hors DB test)
`seed_medias.py` (2 pilotes : cnews.fr audiovisuel, reporterre.net presse en
ligne) · `ingest_artifacts.py` (valide en bloc puis insère — un artefact
invalide = exit non-zéro, rien d'écrit ; idempotent) · `build_eval_input.py`
(exports `eval_inputs/<media>_<critere>.json` + garde-fous amont) ·
`ingest_evaluations.py` (garde-fous aval : signal_ids existants / bon média /
bon critère, score dérivé, corroboration, statuts) · `synthese_fiche.py`
(renormalisation sur les seuls critères évalués, lettre, confiance, fiche md +
ligne DB) · `evaluate_golden_agreement.py` (accord vs gold : exact C9/C11,
|Δ| ≤ 20 % du barème en continu, désaccords N/A-vs-score listés).

## Tests & vérifications

- **91 tests** `tests/scripts/media_eval/` (purs + DB savepoint) : contrats,
  table `derive_score`, bornes fraîcheur 729/730/731 j, fallback 2 vs 3,
  corroboration, JTI, `bloque_acces` jamais 0, renormalisation 0/1/3 N/A
  (cas Reporterre max 34), bornes lettres 84.9/85, matrice confiance,
  idempotence dedupe/évals, rejets (signal d'un autre média/critère,
  artefact partiellement invalide → rien d'écrit), métriques gold.
- Migration sur **DB vide** : `upgrade head` → `downgrade -1` → `upgrade head`
  OK, exactement 1 head (`me01_media_eval_tables`).
- Smoke E2E offline sur DB jetable : seed → ingest artefacts (5 signaux dont
  2 couples débunkage, poids dérivés) → build_eval_input (fallback C1 déclenché
  à 2 débunkages, 6 entrées écrites) → ingest_evaluations (3 évals, C1 N/A) →
  synthese_fiche (10/20 → 50/100, lettre D, confiance moyenne).
- Suite backend complète `pytest` + `ruff check`/`format` OK.

Pas d'entrée changelog : outillage interne, aucun impact user (bypass de la
règle 400 lignes assumé).

## Suite (PR 2)

Collecteurs voie A (`collect_pages_types/cdjm/jti/cppap/pappers/arcom`),
sous-agents `.claude/agents/media-eval-*`, commande `/media-eval-run`, run
pilote `pilote-2026-07` (CNEWS puis Reporterre) + golden set Laurin
(`docs/media-eval/golden/gold_v0.json`) + rapport d'accord. Prérequis :
`PAPPERS_API_TOKEN` (env locale, compte gratuit).
