### PR TITLE
fix(onboarding): sauver les sujets custom à l'ajout (EntityAddSheet) + budget LLM + observabilité

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,14 +1,22 @@
 {
   "unreleased": [
     {
+      "tag": "Onboarding",
+      "summary": "Tes sujets personnalisés sont validés et enregistrés dès que tu les ajoutes."
+    },
+    {
       "tag": "Essentiel",
       "summary": "Les titres de section sont plus lisibles, le « Tout lire » colle à sa section, et « Ton avis compte » est désormais intégré à la carte de fin de tournée."
     },
     {
       "tag": "Tournée",
       "summary": "La lecture de ta tournée est plus fluide, les sections sont mieux cadrées à l'écran, et tu personnalises ta veille en un geste depuis son titre."
+    },
+    {
       "tag": "Recherche",
       "summary": "Trouver une source est plus rapide et mieux ciblé."
+    },
+    {
       "tag": "Veille",
       "summary": "La veille ne montre plus que des articles vraiment liés à ton sujet."
     },

--- a/apps/mobile/lib/core/services/analytics_service.dart
+++ b/apps/mobile/lib/core/services/analytics_service.dart
@@ -431,6 +431,26 @@ class AnalyticsService {
     });
   }
 
+  /// Un ajout de sujet/entité personnalisé a échoué (timeout réseau, 4xx/5xx…).
+  /// origin: 'onboarding' | 'custom_topics'. Sert à mesurer la fréquence réelle
+  /// des échecs autrefois avalés côté client (bug custom-topics-deferred-save).
+  Future<void> trackCustomTopicSaveFailed({
+    required String name,
+    required String origin,
+    String? theme,
+    String? error,
+  }) async {
+    final props = {
+      'session_id': _sessionId,
+      'name': name,
+      'origin': origin,
+      'theme': theme,
+      'error': error,
+    };
+    await _logEvent('custom_topic_save_failed', props);
+    await _capturePostHog('custom_topic_save_failed', props);
+  }
+
   /// Generic settings/preference toggle. `key` is a stable snake_case identifier
   /// (e.g. 'notifications_daily_digest'), oldValue/newValue are coerced to string
   /// to keep the event payload shape uniform across bool/int/string toggles.

--- a/apps/mobile/lib/features/custom_topics/providers/custom_topics_provider.dart
+++ b/apps/mobile/lib/features/custom_topics/providers/custom_topics_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 import '../../../core/api/providers.dart';
 import '../../../core/auth/auth_state.dart';
@@ -118,6 +119,14 @@ class CustomTopicsNotifier extends AsyncNotifier<List<UserTopicProfile>> {
     } catch (e) {
       // Rollback
       state = previousState;
+      // Breadcrumb pour tracer les échecs de suivi (onboarding + réglages) —
+      // ils étaient auparavant avalés côté appelant sans aucun signal Sentry.
+      unawaited(Sentry.addBreadcrumb(Breadcrumb(
+        category: 'custom_topics',
+        message: 'followTopic failed',
+        level: SentryLevel.warning,
+        data: {'name': name, 'slug_parent': slugParent, 'error': e.toString()},
+      )));
       rethrow;
     }
   });
@@ -258,6 +267,17 @@ class CustomTopicsNotifier extends AsyncNotifier<List<UserTopicProfile>> {
       return created;
     } catch (e) {
       state = previousState;
+      unawaited(Sentry.addBreadcrumb(Breadcrumb(
+        category: 'custom_topics',
+        message: 'followEntity failed',
+        level: SentryLevel.warning,
+        data: {
+          'name': name,
+          'entity_type': entityType,
+          'slug_parent': slugParent,
+          'error': e.toString(),
+        },
+      )));
       rethrow;
     }
   });

--- a/apps/mobile/lib/features/custom_topics/widgets/entity_add_sheet.dart
+++ b/apps/mobile/lib/features/custom_topics/widgets/entity_add_sheet.dart
@@ -1,9 +1,11 @@
+import 'dart:async';
 import 'dart:ui';
 
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 import '../../../config/theme.dart';
 import '../../../core/ui/notification_service.dart';
@@ -125,7 +127,9 @@ class _EntityAddSheetState extends ConsumerState<EntityAddSheet> {
           _loading = false;
         });
       }
-    } on DioException catch (e) {
+    } on DioException catch (e, st) {
+      // Mesurable même si l'utilisateur abandonne avant la fin de l'onboarding.
+      unawaited(Sentry.captureException(e, stackTrace: st));
       if (mounted) {
         final detail = e.response?.data;
         final msg = (detail is Map && detail['detail'] is String)
@@ -155,7 +159,8 @@ class _EntityAddSheetState extends ConsumerState<EntityAddSheet> {
           '"${s.canonicalName}" ajouté à vos intérêts',
         );
       }
-    } on DioException catch (e) {
+    } on DioException catch (e, st) {
+      unawaited(Sentry.captureException(e, stackTrace: st));
       if (mounted) {
         final detail = e.response?.data;
         final msg = (detail is Map && detail['detail'] is String)

--- a/apps/mobile/lib/features/onboarding/screens/questions/subtopics_question.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/subtopics_question.dart
@@ -1,14 +1,17 @@
 import 'dart:async';
 
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 import '../../../../config/theme.dart';
 import '../../../../core/providers/analytics_provider.dart';
 import '../../../custom_topics/models/topic_models.dart';
 import '../../../custom_topics/providers/custom_topics_provider.dart';
+import '../../../custom_topics/widgets/entity_add_sheet.dart';
 import '../../providers/onboarding_provider.dart';
 import '../../data/available_subtopics.dart';
 import '../../onboarding_strings.dart';
@@ -26,12 +29,6 @@ class SubtopicsQuestion extends ConsumerStatefulWidget {
 class _SubtopicsQuestionState extends ConsumerState<SubtopicsQuestion> {
   Set<String> _selectedSubtopics = {};
   final Set<String> _selectedEntities = {};
-  final Map<String, List<String>> _customTopics = {};
-  String? _addingForTheme;
-  final TextEditingController _customController = TextEditingController();
-  // Clé sur le champ « sujet custom » pour le faire défiler au-dessus du clavier
-  // dès son apparition (cf. _startAddingCustom).
-  final GlobalKey _customFieldKey = GlobalKey();
   bool _saving = false;
 
   late final PageController _pageController;
@@ -87,7 +84,6 @@ class _SubtopicsQuestionState extends ConsumerState<SubtopicsQuestion> {
 
   @override
   void dispose() {
-    _customController.dispose();
     _pageController.dispose();
     super.dispose();
   }
@@ -128,107 +124,66 @@ class _SubtopicsQuestionState extends ConsumerState<SubtopicsQuestion> {
     });
   }
 
-  void _startAddingCustom(String themeSlug) {
-    setState(() {
-      _addingForTheme = themeSlug;
-      _customController.clear();
-    });
-    // Le champ vient d'apparaître (autofocus → clavier qui monte). On attend que
-    // le clavier soit en place puis on fait défiler le champ au-dessus de lui.
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      Future.delayed(const Duration(milliseconds: 250), () {
-        final ctx = _customFieldKey.currentContext;
-        if (!mounted || ctx == null) return;
-        Scrollable.ensureVisible(
-          ctx,
-          alignment: 0.4,
-          duration: const Duration(milliseconds: 250),
-          curve: Curves.easeOut,
-        );
-      });
-    });
+  /// Ouvre la fenêtre de désambiguïsation (`EntityAddSheet`) — même composant que
+  /// « Mes Intérêts ». Le sujet est validé, créé et confirmé **au moment de
+  /// l'ajout** (plus de batch terminal silencieux). Le chip « saved » apparaît
+  /// ensuite automatiquement car il est dérivé de `customTopicsProvider`.
+  void _openAddSheet(String themeSlug) {
+    HapticFeedback.selectionClick();
+    EntityAddSheet.show(context, themeSlug: themeSlug);
   }
 
-  void _submitCustomTopic(String themeSlug) {
-    final name = _customController.text.trim();
-    if (name.isEmpty) return;
-
-    // Fermer le clavier tant que l'EditableText focalisé est encore monté :
-    // un unfocus après suppression du widget (via setState ci-dessous) est un
-    // no-op qui laisserait le clavier ouvert sur iOS.
-    FocusManager.instance.primaryFocus?.unfocus();
-
-    setState(() {
-      _customTopics.putIfAbsent(themeSlug, () => []);
-      _customTopics[themeSlug]!.add(name);
-      _addingForTheme = null;
-      _customController.clear();
-    });
-  }
-
-  void _removeCustomTopic(String themeSlug, String name) {
-    setState(() {
-      _customTopics[themeSlug]?.remove(name);
-    });
+  /// Retire un sujet custom déjà persisté (chip « saved ») — cohérent avec les
+  /// réglages. Best-effort : le provider rollback son état optimiste en cas
+  /// d'échec réseau.
+  Future<void> _removeSavedCustom(String topicId) async {
+    // Un placeholder optimiste (id `temp_…`) n'existe pas encore côté serveur.
+    if (topicId.startsWith('temp_')) return;
+    HapticFeedback.selectionClick();
+    try {
+      await ref.read(customTopicsProvider.notifier).unfollowTopic(topicId);
+    } catch (_) {
+      // L'état optimiste est déjà restauré par le provider ; rien à faire ici.
+    }
   }
 
   Future<void> _continue() async {
-    // Collect custom topics + entities to save via API BEFORE navigating.
-    // Non-bloquant : les échecs sont loggués et résumés en fin d'onboarding,
-    // jamais opposés à la progression utilisateur.
+    // Les sujets custom sont désormais sauvés à l'ajout via EntityAddSheet — il
+    // ne reste que les entités populaires cochées à persister ici. Non-bloquant :
+    // un échec est mesuré (Sentry + analytics) et résumé en dernier recours,
+    // jamais opposé à la progression utilisateur.
     final notifier = ref.read(customTopicsProvider.notifier);
-    final attempts = <_TopicAttempt>[];
+    final analytics = ref.read(analyticsServiceProvider);
 
-    for (final entry in _customTopics.entries) {
-      for (final topicName in entry.value) {
-        attempts.add(_TopicAttempt(
-          name: topicName,
-          future: notifier
-              .followTopic(topicName, slugParent: entry.key)
-              .then<Object?>((v) => v)
-              .catchError((Object e, StackTrace st) {
-            debugPrint(
-              '[ONBOARDING_TELEMETRY] event=custom_topic_failed '
-              'name="$topicName" theme=${entry.key} error=$e',
-            );
-            return null;
-          }),
-        ));
-      }
-    }
-    for (final entityName in _selectedEntities) {
-      attempts.add(_TopicAttempt(
-        name: entityName,
-        future: notifier
-            .followTopic(entityName)
-            .then<Object?>((v) => v)
-            .catchError((Object e, StackTrace st) {
-          debugPrint(
-            '[ONBOARDING_TELEMETRY] event=custom_entity_failed '
-            'name="$entityName" error=$e',
-          );
-          return null;
-        }),
-      ));
-    }
-
-    if (attempts.isNotEmpty) {
+    if (_selectedEntities.isNotEmpty) {
       setState(() => _saving = true);
-      final results = await Future.wait(attempts.map((a) => a.future));
-      final failedNames = <String>[
-        for (var i = 0; i < attempts.length; i++)
-          if (results[i] == null) attempts[i].name,
-      ];
+      final failedNames = <String>[];
+      for (final entityName in _selectedEntities) {
+        try {
+          await notifier.followTopic(entityName);
+        } catch (e, st) {
+          // 409 = déjà suivi → succès silencieux, pas un échec.
+          if (e is DioException && e.response?.statusCode == 409) continue;
+          unawaited(Sentry.captureException(e, stackTrace: st));
+          unawaited(analytics.trackCustomTopicSaveFailed(
+            name: entityName,
+            origin: 'onboarding',
+            error: e.toString(),
+          ));
+          failedNames.add(entityName);
+        }
+      }
 
       if (failedNames.isNotEmpty) {
-        // Stocke dans l'état — la bottom sheet de synthèse s'affichera
-        // après la conclusion, à la place du snackbar éphémère.
+        // Dernier recours : la bottom sheet de synthèse s'affichera après la
+        // conclusion. Dans le cas nominal cette liste reste vide.
         ref
             .read(onboardingProvider.notifier)
             .recordFailedCustomTopics(failedNames);
       }
     }
 
+    if (!mounted) return;
     // Save subtopics LAST — this triggers navigation to the next step
     ref.read(onboardingProvider.notifier).selectSubtopics(
           _selectedSubtopics.toList(),
@@ -528,8 +483,13 @@ class _SubtopicsQuestionState extends ConsumerState<SubtopicsQuestion> {
       ...defaultEnts
           .where((d) => !backendNames.contains(d.name.toLowerCase())),
     ];
-    final customs = _customTopics[theme.slug] ?? [];
-    final canAddMore = customs.length < 3;
+    // Sujets custom dérivés du provider (source de vérité) filtrés par thème :
+    // ils sont persistés à l'ajout via EntityAddSheet et hydratés au restart.
+    final savedCustoms = (ref.watch(customTopicsProvider).valueOrNull ??
+            const <UserTopicProfile>[])
+        .where((t) => t.slugParent == theme.slug)
+        .toList();
+    final canAddMore = savedCustoms.length < 3;
     final colors = context.facteurColors;
 
     return Container(
@@ -612,18 +572,17 @@ class _SubtopicsQuestionState extends ConsumerState<SubtopicsQuestion> {
             ),
           ],
 
-          // Custom topics
-          if (customs.isNotEmpty) ...[
+          // Custom topics (saved) — dérivés du provider, supprimables.
+          if (savedCustoms.isNotEmpty) ...[
             const SizedBox(height: FacteurSpacing.space2),
             Wrap(
               spacing: FacteurSpacing.space2,
               runSpacing: FacteurSpacing.space2,
-              children: customs
-                  .map((name) => _RemovableCustomChip(
-                        name: name,
+              children: savedCustoms
+                  .map((topic) => _RemovableCustomChip(
+                        name: topic.name,
                         themeColor: theme.color,
-                        onRemove: () =>
-                            _removeCustomTopic(theme.slug, name),
+                        onRemove: () => _removeSavedCustom(topic.id),
                       ))
                   .toList(),
             ),
@@ -631,46 +590,11 @@ class _SubtopicsQuestionState extends ConsumerState<SubtopicsQuestion> {
 
           const SizedBox(height: FacteurSpacing.space2),
 
-          // Add custom topic CTA
-          if (_addingForTheme == theme.slug)
-            Row(
-              children: [
-                Expanded(
-                  child: TextField(
-                    key: _customFieldKey,
-                    controller: _customController,
-                    autofocus: true,
-                    textInputAction: TextInputAction.done,
-                    scrollPadding: EdgeInsets.only(
-                        bottom: MediaQuery.viewInsetsOf(context).bottom + 80),
-                    decoration: InputDecoration(
-                      hintText: AvailableSubtopics
-                              .customTopicPlaceholders[theme.slug] ??
-                          OnboardingStrings.addCustomTopicHint,
-                      isDense: true,
-                      contentPadding: const EdgeInsets.symmetric(
-                          horizontal: 12, vertical: 10),
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                    ),
-                    onSubmitted: (_) => _submitCustomTopic(theme.slug),
-                  ),
-                ),
-                const SizedBox(width: 8),
-                IconButton(
-                  onPressed: () => _submitCustomTopic(theme.slug),
-                  icon: Icon(Icons.check, color: theme.color),
-                  constraints: const BoxConstraints(
-                    minWidth: 36,
-                    minHeight: 36,
-                  ),
-                ),
-              ],
-            )
-          else if (canAddMore)
+          // Add custom topic CTA — ouvre la fenêtre de désambiguïsation qui
+          // valide + confirme + persiste le sujet au moment de l'ajout.
+          if (canAddMore)
             GestureDetector(
-              onTap: () => _startAddingCustom(theme.slug),
+              onTap: () => _openAddSheet(theme.slug),
               child: Container(
                 padding:
                     const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
@@ -703,12 +627,6 @@ class _SubtopicsQuestionState extends ConsumerState<SubtopicsQuestion> {
       ),
     );
   }
-}
-
-class _TopicAttempt {
-  final String name;
-  final Future<Object?> future;
-  const _TopicAttempt({required this.name, required this.future});
 }
 
 class _EntityChip extends StatelessWidget {

--- a/apps/mobile/test/features/onboarding/screens/subtopics_question_test.dart
+++ b/apps/mobile/test/features/onboarding/screens/subtopics_question_test.dart
@@ -1,0 +1,89 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/core/providers/analytics_provider.dart';
+import 'package:facteur/core/services/analytics_service.dart';
+import 'package:facteur/features/custom_topics/models/topic_models.dart';
+import 'package:facteur/features/custom_topics/providers/custom_topics_provider.dart';
+import 'package:facteur/features/onboarding/providers/onboarding_provider.dart';
+import 'package:facteur/features/onboarding/screens/questions/subtopics_question.dart';
+
+/// Fake notifier renvoyant une liste figée de sujets « saved », sans réseau.
+class _FakeCustomTopicsNotifier extends CustomTopicsNotifier {
+  _FakeCustomTopicsNotifier(this._topics);
+  final List<UserTopicProfile> _topics;
+
+  @override
+  Future<List<UserTopicProfile>> build() async => _topics;
+}
+
+void main() {
+  setUpAll(() {
+    Hive.init(Directory.systemTemp.createTempSync('onb_subtopics_test').path);
+  });
+
+  ProviderContainer makeContainer(List<UserTopicProfile> saved) {
+    final container = ProviderContainer(
+      overrides: [
+        customTopicsProvider.overrideWith(
+          () => _FakeCustomTopicsNotifier(saved),
+        ),
+        // Pas d'entités backend → carte simple.
+        popularEntitiesProvider.overrideWith((ref, theme) async => const []),
+        analyticsServiceProvider.overrideWithValue(AnalyticsService.disabled()),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  Widget buildTestWidget(ProviderContainer container) {
+    return UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        theme: FacteurTheme.lightTheme,
+        home: const Scaffold(body: SubtopicsQuestion()),
+      ),
+    );
+  }
+
+  testWidgets(
+      'les chips custom « saved » sont dérivés du provider, filtrés par thème',
+      (tester) async {
+    final container = makeContainer(const [
+      UserTopicProfile(id: 'k1', name: 'Kylian Mbappé', slugParent: 'tech'),
+      // Sujet d'un thème NON sélectionné : ne doit apparaître sur aucune carte.
+      UserTopicProfile(id: 'o1', name: 'Autre', slugParent: 'sport'),
+    ]);
+    container.read(onboardingProvider.notifier).bypassOnboarding();
+
+    await tester.pumpWidget(buildTestWidget(container));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Kylian Mbappé'), findsOneWidget);
+    expect(find.text('Autre'), findsNothing);
+  });
+
+  testWidgets('le CTA d\'ajout ouvre la fenêtre de désambiguïsation',
+      (tester) async {
+    final container = makeContainer(const []);
+    container.read(onboardingProvider.notifier).bypassOnboarding();
+
+    await tester.pumpWidget(buildTestWidget(container));
+    await tester.pumpAndSettle();
+
+    // Le champ inline a disparu ; on ouvre EntityAddSheet à la place.
+    expect(find.text('Ajouter un sujet personnalisé'), findsNothing);
+
+    await tester.tap(find.text('Ajouter un sujet').first);
+    await tester.pumpAndSettle();
+
+    // La bottom sheet (EntityAddSheet) est montée : titre + champ de saisie.
+    expect(find.text('Ajouter un sujet personnalisé'), findsOneWidget);
+  });
+}

--- a/docs/bugs/bug-onboarding-custom-topics-deferred-save.md
+++ b/docs/bugs/bug-onboarding-custom-topics-deferred-save.md
@@ -1,0 +1,75 @@
+# Bug — Onboarding : sujets personnalisés « n'ont pas pu être enregistrés »
+
+**Type** : Bug
+**Statut** : Corrigé (branche `boujonlaurin-dotcom/onboarding-custom-topic-save-error`)
+**Décision PO** : Variant B — réutiliser la fenêtre de désambiguïsation (`EntityAddSheet`)
+dans l'onboarding. Scope complet : UX + robustesse backend + observabilité.
+
+## Symptôme
+
+En toute fin d'onboarding, quand l'utilisateur avait ajouté des sujets personnalisés,
+une modale s'affichait parfois : « Certains sujets personnalisés n'ont pas pu être
+sauvés (…). Tu pourras les réajouter depuis Mes Intérêts. »
+
+## Cause racine (deux couches cumulées)
+
+1. **Architecture — sauvegarde différée en batch terminal.** L'onboarding stockait
+   les sujets custom en simples chaînes locales (`_customTopics`) et différait toutes
+   les sauvegardes à la toute fin (`_continue`, `Future.wait`). Comme `followTopic`
+   passe par un mutex (`_serialized`), ce batch s'exécutait en chaîne séquentielle de
+   N appels lents. Chaque appel frappe `POST /personalization/topics/` →
+   `create_topic`, qui **bloquait sur un enrichissement LLM Mistral (timeout httpx
+   15 s)** avant d'écrire la ligne. Tout appel dépassant le `receiveTimeout` Dio
+   (30 s), ou trébuchant sur le refresh de session 5 s, renvoyait `null` → marqué en
+   échec → modale de synthèse.
+2. **UX — aucun retour à l'ajout.** L'utilisateur ne découvrait l'échec qu'à la ligne
+   d'arrivée, quand plus rien n'était actionnable.
+
+**Observabilité aveugle** : l'échec était avalé côté client (`catchError` +
+`debugPrint`), rien n'allait dans Sentry ⇒ fréquence réelle sous-estimée. Signaux
+corroborants dans Sentry : `FLUTTER-1E` (DioException receive timeout > 30 s) et
+`FLUTTER-6` (TimeoutException 5 s dans le session refresher).
+
+## Correctif
+
+### Mobile
+- `subtopics_question.dart` : l'ajout inline (champ texte local) est remplacé par
+  l'ouverture d'`EntityAddSheet.show(context, themeSlug: …)` — même composant que
+  « Mes Intérêts ». Le sujet est **validé, désambiguïsé, créé et confirmé au moment
+  de l'ajout** (snackbar immédiat, retry inline sur erreur). Plus de batch terminal
+  pour les sujets custom.
+- Les chips « saved » sont **dérivés de `customTopicsProvider`** filtré par
+  `slugParent == themeSlug` (source de vérité, hydratés au restart). Le X appelle
+  `unfollowTopic(id)`. Cap 3/thème conservé côté client.
+- `_continue` ne persiste plus que les entités populaires cochées, séquentiellement,
+  avec observabilité (Sentry + analytics) et 409 traité comme « déjà suivi » (succès).
+- `recordFailedCustomTopics` + la modale finale deviennent un **vrai dernier recours** :
+  dans le cas nominal la liste est vide et la modale ne s'affiche jamais.
+
+### Observabilité
+- `analytics_service.dart` : nouvel event `trackCustomTopicSaveFailed({name, origin,
+  theme, error})`.
+- `custom_topics_provider.dart` : `Sentry.addBreadcrumb` dans les `catch` de
+  `followTopic` / `followEntity` (couvre réglages + onboarding).
+- `entity_add_sheet.dart` : `Sentry.captureException` en plus du snackbar dans les
+  catchs `_submit` / `_followSuggestion`.
+
+### Backend — borne la latence LLM (`_LLM_BUDGET_SECONDS = 8s`)
+- `topic_enrichment_service.enrich` / `disambiguate` acceptent un `llm_timeout` qui
+  enveloppe l'appel LLM dans `asyncio.wait_for`. Sur timeout, retombée sur le
+  fallback fuzzy existant (`_fallback_enrich`). Comme `slug_parent` de la requête
+  prime, la perte de qualité est minime en onboarding (thème connu).
+- `create_topic` et l'endpoint `/disambiguate` passent le budget (8 s < 30 s client).
+- Le `receiveTimeout` client n'est **pas** augmenté (masquerait le problème).
+
+### Migration
+**Aucune.** Fix UX = client-only ; le budget backend est un tweak comportemental dans
+des endpoints existants, sans changement de schéma. Idempotence et cap 3/thème
+inchangés.
+
+## Vérification
+- `flutter test` (custom_topics + onboarding), `flutter analyze` (pas de net-new).
+- `pytest packages/api/tests/test_custom_topics*.py` : idempotence, cap 3 → 409,
+  fallback rapide quand l'enrichissement LLM traîne/échoue (budget).
+- E2E web : sujet ambigu (désambiguïsation) + sujet non ambigu (confirmation directe),
+  échec réseau → retry inline + absence de la modale de fin.

--- a/packages/api/app/routers/custom_topics.py
+++ b/packages/api/app/routers/custom_topics.py
@@ -39,6 +39,12 @@ logger = structlog.get_logger()
 
 router = APIRouter()
 
+# Hard budget (seconds) on the LLM enrichment/disambiguation call for the
+# user-facing create/disambiguate endpoints. Kept well under the mobile client's
+# 30s receive timeout so a slow Mistral response degrades to the fuzzy fallback
+# instead of surfacing as a silent "topic could not be saved" at onboarding end.
+_LLM_BUDGET_SECONDS = 8.0
+
 
 # --- Pydantic Schemas ---
 
@@ -240,10 +246,14 @@ async def create_topic(
     await user_service.get_or_create_profile(current_user_id)
     await db.flush()
 
-    # LLM enrichment (always, for slug_parent + keywords)
+    # LLM enrichment (always, for slug_parent + keywords). Bounded by a budget
+    # (< client receive timeout) so a slow Mistral call falls back to the fuzzy
+    # match instead of silently failing the save (cf. bug custom-topics-deferred).
     enrichment_service = get_topic_enrichment_service()
     try:
-        result = await enrichment_service.enrich(request.name)
+        result = await enrichment_service.enrich(
+            request.name, llm_timeout=_LLM_BUDGET_SECONDS
+        )
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e))
 
@@ -373,7 +383,7 @@ async def disambiguate_topic(
     enrichment_service = get_topic_enrichment_service()
     try:
         candidates = await enrichment_service.disambiguate(
-            request.name, theme=request.theme
+            request.name, theme=request.theme, llm_timeout=_LLM_BUDGET_SECONDS
         )
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e))

--- a/packages/api/app/services/ml/topic_enrichment_service.py
+++ b/packages/api/app/services/ml/topic_enrichment_service.py
@@ -10,7 +10,9 @@ Takes a free-text topic name from the user and maps it to:
 
 from __future__ import annotations
 
+import asyncio
 import json
+from collections.abc import Awaitable
 from dataclasses import dataclass, field
 
 import httpx
@@ -25,6 +27,16 @@ from app.services.ml.classification_service import (
 )
 
 log = structlog.get_logger()
+
+async def _await_with_budget[T](coro: Awaitable[T], timeout: float | None) -> T:
+    """Await [coro], bounding it with [timeout] seconds when provided.
+
+    On timeout the coroutine is cancelled and asyncio.TimeoutError propagates,
+    so callers treat it like any other LLM failure and fall back to fuzzy.
+    """
+    if timeout is not None:
+        return await asyncio.wait_for(coro, timeout=timeout)
+    return await coro
 
 # Build the topic list for the enrichment prompt
 _TOPIC_LIST = "\n".join(
@@ -138,11 +150,18 @@ class TopicEnrichmentService:
             )
         return self._client
 
-    async def enrich(self, topic_name: str) -> TopicEnrichmentResult:
+    async def enrich(
+        self, topic_name: str, *, llm_timeout: float | None = None
+    ) -> TopicEnrichmentResult:
         """Enrich a free-text topic name via LLM one-shot call.
 
         Args:
             topic_name: User-provided topic name (e.g. "Voiture électrique")
+            llm_timeout: Optional hard budget (seconds) on the LLM call. If the
+                call exceeds it, we bail to the fuzzy fallback instead of letting
+                the client hit its own receive timeout. Used on the onboarding /
+                create path where a fast, slightly-degraded answer beats a
+                silent save failure.
 
         Returns:
             TopicEnrichmentResult with slug_parent, keywords, intent_description,
@@ -157,8 +176,10 @@ class TopicEnrichmentService:
         # Try LLM enrichment first
         if self._ready:
             try:
-                return await self._enrich_via_llm(topic_name.strip())
-            except Exception as e:
+                return await _await_with_budget(
+                    self._enrich_via_llm(topic_name.strip()), llm_timeout
+                )
+            except Exception as e:  # incl. asyncio.TimeoutError from wait_for
                 log.warning(
                     "topic_enrichment.llm_failed",
                     topic=topic_name,
@@ -288,12 +309,15 @@ class TopicEnrichmentService:
         )
 
     async def disambiguate(
-        self, name: str, theme: str | None = None
+        self, name: str, theme: str | None = None, *, llm_timeout: float | None = None
     ) -> list[DisambiguationCandidate]:
         """Disambiguate a free-text topic name via LLM.
 
         Returns 1-3 candidates depending on ambiguity.
         Falls back to enrich() if LLM fails.
+
+        [llm_timeout] bounds each LLM call (disambiguation + the enrich fallback)
+        so the endpoint answers well under the client receive timeout.
         """
         if not name or not name.strip():
             raise ValueError("name cannot be empty")
@@ -302,8 +326,10 @@ class TopicEnrichmentService:
 
         if self._ready:
             try:
-                return await self._disambiguate_via_llm(name, theme)
-            except Exception as e:
+                return await _await_with_budget(
+                    self._disambiguate_via_llm(name, theme), llm_timeout
+                )
+            except Exception as e:  # incl. asyncio.TimeoutError from wait_for
                 log.warning(
                     "topic_disambiguation.llm_failed",
                     name=name,
@@ -311,7 +337,7 @@ class TopicEnrichmentService:
                 )
 
         # Fallback: use enrich() and wrap as single candidate
-        result = await self.enrich(name)
+        result = await self.enrich(name, llm_timeout=llm_timeout)
         return [
             DisambiguationCandidate(
                 canonical_name=result.canonical_name or name,

--- a/packages/api/app/services/ml/topic_enrichment_service.py
+++ b/packages/api/app/services/ml/topic_enrichment_service.py
@@ -28,6 +28,7 @@ from app.services.ml.classification_service import (
 
 log = structlog.get_logger()
 
+
 async def _await_with_budget[T](coro: Awaitable[T], timeout: float | None) -> T:
     """Await [coro], bounding it with [timeout] seconds when provided.
 
@@ -37,6 +38,7 @@ async def _await_with_budget[T](coro: Awaitable[T], timeout: float | None) -> T:
     if timeout is not None:
         return await asyncio.wait_for(coro, timeout=timeout)
     return await coro
+
 
 # Build the topic list for the enrichment prompt
 _TOPIC_LIST = "\n".join(

--- a/packages/api/tests/test_topic_enrichment_budget.py
+++ b/packages/api/tests/test_topic_enrichment_budget.py
@@ -1,0 +1,86 @@
+"""Budget LLM sur enrich/disambiguate (bug onboarding custom-topics-deferred-save).
+
+Le chemin create/disambiguate borne l'appel Mistral avec `llm_timeout` : un LLM
+lent doit retomber vite sur le fallback fuzzy au lieu de laisser le client
+onboarding atteindre son `receiveTimeout` (30 s) → échec silencieux de sauvegarde.
+"""
+
+import asyncio
+
+import pytest
+
+from app.services.ml.topic_enrichment_service import (
+    TopicEnrichmentResult,
+    TopicEnrichmentService,
+)
+
+
+def _ready_service() -> TopicEnrichmentService:
+    svc = TopicEnrichmentService()
+    # Force le chemin LLM (indépendamment de la présence d'une vraie clé en CI).
+    svc._ready = True
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_enrich_falls_back_fast_when_llm_hangs():
+    svc = _ready_service()
+
+    async def _hang(_name: str) -> TopicEnrichmentResult:
+        await asyncio.sleep(5)  # LLM qui traîne au-delà du budget
+        raise AssertionError("should have been cancelled by the budget")
+
+    svc._enrich_via_llm = _hang  # type: ignore[assignment]
+
+    result = await asyncio.wait_for(
+        svc.enrich("Voiture électrique", llm_timeout=0.05), timeout=1.0
+    )
+    # Fallback fuzzy → toujours un slug valide, jamais une exception ni un hang.
+    assert isinstance(result, TopicEnrichmentResult)
+    assert result.slug_parent
+    assert result.keywords
+
+
+@pytest.mark.asyncio
+async def test_enrich_uses_llm_result_when_it_answers_in_budget():
+    svc = _ready_service()
+
+    async def _fast(name: str) -> TopicEnrichmentResult:
+        return TopicEnrichmentResult(
+            slug_parent="tech",
+            keywords=["gpt"],
+            intent_description="Suivi de l'IA",
+        )
+
+    svc._enrich_via_llm = _fast  # type: ignore[assignment]
+
+    result = await svc.enrich("GPT-5", llm_timeout=1.0)
+    assert result.slug_parent == "tech"
+    assert result.keywords == ["gpt"]
+
+
+@pytest.mark.asyncio
+async def test_disambiguate_falls_back_fast_when_llm_hangs():
+    svc = _ready_service()
+
+    async def _hang(_name: str, _theme):  # noqa: ANN001
+        await asyncio.sleep(5)
+        raise AssertionError("should have been cancelled by the budget")
+
+    async def _fallback_enrich(name: str, *, llm_timeout=None) -> TopicEnrichmentResult:
+        # La retombée disambiguate → enrich doit elle aussi être bornée.
+        assert llm_timeout == 0.05
+        return TopicEnrichmentResult(
+            slug_parent="tech",
+            keywords=[name.lower()],
+            intent_description="",
+        )
+
+    svc._disambiguate_via_llm = _hang  # type: ignore[assignment]
+    svc.enrich = _fallback_enrich  # type: ignore[assignment]
+
+    candidates = await asyncio.wait_for(
+        svc.disambiguate("Apple", theme="tech", llm_timeout=0.05), timeout=1.0
+    )
+    assert len(candidates) == 1
+    assert candidates[0].slug_parent == "tech"


### PR DESCRIPTION
## Quoi

En fin d'onboarding, une modale « Certains sujets personnalisés n'ont pas pu être sauvés » apparaissait quand l'utilisateur avait ajouté des sujets custom. Ce PR corrige la cause racine (sauvegarde différée en batch terminal + latence LLM non bornée) et rend l'échec mesurable.

- **Mobile** : l'ajout inline (champ texte local + `_customTopics` + batch `Future.wait` dans `_continue`) est remplacé par `EntityAddSheet.show(context, themeSlug: …)` — même composant que « Mes Intérêts ». Le sujet est **validé, désambiguïsé, créé et confirmé au moment de l'ajout**. Les chips « saved » sont **dérivés de `customTopicsProvider`** filtré par `slugParent` (source de vérité, hydratés au restart) ; le X appelle `unfollowTopic`. `_continue` ne persiste plus que les entités populaires cochées, séquentiellement, `409` traité comme « déjà suivi ». `recordFailedCustomTopics` + la modale finale deviennent un **vrai dernier recours** (vide dans le cas nominal).
- **Backend** : `enrich` / `disambiguate` acceptent un `llm_timeout` (`_LLM_BUDGET_SECONDS = 8s`, < 30s receiveTimeout client) qui borne l'appel Mistral via `asyncio.wait_for` → retombée sur le fallback fuzzy existant au lieu d'un échec silencieux. Le `receiveTimeout` client n'est **pas** augmenté (masquerait le problème).

## Pourquoi

Cause racine à deux couches : (1) toutes les sauvegardes custom étaient différées à la fin de l'onboarding et exécutées en chaîne séquentielle via un mutex, chaque appel bloquant sur un enrichissement LLM non borné → dépassement du `receiveTimeout` Dio ; (2) aucun retour à l'ajout, l'échec n'était découvert qu'à la ligne d'arrivée. En prime, l'échec était avalé côté client (`catchError` + `debugPrint`) → invisible dans Sentry. Détail : `docs/bugs/bug-onboarding-custom-topics-deferred-save.md`. Décision PO : Variant B (réutiliser `EntityAddSheet`).

## Observabilité (ex-blind spot)

- `trackCustomTopicSaveFailed({name, origin, theme, error})` (analytics + PostHog).
- `Sentry.addBreadcrumb` dans les `catch` de `followTopic` / `followEntity` (couvre réglages + onboarding).
- `Sentry.captureException` dans `EntityAddSheet` (`_submit` / `_followSuggestion`).

## Comment ça a été vérifié

- [x] `pytest` backend complet : **2067 passed**, 0 échec (dont 3 nouveaux tests budget LLM `test_topic_enrichment_budget.py` + 35 custom_topics).
- [x] `flutter test test/features/onboarding/screens/subtopics_question_test.dart` : 2 nouveaux widget tests OK (chips dérivés/filtrés par thème + CTA ouvre `EntityAddSheet`).
- [x] `flutter analyze` sur les fichiers touchés : aucun net-new (seulement `withOpacity`/`HapticFeedback` pré-existants). `ruff check` OK.
- [x] `/simplify` passé : 2 dedups (catch-all onboarding + helper `_await_with_budget[T]` backend), re-vérifiés.
- Migration Alembic : **aucune** (schéma inchangé — client-only + tweak comportemental d'endpoints existants).

## Zones à risque

- **Onboarding** : réécriture client-only de `subtopics_question.dart` (état custom local supprimé, dérivé du provider).
- **`topic_enrichment_service`** partagé par d'autres appelants — `llm_timeout` est opt-in (défaut `None`) donc les appelants existants sont inchangés.

## Changelog

Entrée « Onboarding » ajoutée à `changelog.json` (unreleased).
