### PR TITLE
feat(mobile): curseur de niveau de suivi sur « Mes intérêts »

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,14 +1,22 @@
 {
   "unreleased": [
     {
+      "tag": "Intérêts",
+      "summary": "Règle le niveau de suivi de chaque thème et sujet d'un simple curseur, comme sur les fiches source."
+    },
+    {
       "tag": "Essentiel",
       "summary": "Les titres de section sont plus lisibles, le « Tout lire » colle à sa section, et « Ton avis compte » est désormais intégré à la carte de fin de tournée."
     },
     {
       "tag": "Tournée",
       "summary": "La lecture de ta tournée est plus fluide, les sections sont mieux cadrées à l'écran, et tu personnalises ta veille en un geste depuis son titre."
+    },
+    {
       "tag": "Recherche",
       "summary": "Trouver une source est plus rapide et mieux ciblé."
+    },
+    {
       "tag": "Veille",
       "summary": "La veille ne montre plus que des articles vraiment liés à ton sujet."
     },

--- a/apps/mobile/lib/features/my_interests/screens/my_interests_screen.dart
+++ b/apps/mobile/lib/features/my_interests/screens/my_interests_screen.dart
@@ -25,6 +25,7 @@ import '../../feed/repositories/personalization_repository.dart';
 import '../models/user_interests_state.dart';
 import '../providers/user_interests_provider.dart';
 import '../../flux_continu/widgets/tournee_composer_sheet.dart';
+import '../widgets/interest_priority_slider.dart';
 import '../widgets/interest_state_picker_sheet.dart';
 
 const Map<String, String> _apiSlugToMacroLabel = {
@@ -70,35 +71,37 @@ class _MyInterestsScreenState extends ConsumerState<MyInterestsScreen> {
     }
   }
 
+  // Le sheet relit l'état courant depuis `userInterestsProvider` (via
+  // `refTarget`) et applique en direct via `onChanged` ; le try/catch +
+  // SnackBar d'erreur restent portés ici.
   Future<void> _pickState({
     required String title,
     required FavoriteRef refTarget,
-    required InterestState currentState,
   }) async {
     final isPinnedTopic = refTarget is CustomTopicFavoriteRef;
-    final selected = await InterestStatePickerSheet.show(
+    await InterestStateSliderSheet.show(
       context,
       title: title,
-      currentState: currentState,
+      refTarget: refTarget,
       favoriteSemantics: isPinnedTopic
           ? FavoriteSemantics.pinnedTopic
           : FavoriteSemantics.theme,
+      onChanged: (selected) async {
+        try {
+          await ref
+              .read(userInterestsProvider.notifier)
+              .setInterestState(refTarget, selected);
+        } catch (e) {
+          if (!mounted) return;
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Impossible de mettre à jour cet intérêt.'),
+              duration: Duration(seconds: 3),
+            ),
+          );
+        }
+      },
     );
-    if (selected == null || selected == currentState) return;
-
-    try {
-      await ref
-          .read(userInterestsProvider.notifier)
-          .setInterestState(refTarget, selected);
-    } catch (e) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: const Text('Impossible de mettre à jour cet intérêt.'),
-          duration: const Duration(seconds: 3),
-        ),
-      );
-    }
   }
 
   @override
@@ -226,7 +229,6 @@ class _MyInterestsScreenState extends ConsumerState<MyInterestsScreen> {
               onTapTopic: (id, name) => _pickState(
                 title: name,
                 refTarget: CustomTopicFavoriteRef(id: id),
-                currentState: InterestState.favorite,
               ),
             ),
             // La création / gestion / archivage de la veille vit désormais dans
@@ -242,15 +244,13 @@ class _MyInterestsScreenState extends ConsumerState<MyInterestsScreen> {
               themeSlug: themeSlug,
               interests: interests,
               sereinMode: sereinMode,
-              onPickThemeState: (current) => _pickState(
+              onPickThemeState: () => _pickState(
                 title: macroLabel,
                 refTarget: ThemeFavoriteRef(slug: themeSlug),
-                currentState: current,
               ),
-              onPickTopicState: (topicId, name, current) => _pickState(
+              onPickTopicState: (topicId, name) => _pickState(
                 title: name,
                 refTarget: CustomTopicFavoriteRef(id: topicId),
-                currentState: current,
               ),
             );
           }),
@@ -295,7 +295,6 @@ class _MyInterestsScreenState extends ConsumerState<MyInterestsScreen> {
                             onRestore: () => _pickState(
                               title: entry.displayName,
                               refTarget: entry.refTarget,
-                              currentState: InterestState.hidden,
                             ),
                           ),
                         )
@@ -528,12 +527,8 @@ class _ThemeBlock extends ConsumerWidget {
   final String themeSlug;
   final UserInterestsState interests;
   final bool sereinMode;
-  final Future<void> Function(InterestState current) onPickThemeState;
-  final Future<void> Function(
-    String topicId,
-    String name,
-    InterestState current,
-  ) onPickTopicState;
+  final Future<void> Function() onPickThemeState;
+  final Future<void> Function(String topicId, String name) onPickTopicState;
 
   const _ThemeBlock({
     required this.macroLabel,
@@ -573,7 +568,7 @@ class _ThemeBlock extends ConsumerWidget {
       return _DiscoverHint(
         macroLabel: macroLabel,
         themeSlug: themeSlug,
-        onPickThemeState: () => onPickThemeState(themeState),
+        onPickThemeState: () => onPickThemeState(),
       );
     }
 
@@ -616,7 +611,7 @@ class _ThemeBlock extends ConsumerWidget {
                 if (!sereinMode)
                   _StateChip(
                     state: themeState,
-                    onTap: () => onPickThemeState(themeState),
+                    onTap: () => onPickThemeState(),
                   ),
               ],
             ),
@@ -630,7 +625,6 @@ class _ThemeBlock extends ConsumerWidget {
                     onPickState: () => onPickTopicState(
                       topic.id,
                       topic.topicName,
-                      topic.state,
                     ),
                   ),
                 ),

--- a/apps/mobile/lib/features/my_interests/widgets/interest_priority_slider.dart
+++ b/apps/mobile/lib/features/my_interests/widgets/interest_priority_slider.dart
@@ -1,0 +1,239 @@
+/// Curseur 4-états réutilisable (Masqué → Neutre → Suivi → Favori).
+///
+/// Extrait verbatim de `_SourcePrioritySlider` (fiche source) pour homogénéiser
+/// l'expérience thèmes / sujets de « Mes intérêts » avec la fiche source. Le
+/// widget est **présentationnel** (sans dépendance provider) : il expose la
+/// position optimiste pendant le drag et persiste via le callback `onChanged`
+/// appelé sur `onChangeEnd`. La resynchronisation sur l'état réel (rollback
+/// inclus) est portée par le parent qui repasse `value`.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../config/theme.dart';
+import '../models/user_interests_state.dart';
+import '../providers/user_interests_provider.dart';
+import 'interest_state_picker_sheet.dart'
+    show FavoriteSemantics, InterestStateSemantics;
+
+/// Curseur 4 points présentationnel. Chaque cran porte l'icône/couleur de son
+/// [InterestState] ; le libellé + la description du cran courant s'actualisent
+/// sous la piste au fil du glissement. `favoriteSemantics` bascule le cran
+/// « Favori » vers « Épinglé » + punaise pour les sujets personnalisés.
+class InterestPrioritySlider extends StatefulWidget {
+  final InterestState value;
+  final ValueChanged<InterestState> onChanged;
+  final FavoriteSemantics favoriteSemantics;
+
+  const InterestPrioritySlider({
+    super.key,
+    required this.value,
+    required this.onChanged,
+    this.favoriteSemantics = FavoriteSemantics.theme,
+  });
+
+  @override
+  State<InterestPrioritySlider> createState() => _InterestPrioritySliderState();
+}
+
+class _InterestPrioritySliderState extends State<InterestPrioritySlider> {
+  // Ordre gauche → droite du curseur.
+  static const List<InterestState> _order = [
+    InterestState.hidden,
+    InterestState.unfollowed,
+    InterestState.followed,
+    InterestState.favorite,
+  ];
+
+  // Position optimiste pendant le drag (null = on suit `widget.value`).
+  int? _pendingIndex;
+
+  // Cran par défaut si `widget.value` sort de `_order` (indexOf == -1).
+  static final int _defaultIndex = _order.indexOf(InterestState.followed);
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+
+    final providerIndex = _order.indexOf(widget.value);
+    final index = _pendingIndex ?? (providerIndex < 0 ? _defaultIndex : providerIndex);
+    final state = _order[index];
+    final accent = state.accent(colors);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SliderTheme(
+          data: SliderThemeData(
+            trackHeight: 4,
+            activeTrackColor: accent,
+            inactiveTrackColor: colors.textPrimary.withValues(alpha: 0.12),
+            thumbColor: accent,
+            overlayColor: accent.withValues(alpha: 0.16),
+            thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 9),
+            tickMarkShape: SliderTickMarkShape.noTickMark,
+          ),
+          child: Slider(
+            value: index.toDouble(),
+            min: 0,
+            max: (_order.length - 1).toDouble(),
+            divisions: _order.length - 1,
+            onChanged: (v) => setState(() => _pendingIndex = v.round()),
+            onChangeEnd: (v) {
+              final picked = _order[v.round()];
+              setState(() => _pendingIndex = null);
+              if (picked != widget.value) widget.onChanged(picked);
+            },
+          ),
+        ),
+        // Icône + libellé court sous chaque point.
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4),
+          child: Row(
+            children: [
+              for (var i = 0; i < _order.length; i++)
+                Expanded(
+                  child: Column(
+                    children: [
+                      Icon(
+                        _order[i].iconFor(widget.favoriteSemantics),
+                        size: 15,
+                        color: i == index
+                            ? _order[i].accent(colors)
+                            : colors.textTertiary,
+                      ),
+                      const SizedBox(height: 3),
+                      Text(
+                        _order[i].labelFor(widget.favoriteSemantics),
+                        textAlign: TextAlign.center,
+                        style: textTheme.labelSmall?.copyWith(
+                          fontSize: 10.5,
+                          letterSpacing: 0,
+                          color: i == index
+                              ? _order[i].accent(colors)
+                              : colors.textTertiary,
+                          fontWeight:
+                              i == index ? FontWeight.w700 : FontWeight.w500,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 12),
+        // Description du statut courant, mise à jour au slide.
+        Text(
+          state.descriptionFor(widget.favoriteSemantics),
+          style: textTheme.labelSmall?.copyWith(
+            color: colors.textSecondary,
+            fontSize: 12,
+            height: 1.4,
+            letterSpacing: 0,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Bottom sheet hébergeant [InterestPrioritySlider] pour un thème / sujet de
+/// « Mes intérêts ». Même habillage que [InterestStatePickerSheet] (poignée +
+/// titre). Le sheet reste ouvert et applique **en direct** via `onChanged`
+/// (parité exacte avec la fiche source) ; l'utilisateur ferme via la
+/// poignée / le scrim. La position se resynchronise sur `userInterestsProvider`
+/// (rollback compris) car le curseur relit `stateOf(refTarget)` à chaque build.
+class InterestStateSliderSheet extends ConsumerWidget {
+  final String title;
+  final FavoriteRef refTarget;
+  final FavoriteSemantics favoriteSemantics;
+  final ValueChanged<InterestState> onChanged;
+
+  const InterestStateSliderSheet({
+    super.key,
+    required this.title,
+    required this.refTarget,
+    required this.onChanged,
+    this.favoriteSemantics = FavoriteSemantics.theme,
+  });
+
+  /// Affiche le curseur en bottom sheet. Applique en direct via [onChanged].
+  static Future<void> show(
+    BuildContext context, {
+    required String title,
+    required FavoriteRef refTarget,
+    required ValueChanged<InterestState> onChanged,
+    FavoriteSemantics favoriteSemantics = FavoriteSemantics.theme,
+  }) {
+    return showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (_) => InterestStateSliderSheet(
+        title: title,
+        refTarget: refTarget,
+        onChanged: onChanged,
+        favoriteSemantics: favoriteSemantics,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+
+    final currentState = ref.watch(userInterestsProvider).valueOrNull
+            ?.stateOf(refTarget) ??
+        InterestState.unfollowed;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: colors.backgroundSecondary,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: SafeArea(
+        top: false,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              margin: const EdgeInsets.only(top: 12, bottom: 16),
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: colors.textTertiary.withValues(alpha: 0.3),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  title,
+                  style: textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: colors.textPrimary,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 20),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 0, 20, 8),
+              child: InterestPrioritySlider(
+                value: currentState,
+                favoriteSemantics: favoriteSemantics,
+                onChanged: onChanged,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/my_interests/widgets/interest_state_picker_sheet.dart
+++ b/apps/mobile/lib/features/my_interests/widgets/interest_state_picker_sheet.dart
@@ -16,6 +16,27 @@ import '../models/user_interests_state.dart';
 ///   Explorer sans entrer dans le top 5 de la Tournée du jour.
 enum FavoriteSemantics { theme, pinnedTopic }
 
+/// Résout label / icône / description d'un [InterestState] en tenant compte de
+/// la sémantique « Épinglé » (sujet personnalisé). Source unique partagée par
+/// le picker (`_StateOption`) et le curseur `InterestPrioritySlider`, pour ne
+/// pas dupliquer l'override pinned (strings + punaise) dans les deux widgets.
+extension InterestStateSemantics on InterestState {
+  bool _isPinned(FavoriteSemantics semantics) =>
+      this == InterestState.favorite &&
+      semantics == FavoriteSemantics.pinnedTopic;
+
+  String labelFor(FavoriteSemantics semantics) =>
+      _isPinned(semantics) ? 'Épinglé' : label;
+
+  IconData iconFor(FavoriteSemantics semantics) => _isPinned(semantics)
+      ? PhosphorIcons.pushPin(PhosphorIconsStyle.fill)
+      : iconData;
+
+  String descriptionFor(FavoriteSemantics semantics) => _isPinned(semantics)
+      ? 'Apparaît comme onglet dans la section Flâner.'
+      : description;
+}
+
 class InterestStatePickerSheet extends StatelessWidget {
   final String title;
   final InterestState currentState;
@@ -122,19 +143,11 @@ class _StateOption extends StatelessWidget {
     required this.favoriteSemantics,
   });
 
-  bool get _isPinnedTopic =>
-      state == InterestState.favorite &&
-      favoriteSemantics == FavoriteSemantics.pinnedTopic;
+  String get _label => state.labelFor(favoriteSemantics);
 
-  String get _label =>
-      _isPinnedTopic ? 'Épinglé' : state.label;
+  String get _description => state.descriptionFor(favoriteSemantics);
 
-  String get _description => _isPinnedTopic
-      ? 'Apparaît comme onglet dans la section Flâner.'
-      : state.description;
-
-  IconData get _icon =>
-      _isPinnedTopic ? PhosphorIcons.pushPin(PhosphorIconsStyle.fill) : state.iconData;
+  IconData get _icon => state.iconFor(favoriteSemantics);
 
   @override
   Widget build(BuildContext context) {

--- a/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
@@ -15,6 +15,7 @@ import '../../flux_continu/utils/theme_color_mapping.dart';
 import '../../flux_continu/widgets/flux_continu_article_card.dart';
 import '../../my_interests/models/user_interests_state.dart';
 import '../../my_interests/providers/user_sources_state_provider.dart';
+import '../../my_interests/widgets/interest_priority_slider.dart';
 import '../models/smart_search_result.dart';
 import '../models/source_model.dart';
 import '../providers/sources_providers.dart';
@@ -1616,137 +1617,37 @@ class _FsSettings extends StatelessWidget {
 }
 
 /// Curseur 4 points (Masqué → Neutre → Suivi → Favori) remplaçant la pastille
-/// + modal de priorité. Chaque point porte son icône `InterestState`, et le
-/// statut courant + sa description s'actualisent sous la piste à chaque
-/// déplacement. Le slide persiste l'état via `userSourcesStateProvider`
-/// (optimiste : la position suit le doigt, puis se resynchronise sur le
-/// provider).
-class _SourcePrioritySlider extends ConsumerStatefulWidget {
+/// + modal de priorité. Fin wrapper autour du widget partagé
+/// [InterestPrioritySlider] : lit l'état courant via `userSourcesStateProvider`
+/// et persiste via `setSourceState` (optimiste ; la position se resynchronise
+/// sur le provider, rollback compris). Le libellé source reste « Favori ».
+class _SourcePrioritySlider extends ConsumerWidget {
   final String sourceId;
   const _SourcePrioritySlider({required this.sourceId});
 
   @override
-  ConsumerState<_SourcePrioritySlider> createState() =>
-      _SourcePrioritySliderState();
-}
-
-class _SourcePrioritySliderState
-    extends ConsumerState<_SourcePrioritySlider> {
-  // Ordre gauche → droite du curseur.
-  static const List<InterestState> _order = [
-    InterestState.hidden,
-    InterestState.unfollowed,
-    InterestState.followed,
-    InterestState.favorite,
-  ];
-
-  // Position optimiste pendant le drag (null = on suit le provider).
-  int? _pendingIndex;
-
-  Future<void> _apply(InterestState picked) async {
-    try {
-      await ref
-          .read(userSourcesStateProvider.notifier)
-          .setSourceState(widget.sourceId, picked);
-    } catch (_) {
-      if (!mounted) return;
-      setState(() => _pendingIndex = null);
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Impossible de mettre à jour cette source.'),
-          duration: Duration(seconds: 3),
-        ),
-      );
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.facteurColors;
-    final textTheme = Theme.of(context).textTheme;
-
+  Widget build(BuildContext context, WidgetRef ref) {
     final providerState = ref.watch(userSourcesStateProvider).valueOrNull;
     final currentState =
-        providerState?.stateOf(widget.sourceId) ?? InterestState.followed;
-    final providerIndex = _order.indexOf(currentState);
-    final index = _pendingIndex ?? providerIndex;
-    final state = _order[index];
-    final accent = state.accent(colors);
+        providerState?.stateOf(sourceId) ?? InterestState.followed;
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        SliderTheme(
-          data: SliderThemeData(
-            trackHeight: 4,
-            activeTrackColor: accent,
-            inactiveTrackColor: colors.textPrimary.withValues(alpha: 0.12),
-            thumbColor: accent,
-            overlayColor: accent.withValues(alpha: 0.16),
-            thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 9),
-            tickMarkShape: SliderTickMarkShape.noTickMark,
-          ),
-          child: Slider(
-            value: index.toDouble(),
-            min: 0,
-            max: (_order.length - 1).toDouble(),
-            divisions: _order.length - 1,
-            onChanged: (v) => setState(() => _pendingIndex = v.round()),
-            onChangeEnd: (v) {
-              final picked = _order[v.round()];
-              setState(() => _pendingIndex = null);
-              if (picked != currentState) _apply(picked);
-            },
-          ),
-        ),
-        // Icône + libellé court sous chaque point.
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 4),
-          child: Row(
-            children: [
-              for (var i = 0; i < _order.length; i++)
-                Expanded(
-                  child: Column(
-                    children: [
-                      Icon(
-                        _order[i].iconData,
-                        size: 15,
-                        color: i == index
-                            ? _order[i].accent(colors)
-                            : colors.textTertiary,
-                      ),
-                      const SizedBox(height: 3),
-                      Text(
-                        _order[i].label,
-                        textAlign: TextAlign.center,
-                        style: textTheme.labelSmall?.copyWith(
-                          fontSize: 10.5,
-                          letterSpacing: 0,
-                          color: i == index
-                              ? _order[i].accent(colors)
-                              : colors.textTertiary,
-                          fontWeight:
-                              i == index ? FontWeight.w700 : FontWeight.w500,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-            ],
-          ),
-        ),
-        const SizedBox(height: 12),
-        // Description du statut courant, mise à jour au slide.
-        Text(
-          state.description,
-          style: textTheme.labelSmall?.copyWith(
-            color: colors.textSecondary,
-            fontSize: 12,
-            height: 1.4,
-            letterSpacing: 0,
-          ),
-        ),
-      ],
+    return InterestPrioritySlider(
+      value: currentState,
+      onChanged: (picked) async {
+        try {
+          await ref
+              .read(userSourcesStateProvider.notifier)
+              .setSourceState(sourceId, picked);
+        } catch (_) {
+          if (!context.mounted) return;
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Impossible de mettre à jour cette source.'),
+              duration: Duration(seconds: 3),
+            ),
+          );
+        }
+      },
     );
   }
 }

--- a/apps/mobile/test/features/my_interests/widgets/interest_priority_slider_test.dart
+++ b/apps/mobile/test/features/my_interests/widgets/interest_priority_slider_test.dart
@@ -1,0 +1,93 @@
+/// Tests du curseur 4-états partagé (thèmes / sujets + fiche source).
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/my_interests/models/user_interests_state.dart';
+import 'package:facteur/features/my_interests/widgets/interest_priority_slider.dart';
+import 'package:facteur/features/my_interests/widgets/interest_state_picker_sheet.dart';
+
+Widget _host(Widget child) => MaterialApp(
+      theme: FacteurTheme.lightTheme,
+      home: Scaffold(body: Center(child: child)),
+    );
+
+void main() {
+  testWidgets('renders the 4 state labels + current description',
+      (tester) async {
+    await tester.pumpWidget(
+      _host(
+        InterestPrioritySlider(
+          value: InterestState.followed,
+          onChanged: (_) {},
+        ),
+      ),
+    );
+
+    expect(find.text('Favori'), findsOneWidget);
+    expect(find.text('Suivi'), findsOneWidget);
+    expect(find.text('Neutre'), findsOneWidget);
+    expect(find.text('Masqué'), findsOneWidget);
+    // Description du cran courant (followed).
+    expect(find.text('Présent dans votre flux'), findsOneWidget);
+  });
+
+  testWidgets('dragging the thumb reports the new state on drag end',
+      (tester) async {
+    InterestState? reported;
+    await tester.pumpWidget(
+      _host(
+        InterestPrioritySlider(
+          value: InterestState.unfollowed,
+          onChanged: (s) => reported = s,
+        ),
+      ),
+    );
+
+    // Glisse le thumb vers la droite (au-delà du dernier cran) → Favori.
+    await tester.drag(find.byType(Slider), const Offset(500, 0));
+    await tester.pumpAndSettle();
+
+    expect(reported, InterestState.favorite);
+  });
+
+  testWidgets('does not report when the state is unchanged', (tester) async {
+    var callCount = 0;
+    await tester.pumpWidget(
+      _host(
+        InterestPrioritySlider(
+          value: InterestState.favorite,
+          onChanged: (_) => callCount++,
+        ),
+      ),
+    );
+
+    // Drag vers la droite alors qu'on est déjà au cran max (favorite).
+    await tester.drag(find.byType(Slider), const Offset(500, 0));
+    await tester.pumpAndSettle();
+
+    expect(callCount, 0);
+  });
+
+  testWidgets('pinnedTopic semantics renders "Épinglé" instead of "Favori"',
+      (tester) async {
+    await tester.pumpWidget(
+      _host(
+        InterestPrioritySlider(
+          value: InterestState.favorite,
+          favoriteSemantics: FavoriteSemantics.pinnedTopic,
+          onChanged: (_) {},
+        ),
+      ),
+    );
+
+    expect(find.text('Épinglé'), findsOneWidget);
+    expect(find.text('Favori'), findsNothing);
+    expect(
+      find.textContaining('onglet dans la section Flâner'),
+      findsOneWidget,
+    );
+  });
+}


### PR DESCRIPTION
## Quoi

Les thèmes et sujets de « Mes intérêts » se règlent désormais avec le même
curseur 4-états (Masqué → Neutre → Suivi → Favori) que les fiches source, à la
place du picker à 4 lignes. Réglage plus direct, cohérent d'un écran à l'autre.

- Extrait `InterestPrioritySlider` (widget présentationnel partagé) depuis
  `_SourcePrioritySlider` ; la fiche source devient un fin wrapper.
- Ajoute `InterestStateSliderSheet` (bottom sheet) pour « Mes intérêts » :
  applique en direct via `onChanged`, se resynchronise sur `userInterestsProvider`
  (rollback compris).
- Consolide l'override « Épinglé » (label/icône/description) dans une extension
  partagée `InterestStateSemantics` réutilisée par le picker et le curseur (fin
  d'une double implémentation).
- Nettoyage : retrait du paramètre mort `currentState` de `_pickState` et de ses
  typedefs / points d'appel.

## Pourquoi

Homogénéise l'expérience de réglage du niveau de suivi (thèmes/sujets ↔ sources)
et supprime la duplication introduite entre le picker existant et le nouveau
curseur.

## Comment ça a été vérifié

- [x] `flutter test` — 138 tests OK (suites `my_interests` + `sources`), dont le
  nouveau `interest_priority_slider_test.dart` (labels, drag→report, no-op si
  inchangé, sémantique « Épinglé »).
- [x] `flutter analyze` sur les fichiers touchés — 0 nouvel issue (seules des
  déprécations `withOpacity`/`activeColor` pré-existantes subsistent).
- [x] `/simplify` passé (4 agents) : dedup override pinned + retrait param mort
  appliqués ; helpers snackbar / chrome de sheet volontairement laissés (hors
  périmètre).

## Zones à risque

UI mobile uniquement, aucune migration, aucun changement backend. Comportement
du curseur inchangé (extraction 1:1) ; le point sensible est le nouveau flux
d'application en direct côté « Mes intérêts », couvert par les tests widget.