### PR TITLE
fix(classif): garde-fou anti-angle-mort — superviseur worker + alerte file

### DIFF
--- a/docs/bugs/bug-classification-worker-stopped.md
+++ b/docs/bugs/bug-classification-worker-stopped.md
@@ -1,0 +1,142 @@
+# Bug — La classification ML est à l'arrêt depuis le 30/06 ~01:00 UTC
+
+Type : **Bug prod**. Statut : cause racine établie (données prod, read-only) ;
+garde-fou code livré ; restauration ops (Railway) restante.
+
+## Symptôme
+
+Le worker de classification ML (in-process, lifespan FastAPI, gaté sur
+`settings.ml_enabled`) ne tourne plus. Conséquence : `content.theme` /
+`content.topics` sont **NULL sur tout le contenu frais** → le scoring
+thème/subtopic est inerte au moment où les users lisent, la curation retombe au
+source-level. ~26 k articles empilés en `pending`, backlog qui grossit.
+
+## Root cause — établie par les données prod (read-only, 09/07/2026)
+
+**Arrêt net, horodaté : 2026-06-30 ~01:00 UTC.**
+
+- `classification_queue` : coupure franche — tout ce qui a > ~9,7 j est
+  `completed`, tout ce qui est plus récent est `pending` (26 063 pending, oldest
+  9 j 16 h). Ce n'est pas un retard qui s'écoule : c'est un traitement qui a
+  **cessé**.
+- `api_usage_events` : le call-site `classification_pass1` (et `good_news_pass2`)
+  produit des appels jusqu'au **30/06 01:00** puis **plus AUCUN appel**, quel que
+  soit le statut, jusqu'à aujourd'hui. Dernier appel OK : 30/06 01:00 (135 ok).
+- **Mistral n'est pas en cause** : le call-site `editorial` (mistral-large)
+  tourne tous les jours jusqu'au 09/07 (~40 appels/j). Clé + provider sains.
+  `ML_ENABLED` a forcément été `true` (des milliers d'appels classif jusqu'au
+  30/06). Ce n'est donc **ni la clé, ni le cap, ni un flip d'env évident**.
+- **Le process est resté vivant** : `editorial` + digest quotidien continuent →
+  ce n'est pas tout le service qui est tombé, c'est **la task asyncio du worker
+  classif qui s'est arrêtée isolément**.
+
+**Mécanisme le plus probable (code) :** `_run_loop()`
+(`classification_worker.py`) ne rattrape que `except Exception` par tour, puis
+`await asyncio.sleep`. Une **`asyncio.CancelledError` (sous-classe de
+`BaseException`, non attrapée)** ou tout autre `BaseException` qui remonte d'un
+`await` interne **termine la task** sans que `self.running` repasse à `False` et
+**sans redémarrage** : le worker reste « down » silencieusement tant que le
+process n'est pas rebooté avec un `start()` neuf. Aucune alerte n'existait sur la
+profondeur de file → 10 j d'angle mort.
+
+**Signal secondaire (pas la cause de l'arrêt permanent) :** le
+**29/06 03:00→15:00**, tempête d'erreurs sur `classification_pass1`
+(~550–900 err/h, latence 55–70 ms = rejets client immédiats, pas des timeouts ni
+du 429 — le 429 est loggé séparément en `rate_limited`). Elle **s'est
+auto-résorbée à 16:00** (retour `ok`, ~900 ms). Distincte de l'arrêt de 01:00 le
+30/06.
+
+### Un vrai bug secondaire repéré (hors périmètre de cette PR)
+
+`classification_worker.py` (`if rec["retry_count"] < 2:`) → après épuisement des
+retries, l'item est `mark_completed_with_entities(topics=[])`, donc **quitte la
+file en `completed` avec `content.theme` NULL**. Explique le plafond ~68 % de
+couverture sur le contenu 7-20 j (pas 100 %). **Décision PO : hors périmètre** —
+à traiter dans une PR séparée si besoin.
+
+## Décisions PO (tranchées)
+
+- **Périmètre** : Volet 1 (restauration ops) + Volet 3 (garde-fou
+  observabilité). La fuite thème NULL `retry_count < 2` est **hors périmètre**.
+- **Service cible du worker** : **`production` uniquement**
+  (`facteur-production`). Cadence hebdo → cohérent avec un arrêt non réparé
+  depuis le 30/06 (pas de reboot prod entre-temps). **Ne PAS activer `ML_ENABLED`
+  sur staging.**
+- **Seuil d'alerte** `oldest_pending_age` : **12 h**.
+
+## Fix — 3 volets
+
+### Volet 1 — Restaurer (ops, nécessite l'accès Railway — BLOQUÉ)
+
+- Sur **`facteur-production`** : confirmer `ML_ENABLED=true` ; **redéployer /
+  restart** le service pour que la lifespan rejoue `start()`. (Ne pas activer sur
+  staging.)
+- Vérifier : `lifespan_ml_worker_started` dans les logs, réapparition d'appels
+  `classification_pass1`, et **décroissance du `pending_count`**.
+
+> **Bloquant** : le token Railway CLI est `Unauthorized` dans ce workspace et le
+> MCP Railway n'est pas chargé → le Volet 1 ne peut pas être exécuté ici. À
+> débloquer avant l'implémentation ops. La vérification décisive des
+> logs/deploys autour du 30/06 01:00 UTC (deploy/restart, `ML_ENABLED` réel,
+> `lifespan_ml_worker_started` vs `_skipped`, trace `CancelledError`/OOM) reste à
+> faire sur le service qui héberge le worker.
+
+### Volet 2 — Rattraper le backlog (26 k), sans régression
+
+- Débit soutenu ≈ `batch_size=5` / `interval_s=10` → ~30 items/min ≈ ~36 k/j
+  théorique ; ingestion ~2 500/j → le backlog (26 k) se résorbe en < 1 j une fois
+  le worker relancé.
+- **Ne PAS remonter `batch_size`** (régression Bonnes Nouvelles, PR #152). Si le
+  drain mesuré est trop lent, le seul knob sûr est une **baisse temporaire bornée
+  de `interval_s`** (env-only), pas le batch size.
+
+### Volet 3 — Garde-fou anti-angle-mort (LIVRÉ dans cette PR)
+
+Deux couches complémentaires :
+
+**a. Superviseur de la task du worker** (`classification_worker.py`) :
+- `start()` attache un `add_done_callback(self._on_task_done)` à `self._task`.
+- `_on_task_done` : si la task se termine alors que `self.running` est encore
+  `True` (mort inattendue, typiquement `CancelledError`), il émet une alerte
+  Sentry (`capture_exception` si exception, sinon `capture_message` level=error)
+  et **relance la task** (via `_spawn_loop`, se ré-attache). Si `self.running`
+  est `False` (arrêt volontaire via `stop()`), il ne fait rien.
+- **Redémarrage borné** : au-delà de `_MAX_RAPID_RESTARTS` (5) morts dans une
+  fenêtre glissante `_RESTART_WINDOW_S` (60 s), il abandonne (alerte `fatal` +
+  `running=False`) et laisse la restart-policy Railway (ALWAYS) recycler le
+  process — évite une tight loop qui spammerait Sentry.
+
+**b. Alerte externe sur la profondeur de file**
+(`scheduler.py` → `_classification_queue_health_check`) :
+- Job APScheduler toutes les 30 min. Lit
+  `ClassificationQueueService.get_pending_stats()` et `capture_message` Sentry
+  `level=error` si `oldest_pending_age > classification_queue_alert_age_hours`
+  (défaut **12 h**, `config.py`). Fonctionne **même si le worker est mort**, tant
+  que le scheduler tourne. Message stable (pas d'âge exact) pour garder un
+  fingerprint Sentry unique ; valeurs exactes dans le log structuré.
+
+## Fichiers modifiés
+
+- `packages/api/app/workers/classification_worker.py` — `start()` +
+  `_on_task_done` (superviseur).
+- `packages/api/app/workers/scheduler.py` — `_classification_queue_health_check`
+  + enregistrement du job (Interval 30 min).
+- `packages/api/app/config.py` — `classification_queue_alert_age_hours = 12`.
+- Tests : `tests/workers/test_classification_worker_supervisor.py` (nouveau),
+  `tests/workers/test_scheduler.py` (job health-check).
+- Aucune migration Alembic (pas de DDL).
+
+## Vérification
+
+- **Garde-fou (a)** : tests unitaires du superviseur — task morte sur exception
+  → `capture_exception` + relance ; task annulée (CancelledError) + running=True
+  → `capture_message` + relance ; running=False (stop volontaire) → no-op.
+- **Garde-fou (b)** : tests unitaires du job — `oldest_age > 12 h` →
+  `capture_message` ; sous le seuil / file vide → pas d'alerte ; erreur DB →
+  swallow (ne crashe pas le scheduler).
+- `cd packages/api && pytest tests/workers/ -q` : vert.
+- **Restauration (post-Railway)** : après restart, logs
+  `lifespan_ml_worker_started` ; `SELECT count(*) FROM classification_queue
+  WHERE status='pending'` décroît ; `api_usage_events` montre des
+  `classification_pass1` récents ; couverture `content.theme` sur 0-24 h repasse
+  > 0 %.

--- a/packages/api/app/config.py
+++ b/packages/api/app/config.py
@@ -140,6 +140,12 @@ class Settings(BaseSettings):
     )
     classification_worker_interval_s: int = 10  # intervalle entre 2 vérifications
 
+    # Garde-fou anti-angle-mort (bug-classification-worker-stopped) : le job
+    # scheduler `classification_queue_health_check` alerte Sentry si le plus
+    # vieux pending dépasse ce seuil (en heures). Signal externe qui fonctionne
+    # même si la task du worker est morte, tant que le scheduler tourne.
+    classification_queue_alert_age_hours: int = 12
+
     # Brave Search API (smart source search)
     brave_api_key: str = ""
     brave_monthly_cap: int = 1800

--- a/packages/api/app/workers/classification_worker.py
+++ b/packages/api/app/workers/classification_worker.py
@@ -23,6 +23,14 @@ from app.services.ml.language_filter import is_french_source, looks_english
 
 settings = get_settings()
 
+# Anti-boucle-serrée du superviseur (_on_task_done) : si le run-loop meurt en
+# rafale (erreur persistante au boot du loop), on ne relance pas indéfiniment —
+# au-delà de _MAX_RAPID_RESTARTS morts dans une fenêtre de _RESTART_WINDOW_S, on
+# abandonne et on laisse la restart-policy Railway (ALWAYS) recycler le process,
+# plutôt que de spammer Sentry en tight loop.
+_MAX_RAPID_RESTARTS = 5
+_RESTART_WINDOW_S = 60.0
+
 
 class ClassificationWorker:
     """Worker qui traite la file d'attente de classification via Mistral API.
@@ -96,6 +104,10 @@ class ClassificationWorker:
         self._good_news_classifier = None
         self._loop_count = 0
 
+        # Superviseur : fenêtre glissante de comptage des redémarrages.
+        self._restart_count = 0
+        self._restart_window_start = 0.0
+
     def _get_classifier(self):
         """Lazy load classification service."""
         if self._classifier is None:
@@ -116,7 +128,90 @@ class ClassificationWorker:
         await self._recover_stuck_items()
 
         self.running = True
+        # Superviseur : si la task du run-loop meurt alors qu'on n'a PAS demandé
+        # l'arrêt (self.running toujours True), on veut le savoir et la relancer.
+        # Cf. incident 2026-06-30 : une CancelledError (BaseException, non
+        # attrapée par le `except Exception` du loop) a terminé la task
+        # silencieusement → classif à l'arrêt 10 j sans alerte.
+        self._spawn_loop()
+
+    def _spawn_loop(self) -> None:
+        """Crée la task du run-loop et attache le superviseur (invariant unique).
+
+        Appelé au démarrage (`start()`) et à chaque relance (`_on_task_done`) :
+        « créer la task + accrocher le done-callback » vit à un seul endroit.
+        """
         self._task = asyncio.create_task(self._run_loop())
+        self._task.add_done_callback(self._on_task_done)
+
+    def _on_task_done(self, task: "asyncio.Task") -> None:
+        """Done-callback superviseur du run-loop.
+
+        Appelé par la boucle asyncio quand `_run_loop` se termine. Deux cas :
+
+        - Arrêt volontaire (`stop()` a mis `self.running=False` avant de
+          `cancel()`) → rien à faire, sortie immédiate.
+        - Mort inattendue (`self.running` encore True) → la task a été tuée par
+          un `BaseException` (typiquement `CancelledError`) qui a échappé au
+          `except Exception` du loop. On émet une alerte Sentry + on **relance**
+          la task (superviseur simple, borné pour éviter une tight loop) pour ne
+          plus rester aveugle.
+        """
+        if not self.running:
+            # Arrêt volontaire (stop()) : comportement attendu, pas d'alerte.
+            return
+
+        import time
+
+        import sentry_sdk
+        import structlog
+
+        logger = structlog.get_logger()
+
+        # task.exception() lèverait CancelledError si la task a été annulée → on
+        # ne l'appelle que si elle n'est pas annulée.
+        exc = task.exception() if not task.cancelled() else None
+        if exc is not None:
+            logger.error(
+                "classification_worker.task_died",
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )
+            sentry_sdk.capture_exception(exc)
+        else:
+            # Annulation externe (CancelledError) ou fin sans exception alors
+            # que running=True : anormal, on alerte quand même.
+            logger.error(
+                "classification_worker.task_died", error="cancelled_or_no_exception"
+            )
+            sentry_sdk.capture_message(
+                "Classification worker task ended unexpectedly while running=True "
+                "(likely CancelledError) — restarting",
+                level="error",
+            )
+
+        # Anti-boucle-serrée : borne les redémarrages sur une fenêtre glissante.
+        now = time.monotonic()
+        if now - self._restart_window_start > _RESTART_WINDOW_S:
+            self._restart_window_start = now
+            self._restart_count = 0
+        self._restart_count += 1
+
+        if self._restart_count > _MAX_RAPID_RESTARTS:
+            logger.error(
+                "classification_worker.restart_giving_up",
+                restarts=self._restart_count,
+                window_s=_RESTART_WINDOW_S,
+            )
+            sentry_sdk.capture_message(
+                f"Classification worker died {self._restart_count}x in "
+                f"<{int(_RESTART_WINDOW_S)}s — giving up, relying on process restart",
+                level="fatal",
+            )
+            self.running = False
+            return
+
+        self._spawn_loop()
 
     async def _recover_stuck_items(self):
         """Reset items stuck in 'processing' state from previous crash/restart."""

--- a/packages/api/app/workers/scheduler.py
+++ b/packages/api/app/workers/scheduler.py
@@ -355,6 +355,60 @@ async def _pool_health_probe() -> None:
         logger.exception("pool_health_probe_failed")
 
 
+async def _classification_queue_health_check() -> None:
+    """Alerte externe si la file de classification stagne (angle-mort worker).
+
+    Bug 2026-06-30 : la task asyncio du ClassificationWorker est morte
+    isolément (CancelledError) sans repasser `running=False` ni redémarrer →
+    26 k pending empilés, `content.theme` NULL sur tout le frais, 10 j sans
+    aucune alerte. Le superviseur `_on_task_done` du worker couvre désormais la
+    mort de la task ; ce job est la **2e couche** : il fonctionne même si le
+    worker est mort (ou jamais démarré), tant que le scheduler tourne.
+
+    Lit `get_pending_stats()` (réutilisé de la gate d'accumulation) et
+    `capture_message` Sentry `level=error` si le plus vieux pending dépasse
+    `classification_queue_alert_age_hours` (défaut 12 h). Le message est
+    volontairement stable (pas d'âge exact dedans) pour garder un fingerprint
+    Sentry unique ; les valeurs exactes vont dans le log structuré.
+    """
+    import sentry_sdk
+
+    from app.database import safe_async_session
+    from app.services.classification_queue_service import ClassificationQueueService
+
+    try:
+        async with safe_async_session() as session:
+            service = ClassificationQueueService(session)
+            pending, oldest_age_s = await service.get_pending_stats()
+
+        threshold_h = settings.classification_queue_alert_age_hours
+        oldest_age_h = (
+            round(oldest_age_s / 3600, 2) if oldest_age_s is not None else None
+        )
+        logger.info(
+            "classification_queue_health",
+            pending=pending,
+            oldest_age_s=oldest_age_s,
+            oldest_age_h=oldest_age_h,
+            threshold_h=threshold_h,
+        )
+
+        if oldest_age_h is not None and oldest_age_h > threshold_h:
+            logger.warning(
+                "classification_queue_stalled",
+                pending=pending,
+                oldest_age_h=oldest_age_h,
+                threshold_h=threshold_h,
+            )
+            sentry_sdk.capture_message(
+                f"Classification queue stalled: oldest pending exceeds "
+                f"{threshold_h}h — worker may be down",
+                level="error",
+            )
+    except Exception:
+        logger.exception("classification_queue_health_check_failed")
+
+
 def start_scheduler() -> None:
     """Démarre le scheduler.
 
@@ -535,6 +589,20 @@ def start_scheduler() -> None:
         max_instances=1,
     )
 
+    # Garde-fou file de classification (30 min) — alerte Sentry si le plus
+    # vieux pending dépasse le seuil (défaut 12 h). 2e couche par-dessus le
+    # superviseur `_on_task_done` du worker : détecte l'angle-mort même si la
+    # task du worker est morte (bug-classification-worker-stopped).
+    scheduler.add_job(
+        _classification_queue_health_check,
+        trigger=IntervalTrigger(minutes=30),
+        id="classification_queue_health_check",
+        name="Classification queue health check (stall alert)",
+        replace_existing=True,
+        coalesce=True,
+        max_instances=1,
+    )
+
     scheduler.start()
     logger.info(
         "Scheduler started",
@@ -548,6 +616,7 @@ def start_scheduler() -> None:
             "zombie_session_sweeper",
             "pool_health_probe",
             "daily_essentiel_push_dispatch",
+            "classification_queue_health_check",
         ],
         rss_interval_minutes=settings.rss_sync_interval_minutes,
         digest_cron="07:30 Europe/Paris",

--- a/packages/api/tests/workers/test_classification_worker_supervisor.py
+++ b/packages/api/tests/workers/test_classification_worker_supervisor.py
@@ -1,0 +1,185 @@
+"""Tests du superviseur du ClassificationWorker (bug-classification-worker-stopped).
+
+Incident 2026-06-30 : la task asyncio du run-loop est morte isolément (probable
+`CancelledError`, sous-classe de `BaseException` non attrapée par le
+`except Exception` du loop) sans repasser `self.running=False` ni redémarrer →
+classif à l'arrêt 10 j, `content.theme` NULL sur tout le frais, aucune alerte.
+
+Le done-callback `_on_task_done` rend cette mort visible (Sentry) + relance la
+task quand elle meurt alors qu'on n'a PAS demandé l'arrêt.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from app.workers.classification_worker import ClassificationWorker
+
+
+def _bare_worker() -> ClassificationWorker:
+    """Worker sans engine réel (init court-circuité)."""
+    with patch.object(ClassificationWorker, "__init__", lambda self: None):
+        worker = ClassificationWorker()
+    worker.running = False
+    worker._task = None
+    worker._restart_count = 0
+    worker._restart_window_start = 0.0
+    return worker
+
+
+def test_on_task_done_restarts_and_captures_exception_when_running():
+    """Task morte sur exception + running=True ⇒ capture_exception + relance."""
+    worker = _bare_worker()
+    worker.running = True
+
+    boom = RuntimeError("boom")
+    dead = MagicMock()
+    dead.cancelled.return_value = False
+    dead.exception.return_value = boom
+
+    new_task = MagicMock()
+
+    def fake_create_task(coro):
+        coro.close()  # évite le warning "coroutine never awaited"
+        return new_task
+
+    fake_sentry = MagicMock()
+    with (
+        patch(
+            "app.workers.classification_worker.asyncio.create_task",
+            side_effect=fake_create_task,
+        ) as mock_create,
+        patch.dict("sys.modules", {"sentry_sdk": fake_sentry}),
+    ):
+        worker._on_task_done(dead)
+
+    fake_sentry.capture_exception.assert_called_once_with(boom)
+    mock_create.assert_called_once()
+    assert worker._task is new_task
+    new_task.add_done_callback.assert_called_once_with(worker._on_task_done)
+
+
+def test_on_task_done_restarts_and_alerts_on_cancellation_when_running():
+    """Task annulée (CancelledError) + running=True ⇒ capture_message + relance.
+
+    C'est le scénario exact de l'incident : une CancelledError termine la task
+    sans que le worker le sache. On alerte et on relance.
+    """
+    worker = _bare_worker()
+    worker.running = True
+
+    dead = MagicMock()
+    dead.cancelled.return_value = True  # annulée → on n'appelle pas exception()
+
+    new_task = MagicMock()
+
+    def fake_create_task(coro):
+        coro.close()  # évite le warning "coroutine never awaited"
+        return new_task
+
+    fake_sentry = MagicMock()
+    with (
+        patch(
+            "app.workers.classification_worker.asyncio.create_task",
+            side_effect=fake_create_task,
+        ) as mock_create,
+        patch.dict("sys.modules", {"sentry_sdk": fake_sentry}),
+    ):
+        worker._on_task_done(dead)
+
+    # On ne doit jamais appeler exception() sur une task annulée (lèverait).
+    dead.exception.assert_not_called()
+    fake_sentry.capture_message.assert_called_once()
+    assert fake_sentry.capture_message.call_args.kwargs["level"] == "error"
+    mock_create.assert_called_once()
+    assert worker._task is new_task
+
+
+def test_on_task_done_noop_on_voluntary_stop():
+    """running=False (arrêt volontaire via stop()) ⇒ pas d'alerte, pas de relance."""
+    worker = _bare_worker()
+    worker.running = False
+
+    dead = MagicMock()
+    dead.cancelled.return_value = True
+
+    fake_sentry = MagicMock()
+    with (
+        patch(
+            "app.workers.classification_worker.asyncio.create_task",
+        ) as mock_create,
+        patch.dict("sys.modules", {"sentry_sdk": fake_sentry}),
+    ):
+        worker._on_task_done(dead)
+
+    fake_sentry.capture_exception.assert_not_called()
+    fake_sentry.capture_message.assert_not_called()
+    mock_create.assert_not_called()
+
+
+def test_supervisor_gives_up_after_rapid_restarts():
+    """Morts en rafale ⇒ après _MAX_RAPID_RESTARTS, on abandonne (running=False)
+    + alerte fatale, au lieu de relancer en boucle serrée (spam Sentry)."""
+    from app.workers.classification_worker import _MAX_RAPID_RESTARTS
+
+    worker = _bare_worker()
+    worker.running = True
+
+    new_task = MagicMock()
+
+    def fake_create_task(coro):
+        coro.close()
+        return new_task
+
+    dead = MagicMock()
+    dead.cancelled.return_value = True
+
+    fake_sentry = MagicMock()
+    with (
+        patch(
+            "app.workers.classification_worker.asyncio.create_task",
+            side_effect=fake_create_task,
+        ) as mock_create,
+        patch.dict("sys.modules", {"sentry_sdk": fake_sentry}),
+    ):
+        # Les morts se produisent dans la même fenêtre (temps réel << 60 s).
+        for _ in range(_MAX_RAPID_RESTARTS + 2):
+            if not worker.running:
+                break
+            worker._on_task_done(dead)
+
+    # A abandonné : plus de relance, alerte fatale émise.
+    assert worker.running is False
+    # _MAX_RAPID_RESTARTS relances effectives, puis l'abandon (pas de spawn).
+    assert mock_create.call_count == _MAX_RAPID_RESTARTS
+    levels = [c.kwargs.get("level") for c in fake_sentry.capture_message.call_args_list]
+    assert "fatal" in levels
+
+
+def test_start_attaches_supervisor_callback():
+    """start() attache _on_task_done au task créé (couverture de l'accroche)."""
+    import asyncio
+
+    worker = _bare_worker()
+    worker.running = False
+
+    async def _noop():
+        return None
+
+    # _recover_stuck_items est awaité dans start() → doit rester un awaitable.
+    worker._recover_stuck_items = _noop
+
+    created = {}
+
+    def fake_create_task(coro):
+        # Ferme la coroutine pour éviter le warning "never awaited".
+        coro.close()
+        task = MagicMock()
+        created["task"] = task
+        return task
+
+    with patch(
+        "app.workers.classification_worker.asyncio.create_task",
+        side_effect=fake_create_task,
+    ):
+        asyncio.run(worker.start())
+
+    created["task"].add_done_callback.assert_called_once_with(worker._on_task_done)

--- a/packages/api/tests/workers/test_scheduler.py
+++ b/packages/api/tests/workers/test_scheduler.py
@@ -9,7 +9,7 @@ Tests:
 - Job trigger parameters
 """
 
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from apscheduler.triggers.cron import CronTrigger
@@ -20,6 +20,7 @@ from app.workers.scheduler import (
     DIGEST_CRON_MINUTE_PARIS,
     SUBTOPIC_DECAY_HOUR_PARIS,
     SUBTOPIC_DECAY_MINUTE_PARIS,
+    _classification_queue_health_check,
     _digest_watchdog,
     decay_user_entity_affinity,
     decay_user_subtopic_weights,
@@ -513,6 +514,115 @@ class TestDigestWatchdogCoverage:
         mock_run.assert_not_awaited()
 
 
+class TestClassificationQueueHealthCheck:
+    """Garde-fou anti-angle-mort (bug-classification-worker-stopped) : alerte
+    Sentry si le plus vieux pending dépasse le seuil (défaut 12 h)."""
+
+    def _patch_stats(self, stats: tuple):
+        """Patch get_pending_stats via une session factice + service mocké."""
+        from contextlib import asynccontextmanager
+
+        mock_session = AsyncMock()
+
+        @asynccontextmanager
+        async def fake_sm():
+            yield mock_session
+
+        service = MagicMock()
+        service.get_pending_stats = AsyncMock(return_value=stats)
+
+        return (
+            patch("app.database.safe_async_session", side_effect=lambda: fake_sm()),
+            patch(
+                "app.services.classification_queue_service.ClassificationQueueService",
+                return_value=service,
+            ),
+        )
+
+    @pytest.mark.asyncio
+    async def test_alerts_when_oldest_exceeds_threshold(self):
+        """oldest_age > 12 h ⇒ capture_message Sentry level=error."""
+        # 13 h en secondes, au-dessus du seuil 12 h.
+        sm_patch, svc_patch = self._patch_stats((26000, 13 * 3600))
+        fake_sentry = MagicMock()
+        with (
+            sm_patch,
+            svc_patch,
+            patch.dict("sys.modules", {"sentry_sdk": fake_sentry}),
+        ):
+            await _classification_queue_health_check()
+
+        fake_sentry.capture_message.assert_called_once()
+        assert fake_sentry.capture_message.call_args.kwargs["level"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_no_alert_under_threshold(self):
+        """oldest_age < 12 h ⇒ aucune alerte."""
+        sm_patch, svc_patch = self._patch_stats((3, 2 * 3600))  # 2 h
+        fake_sentry = MagicMock()
+        with (
+            sm_patch,
+            svc_patch,
+            patch.dict("sys.modules", {"sentry_sdk": fake_sentry}),
+        ):
+            await _classification_queue_health_check()
+
+        fake_sentry.capture_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_alert_when_queue_empty(self):
+        """File vide (oldest=None) ⇒ pas d'alerte, pas de crash."""
+        sm_patch, svc_patch = self._patch_stats((0, None))
+        fake_sentry = MagicMock()
+        with (
+            sm_patch,
+            svc_patch,
+            patch.dict("sys.modules", {"sentry_sdk": fake_sentry}),
+        ):
+            await _classification_queue_health_check()
+
+        fake_sentry.capture_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_swallows_exceptions(self):
+        """Une erreur DB ne doit jamais crasher le scheduler."""
+        from contextlib import asynccontextmanager
+
+        mock_session = AsyncMock()
+
+        @asynccontextmanager
+        async def fake_sm():
+            yield mock_session
+
+        service = MagicMock()
+        service.get_pending_stats = AsyncMock(side_effect=RuntimeError("db down"))
+
+        with (
+            patch("app.database.safe_async_session", side_effect=lambda: fake_sm()),
+            patch(
+                "app.services.classification_queue_service.ClassificationQueueService",
+                return_value=service,
+            ),
+            patch("app.workers.scheduler.logger") as mock_logger,
+        ):
+            await _classification_queue_health_check()  # MUST NOT raise
+
+        mock_logger.exception.assert_called_once_with(
+            "classification_queue_health_check_failed"
+        )
+
+    def test_registered_with_30min_interval(self):
+        """Le job doit être enregistré avec un IntervalTrigger de 30 min."""
+        import inspect
+
+        from app.workers import scheduler as scheduler_mod
+
+        src = inspect.getsource(scheduler_mod.start_scheduler)
+        assert "_classification_queue_health_check" in src
+        assert 'id="classification_queue_health_check"' in src
+        assert "IntervalTrigger(minutes=30)" in src
+
+
 def _capture_all_jobs() -> dict:
     """Run start_scheduler() with a mocked APScheduler and capture every
     add_job(**kwargs) keyed by job id."""
@@ -569,6 +679,7 @@ class TestJobSerialization:
             "zombie_session_sweeper",
             "pool_health_probe",
             "daily_essentiel_push_dispatch",
+            "classification_queue_health_check",
         ):
             assert job_id in captured, f"{job_id} not registered"
 


### PR DESCRIPTION
## fix(classif): garde-fou anti-angle-mort — superviseur worker + alerte file

Bug : la task asyncio du ClassificationWorker est morte isolément le
2026-06-30 ~01:00 UTC (probable `CancelledError`, `BaseException` non attrapée
par le `except Exception` du run-loop) sans repasser `running=False` ni
redémarrer → ~26 k articles en `pending`, `content.theme` NULL sur tout le
frais, **10 j sans aucune alerte**.

Cause racine établie sur données prod (read-only) ; voir
`docs/bugs/bug-classification-worker-stopped.md`.

### Périmètre de cette PR (Volet 3 — code)

Deux couches complémentaires d'observabilité/auto-réparation :

- **a. Superviseur de la task** (`classification_worker.py`) : `start()` attache
  `add_done_callback(self._on_task_done)`. Si la task meurt alors que
  `self.running` est encore `True` → alerte Sentry (`capture_exception` /
  `capture_message`) + **relance** de la task. Arrêt volontaire (`stop()` a mis
  `running=False`) → no-op.
- **b. Alerte externe sur la profondeur de file** (`scheduler.py` →
  `_classification_queue_health_check`, Interval 30 min) : lit
  `get_pending_stats()` et `capture_message` Sentry `level=error` si le plus
  vieux pending dépasse `classification_queue_alert_age_hours` (défaut **12 h**).
  Fonctionne même si le worker est mort, tant que le scheduler tourne.

### Hors périmètre (décisions PO)

- **Volet 1** (restart `facteur-production` + confirmer `ML_ENABLED=true`) :
  ops, **bloqué** sur l'accès Railway (token CLI `Unauthorized`, MCP non chargé).
- **Volet 2** : rattrapage backlog (se résorbe < 1 j une fois le worker relancé ;
  ne PAS remonter `batch_size` — régression Bonnes Nouvelles #152).
- Fuite thème NULL `retry_count < 2` : PR séparée si besoin.

### Tests

- `tests/workers/test_classification_worker_supervisor.py` (nouveau) : mort sur
  exception → capture_exception + relance ; annulation (CancelledError) +
  running=True → capture_message + relance ; running=False → no-op ; start()
  attache le callback.
- `tests/workers/test_scheduler.py` : alerte > 12 h ; pas d'alerte < seuil /
  file vide ; swallow des erreurs DB ; job enregistré (Interval 30 min).
- `pytest tests/workers/` vert (41). `ruff check app/` + `ruff format --check`
  verts.

Aucune migration Alembic (pas de DDL).
