### PR TITLE
fix(media-eval): créer le media_eval_run de test avant insertion signaux/évaluations

### DIFF
--- a/packages/api/tests/scripts/media_eval/test_ingest_artifacts.py
+++ b/packages/api/tests/scripts/media_eval/test_ingest_artifacts.py
@@ -8,6 +8,7 @@ rien. Fixtures savepoint du conftest (`db_session`).
 from __future__ import annotations
 
 import json
+from datetime import date
 from pathlib import Path
 
 import pytest
@@ -16,6 +17,7 @@ from sqlalchemy import func, select
 from app.models.media_eval import (
     MediaEvalDebunkage,
     MediaEvalMedia,
+    MediaEvalRun,
     MediaEvalSignal,
     TypeMedia,
 )
@@ -33,6 +35,11 @@ FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "media_eval"
 
 @pytest.fixture
 async def media_cnews(db_session) -> MediaEvalMedia:
+    db_session.add(
+        MediaEvalRun(
+            run_id="run-test", version_methodo="v1.2", date_reference=date(2026, 1, 1)
+        )
+    )
     media = MediaEvalMedia(
         nom="CNEWS", domaine="cnews.fr", type_media=TypeMedia.AUDIOVISUEL
     )

--- a/packages/api/tests/scripts/media_eval/test_ingest_evaluations.py
+++ b/packages/api/tests/scripts/media_eval/test_ingest_evaluations.py
@@ -7,7 +7,7 @@ critère ; score dérivé par code ; corroboration plafonnée ; `bloque_acces` �
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 
 import pytest
 from sqlalchemy import func, select
@@ -15,6 +15,7 @@ from sqlalchemy import func, select
 from app.models.media_eval import (
     MediaEvalEvaluation,
     MediaEvalMedia,
+    MediaEvalRun,
     MediaEvalSignal,
     StatutSignal,
     TypeMedia,
@@ -35,6 +36,11 @@ RUN_ID = "run-test"
 
 @pytest.fixture
 async def media_cnews(db_session) -> MediaEvalMedia:
+    db_session.add(
+        MediaEvalRun(
+            run_id=RUN_ID, version_methodo="v1.2", date_reference=date(2026, 1, 1)
+        )
+    )
     media = MediaEvalMedia(
         nom="CNEWS", domaine="cnews.fr", type_media=TypeMedia.AUDIOVISUEL
     )


### PR DESCRIPTION
## Summary
- Le merge accidentel de la PR #944 a laissé `main` cassé : le job `test` échouait sur 10 tests media-eval avec `ForeignKeyViolation` (`media_eval_signaux_run_id_fkey` / `media_eval_evaluations_run_id_fkey`).
- Cause : les fixtures `media_cnews` de `test_ingest_artifacts.py` et `test_ingest_evaluations.py` insèrent des signaux/évaluations avec `run_id="run-test"` sans créer la ligne `media_eval_runs` correspondante — FK ajoutée avec les tables runs (7→9 tables du pipeline media-eval).
- Fix : les deux fixtures créent désormais la ligne `MediaEvalRun` avant l'insertion des médias/signaux.

## Test plan
- [x] `pytest tests/ -k media_eval -q` → 91 passed
- [x] `pytest -q` (suite complète) → 2174 passed, 0 failed
- [x] `ruff check` + `ruff format` sur les fichiers modifiés