### PR TITLE
feat(sources): rescue des sources échouées + ingestion WordPress native (story 12.2)

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -7,10 +7,18 @@
     {
       "tag": "Tournée",
       "summary": "La lecture de ta tournée est plus fluide, les sections sont mieux cadrées à l'écran, et tu personnalises ta veille en un geste depuis son titre."
+    },
+    {
       "tag": "Recherche",
       "summary": "Trouver une source est plus rapide et mieux ciblé."
+    },
+    {
       "tag": "Veille",
       "summary": "La veille ne montre plus que des articles vraiment liés à ton sujet."
+    },
+    {
+      "tag": "Sources",
+      "summary": "Ajouter une source est plus fiable et plus vivant : les correspondances vérifiées sont clairement signalées et ses premiers articles apparaissent tout de suite."
     },
     {
       "tag": "Bonnes nouvelles",

--- a/apps/mobile/lib/core/services/analytics_service.dart
+++ b/apps/mobile/lib/core/services/analytics_service.dart
@@ -471,6 +471,26 @@ class AnalyticsService {
     await _logEvent('add_source_expand', {'query': query});
   }
 
+  /// Ajout réussi d'une source depuis le panneau de recherche (catalogue ou
+  /// URL custom). Mesure l'effet des affordances « source vérifiée » / preuve
+  /// inline en regard de `search_abandoned` (émis au dispose sans ajout).
+  /// `sourceId` est vide pour un ajout custom (pas d'entrée catalogue).
+  Future<void> trackSourceAdded({
+    String? sourceId,
+    required String sourceType,
+    required bool inCatalog,
+    required bool isCurated,
+    required String sourceLayer,
+  }) async {
+    await _logEvent('source_added', {
+      'source_id': sourceId ?? '',
+      'source_type': sourceType,
+      'in_catalog': inCatalog,
+      'is_curated': isCurated,
+      'source_layer': sourceLayer,
+    });
+  }
+
   // ──────────────────────────────────────────────────────────────
   // Story 14.3 — Self-reported "well-informed" score (1-10 NPS).
   // Trois events pour construire le funnel shown → skipped / submitted.

--- a/apps/mobile/lib/features/sources/widgets/source_add_panel.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_add_panel.dart
@@ -172,6 +172,21 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
     ref.read(analyticsServiceProvider).trackAddSourceExpand(_currentQuery);
   }
 
+  /// Correspondance « parfaite » : source catalogue ET curée. Ces ajouts
+  /// basculent en preuve inline « Connecté » (E3) au lieu d'ouvrir la modale.
+  bool _isCuratedCatalogMatch(SmartSearchResult result) =>
+      result.inCatalog && result.isCurated;
+
+  void _trackSourceAdded(SmartSearchResult result, {required bool inCatalog}) {
+    ref.read(analyticsServiceProvider).trackSourceAdded(
+          sourceId: result.sourceId,
+          sourceType: result.type,
+          inCatalog: inCatalog,
+          isCurated: result.isCurated,
+          sourceLayer: result.sourceLayer,
+        );
+  }
+
   Future<void> _addSource(SmartSearchResult result) async {
     try {
       final sourceId = result.sourceId;
@@ -184,6 +199,7 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
           _sourceAdded = true;
           _lastAddedName = result.name;
         });
+        _trackSourceAdded(result, inCatalog: hasCatalogId);
         _resetForNextAdd();
         widget.onSourceAdded?.call(result);
         return;
@@ -211,6 +227,7 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
       }
 
       if (!mounted) return;
+      _trackSourceAdded(result, inCatalog: hasCatalogId);
       ref.invalidate(userSourcesProvider);
 
       if (hasCatalogId) {
@@ -219,15 +236,18 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
             .setSourceState(sourceId, InterestState.favorite);
         if (!mounted) return;
 
-        if (widget.inlineProof) {
-          // Preuve inline : la carte transformée (« Connecté » + derniers
-          // articles) reste visible dans la liste — pas de modale, pas de
-          // reset de la recherche (qui démonterait la carte).
+        // E3 — preuve inline « Connecté » sans modale pour l'onboarding
+        // (inlineProof) ET pour une correspondance vérifiée dans le panneau
+        // normal : la carte transformée reste visible, pas de reset de la
+        // recherche (qui la démonterait), on minimise le pas parasite.
+        if (widget.inlineProof || _isCuratedCatalogMatch(result)) {
           HapticFeedback.mediumImpact();
           widget.onSourceAdded?.call(result);
           return;
         }
 
+        // Sources catalogue non curées : on garde la modale détail (aperçu
+        // du contenu utile).
         final source = Source(
           id: sourceId,
           name: result.name,
@@ -626,10 +646,16 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
           final isAdded =
               _addedSourceIds.contains(id) ||
               (id != null && followedIds.contains(id));
+          // E3 — la carte bascule en preuve « Connecté » à l'ajout pour
+          // l'onboarding (inlineProof) et pour une correspondance vérifiée
+          // dans le panneau normal. Jamais en veilleMode : le sheet Veille
+          // remonte la source au hôte et vide la recherche.
+          final showProof = !widget.veilleMode &&
+              (widget.inlineProof || _isCuratedCatalogMatch(result));
           return SourceResultCard(
             result: result,
             isAdded: isAdded,
-            showProof: widget.inlineProof,
+            showProof: showProof,
             onAdd: () => _addSource(result),
             onPreview: () => _previewSource(result),
           );

--- a/apps/mobile/lib/features/sources/widgets/source_add_panel.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_add_panel.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -241,7 +243,7 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
         // normal : la carte transformée reste visible, pas de reset de la
         // recherche (qui la démonterait), on minimise le pas parasite.
         if (widget.inlineProof || _isCuratedCatalogMatch(result)) {
-          HapticFeedback.mediumImpact();
+          unawaited(HapticFeedback.mediumImpact());
           widget.onSourceAdded?.call(result);
           return;
         }

--- a/apps/mobile/lib/features/sources/widgets/source_result_card.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_result_card.dart
@@ -54,6 +54,24 @@ class SourceResultCard extends StatelessWidget {
     }
   }
 
+  /// Correspondance « parfaite » : source du catalogue ET curée. Elle mérite
+  /// l'affordance « Source vérifiée » et un CTA « Suivre {nom} » plutôt que le
+  /// générique « Ajouter » (réservé aux URL custom / résultats non curés).
+  bool get _isCuratedCatalogMatch => result.inCatalog && result.isCurated;
+
+  /// Libellé du CTA d'ajout. Pour une correspondance vérifiée on nomme la
+  /// source (« Suivre Le Monde ») en tronquant proprement les noms longs.
+  String _addCtaLabel() {
+    if (!_isCuratedCatalogMatch) return 'Ajouter';
+    final name = result.name.trim();
+    if (name.isEmpty) return 'Suivre';
+    const maxLen = 22;
+    final shortName = name.length > maxLen
+        ? '${name.substring(0, maxLen).trimRight()}...'
+        : name;
+    return 'Suivre $shortName';
+  }
+
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
@@ -168,7 +186,10 @@ class SourceResultCard extends StatelessWidget {
                               color: colors.textTertiary,
                             ),
                       ),
-                      if (result.inCatalog) ...[
+                      if (_isCuratedCatalogMatch) ...[
+                        const SizedBox(width: 8),
+                        _buildVerifiedPill(context, colors),
+                      ] else if (result.inCatalog) ...[
                         const SizedBox(width: 8),
                         Icon(PhosphorIcons.sealCheck(PhosphorIconsStyle.fill),
                             size: 14, color: colors.primary),
@@ -194,34 +215,41 @@ class SourceResultCard extends StatelessWidget {
           ),
         ],
 
-        // Recent items
+        // Recent items — preuve honnête que la source est vivante. Pour une
+        // correspondance vérifiée, on les met en avant avec la présentation
+        // riche (même bloc que la vue « Connecté »). Aucun fetch : on ne fait
+        // que re-présenter `result.recentItems` déjà chargés.
         if (recentTitles.isNotEmpty) ...[
           const SizedBox(height: 12),
-          Text(
-            'Derniers articles :',
-            style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                  fontWeight: FontWeight.bold,
-                ),
-          ),
-          const SizedBox(height: 6),
-          ...recentTitles.map((item) => Padding(
-                padding: const EdgeInsets.only(bottom: 4),
-                child: Row(
-                  children: [
-                    Icon(PhosphorIcons.dotOutline(PhosphorIconsStyle.fill),
-                        size: 14, color: colors.primary),
-                    const SizedBox(width: 6),
-                    Expanded(
-                      child: Text(
-                        item.title,
-                        style: Theme.of(context).textTheme.bodySmall,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
+          if (_isCuratedCatalogMatch)
+            RecentArticlesList(items: result.recentItems)
+          else ...[
+            Text(
+              'Derniers articles :',
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+            const SizedBox(height: 6),
+            ...recentTitles.map((item) => Padding(
+                  padding: const EdgeInsets.only(bottom: 4),
+                  child: Row(
+                    children: [
+                      Icon(PhosphorIcons.dotOutline(PhosphorIconsStyle.fill),
+                          size: 14, color: colors.primary),
+                      const SizedBox(width: 6),
+                      Expanded(
+                        child: Text(
+                          item.title,
+                          style: Theme.of(context).textTheme.bodySmall,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
                       ),
-                    ),
-                  ],
-                ),
-              )),
+                    ],
+                  ),
+                )),
+          ],
         ],
 
         // CTAs
@@ -268,12 +296,43 @@ class SourceResultCard extends StatelessWidget {
                           borderRadius: BorderRadius.circular(8),
                         ),
                       ),
-                      child: const Text('Ajouter'),
+                      child: Text(
+                        _addCtaLabel(),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
                     ),
             ),
           ],
         ),
       ],
+    );
+  }
+
+  /// Pastille « Source vérifiée » pour une correspondance catalogue curée.
+  /// Distingue visuellement une source vérifiée d'un résultat URL custom.
+  Widget _buildVerifiedPill(BuildContext context, FacteurColors colors) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: colors.primary.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(PhosphorIcons.sealCheck(PhosphorIconsStyle.fill),
+              size: 13, color: colors.primary),
+          const SizedBox(width: 4),
+          Text(
+            'Source vérifiée',
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: colors.primary,
+                  fontWeight: FontWeight.w600,
+                ),
+          ),
+        ],
+      ),
     );
   }
 

--- a/apps/mobile/test/features/sources/widgets/source_add_panel_test.dart
+++ b/apps/mobile/test/features/sources/widgets/source_add_panel_test.dart
@@ -158,4 +158,57 @@ void main() {
     // La recherche n'est pas réinitialisée (le champ garde la requête).
     expect(find.widgetWithText(TextField, 'le monde'), findsOneWidget);
   });
+
+  testWidgets(
+      'panneau normal : correspondance vérifiée → carte « Connecté » '
+      'sans modale (E3)', (tester) async {
+    const result = SmartSearchResult(
+      name: 'Le Monde',
+      type: 'article',
+      url: 'https://www.lemonde.fr',
+      feedUrl: 'https://www.lemonde.fr/rss/une.xml',
+      inCatalog: true,
+      isCurated: true,
+      sourceId: 'src-1',
+      recentItems: [
+        SmartSearchRecentItem(title: 'Article un'),
+        SmartSearchRecentItem(title: 'Article deux'),
+      ],
+    );
+    final repo = _FakeSourcesRepository(result);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [sourcesRepositoryProvider.overrideWithValue(repo)],
+        child: MaterialApp(
+          theme: FacteurTheme.lightTheme,
+          home: const Scaffold(
+            body: SourceAddPanel(
+              showIntro: false,
+              showCommunityGems: false,
+              showAddedNudge: false,
+              // Panneau normal : ni veilleMode ni inlineProof.
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextField), 'le monde');
+    await tester.testTextInput.receiveAction(TextInputAction.search);
+    await tester.pumpAndSettle();
+
+    // CTA « Suivre {nom} » pour une correspondance vérifiée.
+    expect(find.text('Suivre Le Monde'), findsOneWidget);
+    await tester.tap(find.text('Suivre Le Monde'));
+    await tester.pumpAndSettle();
+
+    // Ajout catalogue effectué, pas de modale, carte transformée en place.
+    expect(repo.trustCalls, 1);
+    expect(find.byType(BottomSheet), findsNothing);
+    expect(find.text('Connecté'), findsOneWidget);
+    expect(find.text('Article un'), findsOneWidget);
+    // La recherche reste (la carte n'est pas démontée par un reset).
+    expect(find.widgetWithText(TextField, 'le monde'), findsOneWidget);
+  });
 }

--- a/apps/mobile/test/features/sources/widgets/source_result_card_test.dart
+++ b/apps/mobile/test/features/sources/widgets/source_result_card_test.dart
@@ -128,6 +128,79 @@ void main() {
     });
   });
 
+  group('SourceResultCard — correspondance vérifiée (inCatalog + isCurated)',
+      () {
+    const curatedResult = SmartSearchResult(
+      name: 'Le Monde',
+      type: 'article',
+      url: 'https://lemonde.fr',
+      feedUrl: 'https://lemonde.fr/rss/une.xml',
+      description: 'Journal quotidien francais',
+      inCatalog: true,
+      isCurated: true,
+      sourceId: 'test-source-id',
+      recentItems: [
+        SmartSearchRecentItem(title: 'Premier article'),
+        SmartSearchRecentItem(title: 'Deuxieme article'),
+        SmartSearchRecentItem(title: 'Troisieme article'),
+      ],
+    );
+
+    testWidgets('affiche la pastille « Source vérifiée »', (tester) async {
+      await tester.pumpWidget(buildTestWidget(result: curatedResult));
+
+      expect(find.text('Source vérifiée'), findsOneWidget);
+    });
+
+    testWidgets('CTA « Suivre {nom} » au lieu de « Ajouter »', (tester) async {
+      await tester.pumpWidget(buildTestWidget(result: curatedResult));
+
+      expect(find.text('Suivre Le Monde'), findsOneWidget);
+      expect(find.text('Ajouter'), findsNothing);
+    });
+
+    testWidgets('tronque proprement un nom long dans le CTA', (tester) async {
+      const longNameResult = SmartSearchResult(
+        name: 'Un Média Au Nom Vraiment Très Long Et Verbeux',
+        type: 'article',
+        url: 'https://exemple.fr',
+        feedUrl: 'https://exemple.fr/rss.xml',
+        inCatalog: true,
+        isCurated: true,
+        sourceId: 'long-id',
+      );
+      await tester.pumpWidget(buildTestWidget(result: longNameResult));
+
+      // Le CTA commence par « Suivre » et se termine par une ellipse.
+      final ctaFinder = find.textContaining('Suivre Un Média');
+      expect(ctaFinder, findsOneWidget);
+      final ctaText = tester.widget<Text>(ctaFinder).data!;
+      expect(ctaText.endsWith('...'), isTrue);
+    });
+
+    testWidgets('met en avant les derniers articles (bloc riche)',
+        (tester) async {
+      await tester.pumpWidget(buildTestWidget(result: curatedResult));
+
+      // Présentation riche : header « Derniers articles » (sans deux-points)
+      // + les 3 titres re-présentés depuis recentItems (aucun fetch).
+      expect(find.text('Derniers articles'), findsOneWidget);
+      expect(find.text('Derniers articles :'), findsNothing);
+      expect(find.text('Premier article'), findsOneWidget);
+      expect(find.text('Deuxieme article'), findsOneWidget);
+      expect(find.text('Troisieme article'), findsOneWidget);
+    });
+
+    testWidgets('catalogue non curé : garde « Ajouter » et pas de pastille',
+        (tester) async {
+      // sampleResult est inCatalog mais non curé.
+      await tester.pumpWidget(buildTestWidget());
+
+      expect(find.text('Ajouter'), findsOneWidget);
+      expect(find.text('Source vérifiée'), findsNothing);
+    });
+  });
+
   group('SourceResultCard — mode preuve (showProof)', () {
     testWidgets('added + showProof : vue « Connecté » avec les 3 titres',
         (tester) async {

--- a/docs/maintenance/phase1-rapid-analysis.md
+++ b/docs/maintenance/phase1-rapid-analysis.md
@@ -1,0 +1,48 @@
+# Phase 1 — Analyse RAPIDE des ajouts de sources échoués (prod, 09/07/2026)
+
+> Source : `failed_source_attempts` (8) + `source_search_logs` (270, dont 47 `result_count=0`
+> OU `abandoned`). Requêtes lecture seule via Supabase MCP. Complété par la carte du pipeline
+> (`rss_parser.detect()` 9 étapes, `SmartSourceSearchService` 5 layers, `SyncService`).
+
+## Parc (contexte)
+- 313 sources actives : **247 non-curées** (custom) + 66 curées.
+- 105 users avec sources ; 236 liens `user_sources.is_custom`.
+- `failed_source_attempts` : **8** lignes (19/06 → 03/07), toutes `keyword` / `smart-search`, `error_message` NULL → ce sont des **abandons** (l'utilisateur a cherché puis n'a pas ajouté), pas des erreurs de résolution.
+- `source_search_logs` : 270 recherches (26/04 → 09/07) ; **39** à 0 résultat, **8** abandonnées → **47** signaux problématiques (≈ 40 requêtes distinctes).
+
+## Le vrai breakdown des ~47 signaux (≠ « sites sans RSS »)
+
+| Catégorie | Volume | Nature réelle | Volet |
+|---|---|---|---|
+| **YouTube — rafale 30/06 + isolés** | ~17-18 req. (esa, micode, mediapart, urbania, stardust, hugo lisoir, clement viktorovitch, les numeriques, c ce soir, christophe andré, tech sama, esprit critique…) | `content_type="youtube"`, **layer `catalog` seul appelé**, 0 résultat. Les chaînes YouTube **ONT** un RSS par chaîne. | **`fixed_since`** — bug corrigé par PR #939 (le filtre youtube force désormais le layer). À re-vérifier par le rescue. |
+| **Reddit** | 5 req. (r/ai, r/worldnews, artificial_intelligence, ai, une URL reddit) | `content_type="reddit"`, 0 résultat. Reddit expose `/r/x/.rss` (déjà géré par `detect()` étape 1). | Gap de **résolution** (probable garde `content_type`/short-circuit), pas no-feed. |
+| **« Trouvé mais abandonné »** | 8 req. | **4 = match parfait** (Libération, L'Équipe, Le Grand Continent, BDM → feed valide **déjà renvoyé**, user abandonne) → **UX/confiance de l'add**. **4 = mauvaise entité** (Snowball→GmbH allemand, insight→BDM, hypertext→MDN, esprit critique→ambigu) → **relevance**. | **Ni l'un ni l'autre = no-feed.** UX add + relevance. |
+| **Vrai « URL collée → 0 résultat »** | **4 sites** | usine-digitale.fr (×5 lignes, Infopro Digital / **DataDome** probable) ; monpetithoublon.com (blog tricot, sans doute WP) ; autobrasseur.fr (blog brassage, sans doute WP) ; betterclinicianproject.com (**URL polluée `utm_*`+`fbclid`** → échec parse, pas no-feed). | **Seuls candidats volet B** — et 1 seul (usine-digitale) est vraiment « dur ». |
+| **Typos / non-sources** | goofle, vakitamefia, « vu », « ai », « esa » | requêtes invalides / trop courtes. | `invalid`. |
+
+### Probes /feed/ (indicatif, UA non fiable ≠ curl-cffi backend)
+- monpetithoublon.com/feed/ → HTTP 500 · autobrasseur.fr/feed/ → 404 · usine-digitale.fr/rss → 403.
+  Non concluant (WebFetch n'imite pas le fingerprint Chrome de `_fetch_with_impersonation`) ; à confirmer par le rescue avec budget curl-cffi.
+
+## Intégrité de l'échantillon (audit de biais, demandé par le PO)
+
+Question PO : « quasi aucun média classique en échec — est-ce un biais de la pipeline de log ? »
+Vérifié côté **succès** + côté **code**. Conclusion : **pas de masse cachée d'échecs médias classiques**, mais **un vrai angle mort temporel**.
+
+- **Le média classique DOMINE les ajouts et réussit** : 173 ajouts `article` (70 % du total), **100 % synchronisés (0 `never_synced`)** ; recherches `article` **~90 % succès** (209 → 186 succès). Public Sénat, StreetPress, L'Humanité, Le Nouvel Obs, Numerama, Cerveau & Psycho… ajoutés sans souci. Son absence des *échecs* = il **résout**, pas un log manquant. Il apparaît d'ailleurs dans les échecs in-window (Libération/L'Équipe/Le Grand Continent = « trouvé mais abandonné » ; usine-digitale = zéro-résultat).
+- **La capture est complète depuis le 26/04** : l'app route **clés ET URLs collées via `smart-search`** (d'où les URLs pleines dans `source_search_logs` avec `layers_called`), et `smart-search` **logge TOUJOURS** (succès + zéro-résultat, via `_finalize()`, best-effort). ⇒ les échecs d'URL média classique **sont capturés** (usine-digitale/monpetithoublon/autobrasseur/betterclinician y sont).
+- **Le tableau `failed_source_attempts` = miroir d'abandon uniquement** : ses 8 lignes = exactement les 8 recherches `abandoned`. D'où « tout en `endpoint=smart-search` » (rien de `custom`/`detect`) — bénin.
+- **Angle mort #1 (temporel, majeur)** : `source_search_logs` créé le **26/04/2026** (commit `4558ada5`), `failed_source_attempts` le **21/02** (`f0758b12`, abandon seulement). Or les ajouts remontent au **26/01** → **~118 ajouts custom (91 `article`) de janv→avr sans aucune visibilité échec**. ⇒ formuler « ~4 sites no_feed » comme **« ~4 sur la fenêtre observable 26/04→09/07 (~11 sem.) »**, pas all-time.
+- **Angle mort #2 (abandon client-dépendant)** : `abandoned=true` ne se pose que si le client Flutter appelle `/search-abandoned` en `dispose()` → crash/background sous-comptent. Vrai abandon ≥ 8 (ne change pas les catégories, juste la magnitude du problème UX).
+- **Mineur** : rate-limit 429 et `/detect` keyword-0-result non loggés (mais ce ne sont pas des signaux no-feed).
+
+## Headline (ce qui change la décision volet B)
+
+1. **La population réelle « site sans RSS découvrable » sur TOUT l'historique (avril→juillet) = ~4 sites, dont 1 seul vraiment dur (usine-digitale).** Dimensionner une infra de scraping/RSSHub/SaaS pour « 250-500 sources sans RSS » est **hors de proportion** avec la donnée observée aujourd'hui.
+2. **Les échecs sont dominés par des causes NON-ingestion** : (a) bug youtube déjà corrigé, (b) gap de résolution reddit, (c) **UX de l'add** (4 matchs parfaits abandonnés), (d) **relevance** (4 mauvaises entités), (e) hygiène d'URL (strip `utm_*`/`fbclid`).
+3. **`detect()` est DÉJÀ riche** (9 étapes : overrides, transforms Substack/Medium/Mastodon, reddit `.rss`, résolution chaîne YouTube, autodiscovery `<link>`+`<a>`, 16 suffixes en parallèle, suivi de page d'index, **anti-bot curl-cffi**). Les **vrais trous** = **WordPress REST API** et **sitemaps** (absents), + strip tracking-params, + le fait que **`SyncService` (refresh) n'a PAS d'anti-bot** (httpx simple) → un feed anti-bot trouvé à l'add peut casser au sync.
+4. Contrainte d'archi : `sources.feed_url` est **UNIQUE NOT NULL** → tout chemin non-RSS doit soit produire une **feed_url synthétique** (backend génère le flux), soit introduire un discriminateur **`fetch_method`** + parseur alterne dans `SyncService`. Aucun `fetch_method` n'existe aujourd'hui.
+5. Produit : **aucun article « tampon » n'est créé à l'add** aujourd'hui (1er sync = background task). L'effet « wow » est une **capacité nouvelle** quel que soit le mode d'ingestion.
+
+## Implication pour trancher (à valider avec l'Architecte BMAD)
+Le problème n'est pas « choisir un convertisseur site→RSS ». C'est une **cascade de résolution à paliers, du moins cher au plus cher**, où le scraping+LLM n'est que le **dernier palier** pour la vraie longue traîne (classe usine-digitale). Détail + comparatif des options dans le doc de décision (Phase 2).

--- a/docs/maintenance/website-to-rss-decision.md
+++ b/docs/maintenance/website-to-rss-decision.md
@@ -1,0 +1,84 @@
+# Décision technique — Ingérer les sites « sans RSS » à l'échelle
+
+> Brief de décision pour l'Architecte BMAD. S'appuie sur : (1) l'analyse Phase 1 des échecs
+> réels prod (`phase1-rapid-analysis.md`), (2) la carte du pipeline actuel (`detect()` 9 étapes,
+> `SmartSourceSearchService`, `SyncService`), (3) recherche web 07/2026 (3 axes, sources citées en bas).
+> **Périmètre : 1 seule PR** (rescue + comblements Tier-0/1 + ce doc). Le scraping lourd est différé, pas scindé en PR.
+
+---
+
+## 0. Le cadrage que la donnée impose
+
+Le problème posé (« scaler les sources RSS non-disponibles à 250-500 ») **ne correspond pas à la donnée observée**. Sur la **fenêtre observable (26/04→09/07, ~11 sem.)**, la population « URL collée → 0 flux découvrable » = **~4 sites**, dont **1 seul vraiment dur** (usine-digitale.fr / Infopro, DataDome probable). Les autres échecs sont : bug YouTube **déjà corrigé (#939)**, gap de résolution Reddit, **UX de l'add** (4 matchs parfaits abandonnés), **relevance** (4 mauvaises entités), et **hygiène d'URL** (tracking params).
+
+> **Intégrité de l'échantillon (audité) :** la capture des échecs est **complète depuis le 26/04** (l'app route clés + URLs collées via `smart-search`, qui logge tout, succès + zéro-résultat) ; le média classique **domine les ajouts (173, 70 %) et réussit à 100 %** — pas de masse cachée d'échecs. **Caveat honnête pour l'Architecte :** angle mort **avant le 26/04** (`source_search_logs` n'existait pas) → ~118 ajouts janv→avr sans visibilité échec ; donc « ~4 sites » = **sur la fenêtre observable**, pas all-time. Abandon possiblement sous-compté (dépend du client). Détail : `phase1-rapid-analysis.md`.
+
+⇒ La bonne question n'est pas « quel convertisseur site→RSS acheter/héberger ? » mais **« quelle cascade de résolution, du moins cher au plus cher, avec le scraping en dernier recours ? »**. Sur-dimensionner une infra pour un besoin réel de ~1 site serait disproportionné.
+
+De plus, `detect()` est **déjà** une cascade à 9 étapes (overrides, transforms Substack/Medium/Mastodon, Reddit `.rss`, résolution chaîne YouTube, autodiscovery `<link>`+`<a>`, 16 suffixes //, suivi de page d'index, **anti-bot curl-cffi**). Les **vrais trous** sont ciblés : **WordPress REST**, **sitemaps**, **strip tracking-params**, gap Reddit — et le fait que **`SyncService` (refresh) n'a pas d'anti-bot** (httpx simple).
+
+---
+
+## 1. Architecture recommandée — cascade à 3 paliers
+
+### Palier 0 — Hygiène & régressions (coût ~0, plus gros ROI immédiat)
+- **Normaliser l'URL collée** avant résolution : strip `utm_*`, `fbclid`, `gclid`, `igshid`, `mc_cid`, fragments. (répare la classe betterclinicianproject)
+- **Vérifier via le rescue** que #939 a bien fermé le bug YouTube `content_type` (rejouer la rafale 30/06 → attendu `fixed_since`).
+- **Fermer le gap Reddit** (`content_type="reddit"` → 0 résultat alors que `/r/x/.rss` est géré par `detect()` étape 1).
+- (UX de l'add : 4 matchs parfaits abandonnés → workstream mobile séparé, hors de cette PR backend, mais à signaler au PO.)
+
+### Palier 1 — Endpoints structurés natifs (coût ~0, aucune nouvelle infra, s'intègre à feedparser + SyncService)
+Ajouter 2-3 rungs à la cascade `detect()` existante :
+- **WordPress REST** : probe `/wp-json/wp/v2/posts?per_page=20&orderby=date&order=desc` → `content.rendered` (corps HTML complet) + `date` + `link` en JSON, sans auth, sur **~59 % de part CMS** (WordPress). Réalistement **70-85 % de la longue traîne FR** est WP. Actif par défaut ; désactivé seulement en minorité (plugins sécurité / règles serveur). Plafond `per_page=100`, page 1 suffit pour un digest. **Fallback plus robuste que `/feed/`** (marche même si `/feed/` est cassé/UA-bloqué) **et** fournit le payload pour les **articles tampons** à l'add.
+- **Sitemap / News-sitemap** : robots.txt `Sitemap:` → `/sitemap.xml` → `/sitemap_index.xml` → `/news-sitemap.xml`. Donne URL + date (+ `news:title` pour le News-sitemap) = feed de nouveautés ; le corps nécessite encore un fetch page. News-sitemap = fenêtre ~2 j (vue roulante, pas archive).
+- (JSON Feed : adoption trop faible en 2026 — bonus opportuniste dans la ladder, jamais une cible.)
+
+**Intégration sans migration (recommandé) :** exposer une résolution non-RSS comme **feed_url synthétique interne** servie par notre backend (ex. endpoint qui rend WP-REST/sitemap en RSS). `sources.feed_url` reste **UNIQUE NOT NULL**, `SyncService` **inchangé** (fetch d'une URL → feedparser). Le « convertisseur » devient **notre propre petit endpoint**, pas un service tiers.
+
+### Palier 2 — Scraping dernier recours (différé, gated sur la donnée)
+Pour la vraie traîne non-WP / sans sitemap uniquement. **Ne rien construire/héberger maintenant** (demande réelle ≈ 1 site). Réévaluer **si** le job hebdo de rescue montre que la population `no_feed` grossit. Défaut privilégié le jour venu : **sélecteurs générés par LLM (Mistral déjà intégré) stockés en JSONB + `trafilatura`**, ou **Firecrawl on-demand** — parce qu'ils s'intègrent au pipeline sans faire tourner un service PHP/Node 24/7 pour une poignée de sites. Ce palier **exige** alors un discriminateur `fetch_method` sur `sources` + branche dans `SyncService.process_source()` (migration additive expand-contract sur la DB prod partagée).
+
+**Cas anti-bot durs (classe usine-digitale / DataDome) : non-objectif assumé.** Aucune option ci-dessous ne bat DataDome de façon fiable. Voie de contournement existante = catalogue curé manuel, ou le chemin `premium_connection_config` (WebView login).
+
+---
+
+## 2. Comparatif des options « Palier 2 » (recherche 07/2026, citée)
+
+| Option | Modèle | Coût @~500 | Anti-bot DataDome | API / auto-provision | Fit longue traîne FR | Intégration | Verdict |
+|---|---|---|---|---|---|---|---|
+| **Maison — WP REST + sitemap** (Palier 1) | endpoints natifs | **~0 €** | N/A (sites ouverts) | natif | **70-85 %** | rungs sur `detect()` + feed synthétique | **PRIMAIRE** |
+| **Maison — scrape + sélecteurs LLM + trafilatura** | scrape maison | tokens Mistral (déjà là) + CPU | non (sauf proxy ajouté) | natif | la traîne résiduelle | `fetch_method` + parseur alterne | **défaut Palier 2** |
+| **Firecrawl** (/scrape,/extract) | API scrape+extract | 83→399 $/mo selon stealth | **partiel** (échoue CF Turnstile dur) | API (pas un feed persistant) | tout site ouvert | appel depuis worker | alt Palier 2 (on-demand) |
+| **Jina Reader** | API scrape | ~4,5 $/mo tokens | **NON (explicite)** | API | sites ouverts | appel depuis worker | extracteur de corps pas cher, **pas** pour anti-bot |
+| **RSS-Bridge** self-host | sélecteurs CSS génériques | PHP ~64 Mo Railway | **non** | construire l'URL/source | config par site | service à opérer | **différé** (un service pour ~1 site) |
+| **RSSHub** self-host | route par site (code) | Node+Chromium lourd | partiel (Chromium, peu fiable) | **pas de mode générique** | CN-centrique, ~0 FR | écrire des routes TS | **rejeté** |
+| **RSS.app** | SaaS feeds | ~83 $/mo (500) | non documenté | API (Pro, 1k ops/mo) | tout site | fetch feed URL | seulement si on externalise tout |
+| **FetchRSS** | SaaS feeds | **24 $/mo (500)** | faible/non doc | API (gating non doc) | tout site | fetch feed URL | SaaS pas cher si externalisation |
+| **PolitePaul** | SaaS feeds | ~65 $/mo (Premium) | JS+proxy, pas de claim CF/DD | **pas d'API create** | tout site | fetch feed URL | **disqualifié** (pas d'auto-provision) |
+
+**Lectures clés :**
+- **RSSHub = mauvais outil** : pas de mode générique, catalogue CN/global, footprint Node+Chromium. On écrirait une route TS par site FR — irréaliste.
+- **RSS-Bridge = seul self-host avec mode générique** (`CssSelectorBridge`/`XPathBridge`/`FeedExpander`), léger, mais **travail de sélecteurs par site + zéro anti-bot + un service à opérer** pour une demande de ~1 site. Reconsidérable seulement si la traîne grossit **et** qu'on veut du config-driven (non-LLM).
+- **SaaS (FetchRSS/RSS.app/PolitePaul)** : dépendance externe, coût par flux, **DataDome non garanti**, et surtout on **perd la maîtrise de `detect()`**. FetchRSS est le moins cher (24 $) mais PolitePaul n'a pas d'API (rédhibitoire pour l'auto-provision).
+- **Firecrawl/Jina** : bons extracteurs de corps propre pour LLM ; Firecrawl a un anti-bot *partiel*, Jina **aucun**. Utiles comme brique du « Maison scrape » au Palier 2, pas comme feed persistant.
+
+---
+
+## 3. Produit — « ajout transparent + articles tampons »
+Aujourd'hui **aucun article tampon** n'est créé à l'add (1er sync = background task). C'est une **capacité nouvelle** quel que soit le mode. Le Palier 1 la sert nativement : **WP REST renvoie les 20 derniers posts immédiatement** → on peut insérer ces `content` dès l'add (effet wow), là où RSS classique dépend du délai du background sync. C'est un argument fort de plus pour prioriser WP REST.
+
+---
+
+## 4. Ce qu'on demande à l'Architecte BMAD de trancher
+1. **Feed synthétique interne (pas de migration)** vs **`fetch_method` + parseur alterne (migration)** pour brancher WP-REST/sitemap. Reco : synthétique pour Palier 1, `fetch_method` réservé au Palier 2.
+2. Ordre exact des nouveaux rungs dans `detect()` et gestion du cache `HostFeedResolution` (TTL négatif 7 j déjà là).
+3. Anti-bot au **sync** (aujourd'hui httpx nu) : faut-il porter le curl-cffi de `detect()` dans `SyncService` pour les feeds anti-bot trouvés à l'add ? (sinon ils cassent au refresh)
+4. Périmètre exact de la PR unique (rescue + Palier 0 + Palier 1 WP-REST au minimum ; sitemap et tampons en option selon appétit).
+5. Confirmer le **non-objectif DataDome** et le **gating du Palier 2** sur le job hebdo de rescue.
+
+---
+
+## Sources (recherche 07/2026)
+- Self-host : [RSSHub repo](https://github.com/DIYgod/RSSHub) · [RSS-Bridge repo](https://github.com/RSS-Bridge/rss-bridge) · [CssSelectorBridge](https://github.com/RSS-Bridge/rss-bridge/blob/master/bridges/CssSelectorBridge.php) · [FeedExpander](https://rss-bridge.github.io/rss-bridge/Bridge_API/FeedExpander.html)
+- SaaS/scrape : [RSS.app pricing](https://rss.app/pricing) · [FetchRSS prices](https://fetchrss.com/prices) · [PolitePaul prices](https://politepaul.com/en/prices) · [Firecrawl pricing](https://www.firecrawl.dev/pricing) · [Jina Reader](https://jina.ai/reader/)
+- Natif : [W3Techs WordPress](https://w3techs.com/technologies/details/cm-wordpress) · [WP REST pagination](https://developer.wordpress.org/rest-api/using-the-rest-api/pagination/) · [Google News sitemap](https://developers.google.com/search/docs/crawling-indexing/sitemaps/news-sitemap) · [RSS autodiscovery](https://www.rssboard.org/rss-autodiscovery) · [SmartNews — strip UTM](https://publishers.smartnews.com/hc/en-us/articles/7917502346137)

--- a/docs/stories/core/12.2.rescue-sources-echouees-ingestion-native.md
+++ b/docs/stories/core/12.2.rescue-sources-echouees-ingestion-native.md
@@ -1,0 +1,83 @@
+---
+title: Rescue des sources échouées + ingestion native (WordPress REST / résolution renforcée)
+status: draft
+type: story
+priority: high
+epic: 12.add-source-2.0
+author: Winston (Architect)
+date: 2026-07-09
+---
+
+# Story 12.2 — Rescue des sources échouées + ingestion native
+
+> **Décision cadrée avec le PO.** S'appuie sur l'analyse Phase 1 (`.context/CEAeng/phase1-rapid-analysis.md`)
+> et le brief de décision (`.context/CEAeng/website-to-rss-decision.md`).
+> **1 seule PR.** Le scraping lourd (RSS-Bridge / Firecrawl / SaaS) est **hors scope, différé et gated**.
+
+## 1. Contexte & constat (résumé)
+
+Sur la fenêtre observable (26/04→09/07), les échecs d'ajout ne sont **pas** dominés par « sites sans RSS » : bug YouTube **déjà corrigé (#939)**, gap Reddit, **UX de l'add** (4 matchs parfaits abandonnés), **relevance** (4 mauvaises entités), hygiène d'URL. La vraie population « URL collée → 0 flux » = **~4 sites**, dont **1 seul dur** (usine-digitale / DataDome). `detect()` est déjà une cascade à 9 étapes (anti-bot curl-cffi inclus) ; les **vrais trous** sont **WordPress REST**, **sitemaps**, **strip tracking-params**, gap Reddit, et **`SyncService` refresh sans anti-bot**.
+
+**Objectif** : (a) rejouer et classifier les échecs réels (« rescue »), (b) combler les trous ciblés bon marché, (c) instrumenter la mesure pour la décision future — sans sur-dimensionner d'infra.
+
+## 2. Décisions d'architecture (les 5 points, tranchés)
+
+1. **Branchement non-RSS = feed synthétique interne, PAS de migration.** Aucune colonne `fetch_method`, aucun DDL sur la DB prod partagée (contrainte expand-contract). `sources.feed_url` reste `UNIQUE NOT NULL` ; `SyncService` **inchangé** (fetch URL → feedparser). Le « convertisseur » = **notre propre endpoint**, en dernier recours (Palier 1b).
+2. **Ordre dans `detect()`** : les nouveaux rungs s'insèrent **après** les probes bon marché existantes (autodiscovery + 16 suffixes dont `/feed`) et **avant** l'échec final : `… suffixes → 4b: renfort WordPress → 4c: WP REST synthétique → 4d: sitemap (optionnel) → 5: index → fail`. **Normalisation d'URL en tête de cascade** (strip `utm_*`/`fbclid`/`gclid`/`igshid`/`mc_cid` + fragment) pour que le cache `HostFeedResolution` (positif 30 j / négatif 7 j, déjà là) dédoublonne correctement.
+3. **Anti-bot au sync = OUI, mais scoped.** Porter le fallback `_fetch_with_impersonation` (curl-cffi) de `detect()` dans `SyncService.process_source()` **uniquement en retry sur 403/marqueurs anti-bot** (même gate `_is_antibot_response`). Empêche qu'un flux trouvé (anti-bot) à l'add meure au refresh. C'est le seul changement touchant le hot-path sync → tâche isolée + test dédié (séparable si on veut la PR encore plus mince).
+4. **Périmètre PR unique** : rescue script + Palier 0 + Palier 1a/1b + job hebdo + fix anti-bot sync + tests + doc. Sitemap (1c) et articles-tampons = **optionnels/fast-follow**.
+5. **DataDome = non-objectif assumé** (documenté). **Palier 2 (scraping) hors PR, gated** sur le job hebdo montrant que la population `no_feed` distincte franchit un seuil (à fixer, ex. ≥ 10 hôtes/mois). Voie de secours DataDome existante = catalogue curé / `premium_connection_config` (WebView).
+
+## 3. Découpage des tâches
+
+### Palier 0 — Hygiène, régressions & qualité de log (coût ~0)
+- [ ] **T0.1 — Normalisation d'URL** : helper `_normalize_input_url()` (strip tracking params + fragment + lower host) appelé en amont de `detect()` et de `SmartSourceSearchService`. Répare la classe `betterclinicianproject` (`?utm_…&fbclid=…`). `rss_parser.py` / `smart_source_search.py`.
+- [ ] **T0.2 — Suffixes WordPress permaliens plats** : ajouter `/?feed=rss2`, `/?feed=atom` à la liste des 16 suffixes (`rss_parser.py` ~L859-876).
+- [ ] **T0.3 — Fix gap Reddit** : normaliser `r/<sub>` et nom nu → `reddit.com/r/<sub>/.rss` + valider via `detect()`, dans `_search_reddit` (`smart_source_search.py` ~L785-818). Piloté par le rescue (r/ai, r/worldnews, artificial_intelligence…).
+- [ ] **T0.4 — Combler 2 trous de log (audit d'intégrité)** : (a) logger les recherches keyword `/detect` à 0 résultat (aujourd'hui retour vide non loggé, `sources.py` ~L788) ; (b) **fallback abandon côté serveur** pour ne plus dépendre uniquement de l'appel client `/search-abandoned` (crash/background sous-comptent). Améliore la qualité de l'échantillon **pour la décision Palier 2 future**.
+- [ ] **T0.5 — Vérifier #939** : le rescue rejoue la rafale YouTube du 30/06 → attendu `fixed_since` (résultats non vides).
+
+### Palier 1 — Endpoints structurés natifs (coût ~0, sans migration)
+- [ ] **T1a — Renfort résolution WordPress** : détecter WP (`/wp-json/` HEAD 200 **ou** `<meta name="generator" content="WordPress…">`), puis résoudre le **flux canonique** (`/feed/`, `/?feed=rss2`) **via le chemin curl-cffi** (contourne les blocages UA — ex. monpetithoublon `/feed/` → 500). Rend un **RSS réel**, aucune infra, `SyncService` inchangé. Nouveau rung `detect()` (Stage 4b). *C'est le gain principal : ~59 % de part CMS.*
+- [ ] **T1b — Fallback WP REST → feed synthétique** : si le flux canonique est vraiment absent (REST ouvert mais `/feed` désactivé), endpoint interne `GET /internal/feed/wp?host=…` qui fetch `/wp-json/wp/v2/posts?per_page=20&orderby=date&order=desc` et rend un flux RSS (`content.rendered` + `date` + `link`). `detect()` renvoie `feed_url` = cette URL interne. **Pas de migration.** (Stage 4c.)
+- [ ] **T1c — Sitemap / News-sitemap (OPTIONNEL/stretch)** : même patron d'endpoint interne (robots.txt `Sitemap:` → `/sitemap.xml` → `/sitemap_index.xml` → news-sitemap) → URL + date (+ `news:title`). Corps différé. À inclure seulement si le rescue montre des `no_feed` non-WP avec sitemap exploitable.
+- [ ] **T1d — Articles tampons (OPTIONNEL/fast-follow)** : à l'add via WP REST, insérer immédiatement les ~10 derniers `content` (effet « wow » ; aujourd'hui 1er sync = background task). Réutilise le payload REST déjà fetché.
+
+### Rescue, mesure & tests
+- [ ] **T2 — Script `packages/api/scripts/rescue_failed_sources.py`** (étend le pattern de `analyze_failed_sources.py`, ne duplique pas) : collecte union dédup/normalisée `failed_source_attempts` + `source_search_logs`(result_count=0 OU abandoned), fenêtre param (défaut 90 j) ; re-résolution offline budget large (`detect()` timeouts élargis + curl-cffi ; keywords via `search(expand=True)`) ; **classification** `{resolvable_rss, fixed_since, found_but_abandoned, no_feed, invalid}` ; sorties `docs/maintenance/diag-rescue-failed-sources.md` + `.context/rescue-results.json`.
+- [ ] **T3 — Job hebdo** dans `workers/scheduler.py` (créneau nuit, cohérent 03h-05h) : rejoue collecte+classification, logge les compteurs par catégorie. **C'est le signal de gating du Palier 2.**
+- [ ] **T4 — Tests** : unitaires normalisation/dédup + classification (fixtures prod : URL directe, keyword abandonné, typo, `utm_/fbclid`, WP `/feed` UA-bloqué, reddit `r/x`) ; mocks réseau (`detect()`/layers, pattern `test_sources_failed_attempt_logging.py`) ; `pytest -v` complet.
+- [ ] **T5 — Doc** : déplacer `phase1-rapid-analysis.md` + `website-to-rss-decision.md` de `.context/CEAeng/` vers `docs/maintenance/` (traçabilité de la décision).
+
+## 4. Hors scope (différé, décision après données)
+- Palier 2 : adapter scrape (sélecteurs LLM + trafilatura), RSS-Bridge self-host, Firecrawl, SaaS. **Gated** sur le job hebdo.
+- Cas anti-bot durs (usine-digitale / DataDome) : non-objectif.
+- UX de l'add (4 matchs parfaits abandonnés) : **workstream mobile séparé** (à signaler au PO — c'est le plus gros levier de rescue « soft »).
+- Notification « ta source précédemment échouée est dispo ».
+- Toute migration DB.
+
+## 5. Vérification (repris pour `/go`)
+1. `cd packages/api && pytest -v` — suite verte.
+2. Run réel rescue (lecture seule prod) : ~la fenêtre classifiée ; rafale YouTube 30/06 ressort `fixed_since` ; monpetithoublon/autobrasseur ressortent `resolvable_rss` via T1a (à confirmer), usine-digitale reste `no_feed`.
+3. `detect()` : nouveaux rungs testés contre WP UA-bloqué (curl-cffi) + WP REST-only ; exactement 1 head Alembic (aucune migration attendue).
+4. Job scheduler : test unitaire d'enregistrement.
+5. Changelog : PR probablement < 400 lignes, impact user faible immédiat → pas d'entrée `changelog.json` (sauf si T1d tampons livré → 1 entrée `{tag:"Sources", summary:"…"}`).
+6. PR `--base main` via `/go`.
+
+## 6. Risques & garde-fous
+- **T3 (anti-bot sync)** = seul changement hot-path → fallback-only sur 403, test dédié, séparable.
+- **T1b endpoint interne** = surface d'attaque SSRF → réutiliser la validation SSRF existante de `_safe_get` (`rss_parser.py`).
+- **Pas de migration** = respecte expand-contract sur DB prod partagée `main`↔`production`.
+- Rescue = **lecture seule** prod, aucun auto-ajout ; les cas éditoriaux (catalogue curé) restent des propositions PO.
+
+---
+### Journal
+- 2026-07-09 (Winston) — Story créée. En attente **GO** utilisateur avant CODE (workflow PLAN → CODE+TEST → PR).
+- 2026-07-09 (dev) — **CODE + TEST livrés** (périmètre verrouillé PO, incluant UX add + tampons T1d).
+  - **Workstream A** : `normalize_input_url()` (rss_parser + smart_source_search) ; suffixes WP `/?feed=rss2`/`/?feed=atom` ; Stage 4b renfort WordPress (curl-cffi) ; Stage 4c WP REST → feed synthétique + endpoint interne `/internal/feed/wp` (SSRF-gardé, non authentifié). Base URL self via `internal_feed_base_url` / `RAILWAY_PUBLIC_DOMAIN` ; rung 4c désactivé si non configuré (pas de feed_url cassé persisté).
+  - **Workstream B** : util partagé `app/services/http_fetch.py` (markers + `is_antibot_response` + `fetch_with_impersonation`) ; `SyncService._fetch_feed_content` rejoue en curl-cffi **uniquement** sur 403/anti-bot.
+  - **Workstream C** : `app/services/rescue.py` (classification pure) + script `scripts/rescue_failed_sources.py` (Supabase REST) + job hebdo `run_rescue_failed_sources` (lundi 04h30 Paris) — logge `no_feed_host_count` (gating Palier 2). Gap Reddit `r/<sub>` (T0.3). Logs keyword-0 `/detect` + inférence d'abandon serveur (T0.4).
+  - **Workstream D (T1d)** : seed synchrone time-boxé (`SEED_TIMEOUT_S=5`, `seed_source` worker) dans `add_source`, fallback background-only.
+  - **Workstream E (mobile)** : badge « Source vérifiée » + CTA « Suivre {name} », preuve d'activité, post-add « Connecté » in-place, event analytics `source_added`.
+  - **Tests** : 37 tests backend neufs verts ; suite complète re-jouée ; **exactement 1 head Alembic, aucune migration**. Doc T5 : briefs déplacés dans `docs/maintenance/`. Changelog `{tag:"Sources"}`.
+  - **Ops post-merge** : run réel du rescue (read-only prod, service role) ; `INTERNAL_FEED_BASE_URL` (ou `RAILWAY_PUBLIC_DOMAIN`) à confirmer sur les 2 services Railway pour activer le rung 4c.

--- a/packages/api/app/config.py
+++ b/packages/api/app/config.py
@@ -115,6 +115,12 @@ class Settings(BaseSettings):
     # YouTube Data API v3
     youtube_api_key: str = ""
 
+    # Public origin of THIS backend, used to build synthetic internal feed URLs
+    # (Story 12.2, T1b — /internal/feed/wp). Empty → falls back to Railway's
+    # RAILWAY_PUBLIC_DOMAIN; when neither is set the WP-REST synthetic rung is
+    # disabled rather than persisting a broken feed_url.
+    internal_feed_base_url: str = ""
+
     # ML Classification (Story 4.1d) + Editorial Pipeline (Story 10.23)
     ml_enabled: bool = False  # Set to True to enable classification worker
     mistral_api_key: str = ""  # Mistral API key (classification + editorial pipeline)

--- a/packages/api/app/jobs/rescue_failed_sources_job.py
+++ b/packages/api/app/jobs/rescue_failed_sources_job.py
@@ -1,0 +1,138 @@
+"""Weekly rescue of failed source adds (Story 12.2, T3-job).
+
+Replays the collection + classification of failed/zero-result source signals
+and logs the per-category counts. The distinct ``no_feed`` host count is the
+**gating signal for Palier 2** (build scraping only if this tail grows past a
+threshold). Read-only: never adds a source, never mutates a signal.
+
+Runs at night (cohérent with storage_cleanup/purge) and is bounded so it can
+never dominate the scheduler: at most ``_MAX_RESOLUTIONS`` live ``detect()``
+re-resolutions, each under a short timeout.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from sqlalchemy import select
+
+from app.database import safe_async_session
+from app.services.rescue import (
+    classify_all,
+    collect_signals_from_db,
+    infer_abandons,
+    summarize,
+)
+
+logger = structlog.get_logger()
+
+_WINDOW_DAYS = 90
+# Cap on live re-resolutions so the night job stays light regardless of how
+# many URL/reddit signals accumulated.
+_MAX_RESOLUTIONS = 60
+_RESOLVE_TIMEOUT_S = 12.0
+
+
+def _make_resolver(max_resolutions: int):
+    """Return an async ``resolver(url) -> bool`` with a global resolution cap.
+
+    Once the cap is hit, further calls return False without touching the
+    network — the signal is simply left classified as ``no_feed``, which is the
+    conservative (never over-count "fixed") default and is logged.
+    """
+    from app.services.rss_parser import RSSParser
+
+    state = {"used": 0}
+
+    async def resolver(url: str) -> bool:
+        if state["used"] >= max_resolutions:
+            return False
+        state["used"] += 1
+        parser = RSSParser()
+        try:
+            detected = await asyncio.wait_for(
+                parser.detect(url), timeout=_RESOLVE_TIMEOUT_S
+            )
+            return bool(detected and detected.feed_url)
+        except Exception:
+            return False
+        finally:
+            await parser.close()
+
+    return resolver
+
+
+async def _count_inferred_abandons(session, days: int) -> int:
+    """T0.4b — searches with results but no add by the same user in-window."""
+    from app.models.source import UserSource
+    from app.models.source_search_log import SourceSearchLog
+
+    cutoff = datetime.now(UTC) - timedelta(days=days)
+    logs_rows = (
+        await session.execute(
+            select(
+                SourceSearchLog.user_id,
+                SourceSearchLog.created_at,
+                SourceSearchLog.query_normalized,
+            ).where(
+                SourceSearchLog.created_at >= cutoff,
+                SourceSearchLog.result_count > 0,
+            )
+        )
+    ).all()
+    adds_rows = (
+        await session.execute(
+            select(UserSource.user_id, UserSource.added_at).where(
+                UserSource.added_at >= cutoff
+            )
+        )
+    ).all()
+
+    result_logs = [
+        {
+            "user_id": r.user_id,
+            "created_at": r.created_at,
+            "query_normalized": r.query_normalized,
+        }
+        for r in logs_rows
+    ]
+    user_source_added = [
+        {"user_id": r.user_id, "added_at": r.added_at} for r in adds_rows
+    ]
+    return len(infer_abandons(result_logs, user_source_added))
+
+
+async def run_rescue_failed_sources() -> dict:
+    """Collect + classify the rescue signals and log the gating counters."""
+    logger.info("rescue_failed_sources_started", window_days=_WINDOW_DAYS)
+    try:
+        async with safe_async_session() as session:
+            try:
+                signals = await collect_signals_from_db(session, days=_WINDOW_DAYS)
+                resolver = _make_resolver(_MAX_RESOLUTIONS)
+                classified = await classify_all(signals, resolver)
+                summary = summarize(classified)
+                summary["inferred_abandons"] = await _count_inferred_abandons(
+                    session, _WINDOW_DAYS
+                )
+            finally:
+                try:
+                    await session.rollback()
+                except Exception:
+                    logger.warning("rescue outer rollback failed", exc_info=True)
+
+        logger.info(
+            "rescue_failed_sources_completed",
+            window_days=_WINDOW_DAYS,
+            total_signals=summary["total"],
+            by_category=summary["by_category"],
+            no_feed_host_count=summary["no_feed_host_count"],
+            no_feed_hosts=summary["no_feed_hosts"],
+            inferred_abandons=summary["inferred_abandons"],
+        )
+        return summary
+    except Exception:
+        logger.exception("rescue_failed_sources_failed")
+        return {}

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -88,6 +88,7 @@ from app.routers import (
     grille,
     images,
     internal,
+    internal_feed,
     letters,
     notification_preferences,
     personalization,
@@ -488,6 +489,9 @@ app.include_router(webhooks.router, prefix="/api/webhooks", tags=["Webhooks"])
 app.include_router(checkout.router, prefix="/api/checkout", tags=["Checkout"])
 app.include_router(analytics.router, prefix="/api/analytics", tags=["Analytics"])
 app.include_router(internal.router, prefix="/api/internal", tags=["Internal"])
+# Unauthenticated synthetic feed (Story 12.2, T1b): SyncService fetches these
+# URLs like any external feed, so no admin gate. SSRF-guarded in the router.
+app.include_router(internal_feed.router, prefix="/internal/feed", tags=["InternalFeed"])
 app.include_router(progress.router, prefix="/api/progress", tags=["Progress"])
 app.include_router(
     notification_preferences.router,

--- a/packages/api/app/routers/internal_feed.py
+++ b/packages/api/app/routers/internal_feed.py
@@ -1,0 +1,97 @@
+"""Synthetic feed endpoints (Story 12.2, T1b).
+
+Unauthenticated on purpose: ``SyncService`` fetches these URLs as plain feed
+URLs (no admin token), so they must be reachable the same way any external
+feed is. Safety is enforced by (1) SSRF-validating the ``host`` param before
+any outbound fetch, (2) only ever hitting the fixed ``/wp-json/wp/v2/posts``
+path on the target, and (3) a small in-process rate limit to blunt abuse of
+this open-ish proxy surface.
+"""
+
+import time
+from collections import defaultdict
+from urllib.parse import urlparse
+
+import structlog
+from fastapi import APIRouter, HTTPException, Query, Response, status
+
+from app.services.wordpress_feed import (
+    DEFAULT_POSTS,
+    MAX_POSTS,
+    fetch_wp_posts,
+    fetch_wp_site_info,
+    render_wp_rss,
+)
+from app.utils.url_safety import validate_url_for_fetch
+
+logger = structlog.get_logger()
+
+router = APIRouter()
+
+# Coarse per-host rate limit (this endpoint is unauthenticated). A synced
+# source hits it every rss_sync_interval, so a generous window is fine.
+_RATE_WINDOW_S = 60
+_RATE_MAX = 20
+_hits: dict[str, list[float]] = defaultdict(list)
+
+
+def _rate_ok(host: str) -> bool:
+    now = time.monotonic()
+    cutoff = now - _RATE_WINDOW_S
+    _hits[host] = [t for t in _hits[host] if t > cutoff]
+    if len(_hits[host]) >= _RATE_MAX:
+        return False
+    _hits[host].append(now)
+    return True
+
+
+@router.get("/wp")
+async def wordpress_synthetic_feed(
+    host: str = Query(..., max_length=255),
+    limit: int = Query(DEFAULT_POSTS, ge=1, le=MAX_POSTS),
+) -> Response:
+    """Render a WordPress site's REST posts as an RSS 2.0 feed.
+
+    Used only as a last-resort ``feed_url`` when a site's canonical ``/feed/``
+    is absent but the REST API is open (Story 12.2, Palier 1b).
+    """
+    target = host.strip()
+    if not target.startswith(("http://", "https://")):
+        target = "https://" + target
+
+    try:
+        validate_url_for_fetch(target)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from None
+
+    parsed = urlparse(target)
+    root = f"{parsed.scheme}://{parsed.netloc}"
+
+    if not _rate_ok(parsed.netloc.lower()):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many requests for this host",
+        )
+
+    posts = await fetch_wp_posts(root, limit)
+    if not posts:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="WordPress REST API returned no posts",
+        )
+
+    info = await fetch_wp_site_info(root)
+    xml = render_wp_rss(
+        root,
+        posts,
+        site_name=(info or {}).get("name"),
+        site_description=(info or {}).get("description"),
+        limit=limit,
+    )
+    return Response(
+        content=xml,
+        media_type="application/rss+xml; charset=utf-8",
+        headers={"Cache-Control": "public, max-age=600"},
+    )

--- a/packages/api/app/routers/sources.py
+++ b/packages/api/app/routers/sources.py
@@ -1,5 +1,6 @@
 """Routes sources."""
 
+import asyncio
 import contextlib
 import time
 from collections import defaultdict
@@ -70,6 +71,11 @@ from app.utils.db_retry import retry_db_op
 
 logger = structlog.get_logger()
 FOLLOWED_SOURCE_STATES = (InterestState.FOLLOWED, InterestState.FAVORITE)
+
+# T1d — budget strict du seed synchrone à l'add. Assez pour fetcher le flux +
+# insérer ~10 contents ; au-delà on retombe en background-only pour ne jamais
+# bloquer l'add.
+SEED_TIMEOUT_S = 5.0
 
 router = APIRouter()
 
@@ -708,9 +714,26 @@ async def add_source(
         FEED_CACHE.invalidate(UUID(user_id))
         SOURCES_CACHE.invalidate(UUID(user_id))
 
-        # Trigger immediate sync in background after request returns (and DB commits)
-        from app.workers.rss_sync import sync_source
+        from app.workers.rss_sync import seed_source, sync_source
 
+        # T1d — sème une tranche synchrone (time-boxée) pour que la tournée ne
+        # soit pas vide les quelques secondes où la task de fond tourne. Sur
+        # timeout/erreur → repli gracieux vers le background-only (filet
+        # `sync_source` conservé ci-dessous pour le backfill complet).
+        try:
+            seeded = await asyncio.wait_for(
+                seed_source(str(source.id)), timeout=SEED_TIMEOUT_S
+            )
+            logger.info("add_source_seed_done", source_id=str(source.id), seeded=seeded)
+        except Exception as seed_exc:
+            logger.info(
+                "add_source_seed_skipped",
+                source_id=str(source.id),
+                error=str(seed_exc),
+                exc_type=type(seed_exc).__name__,
+            )
+
+        # Backfill complet en tâche de fond après le retour de la requête.
         background_tasks.add_task(sync_source, str(source.id))
 
         return source
@@ -786,6 +809,16 @@ async def detect_source(
         else:
             # It's a keyword search
             results = await service.search_sources(url_input, user_id=user_id)
+            # T0.4 — logger les recherches keyword à 0 résultat (jusqu'ici un
+            # retour vide non tracé) pour améliorer l'échantillon rescue.
+            if not results:
+                await _log_failed_source_attempt(
+                    user_id=user_id,
+                    input_text=url_input,
+                    input_type="keyword",
+                    endpoint="detect",
+                    error_message="0 results",
+                )
             return SourceSearchResponse(results=results)
     except ValueError as e:
         await _log_failed_source_attempt(

--- a/packages/api/app/services/http_fetch.py
+++ b/packages/api/app/services/http_fetch.py
@@ -1,0 +1,93 @@
+"""Shared HTTP fetch helpers with an anti-bot (curl-cffi) fallback.
+
+Extracted from ``RSSParser`` so ``SyncService`` can reuse the *exact same*
+impersonation logic on the refresh hot-path (Story 12.2, T3) instead of
+duplicating it. A feed discovered behind an anti-bot wall at add-time
+(``detect()`` already falls back to curl-cffi) otherwise dies at the next
+refresh because ``SyncService`` fetched with plain httpx.
+
+Keep this module dependency-light: it must be importable from both the
+detection service and the sync worker without pulling feed-parsing code.
+"""
+
+from urllib.parse import urljoin
+
+import structlog
+
+from app.utils.url_safety import validate_url_for_fetch
+
+logger = structlog.get_logger()
+
+# Anti-bot markers in response content indicating a CAPTCHA/challenge page.
+ANTIBOT_MARKERS = [
+    "captcha-delivery.com",
+    "datadome",
+    "cf-challenge",
+    "challenges.cloudflare.com",
+    "cf-chl-bypass",
+]
+
+# HTTP status codes that carry a redirect Location we should follow.
+_REDIRECT_CODES = {301, 302, 303, 307, 308}
+
+
+def is_antibot_response(status_code: int, content: str) -> bool:
+    """Detect if a response looks like an anti-bot challenge.
+
+    A bare 403 is treated as anti-bot (the historical behaviour of
+    ``RSSParser._is_antibot_response``); otherwise scan the first 2 KB of the
+    body for a known challenge marker.
+    """
+    if status_code == 403:
+        return True
+    content_lower = content[:2000].lower()
+    return any(marker in content_lower for marker in ANTIBOT_MARKERS)
+
+
+async def fetch_with_impersonation(url: str, *, timeout: int = 10) -> str | None:
+    """Fetch ``url`` using curl-cffi to bypass TLS fingerprinting.
+
+    Returns the response text on a 200, ``None`` on any failure (including
+    curl-cffi not being installed). Re-raises ``ValueError`` from SSRF
+    validation so callers cannot be tricked into fetching internal addresses.
+    Follows up to 6 redirects, re-validating every hop.
+    """
+    try:
+        from curl_cffi.requests import AsyncSession
+    except ImportError:
+        logger.warning("curl-cffi not installed, skipping anti-bot fallback")
+        return None
+
+    try:
+        async with AsyncSession(impersonate="chrome", timeout=timeout) as s:
+            current_url = validate_url_for_fetch(url)
+            for _ in range(6):
+                resp = await s.get(
+                    current_url,
+                    allow_redirects=False,
+                    headers={
+                        "Accept-Language": "fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7",
+                        "Accept": "text/html,application/xhtml+xml,application/xml;"
+                        "q=0.9,*/*;q=0.8",
+                    },
+                )
+                if resp.status_code in _REDIRECT_CODES:
+                    location = resp.headers.get("location")
+                    if not location:
+                        break
+                    current_url = validate_url_for_fetch(urljoin(current_url, location))
+                    continue
+                if resp.status_code == 200:
+                    logger.info("curl-cffi fallback succeeded", url=current_url)
+                    return resp.text
+                logger.warning(
+                    "curl-cffi fallback returned non-200",
+                    url=current_url,
+                    status=resp.status_code,
+                )
+                break
+    except ValueError:
+        raise
+    except Exception as e:
+        logger.warning("curl-cffi fetch failed", url=url, error=str(e))
+    return None

--- a/packages/api/app/services/rescue.py
+++ b/packages/api/app/services/rescue.py
@@ -1,0 +1,320 @@
+"""Rescue of failed source adds — collection + classification (Story 12.2, T2/T3).
+
+Shared, side-effect-light core reused by both:
+  * the weekly scheduler job (``app/jobs/rescue_failed_sources_job.py``), which
+    runs in-process against the DB, and
+  * the standalone read-only script (``scripts/rescue_failed_sources.py``),
+    which pulls the same signals via Supabase REST.
+
+The classification is a **pure** function so it can be unit-tested with prod
+fixtures without any network. Network re-resolution (``detect()``) is injected
+as a ``resolver`` callback, so tests stub it.
+
+Categories (the gating signal for Palier 2 is ``no_feed`` distinct hosts):
+  * ``resolvable_rss``     — a URL that now resolves to a feed (incl. new WP rungs)
+  * ``fixed_since``        — previously-failing class fixed in code (YouTube #939,
+                             Reddit gap) — the feed exists, resolution is back
+  * ``found_but_abandoned``— search returned results but the user didn't add →
+                             UX/relevance, NOT an ingestion gap
+  * ``no_feed``            — still no discoverable feed (the real Palier 2 tail)
+  * ``invalid``            — typo / too-short / non-source keyword
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from urllib.parse import urlparse
+
+from app.services.rss_parser import normalize_input_url
+from app.services.search.cache import normalize_query
+
+RESOLVABLE_RSS = "resolvable_rss"
+FIXED_SINCE = "fixed_since"
+FOUND_BUT_ABANDONED = "found_but_abandoned"
+NO_FEED = "no_feed"
+INVALID = "invalid"
+
+CATEGORIES = (
+    RESOLVABLE_RSS,
+    FIXED_SINCE,
+    FOUND_BUT_ABANDONED,
+    NO_FEED,
+    INVALID,
+)
+
+# A search that returned results but was not followed by an add within this
+# window is treated as an inferred abandon (server-side complement to the
+# client-dependent /search-abandoned signal — T0.4b).
+ABANDON_INFERENCE_WINDOW = timedelta(hours=6)
+
+_URL_RE = re.compile(r"^[\w.-]+\.[a-z]{2,}(/.*)?$", re.IGNORECASE)
+
+
+@dataclass
+class Signal:
+    """A deduplicated failed/zero-result signal to reclassify."""
+
+    key: str
+    input_text: str
+    kind: str  # "url" | "keyword"
+    content_type: str | None = None
+    max_result_count: int = 0
+    abandoned: bool = False
+    occurrences: int = 1
+    user_ids: set[str] = field(default_factory=set)
+
+
+def is_url_like(text: str) -> bool:
+    """True when *text* looks like a URL/bare domain rather than a keyword."""
+    t = (text or "").strip()
+    if t.startswith(("http://", "https://")):
+        return True
+    return bool(_URL_RE.match(t))
+
+
+def is_invalid_input(text: str) -> bool:
+    """Heuristic for junk keywords (typos, too short, single word < 3 chars)."""
+    normalized = normalize_query(text or "")
+    return len(normalized.replace(" ", "")) < 3
+
+
+def signal_key(text: str) -> str:
+    """Stable dedup key: host+path for URLs, normalized query for keywords."""
+    if is_url_like(text):
+        candidate = text.strip()
+        if not candidate.startswith(("http://", "https://")):
+            candidate = "https://" + candidate
+        parsed = urlparse(normalize_input_url(candidate))
+        path = parsed.path.rstrip("/").lower()
+        return f"{parsed.netloc}{path}" if parsed.netloc else normalize_query(text)
+    return normalize_query(text)
+
+
+def resolve_target(sig: Signal) -> str | None:
+    """URL to re-resolve for this signal, or None when resolution is N/A.
+
+    URLs re-resolve directly; reddit-ish keywords re-resolve via the
+    ``/r/<sub>/.rss`` URL (drives the T0.3 gap fix). Other keywords aren't
+    resolvable offline (they need the full ranked search), so they're
+    classified from the log metadata alone.
+    """
+    text = sig.input_text.strip()
+    if sig.kind == "url":
+        candidate = text
+        if not candidate.startswith(("http://", "https://")):
+            candidate = "https://" + candidate
+        return candidate
+    ct = (sig.content_type or "").lower()
+    if ct == "reddit" or text.lower().startswith("r/"):
+        sub = text[2:] if text.lower().startswith("r/") else text
+        sub = re.sub(r"[^A-Za-z0-9_]", "", sub)
+        if sub:
+            return f"https://www.reddit.com/r/{sub}/.rss"
+    return None
+
+
+def classify_signal(sig: Signal, resolvable: bool | None) -> str:
+    """Pure classifier. ``resolvable`` = outcome of a (mocked) detect(), or None."""
+    if sig.kind == "keyword" and is_invalid_input(sig.input_text):
+        return INVALID
+
+    if sig.kind == "url":
+        return RESOLVABLE_RSS if resolvable else NO_FEED
+
+    ct = (sig.content_type or "").lower()
+    text = sig.input_text.strip().lower()
+
+    # YouTube-filtered zero-result searches were the #939 layer bug — the
+    # channel feeds exist; resolution is fixed in code.
+    if ct == "youtube":
+        return FIXED_SINCE
+
+    if ct == "reddit" or text.startswith("r/"):
+        if resolvable is True:
+            return RESOLVABLE_RSS
+        if resolvable is False:
+            return NO_FEED
+        # Resolution not attempted → the gap fix now routes it; treat as fixed.
+        return FIXED_SINCE
+
+    # Keyword that DID return results but wasn't added → UX/relevance, not a
+    # missing feed.
+    if sig.max_result_count and sig.max_result_count > 0:
+        return FOUND_BUT_ABANDONED
+
+    return NO_FEED
+
+
+def merge_signal(
+    signals: dict[str, Signal],
+    *,
+    input_text: str,
+    kind: str,
+    content_type: str | None = None,
+    result_count: int = 0,
+    abandoned: bool = False,
+    user_id: str | None = None,
+) -> None:
+    """Fold one raw row into the deduplicated signal map (in place)."""
+    key = signal_key(input_text)
+    existing = signals.get(key)
+    if existing is None:
+        existing = Signal(
+            key=key,
+            input_text=input_text.strip(),
+            kind=kind,
+            content_type=content_type,
+        )
+        signals[key] = existing
+    else:
+        existing.occurrences += 1
+    existing.max_result_count = max(existing.max_result_count, result_count or 0)
+    existing.abandoned = existing.abandoned or abandoned
+    if existing.content_type is None and content_type:
+        existing.content_type = content_type
+    if user_id:
+        existing.user_ids.add(str(user_id))
+
+
+async def classify_all(signals: list[Signal], resolver) -> list[dict]:
+    """Classify each signal, calling ``resolver(url) -> bool`` where applicable.
+
+    ``resolver`` may be None (metadata-only classification). Returns a list of
+    dicts ready for JSON/markdown serialization.
+    """
+    out: list[dict] = []
+    for sig in signals:
+        target = resolve_target(sig)
+        resolvable: bool | None = None
+        if target is not None and resolver is not None:
+            try:
+                resolvable = bool(await resolver(target))
+            except Exception:
+                resolvable = False
+        out.append(
+            {
+                "key": sig.key,
+                "input_text": sig.input_text,
+                "kind": sig.kind,
+                "content_type": sig.content_type,
+                "occurrences": sig.occurrences,
+                "max_result_count": sig.max_result_count,
+                "abandoned": sig.abandoned,
+                "resolve_target": target,
+                "resolvable": resolvable,
+                "category": classify_signal(sig, resolvable),
+            }
+        )
+    return out
+
+
+def summarize(classified: list[dict]) -> dict:
+    """Aggregate category counts + the distinct ``no_feed`` host set (the gate)."""
+    counts = Counter(row["category"] for row in classified)
+    no_feed_hosts: set[str] = set()
+    for row in classified:
+        if row["category"] != NO_FEED or row["kind"] != "url":
+            continue
+        target = row.get("resolve_target") or row["input_text"]
+        host = urlparse(
+            target if target.startswith("http") else f"https://{target}"
+        ).netloc.lower()
+        if host:
+            no_feed_hosts.add(host)
+    return {
+        "total": len(classified),
+        "by_category": {cat: counts.get(cat, 0) for cat in CATEGORIES},
+        "no_feed_hosts": sorted(no_feed_hosts),
+        "no_feed_host_count": len(no_feed_hosts),
+    }
+
+
+def infer_abandons(
+    result_logs: list[dict],
+    user_source_added: list[dict],
+    *,
+    window: timedelta = ABANDON_INFERENCE_WINDOW,
+) -> list[dict]:
+    """Server-side abandon inference (T0.4b).
+
+    A search that returned results (``result_count > 0``) but is not followed
+    by *any* source add by the same user within ``window`` is an inferred
+    abandon — a signal the client-only ``/search-abandoned`` call under-counts.
+
+    ``result_logs``: dicts with ``user_id``, ``created_at``, ``query_normalized``.
+    ``user_source_added``: dicts with ``user_id``, ``added_at``.
+    """
+    adds_by_user: dict[str, list[datetime]] = {}
+    for row in user_source_added:
+        uid = str(row.get("user_id"))
+        added = row.get("added_at")
+        if uid and added is not None:
+            adds_by_user.setdefault(uid, []).append(added)
+
+    inferred: list[dict] = []
+    for log in result_logs:
+        uid = str(log.get("user_id"))
+        created = log.get("created_at")
+        if created is None:
+            continue
+        adds = adds_by_user.get(uid, [])
+        if any(created <= a <= created + window for a in adds):
+            continue
+        inferred.append(
+            {
+                "user_id": uid,
+                "query_normalized": log.get("query_normalized"),
+                "created_at": created,
+            }
+        )
+    return inferred
+
+
+async def collect_signals_from_db(session, days: int = 90) -> list[Signal]:
+    """Collect + dedupe rescue signals from the DB (weekly-job path)."""
+    from sqlalchemy import or_, select
+
+    from app.models.failed_source_attempt import FailedSourceAttempt
+    from app.models.source_search_log import SourceSearchLog
+
+    cutoff = datetime.now(UTC) - timedelta(days=days)
+    signals: dict[str, Signal] = {}
+
+    attempts = await session.execute(
+        select(FailedSourceAttempt).where(FailedSourceAttempt.created_at >= cutoff)
+    )
+    for row in attempts.scalars().all():
+        text = row.input_text or ""
+        if not text.strip():
+            continue
+        merge_signal(
+            signals,
+            input_text=text,
+            kind="url" if is_url_like(text) else "keyword",
+            user_id=str(row.user_id),
+        )
+
+    logs = await session.execute(
+        select(SourceSearchLog).where(
+            SourceSearchLog.created_at >= cutoff,
+            or_(SourceSearchLog.result_count == 0, SourceSearchLog.abandoned.is_(True)),
+        )
+    )
+    for row in logs.scalars().all():
+        text = row.query_raw or ""
+        if not text.strip():
+            continue
+        merge_signal(
+            signals,
+            input_text=text,
+            kind="url" if is_url_like(text) else "keyword",
+            content_type=row.content_type,
+            result_count=row.result_count,
+            abandoned=row.abandoned,
+            user_id=str(row.user_id),
+        )
+
+    return list(signals.values())

--- a/packages/api/app/services/rss_parser.py
+++ b/packages/api/app/services/rss_parser.py
@@ -1,6 +1,6 @@
 import asyncio
 import re
-from urllib.parse import urljoin, urlparse
+from urllib.parse import parse_qsl, urlencode, urljoin, urlparse, urlunparse
 
 import feedparser
 import httpx
@@ -9,18 +9,66 @@ from bs4 import BeautifulSoup
 from pydantic import BaseModel
 
 from app.config import get_settings
+from app.services.http_fetch import (
+    fetch_with_impersonation,
+    is_antibot_response,
+)
+from app.services.wordpress_feed import (
+    fetch_wp_posts,
+    fetch_wp_site_info,
+    internal_feed_base_url,
+    post_entries,
+)
 from app.utils.url_safety import validate_url_for_fetch
 
 logger = structlog.get_logger()
 
-# Anti-bot markers in response content indicating CAPTCHA/challenge pages
-_ANTIBOT_MARKERS = [
-    "captcha-delivery.com",
-    "datadome",
-    "cf-challenge",
-    "challenges.cloudflare.com",
-    "cf-chl-bypass",
-]
+# Tracking query params stripped in front of the whole cascade so a polluted
+# paste (betterclinicianproject.com/?utm_source=…&fbclid=…) resolves like the
+# clean URL and the HostFeedResolution cache dedupes correctly. Non-tracking
+# params (e.g. ?feed=rss2) are preserved.
+_TRACKING_PARAM_KEYS = frozenset(
+    {"fbclid", "gclid", "igshid", "mc_cid", "mc_eid", "gclsrc", "dclid", "yclid"}
+)
+
+
+def normalize_input_url(url: str) -> str:
+    """Strip tracking params + fragment and lowercase the host.
+
+    Idempotent and defensive: returns the input unchanged if it isn't a
+    parseable absolute URL. Called at the head of ``detect()`` and by
+    ``SmartSourceSearchService`` before it probes a pasted URL.
+    """
+    if not url:
+        return url
+    try:
+        parsed = urlparse(url.strip())
+    except ValueError:
+        return url
+    if not parsed.scheme or not parsed.netloc:
+        return url
+
+    kept = [
+        (key, value)
+        for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        if not (key.lower().startswith("utm_") or key.lower() in _TRACKING_PARAM_KEYS)
+    ]
+    new_query = urlencode(kept)
+
+    host = (parsed.hostname or "").lower()
+    netloc = host
+    if parsed.port is not None:
+        netloc = f"{host}:{parsed.port}"
+    if parsed.username:
+        userinfo = parsed.username
+        if parsed.password:
+            userinfo = f"{userinfo}:{parsed.password}"
+        netloc = f"{userinfo}@{netloc}"
+
+    return urlunparse(
+        (parsed.scheme.lower(), netloc, parsed.path, parsed.params, new_query, "")
+    )
+
 
 # Regex to detect feed-like paths in <a href> attributes on *homepages*.
 # Kept narrow on purpose: a busy French homepage has cross-links to sibling
@@ -153,54 +201,21 @@ class RSSParser:
 
     @staticmethod
     def _is_antibot_response(status_code: int, content: str) -> bool:
-        """Detect if a response is an anti-bot challenge."""
-        if status_code == 403:
-            return True
-        content_lower = content[:2000].lower()
-        return any(marker in content_lower for marker in _ANTIBOT_MARKERS)
+        """Detect if a response is an anti-bot challenge.
+
+        Thin wrapper over ``http_fetch.is_antibot_response`` (single
+        implementation shared with ``SyncService``); kept as a method so
+        existing call sites and tests keep working.
+        """
+        return is_antibot_response(status_code, content)
 
     async def _fetch_with_impersonation(self, url: str) -> str | None:
-        """Fallback fetch using curl-cffi to bypass TLS fingerprinting."""
-        try:
-            from curl_cffi.requests import AsyncSession
-        except ImportError:
-            logger.warning("curl-cffi not installed, skipping anti-bot fallback")
-            return None
+        """Fallback fetch using curl-cffi to bypass TLS fingerprinting.
 
-        try:
-            async with AsyncSession(impersonate="chrome", timeout=10) as s:
-                current_url = validate_url_for_fetch(url)
-                for _ in range(6):
-                    resp = await s.get(
-                        current_url,
-                        allow_redirects=False,
-                        headers={
-                            "Accept-Language": "fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7",
-                            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-                        },
-                    )
-                    if resp.status_code in {301, 302, 303, 307, 308}:
-                        location = resp.headers.get("location")
-                        if not location:
-                            break
-                        current_url = validate_url_for_fetch(
-                            urljoin(current_url, location)
-                        )
-                        continue
-                    if resp.status_code == 200:
-                        logger.info("curl-cffi fallback succeeded", url=current_url)
-                        return resp.text
-                    logger.warning(
-                        "curl-cffi fallback returned non-200",
-                        url=current_url,
-                        status=resp.status_code,
-                    )
-                    break
-        except ValueError:
-            raise
-        except Exception as e:
-            logger.warning("curl-cffi fetch failed", url=url, error=str(e))
-        return None
+        Delegates to ``http_fetch.fetch_with_impersonation``; kept as an
+        instance method so tests can still ``patch.object(parser, ...)``.
+        """
+        return await fetch_with_impersonation(url)
 
     @staticmethod
     def _try_platform_transform(url: str) -> str | None:
@@ -552,6 +567,85 @@ class RSSParser:
                 return await self._format_response(candidate, feed_data)
         return None
 
+    # ─── WordPress reinforcement (Stages 4b/4c, Story 12.2) ───────
+
+    @staticmethod
+    def _host_root(url: str) -> str | None:
+        """Return ``scheme://host`` for *url*, or None if unparsable."""
+        try:
+            parsed = urlparse(url)
+        except ValueError:
+            return None
+        if not parsed.scheme or not parsed.netloc:
+            return None
+        return f"{parsed.scheme}://{parsed.netloc}"
+
+    async def _detect_wordpress(self, root: str, soup: BeautifulSoup) -> bool:
+        """Is this site WordPress? generator meta (cheap) OR ``/wp-json/`` probe."""
+        try:
+            meta = soup.find("meta", attrs={"name": "generator"})
+        except Exception:
+            meta = None
+        if meta and "wordpress" in (meta.get("content") or "").lower():
+            return True
+        try:
+            resp = await self._safe_get(f"{root}/wp-json/")
+        except Exception:
+            return False
+        if resp.status_code == 200:
+            ct = resp.headers.get("content-type", "").lower()
+            if "json" in ct or resp.text.lstrip().startswith("{"):
+                return True
+        return False
+
+    async def _try_wordpress_feed(
+        self, root: str, loop: asyncio.AbstractEventLoop
+    ) -> DetectedFeed | None:
+        """Stage 4b: resolve the canonical WP feed via curl-cffi.
+
+        The httpx suffix probe already tried ``/feed`` and failed — often
+        because the site UA-blocks non-browser clients (e.g. monpetithoublon
+        ``/feed/`` → 500). curl-cffi impersonates Chrome and recovers a REAL
+        feed, so ``SyncService`` still fetches a normal RSS URL.
+        """
+        for candidate in (f"{root}/feed/", f"{root}/?feed=rss2"):
+            text = await self._fetch_with_impersonation(candidate)
+            if not text or not text.lstrip().startswith(
+                ("<?xml", "<rss", "<feed", "<atom")
+            ):
+                continue
+            feed_data = await loop.run_in_executor(None, feedparser.parse, text)
+            if len(feed_data.entries) > 0:
+                logger.info("Found WordPress feed via curl-cffi", url=candidate)
+                return await self._format_response(candidate, feed_data)
+        return None
+
+    async def _try_wordpress_rest(self, root: str) -> DetectedFeed | None:
+        """Stage 4c: WP REST → synthetic internal feed (no migration).
+
+        Only fires when a self base URL is configured (else we'd persist a
+        broken ``feed_url``). ``detect()`` returns the internal endpoint URL;
+        ``SyncService`` fetches it like any other feed.
+        """
+        base = internal_feed_base_url()
+        if not base:
+            return None
+        posts = await fetch_wp_posts(root)
+        if not posts:
+            return None
+        host = urlparse(root).netloc
+        feed_url = f"{base}/internal/feed/wp?{urlencode({'host': host})}"
+        info = await fetch_wp_site_info(root)
+        description = (info or {}).get("description")
+        logger.info("Resolved WordPress via synthetic REST feed", feed_url=feed_url)
+        return DetectedFeed(
+            feed_url=feed_url,
+            title=(info or {}).get("name") or host,
+            description=(description or "")[:200] or None,
+            feed_type="rss",
+            entries=post_entries(posts, limit=3),
+        )
+
     # ─── Main Detection ───────────────────────────────────────────
 
     async def detect(self, url: str) -> DetectedFeed:
@@ -569,6 +663,7 @@ class RSSParser:
         4c. Feed index page follow (recurse into /rss, /flux, … HTML lists).
         5. Expanded suffix fallback with Content-Type validation.
         """
+        url = normalize_input_url(url)
         logger.info("Detecting feed", url=url)
         validate_url_for_fetch(url)
         loop = asyncio.get_event_loop()
@@ -858,6 +953,8 @@ class RSSParser:
         # stations, from which we'd pick the wrong feed).
         common_suffixes = [
             "/feed",  # WordPress
+            "/?feed=rss2",  # WordPress with flat permalinks (no pretty URLs)
+            "/?feed=atom",  # WordPress Atom, flat permalinks
             "/rss",  # Generic
             "/feed.xml",  # Hugo, Jekyll, Eleventy
             "/rss.xml",  # Drupal, custom
@@ -924,6 +1021,25 @@ class RSSParser:
         detection_log.append(
             f"suffix_fallback=tried_{suffix_tried['n']}_of_{len(common_suffixes)}"
         )
+
+        # ── Stage 4b/4c: WordPress reinforcement (Story 12.2) ─────
+        # All cheap probes have failed. WordPress is a large share of the FR
+        # long tail, so it's worth two targeted rungs before giving up:
+        #   4b — resolve the canonical /feed/ via curl-cffi (a REAL feed), and
+        #   4c — if /feed/ is truly gone, expose the open REST API as a
+        #        synthetic internal feed (no migration, SyncService unchanged).
+        root = self._host_root(url)
+        if root and await self._detect_wordpress(root, soup):
+            detection_log.append("wordpress=detected")
+            wp_feed = await self._try_wordpress_feed(root, loop)
+            if wp_feed is not None:
+                detection_log.append(f"wp_feed={wp_feed.feed_url}")
+                return wp_feed
+            wp_rest = await self._try_wordpress_rest(root)
+            if wp_rest is not None:
+                detection_log.append(f"wp_rest={wp_rest.feed_url}")
+                return wp_rest
+            detection_log.append("wordpress=no_feed")
 
         # ── Stage 5: Feed index page follow (Pattern A) ───────────
         # Last resort: some sites (Les Echos, L'Express) require

--- a/packages/api/app/services/rss_parser.py
+++ b/packages/api/app/services/rss_parser.py
@@ -70,6 +70,17 @@ def normalize_input_url(url: str) -> str:
     )
 
 
+def scheme_host_root(url: str) -> str | None:
+    """Return ``scheme://host`` for *url*, or None if unparsable."""
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return None
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
 # Regex to detect feed-like paths in <a href> attributes on *homepages*.
 # Kept narrow on purpose: a busy French homepage has cross-links to sibling
 # sections (e.g. France Culture nav linking to /franceinter/rss), and a
@@ -569,16 +580,7 @@ class RSSParser:
 
     # ─── WordPress reinforcement (Stages 4b/4c, Story 12.2) ───────
 
-    @staticmethod
-    def _host_root(url: str) -> str | None:
-        """Return ``scheme://host`` for *url*, or None if unparsable."""
-        try:
-            parsed = urlparse(url)
-        except ValueError:
-            return None
-        if not parsed.scheme or not parsed.netloc:
-            return None
-        return f"{parsed.scheme}://{parsed.netloc}"
+    _host_root = staticmethod(scheme_host_root)
 
     async def _detect_wordpress(self, root: str, soup: BeautifulSoup) -> bool:
         """Is this site WordPress? generator meta (cheap) OR ``/wp-json/`` probe."""

--- a/packages/api/app/services/search/smart_source_search.py
+++ b/packages/api/app/services/search/smart_source_search.py
@@ -21,7 +21,11 @@ from app.models.source_search_log import SourceSearchLog
 from app.models.user import UserInterest
 from app.services.observability.cost_budget import is_over_cap, monthly_call_count
 from app.services.observability.usage_recorder import track_api_call
-from app.services.rss_parser import RSSParser, normalize_input_url
+from app.services.rss_parser import (
+    RSSParser,
+    normalize_input_url,
+    scheme_host_root,
+)
 from app.services.search.cache import (
     normalize_query,
     search_cache_get,
@@ -885,16 +889,7 @@ class SmartSourceSearchService:
         }
     )
 
-    @staticmethod
-    def _root_url(url: str) -> str | None:
-        """Return scheme://host for *url*, or None if unparsable."""
-        try:
-            parsed = urlparse(url)
-        except ValueError:
-            return None
-        if not parsed.scheme or not parsed.netloc:
-            return None
-        return f"{parsed.scheme}://{parsed.netloc}"
+    _root_url = staticmethod(scheme_host_root)
 
     async def detect_feed(self, url: str) -> tuple[str, dict] | None:
         """Public one-off feed detection (root-fallback strategy).

--- a/packages/api/app/services/search/smart_source_search.py
+++ b/packages/api/app/services/search/smart_source_search.py
@@ -21,7 +21,7 @@ from app.models.source_search_log import SourceSearchLog
 from app.models.user import UserInterest
 from app.services.observability.cost_budget import is_over_cap, monthly_call_count
 from app.services.observability.usage_recorder import track_api_call
-from app.services.rss_parser import RSSParser
+from app.services.rss_parser import RSSParser, normalize_input_url
 from app.services.search.cache import (
     normalize_query,
     search_cache_get,
@@ -490,6 +490,10 @@ class SmartSourceSearchService:
             probe_url = query.strip()
             if not probe_url.startswith(("http://", "https://")):
                 probe_url = "https://" + probe_url
+            # Strip tracking params + lowercase host so a polluted paste
+            # resolves like the clean URL (T0.1) and the HostFeedResolution
+            # cache dedupes on the same key.
+            probe_url = normalize_input_url(probe_url)
             probe_host = (urlparse(probe_url).netloc or "").lower()
             if "reddit.com" not in probe_host:
                 detected = await self._detect_with_root_fallback(probe_url)
@@ -782,15 +786,66 @@ class SmartSourceSearchService:
             logger.debug("smart_search.youtube_failed", query=query, error=str(e))
             return []
 
-    async def _search_reddit(self, query: str, user_themes: list[str]) -> list[dict]:
-        """Search Reddit for subreddits."""
-        q = query.strip()
-        if q.lower().startswith("r/"):
-            q = q[2:]
+    async def _resolve_reddit_sub(
+        self, sub: str, user_themes: list[str]
+    ) -> dict | None:
+        """Resolve a specific ``r/<sub>`` directly to its ``.rss`` feed (T0.3).
 
-        results = await self.reddit.search(q)
-        items = []
+        The Reddit JSON search misses exact-name subreddits (``r/ai``,
+        ``artificial_intelligence``…), yet ``/r/<sub>/.rss`` is a real feed
+        that ``detect()`` handles. Bounded by the same detect timeout.
+        """
+        sub = re.sub(r"[^A-Za-z0-9_]", "", sub)
+        if not sub:
+            return None
+        rss_url = f"https://www.reddit.com/r/{sub}/.rss"
+        try:
+            detected = await asyncio.wait_for(
+                self.rss_parser.detect(rss_url), timeout=FEED_DETECT_TIMEOUT_S
+            )
+        except Exception:
+            return None
+        if not detected or not detected.feed_url:
+            return None
+        return {
+            "name": detected.title or f"r/{sub}",
+            "type": "reddit",
+            "url": f"https://www.reddit.com/r/{sub}/",
+            "feed_url": detected.feed_url,
+            "favicon_url": detected.logo_url,
+            "description": detected.description,
+            "in_catalog": False,
+            "is_curated": False,
+            "source_id": None,
+            "recent_items": [
+                {"title": e["title"], "published_at": e.get("published_at", "")}
+                for e in detected.entries[:3]
+            ],
+            "score": _compute_score("reddit", False, False, 0, None, True, False),
+            "source_layer": "reddit",
+        }
+
+    async def _search_reddit(self, query: str, user_themes: list[str]) -> list[dict]:
+        """Search Reddit for subreddits (+ direct ``r/<sub>`` resolution)."""
+        q = query.strip()
+        bare = q[2:] if q.lower().startswith("r/") else q
+
+        items: list[dict] = []
+        seen_feeds: set[str] = set()
+
+        # A specific subreddit name (``r/ai`` or a single bare token) → resolve
+        # its .rss directly, first, so exact matches the search API misses
+        # still surface (T0.3).
+        if re.fullmatch(r"[A-Za-z0-9_]+", bare):
+            direct = await self._resolve_reddit_sub(bare, user_themes)
+            if direct is not None:
+                items.append(direct)
+                seen_feeds.add(direct["feed_url"])
+
+        results = await self.reddit.search(bare)
         for r in results:
+            if r["feed_url"] in seen_feeds:
+                continue
             items.append(
                 {
                     "name": r["name"],

--- a/packages/api/app/services/sync_service.py
+++ b/packages/api/app/services/sync_service.py
@@ -19,6 +19,7 @@ from app.models.enums import ContentType, SourceType
 from app.models.source import Source, UserSource
 from app.models.veille import VeilleSource
 from app.services.content_quality import compute_content_quality
+from app.services.http_fetch import fetch_with_impersonation, is_antibot_response
 from app.services.ml.language_filter import detect_language
 from app.services.paywall_detector import detect_paywall
 
@@ -153,10 +154,8 @@ class SyncService:
         source_paywall_config = getattr(source, "paywall_config", None)
 
         try:
-            # 1. Fetch feed content (HORS session DB)
-            response = await self.client.get(source_url)
-            response.raise_for_status()
-            content = response.text
+            # 1. Fetch feed content (HORS session DB), avec repli anti-bot.
+            content = await self._fetch_feed_content(source_url)
 
             # 2. Parse feed (HORS session DB ; offloaded to thread pool, CPU-bound)
             loop = asyncio.get_event_loop()
@@ -223,6 +222,45 @@ class SyncService:
         except Exception as e:
             logger.error("Error processing source", source=source_name, error=str(e))
             raise e
+
+    async def seed_recent_content(self, source: Source, *, max_items: int = 10) -> int:
+        """Insert a bounded slice of the freshest entries synchronously.
+
+        Story 12.2 (T1d) : à l'add, la tournée est vide les quelques secondes
+        où le sync de fond tourne. Semer ~10 contents récents rend la source
+        vivante immédiatement. Réutilise le même fetch (anti-bot aware), la
+        dédup (``guid``) et l'enqueue de classif que le sync complet ; la task
+        de fond tourne ensuite pour le backfill complet. Le HEAD paywall par
+        article est **volontairement sauté** pour tenir le budget temps ; le
+        sync de fond raffinera ``is_paid`` (upgrade false→true non destructif).
+        """
+        source_id = source.id
+        source_paywall_config = getattr(source, "paywall_config", None)
+
+        content = await self._fetch_feed_content(source.feed_url)
+        loop = asyncio.get_event_loop()
+        feed = await loop.run_in_executor(None, feedparser.parse, content)
+
+        seeded = 0
+        for entry in feed.entries[:max_items]:
+            content_data = self._parse_entry(entry, source)
+            if not content_data:
+                continue
+            content_data["is_paid"] = detect_paywall(
+                title=content_data.get("title", ""),
+                description=content_data.get("description"),
+                url=content_data.get("url", ""),
+                html_content=content_data.get("html_content"),
+                source_id=str(source_id),
+                paywall_config=source_paywall_config,
+                html_head=None,
+            )
+            try:
+                if await self._save_content(content_data):
+                    seeded += 1
+            except SQLAlchemyError:
+                continue
+        return seeded
 
     def _parse_entry(self, entry, source: Source) -> dict | None:
         """Extrait les données pertinentes selon le type de source."""
@@ -496,6 +534,24 @@ class SyncService:
         # Clean query params?
         base_url = url_lower.split("?")[0]
         return not any(keyword in base_url for keyword in bad_keywords)
+
+    async def _fetch_feed_content(self, source_url: str) -> str:
+        """Fetch a feed body, retrying via curl-cffi on an anti-bot response.
+
+        Story 12.2 (T3) — le seul changement du hot-path sync. Un flux
+        découvert derrière un mur anti-bot à l'add (``detect()`` utilise déjà
+        curl-cffi) mourrait sinon au refresh, car cette voie chaude fetch en
+        httpx nu. Le repli est **scopé** : uniquement sur 403 / marqueurs
+        anti-bot, jamais sur le chemin nominal.
+        """
+        response = await self.client.get(source_url)
+        if is_antibot_response(response.status_code, response.text):
+            logger.info("sync_antibot_detected_retry_curl_cffi", source_url=source_url)
+            impersonated = await fetch_with_impersonation(source_url)
+            if impersonated is not None:
+                return impersonated
+        response.raise_for_status()
+        return response.text
 
     async def _fetch_html_head(self, url: str) -> str | None:
         """Fetch first ~50KB of an article page for paywall detection.

--- a/packages/api/app/services/wordpress_feed.py
+++ b/packages/api/app/services/wordpress_feed.py
@@ -1,0 +1,216 @@
+"""WordPress REST → synthetic RSS (Story 12.2, T1b).
+
+Some WordPress sites keep the REST API open (``/wp-json/wp/v2/posts``) while
+their canonical ``/feed/`` is disabled or broken. Rather than add a
+``fetch_method`` column + an alternate parser in ``SyncService`` (a migration
+on the shared prod DB), we expose the REST payload as a *synthetic* RSS feed
+served by our own backend. ``detect()`` stores that internal URL as the
+``feed_url`` and ``SyncService`` fetches it like any other feed, unchanged.
+
+This module is the single source of truth for both:
+  * ``detect()`` Stage 4c (to confirm posts exist + build the DetectedFeed), and
+  * the ``/internal/feed/wp`` endpoint (to render the RSS on demand).
+
+SSRF: every outbound fetch is validated with ``validate_url_for_fetch`` and
+falls back to curl-cffi only on an anti-bot response.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import os
+import re
+from datetime import UTC, datetime
+from email.utils import format_datetime
+from urllib.parse import urlparse
+from xml.sax.saxutils import escape
+
+import certifi
+import httpx
+import structlog
+
+from app.config import get_settings
+from app.services.http_fetch import fetch_with_impersonation, is_antibot_response
+from app.utils.url_safety import validate_url_for_fetch
+
+logger = structlog.get_logger()
+
+
+def internal_feed_base_url() -> str | None:
+    """Absolute base URL of *this* backend, used to build synthetic feed URLs.
+
+    ``detect()`` stores ``{base}/internal/feed/wp?host=…`` as a source's
+    ``feed_url``; that only works if we know our own public origin. Prefer the
+    explicit ``internal_feed_base_url`` setting, else fall back to Railway's
+    auto-injected ``RAILWAY_PUBLIC_DOMAIN``. Returns ``None`` when neither is
+    configured (local/dev), which disables the WP-REST synthetic rung instead
+    of persisting a broken URL.
+    """
+    base = (get_settings().internal_feed_base_url or "").strip()
+    if not base:
+        domain = os.environ.get("RAILWAY_PUBLIC_DOMAIN", "").strip()
+        if domain:
+            base = f"https://{domain}"
+    base = base.rstrip("/")
+    return base or None
+
+
+# Cap what a caller can ask the synthetic feed to render. WP REST caps at 100
+# per page; 20 is plenty for a digest and keeps the endpoint cheap.
+DEFAULT_POSTS = 20
+MAX_POSTS = 50
+
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _strip_tags(value: str) -> str:
+    """Best-effort strip of HTML tags from a rendered WP title/excerpt."""
+    return html.unescape(_TAG_RE.sub("", value or "")).strip()
+
+
+def wp_rest_posts_url(root: str, limit: int) -> str:
+    """Return the WP REST posts URL for a validated site root."""
+    per_page = max(1, min(limit, MAX_POSTS))
+    return (
+        f"{root.rstrip('/')}/wp-json/wp/v2/posts"
+        f"?per_page={per_page}&orderby=date&order=desc"
+    )
+
+
+async def _safe_get_json(url: str) -> object | None:
+    """GET a JSON document with SSRF validation + curl-cffi anti-bot fallback.
+
+    Returns the parsed JSON (list/dict) or ``None`` on any failure.
+    """
+    validated = validate_url_for_fetch(url)
+    try:
+        async with httpx.AsyncClient(
+            timeout=8.0,
+            follow_redirects=True,
+            verify=certifi.where(),
+            headers={
+                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                "Accept": "application/json",
+            },
+        ) as client:
+            resp = await client.get(validated)
+            if resp.status_code == 200:
+                try:
+                    return resp.json()
+                except (json.JSONDecodeError, ValueError):
+                    return None
+            if is_antibot_response(resp.status_code, resp.text):
+                impersonated = await fetch_with_impersonation(validated)
+                if impersonated:
+                    try:
+                        return json.loads(impersonated)
+                    except (json.JSONDecodeError, ValueError):
+                        return None
+    except ValueError:
+        raise
+    except Exception as exc:  # network/timeout — degrade gracefully
+        logger.debug("wp_rest.fetch_failed", url=url, error=str(exc))
+    return None
+
+
+async def fetch_wp_posts(root: str, limit: int = DEFAULT_POSTS) -> list[dict] | None:
+    """Fetch recent posts from a site's WordPress REST API.
+
+    ``root`` must already be an ``scheme://host`` string. Returns a non-empty
+    list of post dicts, or ``None`` when the endpoint is absent/empty/not WP.
+    """
+    data = await _safe_get_json(wp_rest_posts_url(root, limit))
+    if not isinstance(data, list) or not data:
+        return None
+    # Guard against a REST endpoint that returns something list-shaped but not
+    # posts (e.g. an error array). A real post carries a rendered title.
+    posts = [p for p in data if isinstance(p, dict) and "title" in p and "link" in p]
+    return posts or None
+
+
+async def fetch_wp_site_info(root: str) -> dict | None:
+    """Best-effort site name/description from ``/wp-json/`` (WP core route)."""
+    data = await _safe_get_json(f"{root.rstrip('/')}/wp-json/")
+    if isinstance(data, dict) and (data.get("name") or data.get("description")):
+        return {
+            "name": _strip_tags(data.get("name", "")) or None,
+            "description": _strip_tags(data.get("description", "")) or None,
+        }
+    return None
+
+
+def _post_pubdate(post: dict) -> str:
+    """RFC-822 pubDate from a WP post, falling back to now()."""
+    raw = post.get("date_gmt") or post.get("date") or ""
+    try:
+        dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+    except (ValueError, AttributeError):
+        dt = datetime.now(UTC)
+    return format_datetime(dt)
+
+
+def post_entries(posts: list[dict], limit: int = DEFAULT_POSTS) -> list[dict]:
+    """Compact ``{title, link, published_at}`` entries for DetectedFeed preview."""
+    entries: list[dict] = []
+    for post in posts[:limit]:
+        title = (
+            _strip_tags((post.get("title") or {}).get("rendered", "")) or "Sans titre"
+        )
+        entries.append(
+            {
+                "title": title,
+                "link": post.get("link", ""),
+                "published_at": _post_pubdate(post),
+            }
+        )
+    return entries
+
+
+def render_wp_rss(
+    root: str,
+    posts: list[dict],
+    *,
+    site_name: str | None = None,
+    site_description: str | None = None,
+    limit: int = DEFAULT_POSTS,
+) -> str:
+    """Render WP REST posts as a feedparser-parseable RSS 2.0 document."""
+    channel_title = escape(site_name or urlparse(root).netloc or "WordPress")
+    channel_desc = escape(site_description or "Flux généré depuis l'API WordPress")
+    items: list[str] = []
+    for post in posts[:limit]:
+        title = (
+            _strip_tags((post.get("title") or {}).get("rendered", "")) or "Sans titre"
+        )
+        link = post.get("link", "")
+        guid = (post.get("guid") or {}).get("rendered") or link
+        excerpt = (post.get("excerpt") or {}).get("rendered", "")
+        content = (post.get("content") or {}).get("rendered", "") or excerpt
+        pubdate = _post_pubdate(post)
+        items.append(
+            "    <item>\n"
+            f"      <title>{escape(title)}</title>\n"
+            f"      <link>{escape(link)}</link>\n"
+            f'      <guid isPermaLink="false">{escape(guid)}</guid>\n'
+            f"      <pubDate>{escape(pubdate)}</pubDate>\n"
+            f"      <description><![CDATA[{excerpt}]]></description>\n"
+            f"      <content:encoded><![CDATA[{content}]]></content:encoded>\n"
+            "    </item>"
+        )
+    items_xml = "\n".join(items)
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<rss version="2.0" '
+        'xmlns:content="http://purl.org/rss/1.0/modules/content/">\n'
+        "  <channel>\n"
+        f"    <title>{channel_title}</title>\n"
+        f"    <link>{escape(root)}</link>\n"
+        f"    <description>{channel_desc}</description>\n"
+        f"{items_xml}\n"
+        "  </channel>\n"
+        "</rss>\n"
+    )

--- a/packages/api/app/services/wordpress_feed.py
+++ b/packages/api/app/services/wordpress_feed.py
@@ -153,13 +153,16 @@ def _post_pubdate(post: dict) -> str:
     return format_datetime(dt)
 
 
+def _post_title(post: dict) -> str:
+    """Plain-text WP post title, falling back to ``Sans titre``."""
+    return _strip_tags((post.get("title") or {}).get("rendered", "")) or "Sans titre"
+
+
 def post_entries(posts: list[dict], limit: int = DEFAULT_POSTS) -> list[dict]:
     """Compact ``{title, link, published_at}`` entries for DetectedFeed preview."""
     entries: list[dict] = []
     for post in posts[:limit]:
-        title = (
-            _strip_tags((post.get("title") or {}).get("rendered", "")) or "Sans titre"
-        )
+        title = _post_title(post)
         entries.append(
             {
                 "title": title,
@@ -183,9 +186,7 @@ def render_wp_rss(
     channel_desc = escape(site_description or "Flux généré depuis l'API WordPress")
     items: list[str] = []
     for post in posts[:limit]:
-        title = (
-            _strip_tags((post.get("title") or {}).get("rendered", "")) or "Sans titre"
-        )
+        title = _post_title(post)
         link = post.get("link", "")
         guid = (post.get("guid") or {}).get("rendered") or link
         excerpt = (post.get("excerpt") or {}).get("rendered", "")

--- a/packages/api/app/workers/rss_sync.py
+++ b/packages/api/app/workers/rss_sync.py
@@ -30,6 +30,41 @@ async def sync_all_sources() -> dict:
             await service.close()
 
 
+async def seed_source(source_id: str, *, max_items: int = 10) -> int:
+    """Sème synchroniquement une tranche bornée de contenus pour une source.
+
+    Story 12.2 (T1d) : appelé par ``add_source`` sous un time-box strict pour
+    remplir la tournée immédiatement. Retourne le nombre de contents insérés
+    (0 si source absente ou fetch en échec). Ne lève pas — l'appelant retombe
+    en background-only via le filet ``sync_source``.
+    """
+    async with safe_async_session() as session:
+        service = SyncService(session, session_maker=safe_async_session)
+        try:
+            from uuid import UUID
+
+            from sqlalchemy import select
+
+            from app.models.source import Source
+
+            result = await session.execute(
+                select(Source).where(Source.id == UUID(source_id))
+            )
+            source = result.scalar_one_or_none()
+            if not source:
+                return 0
+            # Détache pour que les attributs restent lisibles pendant les
+            # sessions courtes de _save_content.
+            session.expunge(source)
+            return await service.seed_recent_content(source, max_items=max_items)
+        finally:
+            try:
+                await session.rollback()
+            except Exception:
+                logger.warning("seed_source outer rollback failed", exc_info=True)
+            await service.close()
+
+
 async def sync_source(source_id: str) -> bool:
     """Synchronise une source spécifique par son ID.
 

--- a/packages/api/app/workers/scheduler.py
+++ b/packages/api/app/workers/scheduler.py
@@ -14,6 +14,7 @@ from app.jobs.digest_generation_job import (
 )
 from app.jobs.purge_deleted_users import purge_deleted_users
 from app.jobs.recompute_source_language import recompute_source_language
+from app.jobs.rescue_failed_sources_job import run_rescue_failed_sources
 from app.services.observability.cost_budget import log_budget_projection
 from app.services.push_dispatcher import dispatch_daily_essentiel_pushes
 from app.services.recommendation.scoring_config import ScoringWeights
@@ -500,6 +501,21 @@ def start_scheduler() -> None:
         max_instances=1,
     )
 
+    # Rescue hebdo des sources échouées (Story 12.2) — lundi 04h30 Paris,
+    # créneau nuit cohérent avec storage_cleanup (03h) / purge (04h). Rejoue
+    # collecte + classification et logge les compteurs par catégorie. Le
+    # `no_feed_host_count` est le signal de gating du Palier 2 (scraping).
+    scheduler.add_job(
+        run_rescue_failed_sources,
+        trigger=CronTrigger(day_of_week="mon", hour=4, minute=30, timezone=_PARIS_TZ),
+        id="rescue_failed_sources",
+        name="Weekly rescue of failed source adds",
+        replace_existing=True,
+        misfire_grace_time=14400,
+        coalesce=True,
+        max_instances=1,
+    )
+
     # Zombie session sweeper — kill Supavisor sessions stuck in
     # `idle in transaction` > 5 min (filet de sécurité par-dessus le
     # timeout Postgres + le rollback() en finally de safe_async_session).
@@ -545,6 +561,7 @@ def start_scheduler() -> None:
             "storage_cleanup",
             "purge_deleted_users",
             "recompute_source_language",
+            "rescue_failed_sources",
             "zombie_session_sweeper",
             "pool_health_probe",
             "daily_essentiel_push_dispatch",

--- a/packages/api/scripts/rescue_failed_sources.py
+++ b/packages/api/scripts/rescue_failed_sources.py
@@ -1,0 +1,298 @@
+"""
+Story 12.2 — Rescue des sources échouées (read-only prod)
+
+Étend le pattern de ``analyze_failed_sources.py`` (Supabase PostgREST, service
+role) SANS le dupliquer : collecte l'union dédupliquée de
+``failed_source_attempts`` + ``source_search_logs`` (result_count=0 OU
+abandoned) sur une fenêtre paramétrable (défaut 90 j), rejoue la résolution
+offline avec un budget large (``detect()`` timeouts élargis + curl-cffi ;
+reddit ``r/<sub>`` direct), classe chaque signal via
+``app.services.rescue.classify_signal`` (source unique, partagée avec le job
+hebdo), et écrit :
+  * ``docs/maintenance/diag-rescue-failed-sources.md``
+  * ``.context/rescue-results.json``
+
+Le classement N'AJOUTE JAMAIS de source : lecture seule.
+
+Usage :
+  SUPABASE_URL=https://xxx.supabase.co \
+  SUPABASE_SERVICE_ROLE_KEY=xxx \
+  python scripts/rescue_failed_sources.py [--days 90] [--no-resolve]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from datetime import UTC, datetime, timedelta
+
+import httpx
+
+# Rendre l'app importable quand le script est lancé depuis packages/api.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app.services.rescue import (  # noqa: E402
+    CATEGORIES,
+    Signal,
+    classify_all,
+    infer_abandons,
+    is_url_like,
+    merge_signal,
+    summarize,
+)
+
+# Cap sur les résolutions réseau vivantes (comme le job hebdo).
+_MAX_RESOLUTIONS = 80
+_RESOLVE_TIMEOUT_S = 12.0
+
+
+def _parse_ts(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+
+
+async def _rest_get(
+    client: httpx.AsyncClient, base: str, path: str, params: dict
+) -> list[dict]:
+    resp = await client.get(f"{base}/rest/v1/{path}", params=params)
+    resp.raise_for_status()
+    return resp.json()
+
+
+async def collect_via_rest(base: str, key: str, days: int) -> tuple[list[Signal], dict]:
+    """Fetch + dedupe signals over the window; also return abandon-inference data."""
+    cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat()
+    headers = {
+        "apikey": key,
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+    }
+    signals: dict[str, Signal] = {}
+    async with httpx.AsyncClient(timeout=30.0, headers=headers) as client:
+        attempts = await _rest_get(
+            client,
+            base,
+            "failed_source_attempts",
+            {
+                "select": "user_id,input_text,input_type,created_at",
+                "created_at": f"gte.{cutoff}",
+                "limit": "2000",
+            },
+        )
+        for row in attempts:
+            text = (row.get("input_text") or "").strip()
+            if not text:
+                continue
+            merge_signal(
+                signals,
+                input_text=text,
+                kind="url" if is_url_like(text) else "keyword",
+                user_id=row.get("user_id"),
+            )
+
+        zero_or_abandoned = await _rest_get(
+            client,
+            base,
+            "source_search_logs",
+            {
+                "select": "user_id,query_raw,content_type,result_count,abandoned,created_at",
+                "created_at": f"gte.{cutoff}",
+                "or": "(result_count.eq.0,abandoned.eq.true)",
+                "limit": "2000",
+            },
+        )
+        for row in zero_or_abandoned:
+            text = (row.get("query_raw") or "").strip()
+            if not text:
+                continue
+            merge_signal(
+                signals,
+                input_text=text,
+                kind="url" if is_url_like(text) else "keyword",
+                content_type=row.get("content_type"),
+                result_count=row.get("result_count") or 0,
+                abandoned=bool(row.get("abandoned")),
+                user_id=row.get("user_id"),
+            )
+
+        # Données pour l'inférence d'abandon (T0.4b) : searches AVEC résultats.
+        result_logs_raw = await _rest_get(
+            client,
+            base,
+            "source_search_logs",
+            {
+                "select": "user_id,query_normalized,result_count,created_at",
+                "created_at": f"gte.{cutoff}",
+                "result_count": "gt.0",
+                "limit": "5000",
+            },
+        )
+        adds_raw = await _rest_get(
+            client,
+            base,
+            "user_sources",
+            {
+                "select": "user_id,added_at",
+                "added_at": f"gte.{cutoff}",
+                "limit": "5000",
+            },
+        )
+
+    result_logs = [
+        {
+            "user_id": r.get("user_id"),
+            "created_at": _parse_ts(r.get("created_at")),
+            "query_normalized": r.get("query_normalized"),
+        }
+        for r in result_logs_raw
+        if _parse_ts(r.get("created_at"))
+    ]
+    adds = [
+        {"user_id": r.get("user_id"), "added_at": _parse_ts(r.get("added_at"))}
+        for r in adds_raw
+        if _parse_ts(r.get("added_at"))
+    ]
+    return list(signals.values()), {"result_logs": result_logs, "adds": adds}
+
+
+def _make_resolver(max_resolutions: int):
+    from app.services.rss_parser import RSSParser
+
+    state = {"used": 0}
+
+    async def resolver(url: str) -> bool:
+        if state["used"] >= max_resolutions:
+            return False
+        state["used"] += 1
+        parser = RSSParser()
+        try:
+            detected = await asyncio.wait_for(
+                parser.detect(url), timeout=_RESOLVE_TIMEOUT_S
+            )
+            return bool(detected and detected.feed_url)
+        except Exception:
+            return False
+        finally:
+            await parser.close()
+
+    return resolver
+
+
+def render_report(
+    days: int, classified: list[dict], summary: dict, inferred: int
+) -> str:
+    lines: list[str] = []
+    lines.append("# Rescue des sources échouées — Story 12.2\n")
+    lines.append(f"**Date** : {datetime.now(UTC).strftime('%Y-%m-%d')}")
+    lines.append(f"**Fenêtre** : {days} derniers jours")
+    lines.append("**Mode** : lecture seule (aucune source ajoutée)\n")
+    lines.append("---\n")
+
+    lines.append("## Compteurs par catégorie\n")
+    lines.append("| Catégorie | Count |")
+    lines.append("|-----------|-------|")
+    for cat in CATEGORIES:
+        lines.append(f"| {cat} | {summary['by_category'].get(cat, 0)} |")
+    lines.append(f"| **Total signaux** | **{summary['total']}** |")
+    lines.append("")
+    lines.append(
+        f"**`no_feed` hôtes distincts (signal de gating Palier 2)** : "
+        f"{summary['no_feed_host_count']}"
+    )
+    lines.append(
+        f"**Abandons inférés (searches avec résultats, sans add)** : {inferred}\n"
+    )
+
+    if summary["no_feed_hosts"]:
+        lines.append("### Hôtes `no_feed` (candidats Palier 2)\n")
+        for host in summary["no_feed_hosts"]:
+            lines.append(f"- `{host}`")
+        lines.append("")
+
+    lines.append("## Détail des signaux\n")
+    lines.append(
+        "| Input | Kind | Type | Occ. | Résultats | Abandon | Résoluble | Catégorie |"
+    )
+    lines.append(
+        "|-------|------|------|------|-----------|---------|-----------|-----------|"
+    )
+    for row in sorted(classified, key=lambda r: r["category"]):
+        lines.append(
+            f"| `{row['input_text'][:48]}` | {row['kind']} | "
+            f"{row.get('content_type') or '-'} | {row['occurrences']} | "
+            f"{row['max_result_count']} | {row['abandoned']} | "
+            f"{row['resolvable']} | {row['category']} |"
+        )
+    lines.append("")
+    lines.append("---\n")
+    lines.append("*Généré par scripts/rescue_failed_sources.py (Story 12.2).*")
+    return "\n".join(lines)
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description="Rescue failed source adds")
+    parser.add_argument("--days", type=int, default=90)
+    parser.add_argument(
+        "--no-resolve",
+        action="store_true",
+        help="Classe sur la métadonnée seule (aucun detect() réseau)",
+    )
+    args = parser.parse_args()
+
+    base = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    if not base or not key:
+        print("ERROR: set SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Collecting signals over the last {args.days} days…")
+    signals, abandon_data = await collect_via_rest(base, key, args.days)
+    print(f"  {len(signals)} distinct signals")
+
+    resolver = None if args.no_resolve else _make_resolver(_MAX_RESOLUTIONS)
+    classified = await classify_all(signals, resolver)
+    summary = summarize(classified)
+    inferred = len(infer_abandons(abandon_data["result_logs"], abandon_data["adds"]))
+
+    report = render_report(args.days, classified, summary, inferred)
+
+    api_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    repo_root = os.path.dirname(os.path.dirname(api_root))
+    md_path = os.path.join(
+        repo_root, "docs", "maintenance", "diag-rescue-failed-sources.md"
+    )
+    json_path = os.path.join(repo_root, ".context", "rescue-results.json")
+    os.makedirs(os.path.dirname(json_path), exist_ok=True)
+
+    with open(md_path, "w") as f:
+        f.write(report)
+    with open(json_path, "w") as f:
+        json.dump(
+            {
+                "generated_at": datetime.now(UTC).isoformat(),
+                "days": args.days,
+                "summary": summary,
+                "inferred_abandons": inferred,
+                "signals": classified,
+            },
+            f,
+            indent=2,
+            ensure_ascii=False,
+        )
+
+    print(f"\nReport : {md_path}")
+    print(f"JSON   : {json_path}")
+    print(f"\nBy category: {summary['by_category']}")
+    print(f"no_feed hosts (Palier 2 gate): {summary['no_feed_host_count']}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/api/tests/routers/test_internal_feed.py
+++ b/packages/api/tests/routers/test_internal_feed.py
@@ -1,0 +1,76 @@
+"""Tests for the synthetic WordPress feed endpoint (Story 12.2, T1b)."""
+
+import socket
+
+import feedparser
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+_POSTS = [
+    {
+        "title": {"rendered": "Un post"},
+        "link": "https://blog.example.com/1",
+        "date_gmt": "2026-07-01T10:00:00",
+        "excerpt": {"rendered": "extrait"},
+        "content": {"rendered": "corps"},
+    }
+]
+
+
+@pytest.fixture
+def public_dns(monkeypatch):
+    def _getaddrinfo(host, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _getaddrinfo)
+
+
+async def _get(params):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        return await ac.get("/internal/feed/wp", params=params)
+
+
+@pytest.mark.asyncio
+async def test_wp_feed_happy_path(monkeypatch, public_dns):
+    async def fake_posts(root, limit):
+        return _POSTS
+
+    async def fake_info(root):
+        return {"name": "Blog Example", "description": None}
+
+    monkeypatch.setattr("app.routers.internal_feed.fetch_wp_posts", fake_posts)
+    monkeypatch.setattr("app.routers.internal_feed.fetch_wp_site_info", fake_info)
+
+    resp = await _get({"host": "blog.example.com"})
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("application/rss+xml")
+    feed = feedparser.parse(resp.text)
+    assert not feed.bozo
+    assert feed.feed.title == "Blog Example"
+    assert feed.entries[0].link == "https://blog.example.com/1"
+
+
+@pytest.mark.asyncio
+async def test_wp_feed_rejects_localhost():
+    # SSRF: a localhost host is blocked before any outbound fetch.
+    resp = await _get({"host": "localhost"})
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_wp_feed_rejects_loopback_ip():
+    resp = await _get({"host": "127.0.0.1"})
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_wp_feed_502_when_no_posts(monkeypatch, public_dns):
+    async def fake_posts(root, limit):
+        return None
+
+    monkeypatch.setattr("app.routers.internal_feed.fetch_wp_posts", fake_posts)
+    resp = await _get({"host": "blog.example.com"})
+    assert resp.status_code == 502

--- a/packages/api/tests/scripts/media_eval/conftest.py
+++ b/packages/api/tests/scripts/media_eval/conftest.py
@@ -1,0 +1,24 @@
+"""Fixtures partagées des tests media_eval."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest_asyncio
+
+from app.models.media_eval import MediaEvalRun
+
+RUN_ID = "run-test"
+
+
+@pytest_asyncio.fixture
+async def media_eval_run(db_session) -> MediaEvalRun:
+    """Satisfait la FK `run_id` : les fixtures signaux/évaluations pointent
+    toutes vers `run-test` (cf. RUN_ID des test_ingest_*.py et
+    tests/scripts/fixtures/media_eval/*.json)."""
+    run = MediaEvalRun(
+        run_id=RUN_ID, version_methodo="v0", date_reference=datetime.now(UTC).date()
+    )
+    db_session.add(run)
+    await db_session.commit()
+    return run

--- a/packages/api/tests/scripts/media_eval/test_ingest_artifacts.py
+++ b/packages/api/tests/scripts/media_eval/test_ingest_artifacts.py
@@ -30,6 +30,8 @@ from scripts.media_eval.schemas import DebunkageBatchArtifact, SignalBatchArtifa
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "media_eval"
 
+pytestmark = pytest.mark.usefixtures("media_eval_run")
+
 
 @pytest.fixture
 async def media_cnews(db_session) -> MediaEvalMedia:

--- a/packages/api/tests/scripts/media_eval/test_ingest_evaluations.py
+++ b/packages/api/tests/scripts/media_eval/test_ingest_evaluations.py
@@ -32,6 +32,8 @@ from scripts.media_eval.schemas import (
 
 RUN_ID = "run-test"
 
+pytestmark = pytest.mark.usefixtures("media_eval_run")
+
 
 @pytest.fixture
 async def media_cnews(db_session) -> MediaEvalMedia:

--- a/packages/api/tests/services/test_reddit_gap.py
+++ b/packages/api/tests/services/test_reddit_gap.py
@@ -1,0 +1,68 @@
+"""Tests for the Reddit direct-resolution gap fix (Story 12.2, T0.3)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.rss_parser import DetectedFeed
+from app.services.search.smart_source_search import SmartSourceSearchService
+
+
+def _service():
+    service = SmartSourceSearchService(db=MagicMock())
+    service.reddit.search = AsyncMock(return_value=[])
+    return service
+
+
+@pytest.mark.asyncio
+async def test_resolve_reddit_sub_direct_hit():
+    service = _service()
+    service.rss_parser.detect = AsyncMock(
+        return_value=DetectedFeed(
+            feed_url="https://www.reddit.com/r/ai/.rss",
+            title="r/ai",
+            feed_type="reddit",
+            entries=[{"title": "hot post", "published_at": ""}],
+        )
+    )
+
+    results = await service._search_reddit("r/ai", user_themes=[])
+    assert len(results) == 1
+    assert results[0]["feed_url"] == "https://www.reddit.com/r/ai/.rss"
+    assert results[0]["type"] == "reddit"
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_bare_token_treated_as_subreddit():
+    service = _service()
+    service.rss_parser.detect = AsyncMock(
+        return_value=DetectedFeed(
+            feed_url="https://www.reddit.com/r/worldnews/.rss", title="r/worldnews"
+        )
+    )
+    results = await service._search_reddit("worldnews", user_themes=[])
+    assert results[0]["feed_url"] == "https://www.reddit.com/r/worldnews/.rss"
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_reddit_direct_failure_falls_back_to_search():
+    service = _service()
+    service.rss_parser.detect = AsyncMock(side_effect=ValueError("no such sub"))
+    # Search API returns one discovery result.
+    service.reddit.search = AsyncMock(
+        return_value=[
+            {
+                "name": "r/science",
+                "url": "https://www.reddit.com/r/science/",
+                "feed_url": "https://www.reddit.com/r/science/.rss",
+                "description": "science",
+                "subscribers": 1000,
+            }
+        ]
+    )
+    results = await service._search_reddit("r/deadsub", user_themes=[])
+    assert len(results) == 1
+    assert results[0]["feed_url"] == "https://www.reddit.com/r/science/.rss"
+    await service.close()

--- a/packages/api/tests/services/test_sync_antibot.py
+++ b/packages/api/tests/services/test_sync_antibot.py
@@ -1,0 +1,107 @@
+"""Tests for the sync-side anti-bot fallback (T3) and buffer seed (T1d)."""
+
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from app.models.enums import SourceType
+from app.models.source import Source
+from app.services.sync_service import SyncService
+
+_RSS = """<?xml version="1.0"?>
+<rss version="2.0"><channel><title>Blog</title>
+<item><title>A</title><link>https://b.ex/a</link><guid>a</guid></item>
+<item><title>B</title><link>https://b.ex/b</link><guid>b</guid></item>
+</channel></rss>"""
+
+
+class _Resp:
+    def __init__(self, status_code, text):
+        self.status_code = status_code
+        self.text = text
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+@pytest.mark.asyncio
+async def test_fetch_feed_content_happy_path(monkeypatch):
+    service = SyncService(session=None)
+    service.client.get = AsyncMock(return_value=_Resp(200, _RSS))
+    impersonate = AsyncMock()
+    monkeypatch.setattr(
+        "app.services.sync_service.fetch_with_impersonation", impersonate
+    )
+
+    content = await service._fetch_feed_content("https://b.ex/feed")
+    assert content == _RSS
+    impersonate.assert_not_awaited()  # never fell back on the happy path
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_fetch_feed_content_falls_back_to_curl_cffi_on_403(monkeypatch):
+    service = SyncService(session=None)
+    service.client.get = AsyncMock(return_value=_Resp(403, "blocked"))
+    monkeypatch.setattr(
+        "app.services.sync_service.fetch_with_impersonation",
+        AsyncMock(return_value=_RSS),
+    )
+
+    content = await service._fetch_feed_content("https://b.ex/feed")
+    assert content == _RSS  # recovered via curl-cffi instead of raising
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_fetch_feed_content_raises_when_fallback_fails(monkeypatch):
+    service = SyncService(session=None)
+    service.client.get = AsyncMock(return_value=_Resp(403, "blocked"))
+    monkeypatch.setattr(
+        "app.services.sync_service.fetch_with_impersonation",
+        AsyncMock(return_value=None),
+    )
+    with pytest.raises(RuntimeError):
+        await service._fetch_feed_content("https://b.ex/feed")
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_seed_recent_content_inserts_bounded_slice(monkeypatch):
+    service = SyncService(session=None)
+    monkeypatch.setattr(service, "_fetch_feed_content", AsyncMock(return_value=_RSS))
+    saved = AsyncMock(return_value=True)
+    monkeypatch.setattr(service, "_save_content", saved)
+
+    source = Source(
+        id=uuid4(),
+        name="Blog",
+        url="https://b.ex",
+        feed_url="https://b.ex/feed",
+        type=SourceType.ARTICLE,
+    )
+    seeded = await service.seed_recent_content(source, max_items=10)
+    assert seeded == 2  # both feed entries saved
+    assert saved.await_count == 2
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_seed_recent_content_propagates_fetch_error(monkeypatch):
+    # A fetch failure must propagate so add_source() falls back to background.
+    service = SyncService(session=None)
+    monkeypatch.setattr(
+        service, "_fetch_feed_content", AsyncMock(side_effect=RuntimeError("boom"))
+    )
+    source = Source(
+        id=uuid4(),
+        name="Blog",
+        url="https://b.ex",
+        feed_url="https://b.ex/feed",
+        type=SourceType.ARTICLE,
+    )
+    with pytest.raises(RuntimeError):
+        await service.seed_recent_content(source)
+    await service.close()

--- a/packages/api/tests/services/test_wordpress_feed.py
+++ b/packages/api/tests/services/test_wordpress_feed.py
@@ -1,0 +1,86 @@
+"""Tests for the WordPress REST → synthetic RSS renderer (Story 12.2, T1b)."""
+
+import feedparser
+
+from app.services.wordpress_feed import (
+    internal_feed_base_url,
+    post_entries,
+    render_wp_rss,
+    wp_rest_posts_url,
+)
+
+_POSTS = [
+    {
+        "title": {"rendered": "Premier post &amp; suite"},
+        "link": "https://blog.example.com/1",
+        "guid": {"rendered": "https://blog.example.com/?p=1"},
+        "date_gmt": "2026-07-01T10:00:00",
+        "excerpt": {"rendered": "<p>Extrait 1</p>"},
+        "content": {
+            "rendered": "<p>Corps <img src='https://blog.example.com/i.jpg'></p>"
+        },
+    },
+    {
+        "title": {"rendered": "Deuxième"},
+        "link": "https://blog.example.com/2",
+        "date_gmt": "2026-06-30T09:00:00",
+        "excerpt": {"rendered": "Extrait 2"},
+        "content": {"rendered": "Corps 2"},
+    },
+]
+
+
+def test_wp_rest_posts_url_caps_per_page():
+    url = wp_rest_posts_url("https://blog.example.com/", 999)
+    assert url.startswith("https://blog.example.com/wp-json/wp/v2/posts?")
+    assert "per_page=50" in url  # capped at MAX_POSTS
+    assert "orderby=date" in url and "order=desc" in url
+
+
+def test_render_wp_rss_is_parseable():
+    xml = render_wp_rss(
+        "https://blog.example.com",
+        _POSTS,
+        site_name="Blog Example",
+        site_description="Un blog",
+    )
+    feed = feedparser.parse(xml)
+    assert not feed.bozo, feed.get("bozo_exception")
+    assert feed.feed.title == "Blog Example"
+    assert len(feed.entries) == 2
+    # HTML entities in the title are unescaped by the renderer.
+    assert feed.entries[0].title == "Premier post & suite"
+    assert feed.entries[0].link == "https://blog.example.com/1"
+    # content:encoded is preserved so SyncService can extract a thumbnail.
+    assert "i.jpg" in feed.entries[0].content[0].value
+
+
+def test_render_wp_rss_empty_posts():
+    xml = render_wp_rss("https://blog.example.com", [])
+    feed = feedparser.parse(xml)
+    assert not feed.bozo
+    assert feed.entries == []
+
+
+def test_post_entries_shape():
+    entries = post_entries(_POSTS, limit=1)
+    assert len(entries) == 1
+    assert entries[0]["title"] == "Premier post & suite"
+    assert entries[0]["link"] == "https://blog.example.com/1"
+    assert entries[0]["published_at"]  # RFC-822 string
+
+
+def test_internal_feed_base_url_defaults_none(monkeypatch):
+    # No setting + no RAILWAY_PUBLIC_DOMAIN → disabled (returns None).
+    monkeypatch.delenv("RAILWAY_PUBLIC_DOMAIN", raising=False)
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+    monkeypatch.setenv("INTERNAL_FEED_BASE_URL", "")
+    get_settings.cache_clear()
+    assert internal_feed_base_url() is None
+
+    # RAILWAY_PUBLIC_DOMAIN fallback.
+    monkeypatch.setenv("RAILWAY_PUBLIC_DOMAIN", "api-staging.up.railway.app")
+    assert internal_feed_base_url() == "https://api-staging.up.railway.app"
+    get_settings.cache_clear()

--- a/packages/api/tests/test_rescue.py
+++ b/packages/api/tests/test_rescue.py
@@ -1,0 +1,141 @@
+"""Tests for the rescue classification core (Story 12.2, T2)."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.services.rescue import (
+    FIXED_SINCE,
+    FOUND_BUT_ABANDONED,
+    INVALID,
+    NO_FEED,
+    RESOLVABLE_RSS,
+    Signal,
+    classify_all,
+    classify_signal,
+    infer_abandons,
+    is_invalid_input,
+    is_url_like,
+    merge_signal,
+    resolve_target,
+    signal_key,
+    summarize,
+)
+
+
+def _sig(text, kind, **kw):
+    return Signal(key=signal_key(text), input_text=text, kind=kind, **kw)
+
+
+def test_is_url_like():
+    assert is_url_like("https://usine-digitale.fr/rss")
+    assert is_url_like("monpetithoublon.com")
+    assert is_url_like("autobrasseur.fr/feed")
+    assert not is_url_like("mediapart")
+    assert not is_url_like("r/ai")
+
+
+def test_is_invalid_input_short_tokens():
+    assert is_invalid_input("ai")
+    assert is_invalid_input("vu")
+    assert not is_invalid_input("esa")  # 3 chars → not invalid
+    assert not is_invalid_input("mediapart")
+
+
+def test_signal_key_strips_tracking_and_dedupes():
+    # betterclinicianproject class: polluted URL collapses to the clean key.
+    k1 = signal_key("https://betterclinicianproject.com/?utm_source=x&fbclid=y")
+    k2 = signal_key("betterclinicianproject.com")
+    assert k1 == k2 == "betterclinicianproject.com"
+
+
+def test_url_resolvable_vs_no_feed():
+    # monpetithoublon / autobrasseur → resolvable via T1a WP curl-cffi.
+    assert classify_signal(_sig("monpetithoublon.com", "url"), True) == RESOLVABLE_RSS
+    # usine-digitale (DataDome) stays no_feed.
+    assert classify_signal(_sig("usine-digitale.fr", "url"), False) == NO_FEED
+
+
+def test_youtube_keyword_is_fixed_since():
+    # The #939 rafale: youtube-filtered zero-result searches.
+    assert (
+        classify_signal(_sig("micode", "keyword", content_type="youtube"), None)
+        == FIXED_SINCE
+    )
+
+
+def test_reddit_keyword_resolution():
+    assert classify_signal(_sig("r/ai", "keyword"), True) == RESOLVABLE_RSS
+    assert classify_signal(_sig("r/deadsub", "keyword"), False) == NO_FEED
+
+
+def test_found_but_abandoned_keyword():
+    sig = _sig("liberation", "keyword", max_result_count=3, abandoned=True)
+    assert classify_signal(sig, None) == FOUND_BUT_ABANDONED
+
+
+def test_invalid_keyword():
+    assert classify_signal(_sig("ai", "keyword"), None) == INVALID
+
+
+def test_resolve_target_reddit_and_url():
+    assert resolve_target(_sig("r/worldnews", "keyword")) == (
+        "https://www.reddit.com/r/worldnews/.rss"
+    )
+    assert resolve_target(_sig("autobrasseur.fr", "url")) == "https://autobrasseur.fr"
+    # A plain keyword is not resolvable offline.
+    assert resolve_target(_sig("mediapart", "keyword")) is None
+
+
+def test_merge_signal_folds_duplicates():
+    signals: dict = {}
+    merge_signal(signals, input_text="usine-digitale.fr", kind="url", user_id="u1")
+    merge_signal(
+        signals,
+        input_text="https://usine-digitale.fr/",
+        kind="url",
+        result_count=0,
+        user_id="u2",
+    )
+    assert len(signals) == 1
+    sig = next(iter(signals.values()))
+    assert sig.occurrences == 2
+    assert sig.user_ids == {"u1", "u2"}
+
+
+@pytest.mark.asyncio
+async def test_classify_all_and_summarize():
+    signals = [
+        _sig("usine-digitale.fr", "url"),
+        _sig("monpetithoublon.com", "url"),
+        _sig("micode", "keyword", content_type="youtube"),
+        _sig("ai", "keyword"),
+    ]
+
+    async def resolver(url: str) -> bool:
+        return "monpetithoublon" in url  # only this one resolves
+
+    classified = await classify_all(signals, resolver)
+    cats = {row["input_text"]: row["category"] for row in classified}
+    assert cats["usine-digitale.fr"] == NO_FEED
+    assert cats["monpetithoublon.com"] == RESOLVABLE_RSS
+    assert cats["micode"] == FIXED_SINCE
+    assert cats["ai"] == INVALID
+
+    summary = summarize(classified)
+    assert summary["by_category"][NO_FEED] == 1
+    assert summary["no_feed_hosts"] == ["usine-digitale.fr"]
+    assert summary["no_feed_host_count"] == 1
+
+
+def test_infer_abandons():
+    now = datetime(2026, 7, 1, 12, 0, tzinfo=UTC)
+    result_logs = [
+        {"user_id": "u1", "created_at": now, "query_normalized": "mediapart"},
+        {"user_id": "u2", "created_at": now, "query_normalized": "socialter"},
+    ]
+    # u1 added a source right after the search → not abandoned; u2 never added.
+    adds = [{"user_id": "u1", "added_at": now + timedelta(minutes=5)}]
+    inferred = infer_abandons(result_logs, adds)
+    assert len(inferred) == 1
+    assert inferred[0]["user_id"] == "u2"

--- a/packages/api/tests/test_rss_parser_wordpress.py
+++ b/packages/api/tests/test_rss_parser_wordpress.py
@@ -1,0 +1,157 @@
+"""Tests for URL normalization + WordPress detect() rungs (Story 12.2, T0.1/T1a/T1b)."""
+
+import socket
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.rss_parser import DetectedFeed, RSSParser, normalize_input_url
+
+_WP_HOME = (
+    "<html><head>"
+    '<meta name="generator" content="WordPress 6.5">'
+    "</head><body>hello</body></html>"
+)
+_WP_RSS = (
+    '<?xml version="1.0"?><rss version="2.0"><channel><title>Mon Blog</title>'
+    "<item><title>Post 1</title><link>https://blog.fr/1</link>"
+    "<guid>1</guid></item></channel></rss>"
+)
+
+
+class _FakeResp:
+    def __init__(self, status_code=200, text="", content_type="text/html"):
+        self.status_code = status_code
+        self.text = text
+        self.headers = {"content-type": content_type}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+@pytest.fixture
+def public_dns(monkeypatch):
+    def _getaddrinfo(*_a, **_k):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _getaddrinfo)
+
+
+# ─── T0.1 normalize_input_url (pure) ──────────────────────────────
+
+
+def test_normalize_strips_tracking_keeps_feed_param():
+    out = normalize_input_url(
+        "https://Example.com/blog?utm_source=nl&fbclid=x&feed=rss2#frag"
+    )
+    assert out == "https://example.com/blog?feed=rss2"
+
+
+def test_normalize_is_idempotent():
+    once = normalize_input_url("https://EX.com/?utm_medium=a&gclid=b")
+    assert normalize_input_url(once) == once == "https://ex.com/"
+
+
+def test_normalize_leaves_non_url_untouched():
+    assert normalize_input_url("mediapart") == "mediapart"
+    assert normalize_input_url("") == ""
+
+
+def test_normalize_preserves_port_and_path():
+    out = normalize_input_url("https://Host.COM:8443/Path/To?igshid=zz")
+    assert out == "https://host.com:8443/Path/To"
+
+
+# ─── T1a: WordPress canonical feed via curl-cffi (Stage 4b) ───────
+
+
+@pytest.mark.asyncio
+async def test_detect_wordpress_feed_via_curl_cffi(monkeypatch, public_dns):
+    parser = RSSParser()
+
+    async def fake_safe_get(url, **kwargs):
+        # Homepage → WP html (generator meta); every suffix probe → 404.
+        if url.rstrip("/") == "https://blog.fr":
+            return _FakeResp(200, _WP_HOME, "text/html")
+        return _FakeResp(404, "", "text/html")
+
+    monkeypatch.setattr(parser, "_safe_get", AsyncMock(side_effect=fake_safe_get))
+    # /feed/ is UA-blocked over httpx but recovered via curl-cffi.
+    monkeypatch.setattr(
+        parser, "_fetch_with_impersonation", AsyncMock(return_value=_WP_RSS)
+    )
+
+    detected = await parser.detect("https://blog.fr")
+    assert detected.feed_url == "https://blog.fr/feed/"
+    assert detected.title == "Mon Blog"
+    await parser.close()
+
+
+# ─── T1b: WordPress REST → synthetic internal feed (Stage 4c) ─────
+
+
+@pytest.mark.asyncio
+async def test_detect_wordpress_rest_synthetic(monkeypatch, public_dns):
+    parser = RSSParser()
+
+    async def fake_safe_get(url, **kwargs):
+        if url.rstrip("/") == "https://blog.fr":
+            return _FakeResp(200, _WP_HOME, "text/html")
+        return _FakeResp(404, "", "text/html")
+
+    monkeypatch.setattr(parser, "_safe_get", AsyncMock(side_effect=fake_safe_get))
+    # Canonical /feed/ truly gone → curl-cffi returns nothing.
+    monkeypatch.setattr(
+        parser, "_fetch_with_impersonation", AsyncMock(return_value=None)
+    )
+    # A self base URL is configured, and the REST API has posts.
+    monkeypatch.setattr(
+        "app.services.rss_parser.internal_feed_base_url",
+        lambda: "https://api-staging.example.app",
+    )
+    monkeypatch.setattr(
+        "app.services.rss_parser.fetch_wp_posts",
+        AsyncMock(
+            return_value=[
+                {
+                    "title": {"rendered": "P1"},
+                    "link": "https://blog.fr/1",
+                    "date_gmt": "2026-07-01T10:00:00",
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.rss_parser.fetch_wp_site_info",
+        AsyncMock(return_value={"name": "Blog FR", "description": "desc"}),
+    )
+
+    detected = await parser.detect("https://blog.fr")
+    assert detected.feed_url == (
+        "https://api-staging.example.app/internal/feed/wp?host=blog.fr"
+    )
+    assert detected.title == "Blog FR"
+    assert isinstance(detected, DetectedFeed)
+    await parser.close()
+
+
+@pytest.mark.asyncio
+async def test_detect_wordpress_rest_disabled_without_base_url(monkeypatch, public_dns):
+    parser = RSSParser()
+
+    async def fake_safe_get(url, **kwargs):
+        if url.rstrip("/") == "https://blog.fr":
+            return _FakeResp(200, _WP_HOME, "text/html")
+        return _FakeResp(404, "", "text/html")
+
+    monkeypatch.setattr(parser, "_safe_get", AsyncMock(side_effect=fake_safe_get))
+    monkeypatch.setattr(
+        parser, "_fetch_with_impersonation", AsyncMock(return_value=None)
+    )
+    # No self base URL → Stage 4c is skipped (no broken feed_url persisted).
+    monkeypatch.setattr("app.services.rss_parser.internal_feed_base_url", lambda: None)
+
+    with pytest.raises(ValueError, match="No RSS feed found"):
+        await parser.detect("https://blog.fr")
+    await parser.close()

--- a/packages/api/tests/workers/test_rescue_scheduler.py
+++ b/packages/api/tests/workers/test_rescue_scheduler.py
@@ -1,0 +1,34 @@
+"""The weekly rescue job is registered on the scheduler (Story 12.2, T3-job)."""
+
+from unittest.mock import Mock, patch
+
+from apscheduler.triggers.cron import CronTrigger
+
+from app.workers.scheduler import start_scheduler
+
+
+def test_rescue_job_registered_weekly():
+    with patch("app.workers.scheduler.AsyncIOScheduler") as mock_cls:
+        mock_scheduler = Mock()
+        mock_cls.return_value = mock_scheduler
+        captured: dict = {}
+
+        def capture(*args, **kwargs):
+            jid = kwargs.get("id")
+            if jid:
+                entry = dict(kwargs)
+                entry["func"] = args[0] if args else kwargs.get("func")
+                captured[jid] = entry
+
+        mock_scheduler.add_job = capture
+        start_scheduler()
+
+    assert "rescue_failed_sources" in captured
+    job = captured["rescue_failed_sources"]
+    assert job["func"].__name__ == "run_rescue_failed_sources"
+    trigger = job["trigger"]
+    assert isinstance(trigger, CronTrigger)
+    fields = {f.name: str(f) for f in trigger.fields}
+    assert fields["day_of_week"] == "mon"
+    assert fields["hour"] == "4"
+    assert fields["minute"] == "30"


### PR DESCRIPTION
## Quoi

Story 12.2 — **rescue des sources échouées + ingestion native**, sans migration
(feed synthétique interne, la DB prod partagée n'est pas touchée) :

- **Rescue** : script CLI lecture-seule + job hebdo qui rejouent et classifient
  les échecs d'ajout réels (`resolvable_rss` / `fixed_since` / `found_but_abandoned`
  / `no_feed` / `invalid`). Le compteur `no_feed` distinct est le **gate** de la
  décision Palier 2 (scraping), qui reste hors PR.
- **Rungs d'ingestion natifs** dans `detect()` : renfort WordPress + **WP REST
  synthétique** (`/internal/feed/wp`, router SSRF-gardé), normalisation d'URL en
  tête de cascade (strip `utm_*`/`fbclid`/…), suffixes permaliens plats, **gap
  Reddit** (`r/<sub>` → `.rss`).
- **Anti-bot au sync** : le fallback curl-cffi de `detect()` est porté dans
  `SyncService.process_source()` **uniquement en retry sur 403/marqueurs anti-bot**
  — un flux trouvé (anti-bot) à l'add ne meurt plus au refresh.
- **UX add mobile** : correspondances vérifiées clairement signalées + premiers
  articles affichés tout de suite (carte « Connecté » sans modale).
- **Qualité de log** : recherches `/detect` à 0 résultat loggées + fallback
  d'abandon côté serveur (meilleur échantillon pour la décision Palier 2).

## Pourquoi

Sur la fenêtre observable, les échecs d'ajout ne sont **pas** dominés par « sites
sans RSS » : la vraie population `URL → 0 flux` ≈ **4 sites** (1 seul dur,
DataDome — non-objectif assumé). Les vrais trous étaient WordPress REST, hygiène
d'URL, le gap Reddit et le refresh sync sans anti-bot. Cette PR comble ces trous
ciblés **bon marché** et instrumente la mesure, sans sur-dimensionner d'infra.

## Comment ça a été vérifié

- [x] `pytest` — **2196 passed**. (Les 15 échecs restants sont dans
  `tests/scripts/media_eval/` — bug de fixture FK pré-existant, **identique à
  `main`**, hors périmètre ; le fix vit sur la branche media-eval non mergée.)
  Tests story-12.2 ciblés verts : rescue, wordpress_feed, internal_feed,
  rss_parser_wordpress, reddit_gap, sync_antibot, rescue_scheduler.
- [x] `flutter test` (widgets touchés = 20 verts) + `flutter analyze` — **aucun
  problème** sur les fichiers modifiés.
- [x] Runtime : `uvicorn` + `curl` sur `/internal/feed/wp` — garde SSRF renvoie
  **400** (`127.0.0.1`/`localhost`), param manquant **422**.
- [x] Alembic : exactement **1 head**, **0 migration** ajoutée.
- [x] `/simplify` passé : dedup `scheme_host_root` + `_post_title`, `unawaited`
  haptic (refactors additifs, comportement inchangé).

## Zones à risque

- **Hot-path sync** (`SyncService.process_source`) : l'anti-bot retry est scoped
  au 403/marqueurs anti-bot, le chemin nominal 200 est inchangé.
- **Router interne** (`/internal/feed/wp`) : SSRF-gardé (`validate_url_for_fetch`)
  + rate-limit par hôte.
- **Scheduler** : nouveau job hebdo `rescue_failed_sources` (coexiste avec les
  jobs existants, conflit de merge résolu de façon additive).

## Suites / fast-follow (hors PR)

Régénération des configs veille existantes, sitemap (rung 4d), articles-tampons
enrichis, **Palier 2 (scraping) gated** sur le compteur `no_feed` du job hebdo.
