### PR TITLE
feat(mobile): bannière « souci côté device » + signal Sentry user_reported

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "App",
+      "summary": "Un petit signal quand un bug survient : dis-nous ce qui s'est passé et on saura."
+    },
+    {
       "tag": "Tournée",
       "summary": "Des suggestions de sources plus riches par thème, et un accès direct « Tout lire »."
     },

--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -20,8 +20,12 @@ import 'features/app_update/services/playstore_update_service.dart';
 import 'features/onboarding/providers/onboarding_sync_provider.dart';
 import 'features/settings/providers/theme_provider.dart';
 
+import 'package:sentry_flutter/sentry_flutter.dart';
+
 import 'core/api/api_client.dart' show ApiGoneNotifier;
+import 'core/errors/user_facing_error_notifier.dart';
 import 'core/ui/notification_service.dart';
+import 'core/ui/user_facing_error_banner.dart';
 
 const flanerForegroundRefreshThreshold = Duration(minutes: 30);
 
@@ -63,12 +67,16 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
     // les 410 et notifie via ApiGoneNotifier (singleton agnostique de
     // BuildContext).
     ApiGoneNotifier.instance.addListener(_onApiGoneEvent);
+    // Bannière « souci côté device » : le notifier (device-only, cooldowné)
+    // publie un évènement, on l'affiche via le ScaffoldMessenger global.
+    UserFacingErrorNotifier.instance.addListener(_onUserFacingError);
   }
 
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     ApiGoneNotifier.instance.removeListener(_onApiGoneEvent);
+    UserFacingErrorNotifier.instance.removeListener(_onUserFacingError);
     super.dispose();
   }
 
@@ -87,6 +95,70 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
     // Idempotent : on consomme l'event après affichage pour éviter le
     // re-trigger sur rebuild.
     ApiGoneNotifier.instance.clear();
+  }
+
+  void _onUserFacingError() {
+    final event = UserFacingErrorNotifier.instance.pendingEvent;
+    if (event == null) return;
+    final messenger = NotificationService.messengerKey.currentState;
+    if (messenger == null) {
+      UserFacingErrorNotifier.instance.clear();
+      return;
+    }
+    UserFacingErrorBanner.show(
+      messenger,
+      event,
+      onReport: () => _openUserErrorReportSheet(event),
+    );
+    // Consommé après affichage (évite le re-trigger sur rebuild).
+    UserFacingErrorNotifier.instance.clear();
+  }
+
+  void _openUserErrorReportSheet(UserFacingErrorEvent event) {
+    final context = NotificationService.navigatorKey.currentContext;
+    if (context == null) return;
+    unawaited(
+      UserFacingErrorBanner.showReportSheet(
+        context,
+        onSubmit: (comment) => _submitUserErrorReport(event, comment),
+      ),
+    );
+  }
+
+  Future<void> _submitUserErrorReport(
+    UserFacingErrorEvent event,
+    String comment,
+  ) async {
+    // Signal fort → Sentry, tagué user_reported pour l'alerte ops.
+    await Sentry.captureMessage(
+      'Bug signalé par l\'utilisateur',
+      level: SentryLevel.error,
+      withScope: (scope) {
+        scope.setTag('user_reported', 'true');
+        scope.setTag('source', event.source.tag);
+        scope.setContexts('user_error', {
+          'route': event.route ?? 'unknown',
+          'signature': event.signature,
+          if (event.detail != null) 'detail': event.detail,
+          'comment': comment,
+        });
+      },
+    );
+    // Agrégation funnel côté PostHog.
+    try {
+      await ref.read(posthogServiceProvider).capture(
+        event: 'user_error_reported',
+        properties: {
+          'source': event.source.tag,
+          'has_comment': comment.isNotEmpty,
+        },
+      );
+    } catch (_) {
+      // analytics best-effort
+    }
+    // Arme la fenêtre 24h → prochaines bannières en variante courte.
+    await UserFacingErrorNotifier.instance.markReported();
+    NotificationService.showSuccess('Merci, on regarde ça.');
   }
 
   @override

--- a/apps/mobile/lib/config/constants.dart
+++ b/apps/mobile/lib/config/constants.dart
@@ -308,6 +308,19 @@ class SentryConstants {
   static bool get isEnabled => dsn.isNotEmpty;
 }
 
+/// Kill-switch local (dark launch) de la bannière « souci côté device ».
+/// Off par défaut → shipping silencieux ; activation via build define
+/// `USER_ERROR_BANNER_ENABLED=true`. Un vrai remote-flag PostHog viendra en
+/// suivi (cf. plan, choix (b)).
+class UserErrorBannerConstants {
+  UserErrorBannerConstants._();
+
+  static const bool enabled = bool.fromEnvironment(
+    'USER_ERROR_BANNER_ENABLED',
+    defaultValue: false,
+  );
+}
+
 /// Story 22.1 — système d'intérêts unifié 4-états.
 /// Cap dur du nombre de favoris (intérêts ET sources, séparément).
 /// DOIT rester synchronisé avec `packages/api/app/constants.py::FAVORITE_CAP`.

--- a/apps/mobile/lib/core/api/api_client.dart
+++ b/apps/mobile/lib/core/api/api_client.dart
@@ -5,6 +5,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import '../../config/constants.dart';
 import '../auth/session_refresher.dart';
 import 'retry_interceptor.dart';
+import 'user_error_interceptor.dart';
 
 /// Notifier global pour les 410 Gone interceptés par [ApiClient].
 ///
@@ -231,6 +232,11 @@ class ApiClient {
         ],
       ),
     );
+
+    // 3. Interceptor « souci côté device » : remonte à l'utilisateur les 5xx /
+    // timeouts d'un appel opt-in (`extra['userFacing'] == true`), APRÈS les
+    // retries. Silencieux sinon.
+    _dio.interceptors.add(UserErrorInterceptor());
   }
 
   /// Extrait le champ `detail` d'une réponse d'erreur FastAPI (si dispo).

--- a/apps/mobile/lib/core/api/user_error_interceptor.dart
+++ b/apps/mobile/lib/core/api/user_error_interceptor.dart
@@ -1,0 +1,58 @@
+import 'package:dio/dio.dart';
+
+import '../errors/user_facing_error_notifier.dart';
+
+/// Clé `extra` Dio qui opt-in un appel à la remontée « souci côté device ».
+/// Posée par les repositories sur les appels déclenchés par un tap explicite,
+/// lue par [UserErrorInterceptor]. Constante partagée = anti-typo.
+const String kUserFacingExtraKey = 'userFacing';
+
+/// Interceptor Dio (dernier de la chaîne, après [RetryInterceptor]) qui remonte
+/// à l'utilisateur **uniquement** les erreurs d'un appel explicitement marqué
+/// `extra['userFacing'] == true` — c.-à-d. déclenché par un tap, pas un fetch
+/// de fond. Tout le reste continue à filer chez Sentry en silence.
+///
+/// Ne bloque jamais la chaîne : il notifie puis relaie l'erreur telle quelle.
+class UserErrorInterceptor extends Interceptor {
+  UserErrorInterceptor({UserFacingErrorNotifier? notifier})
+      : _notifier = notifier ?? UserFacingErrorNotifier.instance;
+
+  final UserFacingErrorNotifier _notifier;
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) {
+    final source = _classify(err);
+    final userFacing = err.requestOptions.extra[kUserFacingExtraKey] == true;
+    if (source != null && userFacing) {
+      final route = err.requestOptions.path;
+      final statusPart = err.response?.statusCode?.toString() ?? err.type.name;
+      // fire-and-forget : la logique de cooldown vit dans le notifier.
+      _notifier.report(
+        source: source,
+        signature: '${source.tag}|$statusPart|$route',
+        route: route,
+        detail: statusPart,
+      );
+    }
+    handler.next(err);
+  }
+
+  /// Mappe une DioException vers une source whitelistée, ou `null` si elle ne
+  /// doit jamais remonter à l'utilisateur (4xx, 401, annulation, etc.).
+  UserErrorSource? _classify(DioException err) {
+    switch (err.type) {
+      case DioExceptionType.connectionTimeout:
+      case DioExceptionType.receiveTimeout:
+      case DioExceptionType.sendTimeout:
+        return UserErrorSource.timeout;
+      case DioExceptionType.badResponse:
+        final code = err.response?.statusCode;
+        if (code != null && code >= 500 && code < 600) {
+          return UserErrorSource.http5xx;
+        }
+        return null;
+      default:
+        return null;
+    }
+  }
+}

--- a/apps/mobile/lib/core/errors/user_facing_error_notifier.dart
+++ b/apps/mobile/lib/core/errors/user_facing_error_notifier.dart
@@ -1,0 +1,179 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Source déclenchante d'une bannière « un truc s'est mal passé ».
+///
+/// Whitelist stricte (anti-faux-positif) : seuls ces cas remontent à
+/// l'utilisateur. Tout le reste continue à filer chez Sentry en silence.
+enum UserErrorSource { flutterError, http5xx, timeout }
+
+extension UserErrorSourceTag on UserErrorSource {
+  /// Valeur de tag Sentry / PostHog (stable, snake_case).
+  String get tag => switch (this) {
+        UserErrorSource.flutterError => 'flutter_error',
+        UserErrorSource.http5xx => 'http_5xx',
+        UserErrorSource.timeout => 'timeout',
+      };
+}
+
+/// Évènement « bannière à afficher » consommé par le wiring root (app.dart).
+@immutable
+class UserFacingErrorEvent {
+  const UserFacingErrorEvent({
+    required this.source,
+    required this.signature,
+    this.route,
+    this.detail,
+    this.shortAck = false,
+  });
+
+  final UserErrorSource source;
+
+  /// Hash `(source, statusCode|exceptionType, route)` — sert au cooldown
+  /// par-signature ET de contexte Sentry.
+  final String signature;
+
+  /// Route logique où l'erreur s'est produite (best-effort).
+  final String? route;
+
+  /// Contexte court, déjà rédigé/redacted, joint au rapport Sentry.
+  final String? detail;
+
+  /// `true` → variante ultra-discrète « on est au courant, merci » (l'user a
+  /// déjà signalé récemment ; pas de CTA, auto-dismiss court).
+  final bool shortAck;
+}
+
+/// Notifier global (singleton, agnostique de BuildContext — même forme que
+/// `ApiGoneNotifier`) qui centralise la logique de cooldown avant d'exposer
+/// un [UserFacingErrorEvent] à l'UI top-level.
+///
+/// Toute la plomberie de fréquence vit ici pour rester testable sans widget :
+/// un clock et une instance SharedPreferences sont injectables.
+class UserFacingErrorNotifier extends ChangeNotifier {
+  UserFacingErrorNotifier._();
+  static final UserFacingErrorNotifier instance = UserFacingErrorNotifier._();
+
+  /// Constructeur de test : clock + prefs injectés, kill-switch forçable.
+  @visibleForTesting
+  UserFacingErrorNotifier.forTesting({
+    required Future<SharedPreferences> Function() prefs,
+    required DateTime Function() now,
+    bool enabled = true,
+  })  : _prefsLoader = prefs,
+        _now = now,
+        _enabled = enabled;
+
+  // --- Cooldowns (LOCKED, cf. plan) ------------------------------------
+  static const Duration _globalCooldown = Duration(minutes: 5);
+  static const Duration _signatureCooldown = Duration(minutes: 30);
+  static const Duration _reportShortAckWindow = Duration(hours: 24);
+
+  static const String _kLastShownAt = 'user_error_banner_last_shown_at';
+  static const String _kReportLastSentAt = 'user_error_report_last_sent_at';
+  static const String _kSigPrefix = 'user_error_sig_';
+
+  Future<SharedPreferences> Function() _prefsLoader =
+      SharedPreferences.getInstance;
+  DateTime Function() _now = DateTime.now;
+
+  /// Kill-switch : off par défaut (dark launch). Réglé au boot via
+  /// [configureEnabled] (aligné sur `UserErrorBannerConstants.enabled`),
+  /// forçable en test.
+  bool _enabled = false;
+
+  /// Garde synchrone anti-tempête : évite que N erreurs par-frame lancent N
+  /// I/O prefs concurrentes avant que le premier cooldown ne soit persisté.
+  bool _reportInFlight = false;
+
+  UserFacingErrorEvent? _pendingEvent;
+  UserFacingErrorEvent? get pendingEvent => _pendingEvent;
+
+  /// Branche le kill-switch de build (appelé une fois au boot).
+  void configureEnabled(bool enabled) {
+    _enabled = enabled;
+  }
+
+  /// Point d'entrée unique des 3 sources whitelistées. Applique les cooldowns
+  /// puis publie un évènement si la bannière doit s'afficher. No-op silencieux
+  /// sinon (kill-switch off, cooldown actif, etc.).
+  Future<void> report({
+    required UserErrorSource source,
+    required String signature,
+    String? route,
+    String? detail,
+  }) async {
+    if (!_enabled) return;
+    if (_reportInFlight) return;
+    _reportInFlight = true;
+    try {
+      final SharedPreferences prefs;
+      try {
+        prefs = await _prefsLoader();
+      } catch (_) {
+        // Prefs indisponibles → on n'affiche rien plutôt que de risquer un spam.
+        return;
+      }
+      final now = _now();
+
+      // 1. Cooldown par-signature (30 min) — muet si même souci récent.
+      final sigKey = '$_kSigPrefix${_hash(signature)}';
+      if (_within(prefs.getInt(sigKey), now, _signatureCooldown)) return;
+
+      // 2. Cooldown global (5 min) — au plus une bannière par fenêtre.
+      if (_within(prefs.getInt(_kLastShownAt), now, _globalCooldown)) return;
+
+      // 3. Variante « déjà signalé récemment » (24h) → ack ultra-discret.
+      final shortAck =
+          _within(prefs.getInt(_kReportLastSentAt), now, _reportShortAckWindow);
+
+      final ms = now.millisecondsSinceEpoch;
+      await prefs.setInt(sigKey, ms);
+      await prefs.setInt(_kLastShownAt, ms);
+
+      _pendingEvent = UserFacingErrorEvent(
+        source: source,
+        signature: signature,
+        route: route,
+        detail: detail,
+        shortAck: shortAck,
+      );
+      notifyListeners();
+    } finally {
+      _reportInFlight = false;
+    }
+  }
+
+  /// À appeler après un envoi « Nous dire » réussi : arme la fenêtre 24h qui
+  /// bascule les prochaines bannières en variante courte.
+  Future<void> markReported() async {
+    try {
+      final prefs = await _prefsLoader();
+      await prefs.setInt(_kReportLastSentAt, _now().millisecondsSinceEpoch);
+    } catch (_) {
+      // best-effort
+    }
+  }
+
+  /// Consomme l'évènement après affichage (évite le re-trigger sur rebuild).
+  void clear() {
+    if (_pendingEvent == null) return;
+    _pendingEvent = null;
+    notifyListeners();
+  }
+
+  bool _within(int? lastMs, DateTime now, Duration window) {
+    if (lastMs == null) return false;
+    final elapsed = now.difference(DateTime.fromMillisecondsSinceEpoch(lastMs));
+    return !elapsed.isNegative && elapsed < window;
+  }
+
+  /// Hash stable et court d'une signature (clé SharedPrefs bornée).
+  String _hash(String signature) {
+    var h = 0;
+    for (final code in signature.codeUnits) {
+      h = (h * 31 + code) & 0x7fffffff;
+    }
+    return h.toRadixString(16);
+  }
+}

--- a/apps/mobile/lib/core/ui/user_facing_error_banner.dart
+++ b/apps/mobile/lib/core/ui/user_facing_error_banner.dart
@@ -1,0 +1,189 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../../config/theme.dart';
+import '../errors/user_facing_error_notifier.dart';
+import 'notification_service.dart';
+
+/// UI (pure, sans Riverpod) de la bannière « un truc s'est mal passé » et de
+/// sa feuille de report 1-champ. Les effets de bord (Sentry, PostHog,
+/// `markReported`) sont injectés par le wiring root — cf. `app.dart`.
+class UserFacingErrorBanner {
+  UserFacingErrorBanner._();
+
+  static Timer? _autoHideTimer;
+
+  /// Affiche la [MaterialBanner] discrète en bas de la messagerie globale.
+  ///
+  /// - Variante standard : texte + CTA souligné « Nous dire » + ✕, auto-dismiss 8s.
+  /// - Variante [UserFacingErrorEvent.shortAck] : ack court sans CTA, 1,5s.
+  static void show(
+    ScaffoldMessengerState messenger,
+    UserFacingErrorEvent event, {
+    required VoidCallback onReport,
+  }) {
+    _autoHideTimer?.cancel();
+    messenger.hideCurrentMaterialBanner();
+
+    final context = NotificationService.messengerKey.currentContext;
+    final colors = context?.facteurColors;
+    final surface = colors?.surface ?? const Color(0xFF1E1E1E);
+    final border = colors?.border ?? const Color(0xFF3A3A3A);
+    final textPrimary = colors?.textPrimary ?? Colors.white;
+    final textSecondary = colors?.textSecondary ?? Colors.white70;
+    final accent = colors?.primary ?? const Color(0xFFD35400);
+
+    void dismiss() {
+      _autoHideTimer?.cancel();
+      messenger.hideCurrentMaterialBanner();
+    }
+
+    final message = event.shortAck
+        ? 'On est au courant, merci.'
+        : 'Un truc s\'est mal passé de notre côté.';
+
+    messenger.showMaterialBanner(
+      MaterialBanner(
+        backgroundColor: surface,
+        elevation: 0,
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        content: Container(
+          decoration: BoxDecoration(
+            border: Border(top: BorderSide(color: border)),
+          ),
+          padding: const EdgeInsets.only(top: 8),
+          child: Text(
+            message,
+            style: FacteurTypography.bodySmall(
+              event.shortAck ? textSecondary : textPrimary,
+            ),
+          ),
+        ),
+        actions: event.shortAck
+            ? const [SizedBox.shrink()]
+            : [
+                TextButton(
+                  onPressed: () {
+                    dismiss();
+                    onReport();
+                  },
+                  child: Text(
+                    'Nous dire',
+                    style: FacteurTypography.labelMedium(accent).copyWith(
+                      decoration: TextDecoration.underline,
+                    ),
+                  ),
+                ),
+                IconButton(
+                  visualDensity: VisualDensity.compact,
+                  icon: Icon(Icons.close, size: 18, color: textSecondary),
+                  onPressed: dismiss,
+                ),
+              ],
+      ),
+    );
+
+    _autoHideTimer = Timer(
+      event.shortAck
+          ? const Duration(milliseconds: 1500)
+          : const Duration(seconds: 8),
+      dismiss,
+    );
+  }
+
+  /// Feuille basse 1-champ « Qu'est-ce qui s'est passé ? ». Le commentaire est
+  /// optionnel. [onSubmit] reçoit le texte saisi (peut être vide).
+  static Future<void> showReportSheet(
+    BuildContext context, {
+    required Future<void> Function(String comment) onSubmit,
+  }) {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (sheetContext) => _ReportSheet(onSubmit: onSubmit),
+    );
+  }
+}
+
+class _ReportSheet extends StatefulWidget {
+  const _ReportSheet({required this.onSubmit});
+
+  final Future<void> Function(String comment) onSubmit;
+
+  @override
+  State<_ReportSheet> createState() => _ReportSheetState();
+}
+
+class _ReportSheetState extends State<_ReportSheet> {
+  final _controller = TextEditingController();
+  bool _sending = false;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (_sending) return;
+    setState(() => _sending = true);
+    final comment = _controller.text.trim();
+    try {
+      await widget.onSubmit(comment);
+    } finally {
+      if (mounted) Navigator.of(context).pop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+      ),
+      child: Container(
+        decoration: BoxDecoration(
+          color: colors.surface,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+        ),
+        padding: const EdgeInsets.fromLTRB(20, 16, 20, 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              'Qu\'est-ce qui s\'est passé ?',
+              style: FacteurTypography.bodyLarge(colors.textPrimary),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _controller,
+              autofocus: true,
+              maxLines: 2,
+              maxLength: 200,
+              enabled: !_sending,
+              style: FacteurTypography.bodyMedium(colors.textPrimary),
+              decoration: const InputDecoration(
+                hintText: 'Optionnel — ce que tu faisais, ce qui a bugué.',
+              ),
+            ),
+            const SizedBox(height: 8),
+            FilledButton(
+              onPressed: _sending ? null : _submit,
+              child: _sending
+                  ? const SizedBox(
+                      height: 18,
+                      width: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Envoyer'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/digest/repositories/digest_repository.dart
+++ b/apps/mobile/lib/features/digest/repositories/digest_repository.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import '../../../core/api/api_client.dart';
+import '../../../core/api/user_error_interceptor.dart' show kUserFacingExtraKey;
 import '../models/digest_models.dart';
 import '../models/dual_digest_response.dart';
 
@@ -296,6 +297,8 @@ class DigestRepository {
           'reasons': reasons,
           if (comment != null) 'comment': comment,
         },
+        // Tap explicite (pouce) → remonter les 5xx/timeouts à l'utilisateur.
+        options: Options(extra: {kUserFacingExtraKey: true}),
       );
     } catch (e) {
       // Fail silently — feedback should never block the digest flow
@@ -306,7 +309,11 @@ class DigestRepository {
 
   /// Report an article as not serene (misclassified)
   Future<void> reportNotSerene(String contentId) async {
-    await _apiClient.dio.post<dynamic>('contents/$contentId/report-not-serene');
+    await _apiClient.dio.post<dynamic>(
+      'contents/$contentId/report-not-serene',
+      // Tap « Signaler » → l'utilisateur attend un retour ; opt-in bannière.
+      options: Options(extra: {kUserFacingExtraKey: true}),
+    );
   }
 
   /// Update a user preference (key-value)

--- a/apps/mobile/lib/features/feedback/repositories/feedback_repository.dart
+++ b/apps/mobile/lib/features/feedback/repositories/feedback_repository.dart
@@ -1,4 +1,7 @@
+import 'package:dio/dio.dart';
+
 import '../../../core/api/api_client.dart';
+import '../../../core/api/user_error_interceptor.dart' show kUserFacingExtraKey;
 import '../models/feedback_models.dart';
 
 /// Repository pour le système de feedback utilisateur (Epic 13).
@@ -20,6 +23,8 @@ class FeedbackRepository {
           if (date != null)
             'digest_date': date.toIso8601String().split('T').first,
         },
+        // Tap emoji → l'utilisateur attend un retour ; opt-in bannière souci.
+        options: Options(extra: {kUserFacingExtraKey: true}),
       );
     } catch (e) {
       // ignore: avoid_print

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:io' show Platform;
 import 'package:app_links/app_links.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb, kDebugMode;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -23,6 +23,7 @@ import 'core/services/deep_link_service.dart';
 import 'core/services/posthog_service.dart';
 import 'core/services/push_notification_service.dart';
 import 'core/services/server_push_service.dart';
+import 'core/errors/user_facing_error_notifier.dart';
 import 'core/ui/notification_service.dart';
 import 'features/flux_continu/services/tournee_progress_service.dart';
 
@@ -54,8 +55,45 @@ Future<void> main() async {
   }
 }
 
+/// Chaîne un handler « souci côté device » sur le [FlutterError.onError] déjà
+/// posé par SentryFlutter : on préserve la remontée Sentry, puis on notifie
+/// l'utilisateur *uniquement* si l'exception vient d'un frame build/paint
+/// (écran cassé effectivement vu). Filtres : AssertionError debug + `silent`.
+void _installUserFacingErrorHook() {
+  const enabled = UserErrorBannerConstants.enabled;
+  UserFacingErrorNotifier.instance.configureEnabled(enabled);
+  // Dark launch : tant que le kill-switch est off (défaut de shipping), on
+  // n'installe même pas le wrapper — zéro travail sur le hot path par-frame.
+  if (!enabled) return;
+
+  final previous = FlutterError.onError;
+  FlutterError.onError = (FlutterErrorDetails details) {
+    previous?.call(details);
+
+    if (details.silent) return;
+    if (kDebugMode && details.exception is AssertionError) return;
+
+    final lib = details.library ?? '';
+    final fromUiTree =
+        lib.contains('widgets library') || lib.contains('rendering library');
+    if (!fromUiTree) return;
+
+    final type = details.exception.runtimeType.toString();
+    unawaited(
+      UserFacingErrorNotifier.instance.report(
+        source: UserErrorSource.flutterError,
+        signature: 'flutter_error|$type|$lib',
+        route: lib,
+        detail: type,
+      ),
+    );
+  };
+}
+
 Future<void> _bootstrap() async {
   final bootSw = Stopwatch()..start();
+
+  _installUserFacingErrorHook();
 
   timeago.setLocaleMessages('fr', fr_messages.FrMessages());
   timeago.setLocaleMessages('fr_short', FrCompactMessages());

--- a/apps/mobile/test/core/api/user_error_interceptor_test.dart
+++ b/apps/mobile/test/core/api/user_error_interceptor_test.dart
@@ -1,0 +1,129 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:facteur/core/api/user_error_interceptor.dart';
+import 'package:facteur/core/errors/user_facing_error_notifier.dart';
+
+/// Notifier qui enregistre les appels [report] au lieu d'appliquer les cooldowns.
+class _RecordingNotifier extends UserFacingErrorNotifier {
+  _RecordingNotifier()
+      : super.forTesting(
+          prefs: SharedPreferences.getInstance,
+          now: () => DateTime(2026, 7, 10),
+        );
+
+  final List<UserErrorSource> reported = [];
+
+  @override
+  Future<void> report({
+    required UserErrorSource source,
+    required String signature,
+    String? route,
+    String? detail,
+  }) async {
+    reported.add(source);
+  }
+}
+
+/// Handler minimal qui note si [next] a bien été appelé (relais non bloquant).
+class _FakeHandler implements ErrorInterceptorHandler {
+  bool nextCalled = false;
+
+  @override
+  void next(DioException err) => nextCalled = true;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _RecordingNotifier notifier;
+  late UserErrorInterceptor interceptor;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    notifier = _RecordingNotifier();
+    interceptor = UserErrorInterceptor(notifier: notifier);
+  });
+
+  DioException dioError({
+    required DioExceptionType type,
+    int? statusCode,
+    bool userFacing = false,
+  }) {
+    final options = RequestOptions(
+      path: '/api/x',
+      extra: userFacing ? {'userFacing': true} : {},
+    );
+    return DioException(
+      requestOptions: options,
+      type: type,
+      response: statusCode == null
+          ? null
+          : Response(requestOptions: options, statusCode: statusCode),
+    );
+  }
+
+  test('500 + userFacing → report http5xx', () async {
+    final handler = _FakeHandler();
+    interceptor.onError(
+      dioError(
+        type: DioExceptionType.badResponse,
+        statusCode: 500,
+        userFacing: true,
+      ),
+      handler,
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(notifier.reported, [UserErrorSource.http5xx]);
+    expect(handler.nextCalled, isTrue);
+  });
+
+  test('500 SANS userFacing → silence', () async {
+    final handler = _FakeHandler();
+    interceptor.onError(
+      dioError(type: DioExceptionType.badResponse, statusCode: 500),
+      handler,
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(notifier.reported, isEmpty);
+    expect(handler.nextCalled, isTrue);
+  });
+
+  test('404 + userFacing → silence (pas un 5xx)', () async {
+    final handler = _FakeHandler();
+    interceptor.onError(
+      dioError(
+        type: DioExceptionType.badResponse,
+        statusCode: 404,
+        userFacing: true,
+      ),
+      handler,
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(notifier.reported, isEmpty);
+  });
+
+  test('timeout + userFacing → report timeout', () async {
+    final handler = _FakeHandler();
+    interceptor.onError(
+      dioError(type: DioExceptionType.receiveTimeout, userFacing: true),
+      handler,
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(notifier.reported, [UserErrorSource.timeout]);
+  });
+
+  test('timeout SANS userFacing → silence', () async {
+    final handler = _FakeHandler();
+    interceptor.onError(
+      dioError(type: DioExceptionType.receiveTimeout),
+      handler,
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(notifier.reported, isEmpty);
+  });
+}

--- a/apps/mobile/test/core/errors/user_facing_error_notifier_test.dart
+++ b/apps/mobile/test/core/errors/user_facing_error_notifier_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:facteur/core/errors/user_facing_error_notifier.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late DateTime clock;
+
+  UserFacingErrorNotifier makeNotifier({bool enabled = true}) {
+    return UserFacingErrorNotifier.forTesting(
+      prefs: SharedPreferences.getInstance,
+      now: () => clock,
+      enabled: enabled,
+    );
+  }
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    clock = DateTime(2026, 7, 10, 12, 0, 0);
+  });
+
+  test('publie un évènement au premier signalement', () async {
+    final notifier = makeNotifier();
+    var notified = 0;
+    notifier.addListener(() => notified++);
+
+    await notifier.report(
+      source: UserErrorSource.http5xx,
+      signature: 'http_5xx|500|/api/x',
+      route: '/api/x',
+    );
+
+    expect(notifier.pendingEvent, isNotNull);
+    expect(notifier.pendingEvent!.source, UserErrorSource.http5xx);
+    expect(notifier.pendingEvent!.shortAck, isFalse);
+    expect(notified, 1);
+  });
+
+  test('kill-switch off → aucun évènement', () async {
+    final notifier = makeNotifier(enabled: false);
+    await notifier.report(
+      source: UserErrorSource.http5xx,
+      signature: 'http_5xx|500|/api/x',
+    );
+    expect(notifier.pendingEvent, isNull);
+  });
+
+  test('cooldown global 5 min : 2e souci (autre signature) muet', () async {
+    final notifier = makeNotifier();
+
+    await notifier.report(source: UserErrorSource.http5xx, signature: 'a');
+    notifier.clear();
+
+    clock = clock.add(const Duration(minutes: 3));
+    await notifier.report(source: UserErrorSource.timeout, signature: 'b');
+    expect(notifier.pendingEvent, isNull);
+
+    clock = clock.add(const Duration(minutes: 3)); // > 5 min cumulés
+    await notifier.report(source: UserErrorSource.timeout, signature: 'c');
+    expect(notifier.pendingEvent, isNotNull);
+  });
+
+  test('cooldown par-signature 30 min : même signature muette', () async {
+    final notifier = makeNotifier();
+
+    await notifier.report(source: UserErrorSource.http5xx, signature: 'sig');
+    notifier.clear();
+
+    // Au-delà du global (5 min) mais sous le per-signature (30 min).
+    clock = clock.add(const Duration(minutes: 10));
+    await notifier.report(source: UserErrorSource.http5xx, signature: 'sig');
+    expect(notifier.pendingEvent, isNull);
+
+    clock = clock.add(const Duration(minutes: 25)); // > 30 min
+    await notifier.report(source: UserErrorSource.http5xx, signature: 'sig');
+    expect(notifier.pendingEvent, isNotNull);
+  });
+
+  test('markReported → variante shortAck sous 24h', () async {
+    final notifier = makeNotifier();
+    await notifier.markReported();
+
+    clock = clock.add(const Duration(hours: 2));
+    await notifier.report(source: UserErrorSource.timeout, signature: 'x');
+    expect(notifier.pendingEvent!.shortAck, isTrue);
+  });
+
+  test('au-delà de 24h → variante standard', () async {
+    final notifier = makeNotifier();
+    await notifier.markReported();
+
+    clock = clock.add(const Duration(hours: 25));
+    await notifier.report(source: UserErrorSource.timeout, signature: 'x');
+    expect(notifier.pendingEvent!.shortAck, isFalse);
+  });
+}

--- a/apps/mobile/test/core/ui/user_facing_error_banner_test.dart
+++ b/apps/mobile/test/core/ui/user_facing_error_banner_test.dart
@@ -1,0 +1,88 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/core/errors/user_facing_error_notifier.dart';
+import 'package:facteur/core/ui/notification_service.dart';
+import 'package:facteur/core/ui/user_facing_error_banner.dart';
+
+void main() {
+  Widget harness() {
+    return MaterialApp(
+      theme: FacteurTheme.lightTheme,
+      scaffoldMessengerKey: NotificationService.messengerKey,
+      navigatorKey: NotificationService.navigatorKey,
+      home: const Scaffold(body: SizedBox.expand()),
+    );
+  }
+
+  testWidgets('bannière standard : message + CTA « Nous dire »',
+      (tester) async {
+    await tester.pumpWidget(harness());
+    var reportTapped = false;
+
+    UserFacingErrorBanner.show(
+      NotificationService.messengerKey.currentState!,
+      const UserFacingErrorEvent(
+        source: UserErrorSource.http5xx,
+        signature: 'sig',
+      ),
+      onReport: () => reportTapped = true,
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300)); // entrée slide-in
+
+    expect(find.text('Un truc s\'est mal passé de notre côté.'), findsOneWidget);
+    expect(find.text('Nous dire'), findsOneWidget);
+
+    await tester.tap(find.text('Nous dire'));
+    await tester.pump();
+    expect(reportTapped, isTrue);
+  });
+
+  testWidgets('variante shortAck : ack court, pas de CTA', (tester) async {
+    await tester.pumpWidget(harness());
+
+    UserFacingErrorBanner.show(
+      NotificationService.messengerKey.currentState!,
+      const UserFacingErrorEvent(
+        source: UserErrorSource.timeout,
+        signature: 'sig',
+        shortAck: true,
+      ),
+      onReport: () {},
+    );
+    await tester.pump();
+
+    expect(find.text('On est au courant, merci.'), findsOneWidget);
+    expect(find.text('Nous dire'), findsNothing);
+
+    // Laisse l'auto-dismiss (1,5s) fermer la bannière → pas de timer pendant.
+    await tester.pump(const Duration(milliseconds: 1500));
+    await tester.pump();
+    expect(find.text('On est au courant, merci.'), findsNothing);
+  });
+
+  testWidgets('feuille de report : saisie + Envoyer déclenche onSubmit',
+      (tester) async {
+    await tester.pumpWidget(harness());
+    String? submitted;
+
+    unawaited(
+      UserFacingErrorBanner.showReportSheet(
+        NotificationService.navigatorKey.currentContext!,
+        onSubmit: (comment) async => submitted = comment,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Qu\'est-ce qui s\'est passé ?'), findsOneWidget);
+    await tester.enterText(find.byType(TextField), 'écran blanc');
+    await tester.tap(find.text('Envoyer'));
+    await tester.pumpAndSettle();
+
+    expect(submitted, 'écran blanc');
+  });
+}

--- a/docs/runbooks/sentry-user-reported-alert.md
+++ b/docs/runbooks/sentry-user-reported-alert.md
@@ -1,0 +1,43 @@
+# Runbook — Alerte Sentry « bug signalé par l'utilisateur »
+
+> Configuration **manuelle dans Sentry** (hors code app). Complète la feature
+> micro-toast « souci côté device » (device-only, cf. la bannière
+> `UserFacingErrorBanner`).
+
+## Contexte
+
+Quand un utilisateur tape « Nous dire » sur la bannière et envoie, l'app émet :
+
+- un event **Sentry** `Bug signalé par l'utilisateur` (`level: error`) avec les
+  tags `user_reported:true`, `source:<flutter_error|http_5xx|timeout>` et un
+  contexte `user_error` (`route`, `signature`, `detail`, `comment`) ;
+- un event **PostHog** `user_error_reported` (funnel, propriétés `source`,
+  `has_comment`).
+
+Ces events sont le **signal fort** : ils distinguent les vrais bugs UX vécus du
+bruit Sentry ambiant.
+
+## Config de l'alerte (Sentry)
+
+1. **Saved search** : `user_reported:true` (Issues → Custom Search → Save).
+2. **Alert rule** (Alerts → Create Alert → Issues) :
+   - *When* : `An event is seen`
+   - *If* : `The event's tags match user_reported equals true`
+   - *Threshold* : `number of events` **≥ 3 in 24h** sur la même issue.
+   - *Then* : notifier le canal **Slack #ops** (ou email équipe).
+3. Nommer la règle `user-reported bug spike` et l'activer sur les environnements
+   `production` **et** `staging`.
+
+## Kill-switch app
+
+La bannière est en **dark launch** : `UserErrorBannerConstants.enabled` = `false`
+par défaut. Pour l'activer, builder avec
+`--dart-define=USER_ERROR_BANNER_ENABLED=true` (activation progressive : un canal
+d'abord, monitorer le volume `user_reported:true` sur 48h avant généralisation).
+
+Un vrai remote-flag PostHog remplacera ce define en suivi (choix (b) du plan V1).
+
+## Vérif rapide
+
+Forcer un 500 sur un appel opt-in (`extra['userFacing']`) → bannière → tap
+« Nous dire » → envoi → l'event doit apparaître dans la saved search en < 1 min.


### PR DESCRIPTION
## Quoi

Une bannière discrète « un truc s'est mal passé de notre côté » qui remonte à
l'utilisateur une **whitelist stricte** d'erreurs vécues : `FlutterError`
build/paint (écran cassé effectivement vu), HTTP 5xx et timeouts d'appels
déclenchés par un tap. Le CTA « Nous dire » ouvre une feuille 1-champ et émet un
event **Sentry** `user_reported:true` + **PostHog** `user_error_reported`.

## Pourquoi

Le bruit Sentry ambiant noie les vrais bugs UX. Ce signal fort — « un humain a
vu quelque chose casser et a pris la peine de le dire » — permet de prioriser.
La feature est en **dark launch** (`USER_ERROR_BANNER_ENABLED` off par défaut) ;
un runbook décrit la config de l'alerte Sentry côté ops.

## Comment ça marche

- **Notifier singleton** agnostique de BuildContext (même forme que
  `ApiGoneNotifier`), toute la logique de cooldown testable hors widget :
  5 min global · 30 min par-signature · ack ultra-court 24h après un report.
- **Interceptor Dio** en fin de chaîne (après les retries) : ne remonte que les
  appels marqués `extra[kUserFacingExtraKey]` (feedback article, sentiment,
  report-not-serene). Silencieux pour tout fetch de fond.
- **Hook `FlutterError.onError`** chaîné sur celui de SentryFlutter (Sentry
  préservé) ; **non installé du tout quand le kill-switch est off** → zéro
  travail sur le hot path par-frame en shipping.
- **UI pure** (`UserFacingErrorBanner`) sans Riverpod ; effets de bord
  (Sentry/PostHog/`markReported`) injectés par le wiring root.

## Comment ça a été vérifié

- [x] `flutter test` — 14 nouveaux tests (notifier cooldowns + kill-switch,
      interceptor whitelist, bannière + feuille de report) OK.
- [x] `flutter analyze` sur les fichiers touchés — 0 issue introduite
      (seul reste l'import `timeago/src` pré-existant).
- [x] Tests des zones touchées (digest / feedback) OK — les 6 échecs restants
      sont des placeholders `fail('Test not implemented')` pré-existants dans
      `bookmark_test.dart`, sans lien avec ce diff.
- [x] `/simplify` passé (kill-switch collapsé, hot path gardé, constante
      partagée `kUserFacingExtraKey`, garde synchrone anti-tempête).

## Zones à risque

- `main.dart` — chaînage sur `FlutterError.onError` (préserve le handler Sentry
  existant ; hook non installé si feature off).
- `api_client.dart` — nouvel interceptor ajouté en fin de chaîne Dio.
- Aucune migration, aucun changement backend.

## Changelog

Entrée `unreleased` ajoutée (tag « App »).
