### PR TITLE
fix(sources): Basket USA classée « tech » — corrige _guess_theme + reclasse la donnée

### DIFF
--- a/packages/api/app/services/source_service.py
+++ b/packages/api/app/services/source_service.py
@@ -1,5 +1,6 @@
 """Service source."""
 
+import re
 from datetime import UTC, datetime, timedelta
 from uuid import UUID, uuid4
 
@@ -720,7 +721,14 @@ class SourceService:
         return result.scalars().first()
 
     def _guess_theme(self, name: str, description: str) -> str:
-        """Devine le thème d'une source à partir de son nom et description."""
+        """Devine le thème d'une source à partir de son nom et description.
+
+        Matching borné au **début du mot** (`\\bkw`) pour éviter les faux positifs
+        de sous-chaîne interne (ex. `"ia"` matchant dans « média ») tout en gardant
+        le matching par racine/préfixe des stems. En cas d'égalité de score entre
+        plusieurs thèmes (ou de score global nul), on retombe sur le défaut
+        `society` plutôt que sur l'ordre d'insertion du dict.
+        """
         text = f"{name} {description}".lower()
 
         keywords = {
@@ -736,6 +744,18 @@ class SourceService:
                 "innov",
                 "code",
                 "dev",
+            ],
+            "sport": [
+                "sport",
+                "football",
+                "basket",
+                "nba",
+                "tennis",
+                "rugby",
+                "handball",
+                "cyclis",
+                "athlé",
+                "olympi",
             ],
             "society": [
                 "société",
@@ -792,11 +812,20 @@ class SourceService:
         scores = dict.fromkeys(keywords, 0)
         for theme, kws in keywords.items():
             for kw in kws:
-                if kw in text:
+                # Bornage sur le **début** du mot uniquement (`\bkw`) : élimine
+                # les faux positifs de sous-chaîne interne (« ia » dans « média »)
+                # tout en gardant le matching par racine/préfixe voulu pour les
+                # stems (« innov », « cultur », « économ », « olympi »…).
+                if re.search(rf"\b{re.escape(kw)}", text):
                     scores[theme] += 1
 
-        best_theme = max(scores, key=scores.get)
-        if scores[best_theme] > 0:
-            return best_theme
+        best_score = max(scores.values())
+        if best_score == 0:
+            return "society"  # Default common theme for better recs vs 'custom'
 
-        return "society"  # Default common theme for better recs vs 'custom'
+        top = [theme for theme, score in scores.items() if score == best_score]
+        if len(top) > 1:
+            # Égalité entre plusieurs thèmes → pas de choix arbitraire selon
+            # l'ordre du dict ; on retombe sur le défaut neutre.
+            return "society"
+        return top[0]

--- a/packages/api/scripts/fix_basket_usa_theme.py
+++ b/packages/api/scripts/fix_basket_usa_theme.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Correction ponctuelle : `sources.theme` de « Basket USA » (tech -> sport).
+
+Contexte : 3 articles NBA de la source **Basket USA** sont apparus sous le
+thème « Technologie » dans le feed thématique (2026-07-10). Root cause = donnée
+fausse `sources.theme = 'tech'`, produite par le bug de sous-chaîne de
+`SourceService._guess_theme()` (« ia » matchant dans « média », égalité de score
+tie-breakée arbitrairement sur `tech`). Le fix code du heuristique est livré dans
+la même PR ; ce script corrige la **donnée déjà écrite** (DML pure, colonne
+existante, **pas de migration** Alembic nécessaire, insensible au drift).
+
+Garde-fous (calqués sur `apply_source_reclassification.py`) :
+  - **Dry-run par défaut** ; `--apply` gardé (`--allow-prod` requis en prod).
+  - **Idempotent** : re-run sans changement = no-op.
+  - Audit : imprime les autres sources au thème `tech` (relecture nom+desc à la
+    main pour repérer d'autres cas mal rangés type sport), **sans les muter**.
+
+Usage :
+    cd packages/api
+    python3 scripts/fix_basket_usa_theme.py                       # dry-run + audit
+    python3 scripts/fix_basket_usa_theme.py --apply --allow-prod   # prod (gated PO)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+from uuid import UUID
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlalchemy import select, update
+
+from app.config import get_settings
+from app.database import async_session_maker, engine
+from app.models.source import Source
+from scripts.cleanup_orphan_sources import _is_test_db
+
+BASKET_USA_ID = "6e27afbc-92ec-4450-82cf-58d106e2ebe5"
+TARGET_THEME = "sport"
+
+
+async def _audit_tech_sources(session) -> None:
+    """Imprime les sources au thème `tech` pour relecture manuelle (non muté)."""
+    result = await session.execute(
+        select(Source.id, Source.name, Source.description)
+        .where(Source.theme == "tech")
+        .order_by(Source.name)
+    )
+    rows = list(result)
+    print("-" * 78)
+    print(f"AUDIT : {len(rows)} source(s) au thème 'tech' (relecture manuelle) :")
+    for r in rows:
+        desc = (r.description or "").replace("\n", " ")
+        print(f"  • {r.name} ({r.id})")
+        print(f"      {desc[:140]}")
+    print("-" * 78)
+
+
+async def run(apply: bool, allow_prod: bool) -> int:
+    settings = get_settings()
+    db_url = settings.database_url or ""
+    is_test = _is_test_db(db_url)
+    print(
+        f"DB cible : {db_url.split('@')[-1] if '@' in db_url else db_url}  (test={is_test})"
+    )
+    if apply and not is_test and not allow_prod:
+        print("\nABORT : --apply contre une DB non-test sans --allow-prod (gated PO).")
+        return 2
+
+    async with async_session_maker() as session:
+        try:
+            result = await session.execute(
+                select(Source.id, Source.name, Source.theme).where(
+                    Source.id == UUID(BASKET_USA_ID)
+                )
+            )
+            row = result.first()
+            if row is None:
+                print(f"\nABORT : source introuvable ({BASKET_USA_ID}).")
+                return 2
+
+            print(f"\nCible : {row.name} ({row.id})")
+            print(f"  theme : {row.theme} -> {TARGET_THEME}")
+
+            await _audit_tech_sources(session)
+
+            if row.theme == TARGET_THEME:
+                print("\n(no-op — déjà au bon thème.)")
+                return 0
+
+            if not apply:
+                print("\n(dry-run — aucune mutation. Relance avec --apply.)")
+                return 0
+
+            await session.execute(
+                update(Source)
+                .where(Source.id == UUID(BASKET_USA_ID))
+                .values(theme=TARGET_THEME)
+            )
+            await session.commit()
+            print(f"\nAPPLIQUÉ : theme -> {TARGET_THEME}.")
+            return 0
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await engine.dispose()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply", action="store_true", help="exécute (défaut: dry-run)"
+    )
+    parser.add_argument(
+        "--allow-prod", action="store_true", help="autorise --apply en prod"
+    )
+    args = parser.parse_args()
+    sys.exit(asyncio.run(run(apply=args.apply, allow_prod=args.allow_prod)))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/tests/services/test_source_guess_theme.py
+++ b/packages/api/tests/services/test_source_guess_theme.py
@@ -1,0 +1,62 @@
+"""Tests unitaires de `SourceService._guess_theme()`.
+
+Régression de l'incident 2026-07-10 : Basket USA (source sport) taguée `tech`
+parce que le matching sous-chaîne faisait matcher « ia » dans « média », d'où une
+égalité de score `tech`/`culture` tie-breakée arbitrairement sur `tech`.
+"""
+
+from app.services.ml.topic_theme_mapper import VALID_THEMES
+from app.services.source_service import SourceService
+
+
+def _guess(name: str, description: str) -> str:
+    # _guess_theme n'utilise pas la DB : on peut instancier sans session réelle.
+    return SourceService(db=None)._guess_theme(name, description)
+
+
+def test_basket_usa_not_tech():
+    """Le cas réel de l'incident : nom + description Basket USA -> sport, pas tech."""
+    theme = _guess(
+        "Basket USA",
+        "Groupe média spécialisé dans les médias sportifs digitaux, "
+        "média de référence NBA.",
+    )
+    assert theme == "sport"
+    assert theme != "tech"
+
+
+def test_word_boundary_no_substring_false_positive():
+    """« média »/« médiatisation » ne doivent plus matcher le mot-clé tech « ia »."""
+    theme = _guess("Le Média", "Un média d'information et de médiatisation citoyenne.")
+    assert theme != "tech"
+
+
+def test_legit_tech_source_still_matches():
+    """Non-régression : une vraie source tech (mots isolés) reste taguée tech."""
+    theme = _guess(
+        "Next.ink",
+        "Actualité tech : IA, startup, logiciel et innovations du numérique.",
+    )
+    assert theme == "tech"
+
+
+def test_score_tie_falls_back_to_society():
+    """Égalité de score entre deux thèmes -> défaut `society`, pas l'ordre du dict."""
+    # « art » (culture) + « justice » (society) : 1 point chacun, aucun autre match.
+    theme = _guess("Revue", "Chronique sur l'art et la justice.")
+    assert theme == "society"
+
+
+def test_no_match_defaults_to_society():
+    """Aucun mot-clé -> défaut `society`."""
+    assert _guess("Zzz", "Contenu neutre sans mot-clé thématique.") == "society"
+
+
+def test_guessed_theme_is_always_valid():
+    """Tout thème deviné doit appartenir à la taxonomie officielle."""
+    for name, desc in [
+        ("Basket USA", "média sportif NBA"),
+        ("Next.ink", "tech IA startup"),
+        ("Zzz", "neutre"),
+    ]:
+        assert _guess(name, desc) in VALID_THEMES


### PR DESCRIPTION
## Quoi
Des articles NBA de **Basket USA** apparaissaient sous le thème « Technologie » dans le feed thématique. Fix de la root cause (`SourceService._guess_theme()`) + reclassement de la donnée existante.

## Pourquoi
`_guess_theme()` taguait Basket USA `tech` à cause de deux bugs latents :
- **Matching sous-chaîne** : le mot-clé tech `"ia"` matchait dans « média »/« médias » (présents dans la description de Basket USA).
- **Tie-break arbitraire** : à égalité de score (`tech=1`, `culture=1`), `max()` renvoyait la 1ʳᵉ clé de l'ordre d'insertion du dict → `tech`.
- **Catégorie `sport` absente** du dict → une source sport ne pouvait jamais être devinée correctement.

Le fallback « bénéfice du doute » de `apply_theme_focus_filter` (inclut `Content.theme IS NULL` des sources dont le thème primaire matche) a exposé ce mauvais tag à ~100 % du contenu frais, la classification ML étant à l'arrêt depuis ~10j (backlog non résorbé, tracké séparément — PR #948).

## Comment
- Catégorie `sport` ajoutée au dict de mots-clés.
- Matching borné au **début du mot** (`\bkw`) : supprime les faux positifs de sous-chaîne interne tout en gardant le matching par racine/préfixe des stems (`innov`, `cultur`, `économ`…).
- Tie-break durci : égalité de score → défaut `society`, jamais l'ordre du dict.
- Script one-off `scripts/fix_basket_usa_theme.py` (DML pure, **pas de migration**, dry-run par défaut, `--apply --allow-prod` gaté PO) pour reclasser Basket USA `tech → sport` + **auditer** les autres sources `tech`.
- Fallback `apply_theme_focus_filter` **non touché** (décision produit délibérée).

## Comment ça a été vérifié
- [x] `pytest tests/services/test_source_guess_theme.py` — 6 tests OK (cas réel Basket USA, non-régression source tech, égalité, défaut, validité taxonomie)
- [x] `pytest tests/test_source_addition_fix.py tests/test_source_management.py` — 13 OK
- [x] Suite backend : 2165 passed. Les 15 échecs `tests/scripts/media_eval/` sont pré-existants (FK/fixture sur DB de test partagée), sans lien avec ce diff.
- [x] ruff check + format OK
- [x] `/simplify` passé (docstring alignée sur l'implémentation)
- [ ] Backend-only — pas de mobile / Playwright
- [ ] Étape PO post-merge : lancer `python3 scripts/fix_basket_usa_theme.py --apply --allow-prod`

## Zones à risque
- `_guess_theme()` — heuristique d'ajout de source custom ; couverte par tests de non-régression.
- Script DML : idempotent, dry-run par défaut, prod gaté `--allow-prod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)