### PR TITLE
fix(ux): carte de source (réglages + « Lire plus ») + notifs inlines moins insistantes

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,84 +1,58 @@
-# feat(media-eval): fondations (schéma, contrats, moteur d'évaluation)
+# PR — 2 fixes UX/UI : carte de source + notifs inlines
 
-PR 1/2 du MVP pipeline d'évaluation des médias C1–C11 (story
-`docs/stories/core/media-eval.0.mvp-pipeline-evaluation.md`, plan PO validé le
-07/07/2026). Entièrement testable offline — la collecte (voie A + agents) et le
-run pilote arrivent en PR 2.
+Deux irritants UX signalés par le PO, regroupés en une seule PR (`--base main`).
+Pas de migration, pas de DDL → aucune contrainte expand-contract.
 
-## Ce que fait cette PR
+## Partie 1 — Carte de source (`SourceDetailModal`)
 
-### Docs source de vérité PO (`docs/media-eval/`)
-- Import de la méthodologie v1.1.1 (PDF converti) + amendements v1.2 actés
-  (raccourci JTI, pondération débunkages, temporalité, lettres A–E).
-- Import de l'architecture collecte ≠ évaluation du 07/07/2026.
-- **Rubriques évaluateur** (`rubrics/_common.md` + `C1/C5/C7/C8/C9/C11.md`) :
-  barème §4 verbatim + section « Sortie structurée » (`determinations`
-  énumérables). Lues verbatim par `build_eval_input.py` ;
-  `version_prompt` = sha256 du fichier rubrique.
+- **1a — Priorité + Abonnement remontés quand la source est suivie.** Dans
+  `_FsBody._assemble`, quand `display.isTrusted`, `_FsSettings` (priorité dans
+  le flux) **et** `_FsManage` (connexion abonnement) passent juste sous
+  `_FsEval`, avant la couverture / les derniers articles. Source non suivie :
+  `_FsManage` reste le CTA de découverte (paywall) sous le contenu, `_FsSettings`
+  masqué (gate `isTrusted` inchangé).
+- **1b — « Lire plus » sur Derniers articles (3 → 10, sans requête réseau).**
+  - Backend `sources.py:get_source_profile` : `recent_articles` limite `3 → 10`
+    (additif, pas de rupture de contrat ; anciens clients prennent 3 via
+    `.take(3)`). Docstring MAJ.
+  - Mobile `_FsArticlesSection` → `StatefulWidget` : replié = `take(3)`, déplié =
+    `take(10)`, bouton discret « Lire plus » / « Réduire » (idiome
+    `_ExpandableDescription`) si `articles.length > 3`. Aucune requête : les 10
+    articles sont déjà dans le payload profil.
+  - Hors scope (noté) : mode smart-search (`_ArticlesContent`) et
+    `recent_articles_list.dart` restent à 3 (autre chemin de préchargement).
 
-### Schéma DB (migration `me01_media_eval_tables`, additive, RLS deny-all)
-7 tables `media_eval_*` : medias (référentiel niveau domaine), snapshots,
-corpus_articles (créée mais vide en V0), signaux (pivot ; statuts
-present/absent_verifie/partiel/bloque_acces ; dédup idempotente par
-`dedupe_key`), debunkages (qualification émetteur/gravité/suite, couple 1-1
-avec un signal C1), evaluations (score NULL si N/A, `signal_ids` cités,
-version_methodo/version_prompt), fiches (renormalisation, lettre, confiance).
-- `down_revision = ue01_user_entity_affinity` → 1 seul head. Idempotente
-  (guard `has_table` par table — la chaîne boote sur les 2 services Railway).
-  RLS pattern `sec02` (ENABLE + REVOKE anon/authenticated, aucune policy).
-- Modèles `app/models/media_eval.py` (StrEnum locaux, enums VARCHAR non natifs,
-  pattern `Source`), enregistrés dans `app/models/__init__.py`.
+## Partie 2 — Notifs inlines (« Notif du jour »)
 
-### Contrats & garde-fous codés en dur (`scripts/media_eval/`)
-- `schemas.py` : `BAREMES` (100 pts), `CRITERES_VAGUE_1` (54 pts),
-  `NIVEAU_SCORES` C9/C11, `LETTRES`, registre `type_signal` figé, artefacts
-  Pydantic (Signal/Debunkage/Evaluation + enveloppes batch, GoldenSet).
-  **`derive_score(critere, determinations)`** : le score faisant foi est dérivé
-  par code, jamais choisi par le LLM (philosophie `derive_reliability`).
-  Validator dur : éval sans `signal_ids_cites` rejetée (sauf flag
-  `donnees_insuffisantes` → N/A). `poids_emetteur` des débunkages dérivé par
-  code (`arcom/justice/cdjm` = fort, fact-checkers de médias concurrents =
-  moyen, inconnu = faible).
-- `garde_fous.py` (fonctions pures) : fraîcheur 730 j (signaux événementiels
-  seulement, structurels constatés à date), fallback C1 (< 3 débunkages/2 ans),
-  raccourci JTI, corroboration (score plein sans ≥ 2 domaines sources
-  indépendants → palier inférieur + flag `corroboration_insuffisante`),
-  `bloque_acces` → `revue_requise` — jamais converti en 0.
+- **2a — Cooldown durable au dismiss (~30j).** Nouveau store
+  `notif_du_jour_dismissal_store.dart` (clé `notif_du_jour_dismissals_v1`, JSON
+  `{ id: 'YYYY-MM-DD' }`, `kNotifDismissCooldownDays = 30`, clock injectable).
+  `notifDuJourQueueProvider` filtre les `activeCooldownIds(now)` (même clé jour
+  que le day store). Le cooldown se pose **au dismiss (croix) uniquement**
+  (`_CloseButton` → `recordDismissed`), jamais au tap. Anti-flash : la carte
+  gate désormais sur `day.loaded` **et** `dismissalStore.loaded`.
+- **2b — « Mode serein » remonte.** Relevance `0.4 → 0.55` (au-dessus de
+  `tournee` 0.5, sous les prompts temps-sensibles). Combiné au cooldown, serein
+  émerge une fois les autres messages profil dismissés.
+- **2c — Sondage « bien informé » non tronqué.** Titre `maxLines: 1 →
+  hasCustomBody ? 2 : 1` (la question s'affiche en entier au-dessus de la
+  rangée NPS ; une ligne, sans impact sur les autres messages).
 
-### Scripts moteur (dry-run par défaut, `--apply` gardé, `--allow-prod` hors DB test)
-`seed_medias.py` (2 pilotes : cnews.fr audiovisuel, reporterre.net presse en
-ligne) · `ingest_artifacts.py` (valide en bloc puis insère — un artefact
-invalide = exit non-zéro, rien d'écrit ; idempotent) · `build_eval_input.py`
-(exports `eval_inputs/<media>_<critere>.json` + garde-fous amont) ·
-`ingest_evaluations.py` (garde-fous aval : signal_ids existants / bon média /
-bon critère, score dérivé, corroboration, statuts) · `synthese_fiche.py`
-(renormalisation sur les seuls critères évalués, lettre, confiance, fiche md +
-ligne DB) · `evaluate_golden_agreement.py` (accord vs gold : exact C9/C11,
-|Δ| ≤ 20 % du barème en continu, désaccords N/A-vs-score listés).
+## Tests
 
-## Tests & vérifications
+- Backend `test_source_profile.py` : happy path aligné (4 contents ≤ 10) +
+  nouveau `test_profile_recent_articles_capped_at_10` (14 contents → 10).
+  **7 passed** (`DATABASE_URL=postgresql+psycopg://facteur:facteur@localhost:54322/facteur_test`).
+- Mobile : nouveau `notif_du_jour_dismissal_store_test.dart` (record + cooldown
+  30j + expiration + date illisible) ; `notif_du_jour_provider_test.dart` étendu
+  (id en cooldown filtré, cooldown expiré, serein remonte quand les autres sont
+  en cooldown) ; `notif_du_jour_card_test.dart` (titre 2 lignes hasCustomBody,
+  1 ligne standard) ; `source_detail_modal_test.dart` (ordre Priorité/Abonnement
+  au-dessus des articles si suivie / paywall dessous si non suivie ; « Lire plus »
+  déroule à 10 puis « Réduire » ; pas de bouton si ≤ 3). **76 passed.**
+- `flutter analyze` sur les fichiers touchés : **No issues found.**
 
-- **91 tests** `tests/scripts/media_eval/` (purs + DB savepoint) : contrats,
-  table `derive_score`, bornes fraîcheur 729/730/731 j, fallback 2 vs 3,
-  corroboration, JTI, `bloque_acces` jamais 0, renormalisation 0/1/3 N/A
-  (cas Reporterre max 34), bornes lettres 84.9/85, matrice confiance,
-  idempotence dedupe/évals, rejets (signal d'un autre média/critère,
-  artefact partiellement invalide → rien d'écrit), métriques gold.
-- Migration sur **DB vide** : `upgrade head` → `downgrade -1` → `upgrade head`
-  OK, exactement 1 head (`me01_media_eval_tables`).
-- Smoke E2E offline sur DB jetable : seed → ingest artefacts (5 signaux dont
-  2 couples débunkage, poids dérivés) → build_eval_input (fallback C1 déclenché
-  à 2 débunkages, 6 entrées écrites) → ingest_evaluations (3 évals, C1 N/A) →
-  synthese_fiche (10/20 → 50/100, lettre D, confiance moyenne).
-- Suite backend complète `pytest` + `ruff check`/`format` OK.
+## Changelog
 
-Pas d'entrée changelog : outillage interne, aucun impact user (bypass de la
-règle 400 lignes assumé).
-
-## Suite (PR 2)
-
-Collecteurs voie A (`collect_pages_types/cdjm/jti/cppap/pappers/arcom`),
-sous-agents `.claude/agents/media-eval-*`, commande `/media-eval-run`, run
-pilote `pilote-2026-07` (CNEWS puis Reporterre) + golden set Laurin
-(`docs/media-eval/golden/gold_v0.json`) + rapport d'accord. Prérequis :
-`PAPPERS_API_TOKEN` (env locale, compte gratuit).
+2 entrées `unreleased` : « Sources » (réglages en tête + Lire plus) + « Feed »
+(notifs moins insistantes).

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,14 @@
 {
   "unreleased": [
     {
+      "tag": "Sources",
+      "summary": "Sur une source suivie, la priorité dans ton flux et la connexion d'abonnement passent en tête de fiche, et « Lire plus » déroule ses derniers articles."
+    },
+    {
+      "tag": "Feed",
+      "summary": "Les notifs en tête de feed sont moins insistantes : une notif écartée ne revient plus avant un mois, et le sondage « bien informé » s'affiche en entier."
+    },
+    {
       "tag": "Tournée",
       "summary": "Des suggestions de sources plus riches par thème, et un accès direct « Tout lire »."
     },

--- a/apps/mobile/lib/features/notif_du_jour/providers/notif_du_jour_dismissal_store.dart
+++ b/apps/mobile/lib/features/notif_du_jour/providers/notif_du_jour_dismissal_store.dart
@@ -1,0 +1,99 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'notif_du_jour_day_store.dart';
+
+/// Clé de persistance des dismiss durables. Suffixe `_v1` cohérent avec les
+/// autres prefs (`notif_du_jour_state_v1`).
+const String kNotifDuJourDismissalsKey = 'notif_du_jour_dismissals_v1';
+
+/// Durée du cooldown après un dismiss (croix) : un message dismissé ne
+/// réapparaît pas avant 30 jours. Complète le day store (cap 3/jour) : le day
+/// store empêche le harcèlement *intra-journée*, le cooldown empêche le nag
+/// *inter-jours* d'un message explicitement rejeté.
+const int kNotifDismissCooldownDays = 30;
+
+/// État persisté : map `{ id: 'YYYY-MM-DD' }` du dernier dismiss par message.
+///
+/// `loaded` gate anti-flash : la carte ne rend rien tant que les prefs ne sont
+/// pas chargées (comme le day store), pour ne pas flasher un message en
+/// cooldown le temps de lire le disque.
+class NotifDuJourDismissalState {
+  final bool loaded;
+  final Map<String, String> dismissedOn;
+
+  const NotifDuJourDismissalState({
+    this.loaded = false,
+    this.dismissedOn = const {},
+  });
+
+  /// Ids dismissés il y a moins de [kNotifDismissCooldownDays] jours (à
+  /// filtrer de la file). [now] = jour vécu par l'utilisateur (même clé que le
+  /// day store).
+  Set<String> activeCooldownIds(DateTime now) {
+    final active = <String>{};
+    dismissedOn.forEach((id, day) {
+      final at = DateTime.tryParse(day);
+      if (at == null) return;
+      if (now.difference(at).inDays < kNotifDismissCooldownDays) active.add(id);
+    });
+    return active;
+  }
+}
+
+final notifDuJourDismissalStoreProvider =
+    StateNotifierProvider<NotifDuJourDismissalStore, NotifDuJourDismissalState>(
+      (ref) => NotifDuJourDismissalStore(),
+    );
+
+/// Store SharedPreferences des dismiss durables de la file « Notif du jour ».
+///
+/// Écritures best-effort (l'état mémoire reste appliqué pour la session si les
+/// prefs échouent), clock injectable pour les tests — même pattern que le day
+/// store.
+class NotifDuJourDismissalStore
+    extends StateNotifier<NotifDuJourDismissalState> {
+  NotifDuJourDismissalStore({DateTime Function()? clock})
+    : _clock = clock ?? DateTime.now,
+      super(const NotifDuJourDismissalState()) {
+    _load();
+  }
+
+  final DateTime Function() _clock;
+
+  Future<void> _load() async {
+    var dismissedOn = const <String, String>{};
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString(kNotifDuJourDismissalsKey);
+      if (raw != null) {
+        final decoded = jsonDecode(raw);
+        if (decoded is Map<String, dynamic>) {
+          dismissedOn = {
+            for (final entry in decoded.entries)
+              if (entry.value is String) entry.key: entry.value as String,
+          };
+        }
+      }
+    } catch (_) {
+      // best-effort : prefs illisibles → repart sans cooldown.
+    }
+    if (!mounted) return;
+    state = NotifDuJourDismissalState(loaded: true, dismissedOn: dismissedOn);
+  }
+
+  /// Pose le cooldown sur [id] (dismiss croix) et persiste.
+  Future<void> recordDismissed(String id) async {
+    final today = notifDuJourDayKey(_clock());
+    final dismissedOn = {...state.dismissedOn, id: today};
+    state = NotifDuJourDismissalState(loaded: true, dismissedOn: dismissedOn);
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(kNotifDuJourDismissalsKey, jsonEncode(dismissedOn));
+    } catch (_) {
+      // best-effort.
+    }
+  }
+}

--- a/apps/mobile/lib/features/notif_du_jour/providers/notif_du_jour_provider.dart
+++ b/apps/mobile/lib/features/notif_du_jour/providers/notif_du_jour_provider.dart
@@ -9,6 +9,7 @@ import '../../veille/providers/veille_active_config_provider.dart';
 import '../../well_informed/providers/well_informed_prompt_provider.dart';
 import '../models/notif_du_jour_message.dart';
 import 'notif_du_jour_day_store.dart';
+import 'notif_du_jour_dismissal_store.dart';
 
 /// Amplitude du jitter quotidien (ε). Assez pour permuter des messages de
 /// pertinence proche jour à jour, trop peu pour faire passer un 0.6 devant
@@ -133,7 +134,11 @@ final notifDuJourQueueProvider = Provider<List<String>>((ref) {
 
   final serein = ref.watch(sereinToggleProvider);
   if (!serein.enabled && !serein.isLoading) {
-    candidates.add(const NotifCandidate(NotifDuJourIds.serein, 0.4));
+    // Relevance au-dessus de `tournee` (0.5), sous les prompts temps-sensibles :
+    // combiné au cooldown de dismiss (30j), « Serein » finit par émerger une
+    // fois les autres messages profil dismissés. Knob calibrable comme
+    // `kRotationJitter`.
+    candidates.add(const NotifCandidate(NotifDuJourIds.serein, 0.55));
   }
 
   // Fallback : garantit une file jamais vide.
@@ -148,5 +153,16 @@ final notifDuJourQueueProvider = Provider<List<String>>((ref) {
   final day = dayKey.isEmpty
       ? DateTime.now()
       : DateTime.parse(dayKey); // 'YYYY-MM-DD' → minuit local du jour clé
-  return rankNotifQueue(candidates, notifEpochDay(day));
+
+  // Cooldown durable : retire les messages dismissés (croix) il y a moins de
+  // 30j. Utilise la même clé jour que le day store pour le `now`, pour que le
+  // cooldown bascule sur la même frontière que le cap/rotation.
+  final cooldown = ref
+      .watch(notifDuJourDismissalStoreProvider)
+      .activeCooldownIds(day);
+  final eligible = cooldown.isEmpty
+      ? candidates
+      : [for (final c in candidates) if (!cooldown.contains(c.id)) c];
+
+  return rankNotifQueue(eligible, notifEpochDay(day));
 });

--- a/apps/mobile/lib/features/notif_du_jour/widgets/notif_du_jour_card.dart
+++ b/apps/mobile/lib/features/notif_du_jour/widgets/notif_du_jour_card.dart
@@ -11,6 +11,7 @@ import '../../../core/orchestration/first_impression_orchestrator.dart';
 import '../../lettres/widgets/lettres_notification_banner.dart';
 import '../models/notif_du_jour_message.dart';
 import '../providers/notif_du_jour_day_store.dart';
+import '../providers/notif_du_jour_dismissal_store.dart';
 import '../providers/notif_du_jour_provider.dart';
 
 /// « Notif du jour » : ligne de notification unique en tête de l'Essentiel.
@@ -74,8 +75,14 @@ class _NotifDuJourCardState extends ConsumerState<NotifDuJourCard> {
     }
 
     final day = ref.watch(notifDuJourDayStoreProvider);
-    // Anti-flash : rien tant que les prefs jour ne sont pas chargées.
-    if (!day.loaded || day.capReached) return const SizedBox.shrink();
+    final dismissalLoaded = ref.watch(
+      notifDuJourDismissalStoreProvider.select((s) => s.loaded),
+    );
+    // Anti-flash : rien tant que les deux stores (jour + cooldown) ne sont pas
+    // chargés — sinon on flasherait un message en cooldown le temps du disque.
+    if (!day.loaded || !dismissalLoaded || day.capReached) {
+      return const SizedBox.shrink();
+    }
 
     final queue = ref.watch(notifDuJourQueueProvider);
     final visibleId = _collapsingId ??
@@ -156,7 +163,10 @@ class _NotifDuJourCardState extends ConsumerState<NotifDuJourCard> {
                 children: [
                   Text(
                     message.title,
-                    maxLines: 1,
+                    // Les prompts à corps custom (sondage NPS « bien informé »)
+                    // portent une vraie question : 2 lignes pour ne pas la
+                    // tronquer. Les autres restent sur 1 ligne.
+                    maxLines: hasCustomBody ? 2 : 1,
                     overflow: TextOverflow.ellipsis,
                     style: GoogleFonts.dmSans(
                       fontSize: 13.5,
@@ -181,11 +191,17 @@ class _NotifDuJourCardState extends ConsumerState<NotifDuJourCard> {
             ),
             const SizedBox(width: 8),
             _CloseButton(
+              // Dismiss (croix) : pose le cooldown durable (~30j) sur ce
+              // message en plus de l'effet éventuel `onDismissed`. Le cooldown
+              // ne se pose qu'au dismiss, jamais au tap (un tap = intérêt).
               onTap: () => _consume(
                 message,
-                sideEffect: message.onDismissed == null
-                    ? null
-                    : () => message.onDismissed!(ref),
+                sideEffect: () async {
+                  await ref
+                      .read(notifDuJourDismissalStoreProvider.notifier)
+                      .recordDismissed(message.id);
+                  await message.onDismissed?.call(ref);
+                },
               ),
             ),
           ],

--- a/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_detail_modal.dart
@@ -265,9 +265,16 @@ class _FsBody extends ConsumerWidget {
       children: [
         _FsHeader(source: display, frequencyLabel: frequencyLabel),
         _FsEval(source: display),
+        // Source suivie : les réglages les plus utiles (priorité dans le flux +
+        // connexion abonnement) remontent juste sous l'évaluation, avant la
+        // couverture / les derniers articles. Non suivie : `_FsManage` reste le
+        // CTA de découverte (paywall) sous le contenu, et `_FsSettings` masqué.
+        if (display.isTrusted) ...[
+          _FsSettings(source: display),
+          _FsManage(source: display),
+        ],
         ...middle,
-        if (display.isTrusted) _FsSettings(source: display),
-        _FsManage(source: display),
+        if (!display.isTrusted) _FsManage(source: display),
       ],
     );
   }
@@ -1208,15 +1215,33 @@ class _CoverageSkeleton extends StatelessWidget {
 /// Mode normal : articles récents en carte standard [FluxContinuArticleCard]
 /// (tap → reader, read-sync, preview en appui long — gérés par la carte). Les
 /// `Content` viennent complets du profil unifié.
-class _FsArticlesSection extends StatelessWidget {
+class _FsArticlesSection extends StatefulWidget {
   final List<Content> articles;
   final SourceArticleOpener? articleOpener;
 
   const _FsArticlesSection({required this.articles, this.articleOpener});
 
   @override
+  State<_FsArticlesSection> createState() => _FsArticlesSectionState();
+}
+
+class _FsArticlesSectionState extends State<_FsArticlesSection> {
+  /// Articles affichés replié / déplié. Les 10 articles sont déjà dans le
+  /// payload profil (`recentArticles`) : « Lire plus » ne déclenche aucune
+  /// requête réseau, il déroule simplement la liste locale.
+  static const int _collapsedCount = 3;
+  static const int _expandedCount = 10;
+  bool _expanded = false;
+
+  @override
   Widget build(BuildContext context) {
-    final visible = articles.take(3).toList();
+    final colors = context.facteurColors;
+    final textTheme = Theme.of(context).textTheme;
+    final articles = widget.articles;
+    final visible = articles
+        .take(_expanded ? _expandedCount : _collapsedCount)
+        .toList();
+    final canExpand = articles.length > _collapsedCount;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -1230,7 +1255,7 @@ class _FsArticlesSection extends StatelessWidget {
             padding: EdgeInsets.symmetric(horizontal: 16),
             child: _ArticlesEmptyCard(message: 'Aucun article récent.'),
           )
-        else
+        else ...[
           // FluxContinuArticleCard porte 12px de padding horizontal interne ;
           // +4px ici aligne les cartes sur les 16px du reste de la fiche.
           Padding(
@@ -1245,12 +1270,38 @@ class _FsArticlesSection extends StatelessWidget {
               ],
             ),
           ),
+          // Bouton discret « Lire plus » / « Réduire » (idiome de
+          // `_ExpandableDescription`) : n'apparaît que si la source a plus de 3
+          // articles dans le payload.
+          if (canExpand)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 4, 16, 0),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: InkWell(
+                  onTap: () => setState(() => _expanded = !_expanded),
+                  borderRadius: BorderRadius.circular(6),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 4),
+                    child: Text(
+                      _expanded ? 'Réduire' : 'Lire plus',
+                      style: textTheme.labelSmall?.copyWith(
+                        color: colors.primary,
+                        fontWeight: FontWeight.w600,
+                        letterSpacing: 0,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+        ],
       ],
     );
   }
 
   void _openArticle(BuildContext context, Content article) {
-    final opener = articleOpener;
+    final opener = widget.articleOpener;
     if (opener != null) {
       opener(context, article);
       return;

--- a/apps/mobile/test/features/notif_du_jour/notif_du_jour_card_test.dart
+++ b/apps/mobile/test/features/notif_du_jour/notif_du_jour_card_test.dart
@@ -189,6 +189,25 @@ void main() {
     expect(find.byIcon(PhosphorIcons.arrowRight()), findsNothing);
   });
 
+  testWidgets('sondage bien informé : titre sur 2 lignes (non tronqué)',
+      (tester) async {
+    await tester.pumpWidget(_wrap(queue: const ['well_informed']));
+    await tester.pumpAndSettle();
+    final title = tester.widget<Text>(
+      find.text('Te sens-tu bien informé·e en ce moment ?'),
+    );
+    expect(title.maxLines, 2);
+  });
+
+  testWidgets('message standard : titre sur 1 ligne', (tester) async {
+    await tester.pumpWidget(_wrap(queue: profileQueue));
+    await tester.pumpAndSettle();
+    final title = tester.widget<Text>(
+      find.text('Pas dans le mood pour l\'actu chaude ?'),
+    );
+    expect(title.maxLines, 1);
+  });
+
   testWidgets('cède aux modales de l\'orchestrateur', (tester) async {
     await tester.pumpWidget(
       _wrap(queue: profileQueue, slot: FirstImpressionSlot.notifModal),

--- a/apps/mobile/test/features/notif_du_jour/notif_du_jour_dismissal_store_test.dart
+++ b/apps/mobile/test/features/notif_du_jour/notif_du_jour_dismissal_store_test.dart
@@ -1,0 +1,104 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:facteur/features/notif_du_jour/providers/notif_du_jour_dismissal_store.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<void> settle() => Future<void>.delayed(Duration.zero);
+
+  test('chargement : vide si rien de persisté', () async {
+    SharedPreferences.setMockInitialValues({});
+    final store = NotifDuJourDismissalStore();
+    await settle();
+    expect(store.state.loaded, isTrue);
+    expect(store.state.dismissedOn, isEmpty);
+  });
+
+  test('chargement : reprend les dismiss persistés', () async {
+    SharedPreferences.setMockInitialValues({
+      kNotifDuJourDismissalsKey: jsonEncode({
+        'serein': '2026-07-01',
+        'veille': '2026-06-15',
+      }),
+    });
+    final store = NotifDuJourDismissalStore();
+    await settle();
+    expect(store.state.dismissedOn, {
+      'serein': '2026-07-01',
+      'veille': '2026-06-15',
+    });
+  });
+
+  test('recordDismissed pose la date du jour et persiste', () async {
+    SharedPreferences.setMockInitialValues({});
+    final now = DateTime(2026, 7, 10, 8, 30);
+    final store = NotifDuJourDismissalStore(clock: () => now);
+    await settle();
+
+    await store.recordDismissed('serein');
+    expect(store.state.dismissedOn['serein'], '2026-07-10');
+
+    final prefs = await SharedPreferences.getInstance();
+    final raw = jsonDecode(prefs.getString(kNotifDuJourDismissalsKey)!)
+        as Map<String, dynamic>;
+    expect(raw['serein'], '2026-07-10');
+  });
+
+  test('recordDismissed écrase la date précédente du même id', () async {
+    SharedPreferences.setMockInitialValues({
+      kNotifDuJourDismissalsKey: jsonEncode({'serein': '2026-06-01'}),
+    });
+    var now = DateTime(2026, 7, 10);
+    final store = NotifDuJourDismissalStore(clock: () => now);
+    await settle();
+
+    await store.recordDismissed('serein');
+    expect(store.state.dismissedOn['serein'], '2026-07-10');
+  });
+
+  test('activeCooldownIds : id dismissé < 30j est actif', () async {
+    SharedPreferences.setMockInitialValues({
+      kNotifDuJourDismissalsKey: jsonEncode({'serein': '2026-07-01'}),
+    });
+    final store = NotifDuJourDismissalStore();
+    await settle();
+
+    // 9 jours après le dismiss → toujours en cooldown.
+    expect(
+      store.state.activeCooldownIds(DateTime(2026, 7, 10)),
+      contains('serein'),
+    );
+  });
+
+  test('activeCooldownIds : cooldown expiré après 30j', () async {
+    SharedPreferences.setMockInitialValues({
+      kNotifDuJourDismissalsKey: jsonEncode({'serein': '2026-06-01'}),
+    });
+    final store = NotifDuJourDismissalStore();
+    await settle();
+
+    // 30 jours pile après → hors cooldown (< 30 strict).
+    expect(
+      store.state.activeCooldownIds(DateTime(2026, 7, 1)),
+      isNot(contains('serein')),
+    );
+    // 40 jours après → hors cooldown.
+    expect(
+      store.state.activeCooldownIds(DateTime(2026, 7, 11)),
+      isEmpty,
+    );
+  });
+
+  test('activeCooldownIds : date illisible ignorée', () async {
+    SharedPreferences.setMockInitialValues({
+      kNotifDuJourDismissalsKey: jsonEncode({'serein': 'pas-une-date'}),
+    });
+    final store = NotifDuJourDismissalStore();
+    await settle();
+    expect(store.state.activeCooldownIds(DateTime(2026, 7, 10)), isEmpty);
+  });
+}

--- a/apps/mobile/test/features/notif_du_jour/notif_du_jour_provider_test.dart
+++ b/apps/mobile/test/features/notif_du_jour/notif_du_jour_provider_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -6,6 +8,7 @@ import 'package:facteur/features/digest/providers/serein_toggle_provider.dart';
 import 'package:facteur/features/flux_continu/providers/geoloc_prompt_provider.dart';
 import 'package:facteur/features/flux_continu/providers/tournee_order_prefs_provider.dart';
 import 'package:facteur/features/notif_du_jour/models/notif_du_jour_message.dart';
+import 'package:facteur/features/notif_du_jour/providers/notif_du_jour_dismissal_store.dart';
 import 'package:facteur/features/notif_du_jour/providers/notif_du_jour_provider.dart';
 import 'package:facteur/features/notifications/providers/notification_renudge_provider.dart';
 import 'package:facteur/features/sources/models/source_model.dart';
@@ -177,7 +180,7 @@ void main() {
         NotifDuJourIds.geoloc,
       ]),
     );
-    // relevance 0.9/0.85 : devant serein (0.4) même avec jitter max (0.15).
+    // relevance 0.9/0.85 : devant serein (0.55) même avec jitter max (0.15).
     expect(
       queue.indexOf(NotifDuJourIds.notifRenudge),
       lessThan(queue.indexOf(NotifDuJourIds.serein)),
@@ -188,6 +191,47 @@ void main() {
     expect(quiet, isNot(contains(NotifDuJourIds.notifRenudge)));
     expect(quiet, isNot(contains(NotifDuJourIds.wellInformed)));
     expect(quiet, isNot(contains(NotifDuJourIds.geoloc)));
+  });
+
+  String _today() => DateTime.now().toIso8601String().substring(0, 10);
+
+  test('id dismissé (< 30j) filtré de la file (cooldown)', () async {
+    SharedPreferences.setMockInitialValues({
+      kNotifDuJourDismissalsKey: jsonEncode({NotifDuJourIds.serein: _today()}),
+    });
+    final container = _container(sereinEnabled: false);
+    expect(await _queue(container), isNot(contains(NotifDuJourIds.serein)));
+  });
+
+  test('cooldown expiré (> 30j) → id de nouveau éligible', () async {
+    SharedPreferences.setMockInitialValues({
+      kNotifDuJourDismissalsKey:
+          jsonEncode({NotifDuJourIds.serein: '2020-01-01'}),
+    });
+    final container = _container(sereinEnabled: false);
+    expect(await _queue(container), contains(NotifDuJourIds.serein));
+  });
+
+  test('serein remonte quand les autres messages profil sont en cooldown',
+      () async {
+    final today = _today();
+    SharedPreferences.setMockInitialValues({
+      kNotifDuJourDismissalsKey: jsonEncode({
+        NotifDuJourIds.source: today,
+        NotifDuJourIds.tournee: today,
+        NotifDuJourIds.veille: today,
+      }),
+    });
+    // Profil : source < 3, tournée non customisée, veille absente, serein OFF.
+    final container = _container(sereinEnabled: false, veille: null);
+    final queue = await _queue(container);
+    // Concurrents profil filtrés → serein passe devant le fallback recommencer.
+    expect(queue, contains(NotifDuJourIds.serein));
+    expect(queue, isNot(contains(NotifDuJourIds.source)));
+    expect(
+      queue.indexOf(NotifDuJourIds.serein),
+      lessThan(queue.indexOf(NotifDuJourIds.recommencer)),
+    );
   });
 
   test('catalogue : chaque id de la file a un message affichable', () async {

--- a/apps/mobile/test/features/sources/widgets/source_detail_modal_test.dart
+++ b/apps/mobile/test/features/sources/widgets/source_detail_modal_test.dart
@@ -535,6 +535,120 @@ void main() {
 
       expect(find.text('Aucun article récent.'), findsOneWidget);
     });
+
+    testWidgets('« Lire plus » déroule jusqu\'à 10 articles puis « Réduire »', (
+      tester,
+    ) async {
+      final source = Source(
+        id: 'monde',
+        name: 'Le Monde',
+        type: SourceType.article,
+      );
+      final profile = SourceProfile(
+        recentArticles: [
+          for (var i = 0; i < 12; i++) _article('id$i', 'Article $i'),
+        ],
+      );
+
+      await tester.pumpWidget(_wrap(source: source, profile: profile));
+      await tester.pumpAndSettle();
+
+      // Replié : 3 articles visibles, bouton « Lire plus ».
+      expect(find.text('Article 0'), findsOneWidget);
+      expect(find.text('Article 2'), findsOneWidget);
+      expect(find.text('Article 3'), findsNothing);
+      expect(find.text('Lire plus'), findsOneWidget);
+      expect(find.text('Réduire'), findsNothing);
+
+      await tester.ensureVisible(find.text('Lire plus'));
+      await tester.tap(find.text('Lire plus'));
+      await tester.pumpAndSettle();
+
+      // Déplié : 10 articles (0..9), le 11e reste caché, bascule en « Réduire ».
+      expect(find.text('Article 9'), findsOneWidget);
+      expect(find.text('Article 10'), findsNothing);
+      expect(find.text('Réduire'), findsOneWidget);
+      expect(find.text('Lire plus'), findsNothing);
+    });
+
+    testWidgets('≤ 3 articles → pas de bouton « Lire plus »', (tester) async {
+      final source = Source(
+        id: 'monde',
+        name: 'Le Monde',
+        type: SourceType.article,
+      );
+      final profile = SourceProfile(
+        recentArticles: [
+          _article('a', 'Article A'),
+          _article('b', 'Article B'),
+          _article('c', 'Article C'),
+        ],
+      );
+
+      await tester.pumpWidget(_wrap(source: source, profile: profile));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Lire plus'), findsNothing);
+    });
+  });
+
+  group('SourceDetailModal — priorité/abonnement remontés si suivie', () {
+    testWidgets(
+      'followed: Réglages + Gestion sont au-dessus des Derniers articles',
+      (tester) async {
+        final followed = Source(
+          id: 'monde',
+          name: 'Le Monde',
+          type: SourceType.article,
+          isTrusted: true,
+          premiumConnection: const PremiumConnection(
+            loginUrl: 'https://lemonde.fr/login',
+            testUrl: 'https://lemonde.fr/test',
+            isGeneric: true,
+          ),
+        );
+        final profile = SourceProfile(
+          recentArticles: [_article('a', 'Article A')],
+        );
+
+        await tester.pumpWidget(_wrap(source: followed, profile: profile));
+        await tester.pumpAndSettle();
+
+        final settingsY = tester.getTopLeft(find.text('Réglages de suivi')).dy;
+        final manageY = tester.getTopLeft(find.text('Gestion de la source')).dy;
+        final articlesY = tester.getTopLeft(find.text('Derniers articles')).dy;
+        expect(settingsY, lessThan(articlesY));
+        expect(manageY, lessThan(articlesY));
+      },
+    );
+
+    testWidgets(
+      'unfollowed: Gestion (paywall) reste sous les Derniers articles',
+      (tester) async {
+        final notFollowed = Source(
+          id: 'monde',
+          name: 'Le Monde',
+          type: SourceType.article,
+          isTrusted: false,
+          premiumConnection: const PremiumConnection(
+            loginUrl: 'https://lemonde.fr/login',
+            testUrl: 'https://lemonde.fr/test',
+            isGeneric: true,
+          ),
+        );
+        final profile = SourceProfile(
+          recentArticles: [_article('a', 'Article A')],
+        );
+
+        await tester.pumpWidget(_wrap(source: notFollowed, profile: profile));
+        await tester.pumpAndSettle();
+
+        final manageY = tester.getTopLeft(find.text('Gestion de la source')).dy;
+        final articlesY = tester.getTopLeft(find.text('Derniers articles')).dy;
+        expect(manageY, greaterThan(articlesY));
+        expect(find.text('Réglages de suivi'), findsNothing);
+      },
+    );
   });
 
   group('SourceDetailModal — fallback réseau (/profile en erreur)', () {

--- a/packages/api/app/routers/sources.py
+++ b/packages/api/app/routers/sources.py
@@ -944,8 +944,10 @@ async def get_source_profile(
     Une seule réponse regroupe : l'identité de la source, sa couverture par
     thèmes sur 30 jours (`theme_distribution` + `articles_30d`), la date du
     plus ancien contenu connu (`oldest_content_at`, hors fenêtre, pour clamper
-    la fréquence côté mobile) et ses 3 articles les plus récents (objets
-    `Content` complets → carte standard cliquable). Placé après `/coverage`,
+    la fréquence côté mobile) et ses 10 articles les plus récents (objets
+    `Content` complets → carte standard cliquable ; la fiche en montre 3 par
+    défaut et déroule jusqu'à 10 via « Lire plus », sans nouvelle requête).
+    Placé après `/coverage`,
     donc après toutes les routes statiques (`/catalog`, `/trending`…).
     """
     source = (
@@ -1003,7 +1005,7 @@ async def get_source_profile(
         .options(selectinload(Content.source))
         .where(Content.source_id == source_id)
         .order_by(Content.published_at.desc())
-        .limit(3)
+        .limit(10)
     )
     recent_articles: list[ContentResponse] = []
     for content in recent_result.scalars().all():

--- a/packages/api/tests/test_source_profile.py
+++ b/packages/api/tests/test_source_profile.py
@@ -1,12 +1,14 @@
 """Tests de l'endpoint `/sources/{id}/profile` (fiche source v3).
 
 Endpoint unifié : identité source + couverture par thèmes (30 j) +
-`articles_30d` + `oldest_content_at` (hors fenêtre) + 3 articles récents
-(objets `Content` complets, cliquables côté mobile).
+`articles_30d` + `oldest_content_at` (hors fenêtre) + 10 articles récents
+(objets `Content` complets, cliquables côté mobile ; la fiche en montre 3 par
+défaut et déroule jusqu'à 10 via « Lire plus »).
 
 Couvre :
-- happy path : source + ≥4 contents → recent_articles ≤3 (source imbriquée),
+- happy path : source + 4 contents → recent_articles (source imbriquée),
   theme_distribution cohérent (counts/parts), articles_30d correct ;
+- cap : ≥10 contents → recent_articles plafonné à 10 ;
 - fenêtre 30 j : un content à 40 j exclu du volume/distribution mais reflété
   par `oldest_content_at` ;
 - 404 source inconnue ;
@@ -107,19 +109,39 @@ async def test_profile_happy_path(profile_client):
     assert dist[1]["share"] == pytest.approx(0.25)
     assert sum(d["count"] for d in dist) == body["articles_30d"]
 
-    # Articles récents : max 3, triés desc, source imbriquée complète.
+    # Articles récents : max 10, triés desc, source imbriquée complète.
+    # Ici 4 contents (< 10) → les 4 remontent.
     recent = body["recent_articles"]
-    assert len(recent) == 3
+    assert len(recent) == 4
     first = recent[0]
     assert first["source"]["id"] == str(source.id)
     assert first["source"]["name"] == "Profile Source"
     assert first["source"]["logo_url"] == "https://profile.example.com/logo.png"
-    # Tri chronologique décroissant (days_ago 0 → 1 → 2).
+    # Tri chronologique décroissant (days_ago 0 → 1 → 2 → 5).
     titles = [r["title"] for r in recent]
-    assert titles == ["Pol 0", "Pol 1", "Pol 2"]
+    assert titles == ["Pol 0", "Pol 1", "Pol 2", "Tech"]
 
     # oldest_content_at = le plus ancien (tech, 5 j).
     assert body["oldest_content_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_profile_recent_articles_capped_at_10(profile_client):
+    """≥10 contents → recent_articles plafonné à 10 (les 10 plus récents)."""
+    ac, source, db = profile_client
+    # 14 contents, tous < 30 j, days_ago croissant → titres 0..13.
+    for i in range(14):
+        db.add(_content(source.id, theme="politics", days_ago=i, title=f"A{i}"))
+    await db.commit()
+
+    resp = await ac.get(f"/api/sources/{source.id}/profile")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    recent = body["recent_articles"]
+    assert len(recent) == 10
+    # Les 10 plus récents (days_ago 0..9), triés desc.
+    assert [r["title"] for r in recent] == [f"A{i}" for i in range(10)]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# PR — 2 fixes UX/UI : carte de source + notifs inlines

Deux irritants UX signalés par le PO, regroupés en une seule PR (`--base main`).
Pas de migration, pas de DDL → aucune contrainte expand-contract.

## Partie 1 — Carte de source (`SourceDetailModal`)

- **1a — Priorité + Abonnement remontés quand la source est suivie.** Dans
  `_FsBody._assemble`, quand `display.isTrusted`, `_FsSettings` (priorité dans
  le flux) **et** `_FsManage` (connexion abonnement) passent juste sous
  `_FsEval`, avant la couverture / les derniers articles. Source non suivie :
  `_FsManage` reste le CTA de découverte (paywall) sous le contenu, `_FsSettings`
  masqué (gate `isTrusted` inchangé).
- **1b — « Lire plus » sur Derniers articles (3 → 10, sans requête réseau).**
  - Backend `sources.py:get_source_profile` : `recent_articles` limite `3 → 10`
    (additif, pas de rupture de contrat ; anciens clients prennent 3 via
    `.take(3)`). Docstring MAJ.
  - Mobile `_FsArticlesSection` → `StatefulWidget` : replié = `take(3)`, déplié =
    `take(10)`, bouton discret « Lire plus » / « Réduire » (idiome
    `_ExpandableDescription`) si `articles.length > 3`. Aucune requête : les 10
    articles sont déjà dans le payload profil.
  - Hors scope (noté) : mode smart-search (`_ArticlesContent`) et
    `recent_articles_list.dart` restent à 3 (autre chemin de préchargement).

## Partie 2 — Notifs inlines (« Notif du jour »)

- **2a — Cooldown durable au dismiss (~30j).** Nouveau store
  `notif_du_jour_dismissal_store.dart` (clé `notif_du_jour_dismissals_v1`, JSON
  `{ id: 'YYYY-MM-DD' }`, `kNotifDismissCooldownDays = 30`, clock injectable).
  `notifDuJourQueueProvider` filtre les `activeCooldownIds(now)` (même clé jour
  que le day store). Le cooldown se pose **au dismiss (croix) uniquement**
  (`_CloseButton` → `recordDismissed`), jamais au tap. Anti-flash : la carte
  gate désormais sur `day.loaded` **et** `dismissalStore.loaded`.
- **2b — « Mode serein » remonte.** Relevance `0.4 → 0.55` (au-dessus de
  `tournee` 0.5, sous les prompts temps-sensibles). Combiné au cooldown, serein
  émerge une fois les autres messages profil dismissés.
- **2c — Sondage « bien informé » non tronqué.** Titre `maxLines: 1 →
  hasCustomBody ? 2 : 1` (la question s'affiche en entier au-dessus de la
  rangée NPS ; une ligne, sans impact sur les autres messages).

## Tests

- Backend `test_source_profile.py` : happy path aligné (4 contents ≤ 10) +
  nouveau `test_profile_recent_articles_capped_at_10` (14 contents → 10).
  **7 passed** (`DATABASE_URL=postgresql+psycopg://facteur:facteur@localhost:54322/facteur_test`).
- Mobile : nouveau `notif_du_jour_dismissal_store_test.dart` (record + cooldown
  30j + expiration + date illisible) ; `notif_du_jour_provider_test.dart` étendu
  (id en cooldown filtré, cooldown expiré, serein remonte quand les autres sont
  en cooldown) ; `notif_du_jour_card_test.dart` (titre 2 lignes hasCustomBody,
  1 ligne standard) ; `source_detail_modal_test.dart` (ordre Priorité/Abonnement
  au-dessus des articles si suivie / paywall dessous si non suivie ; « Lire plus »
  déroule à 10 puis « Réduire » ; pas de bouton si ≤ 3). **76 passed.**
- `flutter analyze` sur les fichiers touchés : **No issues found.**

## Changelog

2 entrées `unreleased` : « Sources » (réglages en tête + Lire plus) + « Feed »
(notifs moins insistantes).
