### PR TITLE
feat(checkout): POST /api/checkout/send-link — lien de checkout par email (magic link Supabase)

### DIFF
--- a/packages/api/app/routers/checkout.py
+++ b/packages/api/app/routers/checkout.py
@@ -23,7 +23,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
 from app.database import get_db
-from app.schemas.checkout import CheckoutStartRequest, CheckoutStartResponse
+from app.dependencies import get_current_user_id
+from app.schemas.checkout import (
+    CheckoutSendLinkRequest,
+    CheckoutSendLinkResponse,
+    CheckoutStartRequest,
+    CheckoutStartResponse,
+)
 from app.services.posthog_client import get_posthog_client
 from app.services.subscription_service import SubscriptionService
 
@@ -169,3 +175,110 @@ async def start_passwordless(
         checkout_url=checkout_url,
         is_new_user=is_new_user,
     )
+
+
+async def _supabase_admin_get_user_email(user_id: str) -> str | None:
+    """Retourne l'email Supabase de ce user_id, ou None s'il est introuvable."""
+    settings = get_settings()
+    if not (settings.supabase_url and settings.supabase_service_role_key):
+        return None
+
+    url = f"{settings.supabase_url}/auth/v1/admin/users/{user_id}"
+    headers = {
+        "Authorization": f"Bearer {settings.supabase_service_role_key}",
+        "apikey": settings.supabase_service_role_key,
+    }
+    async with httpx.AsyncClient(verify=certifi.where(), timeout=10.0) as client:
+        resp = await client.get(url, headers=headers)
+    if resp.status_code != 200:
+        return None
+    return resp.json().get("email") or None
+
+
+async def _supabase_send_magic_link(email: str, redirect_to: str) -> None:
+    """Envoie le magic link Supabase (OTP) qui redirige vers l'URL de checkout.
+
+    Supabase envoie l'email lui-même ; le rate-limit OTP (~1/min par email)
+    remonte en 429 côté client mobile pour le bouton « Renvoyer le lien ».
+    """
+    settings = get_settings()
+    if not (settings.supabase_url and settings.supabase_anon_key):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Supabase auth config missing",
+        )
+
+    url = (
+        f"{settings.supabase_url}/auth/v1/otp?{urlencode({'redirect_to': redirect_to})}"
+    )
+    headers = {
+        "apikey": settings.supabase_anon_key,
+        "Content-Type": "application/json",
+    }
+    body = {"email": email, "create_user": False}
+    async with httpx.AsyncClient(verify=certifi.where(), timeout=10.0) as client:
+        resp = await client.post(url, headers=headers, json=body)
+
+    if resp.status_code == 429:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Magic link rate-limited, retry in a minute",
+        )
+    if resp.status_code not in (200, 204):
+        logger.warning(
+            "checkout.supabase_send_magic_link_failed",
+            status=resp.status_code,
+            body=resp.text[:500],
+        )
+        sentry_sdk.capture_message(
+            "checkout.supabase_send_magic_link_failed", level="warning"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Could not send checkout link",
+        )
+
+
+@router.post("/send-link", response_model=CheckoutSendLinkResponse)
+async def send_link(
+    request: CheckoutSendLinkRequest,
+    user_id: str = Depends(get_current_user_id),
+    db: AsyncSession = Depends(get_db),
+) -> CheckoutSendLinkResponse:
+    """Envoie par email le lien de checkout Web Billing à l'utilisateur courant.
+
+    Le CTA mobile n'ouvre jamais un paiement in-app (règles stores) : on envoie
+    un magic link Supabase dont le redirect_to est l'URL RevenueCat Web Billing
+    pré-remplie avec l'app_user_id.
+    """
+    email = await _supabase_admin_get_user_email(user_id)
+    if not email:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User email not found",
+        )
+
+    checkout_url = _build_checkout_url(request.offering, user_id)
+    await _supabase_send_magic_link(email, checkout_url)
+
+    service = SubscriptionService(db)
+    await service._get_or_create_subscription(user_id)
+    await db.commit()
+
+    get_posthog_client().capture(
+        user_id=user_id,
+        event="checkout_link_sent",
+        properties={
+            "offering": request.offering,
+            "resend": request.resend,
+        },
+    )
+
+    logger.info(
+        "checkout.send_link",
+        user_id=user_id,
+        offering=request.offering,
+        resend=request.resend,
+    )
+
+    return CheckoutSendLinkResponse(sent=True, email=email)

--- a/packages/api/app/schemas/checkout.py
+++ b/packages/api/app/schemas/checkout.py
@@ -21,3 +21,17 @@ class CheckoutStartResponse(BaseModel):
     user_id: str
     checkout_url: str
     is_new_user: bool
+
+
+class CheckoutSendLinkRequest(BaseModel):
+    """Envoi du lien de checkout par email (magic link Supabase)."""
+
+    offering: Literal["default", "founder"] = "default"
+    resend: bool = False
+
+
+class CheckoutSendLinkResponse(BaseModel):
+    """Réponse : confirmation d'envoi + email masquable côté client."""
+
+    sent: bool
+    email: EmailStr

--- a/packages/api/tests/routers/test_checkout_send_link.py
+++ b/packages/api/tests/routers/test_checkout_send_link.py
@@ -1,0 +1,136 @@
+"""Tests pour POST /api/checkout/send-link."""
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI, HTTPException, status
+from fastapi.testclient import TestClient
+
+from app.database import get_db
+from app.dependencies import get_current_user_id
+from app.routers.checkout import router
+
+
+def _make_client(db_session, user_id: str) -> TestClient:
+    app = FastAPI()
+    app.include_router(router, prefix="/api/checkout")
+    app.dependency_overrides[get_db] = lambda: db_session
+    app.dependency_overrides[get_current_user_id] = lambda: user_id
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.mark.asyncio
+async def test_send_link_happy_path(db_session):
+    user_id = str(uuid4())
+    send_mock = AsyncMock(return_value=None)
+
+    with (
+        patch(
+            "app.routers.checkout._supabase_admin_get_user_email",
+            new=AsyncMock(return_value="user@example.com"),
+        ),
+        patch("app.routers.checkout._supabase_send_magic_link", new=send_mock),
+        _make_client(db_session, user_id) as client,
+    ):
+        resp = client.post("/api/checkout/send-link", json={})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["sent"] is True
+    assert body["email"] == "user@example.com"
+
+    # Le redirect_to du magic link est l'URL de checkout avec l'app_user_id.
+    email_arg, redirect_arg = send_mock.await_args.args
+    assert email_arg == "user@example.com"
+    assert redirect_arg.startswith("https://pay.rev.cat/facteur-premium")
+    assert f"app_user_id={user_id}" in redirect_arg
+
+
+@pytest.mark.asyncio
+async def test_send_link_founder_offering(db_session):
+    user_id = str(uuid4())
+    send_mock = AsyncMock(return_value=None)
+
+    with (
+        patch(
+            "app.routers.checkout._supabase_admin_get_user_email",
+            new=AsyncMock(return_value="user@example.com"),
+        ),
+        patch("app.routers.checkout._supabase_send_magic_link", new=send_mock),
+        _make_client(db_session, user_id) as client,
+    ):
+        resp = client.post("/api/checkout/send-link", json={"offering": "founder"})
+
+    assert resp.status_code == 200
+    _, redirect_arg = send_mock.await_args.args
+    assert redirect_arg.startswith("https://pay.rev.cat/facteur-founder")
+
+
+@pytest.mark.asyncio
+async def test_send_link_email_not_found(db_session):
+    user_id = str(uuid4())
+
+    with (
+        patch(
+            "app.routers.checkout._supabase_admin_get_user_email",
+            new=AsyncMock(return_value=None),
+        ),
+        _make_client(db_session, user_id) as client,
+    ):
+        resp = client.post("/api/checkout/send-link", json={})
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_send_link_rate_limited_propagates_429(db_session):
+    user_id = str(uuid4())
+
+    with (
+        patch(
+            "app.routers.checkout._supabase_admin_get_user_email",
+            new=AsyncMock(return_value="user@example.com"),
+        ),
+        patch(
+            "app.routers.checkout._supabase_send_magic_link",
+            new=AsyncMock(
+                side_effect=HTTPException(
+                    status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                    detail="Magic link rate-limited, retry in a minute",
+                )
+            ),
+        ),
+        _make_client(db_session, user_id) as client,
+    ):
+        resp = client.post("/api/checkout/send-link", json={})
+
+    assert resp.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_send_link_resend_flag_tracked(db_session):
+    user_id = str(uuid4())
+    posthog_mock = type("P", (), {"captured": None})()
+
+    def capture(**kwargs):
+        posthog_mock.captured = kwargs
+
+    with (
+        patch(
+            "app.routers.checkout._supabase_admin_get_user_email",
+            new=AsyncMock(return_value="user@example.com"),
+        ),
+        patch(
+            "app.routers.checkout._supabase_send_magic_link",
+            new=AsyncMock(return_value=None),
+        ),
+        patch("app.routers.checkout.get_posthog_client") as posthog_client,
+    ):
+        posthog_client.return_value.capture = capture
+        with _make_client(db_session, user_id) as client:
+            resp = client.post("/api/checkout/send-link", json={"resend": True})
+
+    assert resp.status_code == 200
+    assert posthog_mock.captured["event"] == "checkout_link_sent"
+    assert posthog_mock.captured["properties"]["resend"] is True


### PR DESCRIPTION
## PR 1/2 — Paywalls Premium « Fact·eur·isse » (backend)

Implémente l'envoi du lien de checkout **par email**, conformément à la maquette Paywalls Premium (le CTA mobile n'ouvre jamais un paiement in-app, règles stores).

### Contenu
- `POST /api/checkout/send-link` (authentifié `get_current_user_id`) :
  - `_supabase_admin_get_user_email(user_id)` via l'Admin API (mêmes headers service-role que le lookup existant) ;
  - URL de checkout via `_build_checkout_url(offering, user_id)` existant ;
  - magic link Supabase `POST /auth/v1/otp` (`create_user: false`, `redirect_to=<checkout_url>`, apikey anon) — Supabase envoie l'email lui-même ;
  - `_get_or_create_subscription` + commit (parité `start-passwordless`) ;
  - PostHog `checkout_link_sent {offering, resend}` ;
  - **429** Supabase (rate-limit OTP ~1/min) propagé proprement pour « Renvoyer le lien ».
- Schemas `CheckoutSendLinkRequest` / `CheckoutSendLinkResponse`.
- **Aucune migration Alembic.** Zéro nouveau secret.

### Tests
5 nouveaux tests (`test_checkout_send_link.py`) : happy path (redirect_to contient app_user_id), offering founder, email introuvable → 404, 429 propagé, flag resend tracké. Suite backend complète : 2177 passed (15 échecs pré-existants `tests/scripts/media_eval` — FK locale, non liés).

### ⚠️ Étape manuelle PO (avant activation)
Ajouter l'URL de redirect à l'allow-list Supabase Auth : option A `https://pay.rev.cat/*`, option B page `checkout-redirect.html` sur la landing qui forwarde. Vérifier aussi le wording du template email magic-link.

La PR 2 (mobile : écran Soutien, murs de feature, gating client-side) suit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)