### PR TITLE
feat(mobile): ouvrir Flâner par défaut une fois l'Essentiel du jour parcouru

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -2,6 +2,10 @@
   "unreleased": [
     {
       "tag": "App",
+      "summary": "Une fois ta tournée du jour parcourue, l'app t'ouvre directement sur Flâner."
+    },
+    {
+      "tag": "App",
       "summary": "Un petit signal quand un bug survient : dis-nous ce qui s'est passé et on saura."
     },
     {

--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -192,11 +192,10 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
         // le widget gèle tant que l'utilisateur n'ouvre pas explicitement
         // Flâner.
         _ensureWidgetFresh(stale: shouldRefreshFlanerOnForeground(elapsed));
+        final tournee = ref.read(tourneeProgressServiceProvider);
         if (isAuthenticated &&
             currentPath == RoutePaths.fluxContinu &&
-            ref
-                .read(tourneeProgressServiceProvider)
-                .isClosingDismissedTodaySync()) {
+            tournee.hasBrowsedEssentielTodaySync()) {
           router.go(RoutePaths.flaner);
           return;
         }

--- a/apps/mobile/lib/config/routes.dart
+++ b/apps/mobile/lib/config/routes.dart
@@ -183,7 +183,7 @@ final routerProvider = Provider<GoRouter>((ref) {
       final authState = ref.read(authStateProvider);
       String postAuthHomePath() {
         final tournee = ref.read(tourneeProgressServiceProvider);
-        return tournee.isClosingDismissedTodaySync()
+        return tournee.hasBrowsedEssentielTodaySync()
             ? RoutePaths.flaner
             : RoutePaths.fluxContinu;
       }

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -165,6 +165,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   final Set<String> _dismissedIds = <String>{};
 
   bool _closingPersistQueued = false;
+  bool _essentielViewedMarked = false;
 
   /// `sectionKey` des sections favorites (thème/source/veille) dont le fetch du
   /// fan-out a **résolu** ce cycle (réponse arrivée, vide ou non). La
@@ -521,7 +522,10 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     // Issue #1 — seed des coquilles « Choisie pour vous » AVANT le fan-out
     // (mêmes clés que le rendu réel) : elles sont ordonnées dès la Phase 1 et se
     // remplissent sur place au lieu d'apparaître en net-new (le « pop » ressenti).
-    final suggestions = [for (final t in topThemes) if (t.isSuggested) t];
+    final suggestions = [
+      for (final t in topThemes)
+        if (t.isSuggested) t
+    ];
     _suggested = _shellSuggestedSections(_usableSuggestions(suggestions));
     // Reseed complet ⇒ les coquilles ne sont pas encore résolues : on repart
     // d'une classification vierge (aucune section maigre tant que le fan-out /
@@ -529,6 +533,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     _resolvedSectionKeys.clear();
     _closingDismissed = await _loadClosingDismissedForToday();
     unawaited(_purgeOldPrefsKeys());
+    unawaited(_markEssentielViewedIfNeeded());
 
     if (!fetchThemes) {
       // Chemin cache in-day : pas de fan-out réseau, on compose directement.
@@ -1226,7 +1231,8 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
           // son plancher (kind=essentiel) → on réapplique le seuil pour éviter
           // un bandeau réduit à une carte isolée. Les autres DigestTopicSection
           // (Bonnes Nouvelles) ne sont retirées que si totalement vidées.
-          final minKept = s.kind == SectionKind.essentiel ? _kActusMinTopics : 1;
+          final minKept =
+              s.kind == SectionKind.essentiel ? _kActusMinTopics : 1;
           if (kept.length < minKept) continue;
           result.add(
             DigestTopicSection(
@@ -1462,6 +1468,15 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     await ref.read(tourneeProgressServiceProvider).purgeOldPrefsKeys();
   }
 
+  /// Marks that the user has actually loaded Essentiel content today, so the
+  /// app can default to Flâner on the next cold start / resume. Write-once
+  /// per notifier instance to avoid redundant prefs writes on refetches.
+  Future<void> _markEssentielViewedIfNeeded() async {
+    if (_essentielViewedMarked) return;
+    _essentielViewedMarked = true;
+    await ref.read(tourneeProgressServiceProvider).markEssentielViewedToday();
+  }
+
   /// Pull-to-refresh: refetch all upstream calls from scratch.
   ///
   /// Crucially we do NOT bounce through [AsyncLoading] — doing so would
@@ -1635,7 +1650,8 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
         // suggérées du même payload transitent par le fan-out progressif
         // (`_fanOutSectionsProgressive` → `_buildSuggestedSection`).
         final valid = topFallback
-            .where((t) => !t.isSuggested && themeMap.containsKey(t.interestSlug))
+            .where(
+                (t) => !t.isSuggested && themeMap.containsKey(t.interestSlug))
             .map<FavoriteRef>((t) => ThemeFavoriteRef(slug: t.interestSlug))
             .toList();
         themeRefs = valid.take(_kMaxFavoriteSections).toList(growable: false);
@@ -1858,10 +1874,9 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   // ---------------------------------------------------------------------------
 
   /// Clé `sectionKey`-compatible d'une suggestion backend (`theme:`/`source:`).
-  String _suggestionKey(TopTheme s) =>
-      s.kind == 'source' && s.sourceId != null
-          ? tourneeSourceKey(s.sourceId!)
-          : tourneeThemeKey(s.interestSlug);
+  String _suggestionKey(TopTheme s) => s.kind == 'source' && s.sourceId != null
+      ? tourneeSourceKey(s.sourceId!)
+      : tourneeThemeKey(s.interestSlug);
 
   /// Suggestions « Choisie pour vous » réellement fetchables : filtre amont
   /// celles déjà masquées (dismiss) ou vivant en onglet Flâner — évite des
@@ -2048,8 +2063,12 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
 
   /// Retire de [list] la section de `sectionKey` == [key]. Issue #1 — une
   /// suggestion seedée mais résolue sans contenu disparaît après le fan-out.
-  List<FeedThemeSection> _removeByKey(List<FeedThemeSection> list, String key) =>
-      [for (final s in list) if (sectionKey(s) != key) s];
+  List<FeedThemeSection> _removeByKey(
+          List<FeedThemeSection> list, String key) =>
+      [
+        for (final s in list)
+          if (sectionKey(s) != key) s
+      ];
 
   /// `true` ssi [list] contient déjà une section de même `sectionKey` que
   /// [section]. Sert aux chemins de refetch à n'upserter qu'une coquille encore
@@ -2106,9 +2125,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
             .setSourceState(section.sourceId!, InterestState.favorite);
         await _appendTourneeOrder(tourneeSourceKey(section.sourceId!));
       } else if (section.themeSlug != null) {
-        await ref
-            .read(userInterestsProvider.notifier)
-            .setInterestState(
+        await ref.read(userInterestsProvider.notifier).setInterestState(
               ThemeFavoriteRef(slug: section.themeSlug!),
               InterestState.favorite,
             );

--- a/apps/mobile/lib/features/flux_continu/services/tournee_progress_service.dart
+++ b/apps/mobile/lib/features/flux_continu/services/tournee_progress_service.dart
@@ -15,6 +15,7 @@ final tourneeProgressServiceProvider = Provider<TourneeProgressService>((ref) {
 });
 
 const String kClosingPrefsKeyPrefix = 'flux_continu_closing_dismissed_';
+const String kEssentielViewedPrefsKeyPrefix = 'flux_continu_essentiel_viewed_';
 
 /// Boundary hour (Paris time) at which the "tournée day" flips.
 const int kTourneeDayBoundaryHour = 7;
@@ -33,7 +34,7 @@ class TourneeProgressService {
   final SharedPreferences? _prefsOverride;
 
   const TourneeProgressService({SharedPreferences? prefs})
-    : _prefsOverride = prefs;
+      : _prefsOverride = prefs;
 
   Future<SharedPreferences> _prefs() async =>
       _prefsOverride ?? await SharedPreferences.getInstance();
@@ -42,8 +43,7 @@ class TourneeProgressService {
   /// using a 07:30 Europe/Paris boundary instead of midnight.
   static String dayKey(DateTime now) {
     final paris = tz.TZDateTime.from(now, _parisTz());
-    final shifted =
-        (paris.hour < kTourneeDayBoundaryHour ||
+    final shifted = (paris.hour < kTourneeDayBoundaryHour ||
             (paris.hour == kTourneeDayBoundaryHour &&
                 paris.minute < kTourneeDayBoundaryMinute))
         ? paris.subtract(const Duration(days: 1))
@@ -53,6 +53,9 @@ class TourneeProgressService {
 
   static String closingPrefsKey(DateTime day) =>
       '$kClosingPrefsKeyPrefix${dayKey(day)}';
+
+  static String essentielViewedPrefsKey(DateTime day) =>
+      '$kEssentielViewedPrefsKeyPrefix${dayKey(day)}';
 
   bool isClosingDismissedTodaySync({DateTime? now}) {
     final prefs = _prefsOverride;
@@ -79,17 +82,46 @@ class TourneeProgressService {
     }
   }
 
+  bool isEssentielViewedTodaySync({DateTime? now}) {
+    final prefs = _prefsOverride;
+    if (prefs == null) return false;
+    return prefs.getBool(essentielViewedPrefsKey(now ?? DateTime.now())) ??
+        false;
+  }
+
+  /// `true` ssi l'utilisateur a déjà « parcouru » l'Essentiel aujourd'hui —
+  /// soit en fermant explicitement le bandeau, soit en ayant chargé son
+  /// contenu. Sert à router vers Flâner par défaut (cold start / resume).
+  bool hasBrowsedEssentielTodaySync({DateTime? now}) =>
+      isClosingDismissedTodaySync(now: now) ||
+      isEssentielViewedTodaySync(now: now);
+
+  Future<void> markEssentielViewedToday({DateTime? now}) async {
+    try {
+      final prefs = await _prefs();
+      await prefs.setBool(essentielViewedPrefsKey(now ?? DateTime.now()), true);
+    } catch (e) {
+      debugPrint('TourneeProgress: markEssentielViewedToday failed: $e');
+    }
+  }
+
   Future<void> purgeOldPrefsKeys({DateTime? now}) async {
     try {
       final prefs = await _prefs();
       final today = now ?? DateTime.now();
       final closingToday = closingPrefsKey(today);
-      // Purge stale closing-dismissed keys (previous days) **and** any leftover
-      // `flux_continu_folded_*` blobs from before the fold mechanic was removed
-      // (2026-06), so they don't linger in SharedPreferences forever.
+      final essentielViewedToday = essentielViewedPrefsKey(today);
+      // Purge stale closing-dismissed/essentiel-viewed keys (previous days)
+      // **and** any leftover `flux_continu_folded_*` blobs from before the
+      // fold mechanic was removed (2026-06), so they don't linger in
+      // SharedPreferences forever.
       final stale = prefs.getKeys().where((k) {
         if (k.startsWith('flux_continu_folded_')) return true;
         if (k.startsWith(kClosingPrefsKeyPrefix) && k != closingToday) {
+          return true;
+        }
+        if (k.startsWith(kEssentielViewedPrefsKeyPrefix) &&
+            k != essentielViewedToday) {
           return true;
         }
         return false;

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
@@ -13,6 +13,7 @@ import 'package:facteur/features/flux_continu/providers/flux_continu_provider.da
 import 'package:facteur/features/flux_continu/repositories/essentiel_repository.dart';
 import 'package:facteur/features/flux_continu/repositories/flux_continu_repository.dart';
 import 'package:facteur/features/flux_continu/services/flux_continu_cache_service.dart';
+import 'package:facteur/features/flux_continu/services/tournee_progress_service.dart';
 import 'package:facteur/features/grille/models/grille_models.dart';
 import 'package:facteur/features/grille/providers/grille_provider.dart';
 import 'package:facteur/features/grille/repositories/grille_repository.dart';
@@ -101,6 +102,9 @@ String _todayIso() {
 }
 
 String _todayClosingKey() => 'flux_continu_closing_dismissed_${_todayIso()}';
+
+String _todayEssentielViewedKey() =>
+    TourneeProgressService.essentielViewedPrefsKey(DateTime.now());
 
 FeedResponse _feedResponseWith(int items) {
   return FeedResponse(
@@ -275,6 +279,39 @@ void main() {
       final state = await settle(container);
 
       expect(state.closingDismissed, isFalse);
+    });
+
+    test('marks Essentiel viewed today after a successful load', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      await settle(container);
+      // Marked via `unawaited` — give the microtask queue a beat.
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool(_todayEssentielViewedKey()), isTrue);
+    });
+
+    test('a refetch does not error and keeps essentiel-viewed set', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      await settle(container);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      await container.read(fluxContinuProvider.notifier).refresh();
+      await settle(container);
+      await Future<void>.delayed(Duration.zero);
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool(_todayEssentielViewedKey()), isTrue);
     });
   });
 
@@ -862,7 +899,6 @@ void main() {
         );
       },
     );
-
   });
 
   group('FluxContinuNotifier — dedup inter-sections', () {
@@ -1422,7 +1458,8 @@ void main() {
                   .every((t) => t.items.isEmpty),
         );
         expect(baseIdx, greaterThan(skeletonIdx),
-            reason: 'les en-têtes (haut de page + coquilles favoris) remplacent '
+            reason:
+                'les en-têtes (haut de page + coquilles favoris) remplacent '
                 'le squelette avant le remplissage du fan-out');
 
         // complet : la section thème 'tech' est REMPLIE (items non vides),

--- a/apps/mobile/test/features/flux_continu/services/tournee_progress_service_test.dart
+++ b/apps/mobile/test/features/flux_continu/services/tournee_progress_service_test.dart
@@ -1,0 +1,76 @@
+import 'package:facteur/features/flux_continu/services/tournee_progress_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TourneeProgressService — essentiel viewed', () {
+    test('isEssentielViewedTodaySync defaults to false', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final prefs = await SharedPreferences.getInstance();
+      final service = TourneeProgressService(prefs: prefs);
+
+      expect(service.isEssentielViewedTodaySync(), isFalse);
+    });
+
+    test('markEssentielViewedToday flips the sync flag for today', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final prefs = await SharedPreferences.getInstance();
+      final service = TourneeProgressService(prefs: prefs);
+
+      await service.markEssentielViewedToday();
+
+      expect(service.isEssentielViewedTodaySync(), isTrue);
+    });
+
+    test('hasBrowsedEssentielTodaySync reflects either flag', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final prefs = await SharedPreferences.getInstance();
+      final service = TourneeProgressService(prefs: prefs);
+
+      expect(service.hasBrowsedEssentielTodaySync(), isFalse);
+
+      await service.markEssentielViewedToday();
+
+      expect(service.hasBrowsedEssentielTodaySync(), isTrue);
+    });
+
+    test('essentiel-viewed and closing-dismissed flags are independent',
+        () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final prefs = await SharedPreferences.getInstance();
+      final service = TourneeProgressService(prefs: prefs);
+
+      await service.markEssentielViewedToday();
+
+      expect(service.isEssentielViewedTodaySync(), isTrue);
+      expect(service.isClosingDismissedTodaySync(), isFalse);
+
+      await service.setClosingDismissedToday(true);
+
+      expect(service.isClosingDismissedTodaySync(), isTrue);
+      expect(service.isEssentielViewedTodaySync(), isTrue);
+    });
+
+    test('purgeOldPrefsKeys removes a previous day\'s key, keeps today\'s',
+        () async {
+      const oldKey = 'flux_continu_essentiel_viewed_2020-01-01';
+      final today = TourneeProgressService.essentielViewedPrefsKey(
+        DateTime.now(),
+      );
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        oldKey: true,
+        today: true,
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final service = TourneeProgressService(prefs: prefs);
+
+      await service.purgeOldPrefsKeys();
+
+      final keys = prefs.getKeys();
+      expect(keys, isNot(contains(oldKey)));
+      expect(keys, contains(today));
+    });
+  });
+}


### PR DESCRIPTION
## Quoi
Une fois la tournée du jour parcourue (bandeau de clôture fermé **ou** contenu Essentiel chargé), l'app ouvre directement l'onglet **Flâner** au lancement à froid et à la reprise en foreground, au lieu de retomber sur l'Essentiel déjà lu.

## Pourquoi
Après avoir fait sa tournée, l'utilisateur qui rouvre l'app n'a plus rien de neuf à voir dans l'Essentiel : le renvoyer sur Flâner (où il explore) est le comportement attendu. Jusqu'ici seul le *dismiss* explicite du bandeau déclenchait ce basculement ; ceux qui lisent sans fermer le bandeau restaient bloqués sur l'Essentiel.

## Comment
- Nouveau flag SharedPreferences `flux_continu_essentiel_viewed_<jour>` (frontière 07h30 Paris, purge des jours passés) posé une fois par session dès qu'un contenu Essentiel se charge (`_markEssentielViewedIfNeeded`, write-once, `unawaited` → hors chemin bloquant).
- Helper composé `TourneeProgressService.hasBrowsedEssentielTodaySync()` = closing-dismissed **OU** essentiel-viewed, appelé par le routing post-auth (`routes.dart`) et la reprise foreground (`app.dart`).

## Comment ça a été vérifié
- [x] `flutter test` flux_continu (provider + nouveau service test) — All tests passed
- [x] `flutter analyze` sur les fichiers modifiés — No issues found
- [x] `/simplify` passé (helper composé, suppression du loader async mort)

## Zones à risque
Routing de démarrage (`routes.dart` postAuthHomePath) et reprise foreground (`app.dart`) — deux couches qui partagent désormais le même helper. Aucune migration, aucun backend.
