### PR TITLE
fix(bonnes-nouvelles): fallback on-demand serein filtre is_good_news + fail-closed

### DIFF
--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -929,7 +929,6 @@ class DigestService:
                 user_id=user_id,
                 limit=target_size,
                 is_serene=is_serene,
-                sensitive_themes=sensitive_themes,
                 excluded_topics=excluded_topics,
             )
             fallback_time = time.time() - step_start
@@ -1064,7 +1063,6 @@ class DigestService:
         user_id: UUID,
         limit: int = 5,
         is_serene: bool = False,
-        sensitive_themes: list[str] | None = None,
         excluded_topics: list[Any] | None = None,
     ) -> list[Any]:
         """Last resort: get most recent content from user's followed sources first.
@@ -1081,8 +1079,16 @@ class DigestService:
 
         from app.models.content import Content
         from app.models.source import Source
-        from app.services.recommendation.filter_presets import apply_serein_filter
+        from app.services.recommendation.filter_presets import apply_good_news_filter
 
+        # Mode serein = "Bonnes nouvelles du jour" : la promesse (is_good_news=True)
+        # prime sur la quantité. On applique le MÊME hard-filter que le reste du
+        # chemin serein (cf. apply_good_news_filter partout dans digest_selector /
+        # digest_generation_job) au lieu de l'ancien apply_serein_filter (is_serene),
+        # oublié lors de la migration is_serene → is_good_news. Sans ça, quand le
+        # pool good-news est vide (ex. worker de classif à l'arrêt → tout le frais
+        # is_good_news=NULL), le fallback laissait passer du contenu quelconque
+        # non-anxiogène (transactions NBA…) dans « Bonnes nouvelles ».
         MAX_PER_SOURCE = 2  # Same constraint as DigestSelector
         # Fetch more candidates than needed so we can apply diversity
         fetch_limit = limit * 5
@@ -1117,9 +1123,8 @@ class DigestService:
                 .limit(fetch_limit)
             )
             if is_serene:
-                stmt = apply_serein_filter(
+                stmt = apply_good_news_filter(
                     stmt,
-                    sensitive_themes=sensitive_themes,
                     excluded_topics=excluded_topics,
                 )
 
@@ -1145,9 +1150,8 @@ class DigestService:
                     Content.id.notin_(list(existing_ids))
                 )
             if is_serene:
-                curated_query = apply_serein_filter(
+                curated_query = apply_good_news_filter(
                     curated_query,
-                    sensitive_themes=sensitive_themes,
                     excluded_topics=excluded_topics,
                 )
             stmt = curated_query
@@ -1156,8 +1160,11 @@ class DigestService:
             all_contents.extend(result.scalars().all())
 
         # LAST RESORT: If still not enough, query ANY active source with wider window (30 days)
-        # This guarantees new users always get a digest even if curated sources have no recent content
-        if len(all_contents) < limit:
+        # This guarantees new users always get a digest even if curated sources have no recent content.
+        # EXCEPTION serein : on NE fait PAS ce repli élargi. « Bonnes nouvelles du
+        # jour » est fail-closed (comme le batch) — mieux vaut un digest partiel
+        # que d'élargir à toute source active sur 30 j sans garantie is_good_news.
+        if len(all_contents) < limit and not is_serene:
             existing_ids = {c.id for c in all_contents}
             wider_cutoff = datetime.now(UTC) - timedelta(days=30)
             any_source_query = (
@@ -1174,12 +1181,6 @@ class DigestService:
             if existing_ids:
                 any_source_query = any_source_query.where(
                     Content.id.notin_(list(existing_ids))
-                )
-            if is_serene:
-                any_source_query = apply_serein_filter(
-                    any_source_query,
-                    sensitive_themes=sensitive_themes,
-                    excluded_topics=excluded_topics,
                 )
 
             result = await self.session.execute(any_source_query)

--- a/packages/api/tests/test_emergency_candidates_serein.py
+++ b/packages/api/tests/test_emergency_candidates_serein.py
@@ -1,0 +1,127 @@
+"""Tests for DigestService._get_emergency_candidates in serein mode.
+
+Régression : le fallback d'urgence on-demand utilisait `apply_serein_filter`
+(is_serene) au lieu de `apply_good_news_filter` (is_good_news). Quand la classif
+est à l'arrêt (tout le frais is_good_news=NULL, is_serene=NULL), il laissait
+passer du contenu quelconque non-anxiogène (transactions NBA…) dans le digest
+« Bonnes nouvelles du jour ». Ces tests verrouillent le hard-filter is_good_news
+et l'absence de repli élargi 30 j en serein.
+"""
+
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+
+from app.models.content import Content
+from app.models.enums import ContentType, InterestState, SourceType
+from app.models.source import Source, UserSource
+from app.services.digest_service import DigestService
+
+
+async def _make_source(db_session, *, theme="tech", is_curated=True):
+    src = Source(
+        id=uuid4(),
+        name="Basket USA",
+        url="https://basketusa.example.com",
+        feed_url=f"https://basketusa.example.com/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme=theme,
+        is_active=True,
+        is_curated=is_curated,
+    )
+    db_session.add(src)
+    await db_session.commit()
+    return src
+
+
+async def _make_content(db_session, source, title, *, is_good_news, is_serene=None):
+    content = Content(
+        id=uuid4(),
+        source_id=source.id,
+        title=title,
+        url=f"https://example.com/{uuid4()}",
+        guid=f"guid-{uuid4()}",
+        published_at=datetime.utcnow(),
+        content_type=ContentType.ARTICLE,
+        is_good_news=is_good_news,
+        is_serene=is_serene,
+    )
+    db_session.add(content)
+    await db_session.commit()
+    return content
+
+
+@pytest.mark.asyncio
+async def test_serein_emergency_keeps_only_good_news(db_session):
+    """En serein, seul is_good_news=True survit ; NULL (non classifié) et False exclus."""
+    source = await _make_source(db_session)
+
+    good = await _make_content(
+        db_session,
+        source,
+        "Une avancée concrète pour l'accès à l'eau",
+        is_good_news=True,
+    )
+    # Transaction NBA fraîche, non classifiée (worker classif à l'arrêt).
+    await _make_content(
+        db_session, source, "Ja Morant transféré aux Blazers !", is_good_news=None
+    )
+    await _make_content(db_session, source, "Article anxiogène", is_good_news=False)
+
+    service = DigestService(db_session)
+    items = await service._get_emergency_candidates(
+        user_id=uuid4(), limit=5, is_serene=True
+    )
+
+    returned_ids = {item.content.id for item in items}
+    assert returned_ids == {good.id}
+
+
+@pytest.mark.asyncio
+async def test_serein_emergency_empty_when_no_good_news(db_session):
+    """Aucun is_good_news=True → digest vide (fail-closed), pas de repli 30 j."""
+    source = await _make_source(db_session)
+    await _make_content(
+        db_session, source, "Ja Morant transféré aux Blazers !", is_good_news=None
+    )
+
+    service = DigestService(db_session)
+    items = await service._get_emergency_candidates(
+        user_id=uuid4(), limit=5, is_serene=True
+    )
+
+    assert items == []
+
+
+@pytest.mark.asyncio
+async def test_serein_emergency_followed_source_not_bypassed(db_session):
+    """Une source SUIVIE ne contourne pas le gate is_good_news en serein."""
+    source = await _make_source(db_session, is_curated=False)
+    user_id = uuid4()
+    db_session.add(
+        UserSource(user_id=user_id, source_id=source.id, state=InterestState.FOLLOWED)
+    )
+    await _make_content(db_session, source, "Rumeur NBA du jour", is_good_news=None)
+    await db_session.commit()
+
+    service = DigestService(db_session)
+    items = await service._get_emergency_candidates(
+        user_id=user_id, limit=5, is_serene=True
+    )
+
+    assert items == []
+
+
+@pytest.mark.asyncio
+async def test_non_serein_emergency_unaffected(db_session):
+    """Mode non-serein : le fallback reste permissif (pas de gate is_good_news)."""
+    source = await _make_source(db_session)
+    await _make_content(db_session, source, "Actu tech du jour", is_good_news=None)
+
+    service = DigestService(db_session)
+    items = await service._get_emergency_candidates(
+        user_id=uuid4(), limit=5, is_serene=False
+    )
+
+    assert len(items) == 1


### PR DESCRIPTION
## Quoi

Les articles NBA de **Basket USA** apparaissaient dans « Bonnes nouvelles du jour » (`mode='serein'`). Fix du **chemin on-demand** (`_get_emergency_candidates`) : il appliquait `apply_serein_filter` (**is_serene**) au lieu de `apply_good_news_filter` (**is_good_news**) — oubli de la migration `is_serene → is_good_news`. La passe « LAST RESORT » (30 j / toute source) est désormais **désactivée en mode serein** (fail-closed).

## Pourquoi

Diagnostic prouvé sur la donnée prod — 3 défauts cumulés :

| # | Défaut | Nature |
|---|--------|--------|
| **A** | Worker de classif arrêté ~30/06 → tout le frais a `is_good_news/is_serene/theme = NULL` ⇒ pool strict vide | Opérationnel (déclencheur) |
| **B** | `_get_emergency_candidates` filtrait `is_serene` au lieu de `is_good_news` ; avec `is_serene` NULL → fallback mots-clés qui laisse passer les transactions NBA, et la passe « last resort » élargissait à 30 j / toute source | **Bug code (cette PR)** |
| **C** | Basket USA thématisée `tech` (bug `_guess_theme`) → cartes rangées sous « Tech » | Cosmétique |

Le batch nocturne échoue proprement (fail-closed) — la fuite était **spécifique au chemin on-demand**.

Cette PR corrige **B** :
- passes *followed* + *curated* → `apply_good_news_filter`
- passe « LAST RESORT » **désactivée** en serein (`and not is_serene`) → fail-closed : la promesse « bonnes nouvelles » prime sur la quantité (mieux vaut un digest partiel qu'élargir sans garantie `is_good_news`)
- retrait du paramètre `sensitive_themes` désormais mort dans la fonction

## Comment ça a été vérifié

- [x] pytest — `test_emergency_candidates_serein.py` (4 cas : garde is_good_news, digest vide fail-closed, source suivie non-bypassée, non-serein inchangé) + non-régression `test_digest_service.py` + `test_serein_filter.py` (30 + 29 passés)
- [x] ruff check + format OK
- [x] /simplify passé (retrait threading `sensitive_themes` mort)
- N/A flutter / Playwright (backend-only, pas d'UI)
- N/A migration Alembic (aucune)

## Restes (suivis séparés, hors PR)

- **A** — relancer le worker classif + backfill des ~25 k articles NULL (bloqué sur accès Railway, cf. PR #948).
- **C** — `scripts/fix_basket_usa_theme.py --apply --allow-prod` (tech → sport).

## Zones à risque

`DigestService._get_emergency_candidates` — chemin de secours du digest serein uniquement. Fail-closed : en cas de pool good-news vide, « Bonnes nouvelles » peut retourner un digest partiel plutôt que du contenu quelconque.

🤖 Generated with [Claude Code](https://claude.com/claude-code)