### PR TITLE
fix(widget): fiabilise le bouton refresh + enchaînement de lecture des articles

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -5,6 +5,10 @@
       "summary": "Le bouton rafraîchir du widget d'accueil répare désormais l'Essentiel et le Flux d'un coup, même après un blocage."
     },
     {
+      "tag": "Widget",
+      "summary": "Depuis le widget, tu peux ouvrir un article puis en enchaîner un autre sans repasser par l'accueil."
+    },
+    {
       "tag": "Sources",
       "summary": "Sur une source suivie, la priorité dans ton flux et la connexion d'abonnement passent en tête de fiche, et « Lire plus » déroule ses derniers articles."
     },

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,12 +1,18 @@
 {
   "unreleased": [
     {
+      "tag": "Widget",
+      "summary": "Le bouton rafraîchir du widget d'accueil répare désormais l'Essentiel et le Flux d'un coup, même après un blocage."
+    },
+    {
       "tag": "Sources",
       "summary": "Sur une source suivie, la priorité dans ton flux et la connexion d'abonnement passent en tête de fiche, et « Lire plus » déroule ses derniers articles."
     },
     {
       "tag": "Feed",
       "summary": "Les notifs en tête de feed sont moins insistantes : une notif écartée ne revient plus avant un mois, et le sondage « bien informé » s'affiche en entier."
+    },
+    {
       "tag": "App",
       "summary": "Un petit signal quand un bug survient : dis-nous ce qui s'est passé et on saura."
     },

--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -9,6 +9,7 @@ import 'core/auth/auth_state.dart';
 import 'core/providers/analytics_provider.dart';
 import 'core/services/deep_link_service.dart';
 import 'core/services/widget_service.dart';
+import 'features/digest/providers/digest_provider.dart';
 import 'features/feed/providers/feed_preload_provider.dart';
 import 'features/feed/providers/feed_provider.dart';
 import 'features/feed/services/read_sync_service.dart';
@@ -258,9 +259,16 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
     DeepLinkService.instance.bind(
       router: router,
       analytics: analytics,
-      // Widget refresh button → réveille l'app, force un refresh Flâner (qui
-      // re-pushe le widget via le chemin existant).
-      onRefreshRequested: () => ref.read(feedProvider.notifier).refresh(),
+      // Widget refresh button → réveille l'app et répare les DEUX côtés du
+      // widget : l'Essentiel (digest) ET le Flux (feed). Le refresh Flâner
+      // simple ne reconstruisait jamais l'Essentiel et pouvait rester un no-op
+      // silencieux (filtre actif / signature identique / erreur réseau) — d'où
+      // le bouton « sans effet ». On force donc un re-push complet des deux
+      // caches. Fire-and-forget : le handler de deep link est synchrone.
+      onRefreshRequested: () {
+        unawaited(ref.read(digestProvider.notifier).syncWidgetFromRefresh());
+        unawaited(ref.read(feedProvider.notifier).refreshForWidget());
+      },
     );
 
     if (!_deepLinksStarted) {

--- a/apps/mobile/lib/core/services/deep_link_service.dart
+++ b/apps/mobile/lib/core/services/deep_link_service.dart
@@ -227,7 +227,12 @@ class DeepLinkService {
           position: action.position,
           topicId: action.topicId,
         );
-        router.go(action.route!);
+        // push (not go) so the reader STACKS on top of what's showing — even an
+        // already-open reader. Lets the user chain article reads from the widget
+        // (back returns to the previous article), matching the in-app feed-card
+        // and deep-reco navigation. `go` reused the current content/:id route in
+        // place, so tapping a widget article while already reading was a no-op.
+        router.push(action.route!);
         return;
       case WidgetDeepLinkTarget.digest:
         _analytics?.trackWidgetAppOpened(target: 'digest');

--- a/apps/mobile/lib/features/digest/providers/digest_provider.dart
+++ b/apps/mobile/lib/features/digest/providers/digest_provider.dart
@@ -290,6 +290,30 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
     WidgetService.updateWidget(digest: _normalDigest);
   }
 
+  /// Re-push the Essentiel side of the widget on explicit demand — the home
+  /// screen widget's refresh button.
+  ///
+  /// The Flux-side `refresh()` never rebuilds the Essentiel cache
+  /// (`articles_json`), so a degenerate/empty Essentiel payload can only be
+  /// repaired here. When the digest isn't in memory yet — precisely the state
+  /// that leaves the widget's Essentiel side empty (`articles_json = []`) — we
+  /// load it first so the refresh actually rebuilds it instead of re-pushing
+  /// `null`. Silent on failure: the Flux side of the refresh still proceeds.
+  Future<void> syncWidgetFromRefresh() async {
+    try {
+      if (_normalDigest == null) {
+        // _loadBothDigests() already re-pushes the widget on success, so no
+        // extra _syncWidget() is needed on the cold-cache path.
+        await _loadBothDigests();
+      } else {
+        _syncWidget();
+      }
+    } catch (e) {
+      // ignore: avoid_print
+      print('DigestNotifier: syncWidgetFromRefresh failed: $e');
+    }
+  }
+
   /// Clear the in-memory cache (forces next load to call API).
   void _clearCache() {
     _normalDigest = null;

--- a/apps/mobile/lib/features/feed/providers/feed_provider.dart
+++ b/apps/mobile/lib/features/feed/providers/feed_provider.dart
@@ -441,25 +441,40 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
   /// filter/theme/source/etc. is active — only the canonical, unfiltered Flux
   /// is mirrored to the widget. Debounced + signature-guarded so optimistic
   /// taps and loadMore bursts don't churn SharedPreferences.
-  void _scheduleWidgetPush(List<Content> items) {
-    if (_selectedFilter != null ||
-        _selectedTheme != null ||
-        _selectedTopic != null ||
-        _selectedSourceId != null ||
-        _selectedEntity != null ||
-        _selectedKeyword != null) {
+  ///
+  /// [force] bypasses **both** the filter guard and the signature guard and
+  /// pushes immediately (no debounce). It is reserved to the explicit
+  /// home-screen widget refresh button ([refreshForWidget]): that gesture must
+  /// never be a silent no-op, even when the payload is byte-identical to the
+  /// last push or a Flâner filter is active in-app. Callers on the [force]
+  /// path are responsible for passing the canonical *unfiltered* items.
+  void _scheduleWidgetPush(List<Content> items, {bool force = false}) {
+    if (!force &&
+        (_selectedFilter != null ||
+            _selectedTheme != null ||
+            _selectedTopic != null ||
+            _selectedSourceId != null ||
+            _selectedEntity != null ||
+            _selectedKeyword != null)) {
       return;
     }
     final slice = items.take(_widgetFluxCap).toList(growable: false);
-    final signature = slice.isEmpty
-        ? '0'
-        : '${slice.length}|${slice.first.id}|${slice.last.id}';
-    if (signature == _lastWidgetPushSignature) return;
+    if (slice.isEmpty) return;
+    final signature = '${slice.length}|${slice.first.id}|${slice.last.id}';
+    if (!force && signature == _lastWidgetPushSignature) return;
     _widgetPushDebounce?.cancel();
-    _widgetPushDebounce = Timer(_widgetPushDelay, () {
+    void push() {
       _lastWidgetPushSignature = signature;
       WidgetService.updateWidget(feedItems: slice);
-    });
+    }
+
+    if (force) {
+      // Synchronous push (no Timer) so the widget repaints before the
+      // deep-link handler returns — Timer(Duration.zero) would still defer.
+      push();
+    } else {
+      _widgetPushDebounce = Timer(_widgetPushDelay, push);
+    }
   }
 
   /// Prefetch additional pages purely to feed the widget. Calls the repository
@@ -848,6 +863,66 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     } finally {
       ref.read(feedRefreshingProvider.notifier).state = false;
     }
+  }
+
+  /// Explicit refresh path for the home-screen widget's refresh button
+  /// (`io.supabase.facteur://feed?refresh=1`).
+  ///
+  /// The ambient [refresh] + [_scheduleWidgetPush] chain is deliberately
+  /// conservative: it skips the widget push under an active Flâner filter, when
+  /// the content signature is unchanged, or on network error — which makes the
+  /// button feel like a no-op precisely when the widget is stuck. This method
+  /// guarantees the button always re-pushes the canonical **unfiltered** Flux:
+  ///
+  ///  1. Fetches a fresh unfiltered page 1 (respecting the Serein toggle),
+  ///     without disturbing any in-app filter/scroll state.
+  ///  2. Force-pushes it to the widget, bypassing the filter + signature guards.
+  ///  3. Restores widget depth (up to 80) via [_prefetchForWidget].
+  ///  4. On network failure, still force-pushes the last known unfiltered feed
+  ///     ([_globalItems]) so the widget is never left silently stale.
+  ///
+  /// The Essentiel side is repaired separately by
+  /// `digestProvider.syncWidgetFromRefresh()`, wired in the same deep-link
+  /// handler (`app.dart`).
+  Future<void> refreshForWidget() async {
+    final isSerein = ref.read(sereinToggleProvider).enabled;
+    List<Content> unfiltered = const <Content>[];
+    try {
+      final repository = ref.read(feedRepositoryProvider);
+      final response = await repository.getFeed(
+        page: 1,
+        limit: _limit,
+        serein: isSerein,
+        forceFresh: true,
+      );
+      unfiltered = response.items;
+
+      // When no filter is active in-app, mirror the fresh page into the
+      // on-screen feed and the unfiltered snapshot so the app and the widget
+      // stay consistent. Under an active filter we must NOT touch the visible
+      // (filtered) state — only the widget payload is refreshed.
+      if (_isUnfiltered && unfiltered.isNotEmpty) {
+        final overlaid =
+            _overlayConsumed(unfiltered, state.value?.carousels ?? const []);
+        unfiltered = overlaid.items;
+        _globalItems = overlaid.items;
+        _hasNext = response.pagination.hasNext && response.items.isNotEmpty;
+        state = AsyncData(
+          FeedState(items: overlaid.items, carousels: overlaid.carousels),
+        );
+      }
+    } catch (e) {
+      // Network failure: fall back to the last known unfiltered feed so the
+      // refresh button still repaints the widget instead of leaving it stuck.
+      // ignore: avoid_print
+      print(
+          'FeedNotifier: refreshForWidget fetch failed, using cached feed: $e');
+    }
+
+    final toPush = unfiltered.isNotEmpty ? unfiltered : _globalItems;
+    if (toPush.isEmpty) return;
+    _scheduleWidgetPush(toPush, force: true);
+    unawaited(_prefetchForWidget(toPush));
   }
 
   /// Refresh feed: mark visible articles (cards + carousel items qui sont

--- a/apps/mobile/test/core/services/deep_link_service_test.dart
+++ b/apps/mobile/test/core/services/deep_link_service_test.dart
@@ -1,5 +1,7 @@
 import 'package:facteur/core/services/deep_link_service.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 
 void main() {
   group('DeepLinkService.parse', () {
@@ -221,5 +223,108 @@ void main() {
       );
       expect(service.pendingRoute(), isNull);
     });
+  });
+
+  // Regression: a widget article tap must open the reader by STACKING (push),
+  // not replacing (go), so it works even when a reader is already on screen —
+  // letting the user chain article reads from the home-screen widget.
+  group('DeepLinkService article navigation (widget tap → reader stacks)', () {
+    tearDown(DeepLinkService.resetForTest);
+
+    // Minimal router mirroring the two reader paths the widget deep links
+    // resolve to (`/flaner/content/:id`, `/flux-continu/content/:id`). The
+    // placeholder reader just renders its id so we can assert what's on top.
+    GoRouter buildRouter(GlobalKey<NavigatorState> navKey) {
+      Widget reader(BuildContext c, GoRouterState s) =>
+          Scaffold(body: Text('reader-${s.pathParameters['id']}'));
+      return GoRouter(
+        navigatorKey: navKey,
+        initialLocation: '/flaner',
+        routes: [
+          GoRoute(
+            path: '/flaner',
+            builder: (c, s) => const Scaffold(body: Text('flaner-home')),
+          ),
+          GoRoute(path: '/flaner/content/:id', builder: reader),
+          GoRoute(
+            path: '/flux-continu',
+            builder: (c, s) => const Scaffold(body: Text('flux-home')),
+          ),
+          GoRoute(path: '/flux-continu/content/:id', builder: reader),
+        ],
+      );
+    }
+
+    Future<DeepLinkService> boundService(
+      WidgetTester tester,
+      GlobalKey<NavigatorState> navKey,
+    ) async {
+      final router = buildRouter(navKey);
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      final service = DeepLinkService.forTest();
+      DeepLinkService.setInstanceForTest(service);
+      service.bind(router: router);
+      service.setAuthenticated(true);
+      return service;
+    }
+
+    testWidgets(
+      'Flux article: tapping a 2nd widget article while already in a reader '
+      'stacks a new reader (chaining), not a no-op / replace',
+      (tester) async {
+        final navKey = GlobalKey<NavigatorState>();
+        final service = await boundService(tester, navKey);
+
+        // First tap → user is now "in an article".
+        service.handle(Uri.parse('io.supabase.facteur://feed/content/first'));
+        await tester.pumpAndSettle();
+        expect(find.text('reader-first'), findsOneWidget);
+
+        // Second tap WHILE inside the reader → opens the second article on top.
+        service.handle(Uri.parse('io.supabase.facteur://feed/content/second'));
+        await tester.pumpAndSettle();
+        expect(find.text('reader-second'), findsOneWidget);
+
+        // Proof it STACKED: popping the top reveals the first article. Under the
+        // old `go` (replace) there would be no first reader to pop back to.
+        navKey.currentState!.pop();
+        await tester.pumpAndSettle();
+        expect(find.text('reader-first'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Essentiel (digest) article stacks a reader the same way',
+      (tester) async {
+        final navKey = GlobalKey<NavigatorState>();
+        final service = await boundService(tester, navKey);
+
+        service.handle(Uri.parse('io.supabase.facteur://digest/aaa'));
+        await tester.pumpAndSettle();
+        expect(find.text('reader-aaa'), findsOneWidget);
+
+        service.handle(Uri.parse('io.supabase.facteur://digest/bbb'));
+        await tester.pumpAndSettle();
+        expect(find.text('reader-bbb'), findsOneWidget);
+
+        navKey.currentState!.pop();
+        await tester.pumpAndSettle();
+        expect(find.text('reader-aaa'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'from the home tab (no reader open) a widget article still opens the '
+      'reader',
+      (tester) async {
+        final navKey = GlobalKey<NavigatorState>();
+        final service = await boundService(tester, navKey);
+        expect(find.text('flaner-home'), findsOneWidget);
+
+        service.handle(Uri.parse('io.supabase.facteur://feed/content/solo'));
+        await tester.pumpAndSettle();
+        expect(find.text('reader-solo'), findsOneWidget);
+      },
+    );
   });
 }

--- a/apps/mobile/test/features/feed/feed_provider_widget_refresh_test.dart
+++ b/apps/mobile/test/features/feed/feed_provider_widget_refresh_test.dart
@@ -1,0 +1,268 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:facteur/features/feed/providers/feed_provider.dart';
+import 'package:facteur/features/feed/models/content_model.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
+import 'package:facteur/features/feed/repositories/feed_repository.dart';
+import 'package:facteur/features/feed/repositories/personalization_repository.dart';
+import 'package:facteur/core/auth/auth_state.dart' as app_auth;
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+/// Regression tests for `FeedNotifier.refreshForWidget()` — the explicit
+/// refresh path wired to the home-screen widget's refresh button.
+///
+/// Bug (widget « 1 seul article » chez Django) : le bouton refresh du widget
+/// se contentait d'appeler `refresh()`, qui (a) ne pousse jamais la version
+/// canonique **non filtrée** quand un filtre Flâner est actif, et (b) peut
+/// rester un no-op silencieux. `refreshForWidget()` garantit qu'un appui
+/// re-pousse toujours le Flux non filtré, sans perturber l'état filtré affiché.
+class MockFeedRepository extends Mock implements FeedRepository {}
+
+class MockPersonalizationRepository extends Mock
+    implements PersonalizationRepository {}
+
+class MockAuthStateNotifier extends StateNotifier<app_auth.AuthState>
+    implements app_auth.AuthStateNotifier {
+  MockAuthStateNotifier()
+      : super(
+          const app_auth.AuthState(
+            user: supabase.User(
+              id: 'u1',
+              appMetadata: {},
+              userMetadata: {},
+              aud: 'authenticated',
+              createdAt: '2023-01-01',
+              emailConfirmedAt: '2023-01-01',
+            ),
+          ),
+        );
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockFeedRepository mockFeedRepo;
+  late MockPersonalizationRepository mockPersoRepo;
+  late MockAuthStateNotifier mockAuthNotifier;
+  late ProviderContainer container;
+
+  final mockSource = Source(
+    id: 's1',
+    name: 'Source 1',
+    url: 'url',
+    type: SourceType.article,
+    theme: 'TECH',
+  );
+
+  Content makeContent(String id) => Content(
+        id: id,
+        title: 'Title $id',
+        url: 'url',
+        contentType: ContentType.article,
+        publishedAt: DateTime.now(),
+        source: mockSource,
+      );
+
+  FeedResponse resp(List<Content> items, {bool hasNext = false}) =>
+      FeedResponse(
+        items: items,
+        pagination: Pagination(
+          page: 1,
+          perPage: 20,
+          total: items.length,
+          hasNext: hasNext,
+        ),
+      );
+
+  setUp(() {
+    mockFeedRepo = MockFeedRepository();
+    mockPersoRepo = MockPersonalizationRepository();
+    mockAuthNotifier = MockAuthStateNotifier();
+
+    container = ProviderContainer(
+      overrides: [
+        feedRepositoryProvider.overrideWithValue(mockFeedRepo),
+        personalizationRepositoryProvider.overrideWithValue(mockPersoRepo),
+        app_auth.authStateProvider.overrideWith((ref) => mockAuthNotifier),
+      ],
+    );
+  });
+
+  tearDown(() {
+    container.dispose();
+  });
+
+  DioException dioError() {
+    final req = RequestOptions(path: '/feed/');
+    return DioException(
+      requestOptions: req,
+      response: Response<dynamic>(
+        requestOptions: req,
+        statusCode: 500,
+      ),
+      type: DioExceptionType.badResponse,
+    );
+  }
+
+  test(
+    'refreshForWidget fetches the UNFILTERED feed even while a Flâner filter is active, '
+    'without disturbing the in-app filtered state',
+    () async {
+      // getFeed returns the filtered payload when `mode` is set, the canonical
+      // unfiltered payload otherwise — so we can assert which one was fetched.
+      when(
+        () => mockFeedRepo.getFeed(
+          page: any(named: 'page'),
+          limit: any(named: 'limit'),
+          contentType: any(named: 'contentType'),
+          savedOnly: any(named: 'savedOnly'),
+          mode: any(named: 'mode'),
+          theme: any(named: 'theme'),
+          topic: any(named: 'topic'),
+          hasNote: any(named: 'hasNote'),
+          sourceId: any(named: 'sourceId'),
+          entity: any(named: 'entity'),
+          keyword: any(named: 'keyword'),
+          includeUnfollowed: any(named: 'includeUnfollowed'),
+          serein: any(named: 'serein'),
+          personalized: any(named: 'personalized'),
+          followedOnly: any(named: 'followedOnly'),
+          forceFresh: any(named: 'forceFresh'),
+        ),
+      ).thenAnswer((inv) async {
+        final mode = inv.namedArguments[#mode] as String?;
+        if (mode == 'tech') {
+          return resp([makeContent('filtered-1')]);
+        }
+        return resp([makeContent('flux-a'), makeContent('flux-b')]);
+      });
+
+      final notifier = container.read(feedProvider.notifier);
+      await container.read(feedProvider.future);
+
+      // Apply an in-app filter → visible feed becomes the filtered payload.
+      await notifier.setFilter('tech');
+      expect(container.read(feedProvider).value!.items.map((c) => c.id), [
+        'filtered-1',
+      ]);
+
+      // Widget refresh button.
+      await notifier.refreshForWidget();
+
+      // The visible (filtered) state must be untouched...
+      expect(
+        container.read(feedProvider).value!.items.map((c) => c.id),
+        ['filtered-1'],
+        reason: 'refreshForWidget must not overwrite the in-app filtered view',
+      );
+
+      // ...and an unfiltered, force-fresh fetch must have happened for the widget.
+      verify(
+        () => mockFeedRepo.getFeed(
+          page: 1,
+          limit: any(named: 'limit'),
+          mode: null,
+          theme: null,
+          topic: null,
+          sourceId: null,
+          entity: null,
+          keyword: null,
+          serein: any(named: 'serein'),
+          forceFresh: true,
+        ),
+      ).called(1);
+    },
+  );
+
+  test(
+    'refreshForWidget (unfiltered) refreshes the visible feed with fresh items',
+    () async {
+      var call = 0;
+      when(
+        () => mockFeedRepo.getFeed(
+          page: any(named: 'page'),
+          limit: any(named: 'limit'),
+          contentType: any(named: 'contentType'),
+          savedOnly: any(named: 'savedOnly'),
+          mode: any(named: 'mode'),
+          theme: any(named: 'theme'),
+          topic: any(named: 'topic'),
+          hasNote: any(named: 'hasNote'),
+          sourceId: any(named: 'sourceId'),
+          entity: any(named: 'entity'),
+          keyword: any(named: 'keyword'),
+          includeUnfollowed: any(named: 'includeUnfollowed'),
+          serein: any(named: 'serein'),
+          personalized: any(named: 'personalized'),
+          followedOnly: any(named: 'followedOnly'),
+          forceFresh: any(named: 'forceFresh'),
+        ),
+      ).thenAnswer((_) async {
+        call++;
+        if (call == 1) return resp([makeContent('old')]);
+        return resp([makeContent('fresh-1'), makeContent('fresh-2')]);
+      });
+
+      final notifier = container.read(feedProvider.notifier);
+      await container.read(feedProvider.future);
+      expect(container.read(feedProvider).value!.items.map((c) => c.id), [
+        'old',
+      ]);
+
+      await notifier.refreshForWidget();
+
+      expect(
+        container.read(feedProvider).value!.items.map((c) => c.id),
+        ['fresh-1', 'fresh-2'],
+        reason: 'unfiltered widget refresh mirrors the fresh page in-app too',
+      );
+    },
+  );
+
+  test(
+    'refreshForWidget never throws and preserves state on a network failure',
+    () async {
+      var call = 0;
+      when(
+        () => mockFeedRepo.getFeed(
+          page: any(named: 'page'),
+          limit: any(named: 'limit'),
+          contentType: any(named: 'contentType'),
+          savedOnly: any(named: 'savedOnly'),
+          mode: any(named: 'mode'),
+          theme: any(named: 'theme'),
+          topic: any(named: 'topic'),
+          hasNote: any(named: 'hasNote'),
+          sourceId: any(named: 'sourceId'),
+          entity: any(named: 'entity'),
+          keyword: any(named: 'keyword'),
+          includeUnfollowed: any(named: 'includeUnfollowed'),
+          serein: any(named: 'serein'),
+          personalized: any(named: 'personalized'),
+          followedOnly: any(named: 'followedOnly'),
+          forceFresh: any(named: 'forceFresh'),
+        ),
+      ).thenAnswer((_) async {
+        call++;
+        if (call == 1) return resp([makeContent('a'), makeContent('b')]);
+        throw dioError();
+      });
+
+      final notifier = container.read(feedProvider.notifier);
+      await container.read(feedProvider.future);
+      expect(container.read(feedProvider).value!.items.length, 2);
+
+      // Must complete without throwing.
+      await notifier.refreshForWidget();
+
+      final state = container.read(feedProvider);
+      expect(state.hasError, isFalse);
+      expect(state.value!.items.map((c) => c.id), ['a', 'b']);
+    },
+  );
+}


### PR DESCRIPTION
Deux fixes du widget d'accueil Android, groupés sur la même branche. Mobile-only, **aucune migration / DDL**.

---

## Fix 1 — Bouton refresh répare l'Essentiel ET le Flux (force-push)

Le bouton « rafraîchir » restait **sans effet** (bug Django, Pixel 9 — widget figé à 1 seul article) : il ne rejouait qu'un `feedProvider.refresh()`, qui ne reconstruit jamais l'Essentiel et pouvait rester un no-op silencieux (filtre Flâner actif / signature identique / erreur réseau).

- **`app.dart`** — `onRefreshRequested` répare les **deux côtés** en parallèle : `digestProvider.syncWidgetFromRefresh()` (Essentiel) + `feedProvider.refreshForWidget()` (Flux).
- **`feed_provider.dart`** — `refreshForWidget()` : fetch page 1 **non filtrée** `forceFresh`, **force-push** (bypass gardes filtre + signature), prefetch 80, fallback `_globalItems` sur échec réseau — sans perturber l'état filtré affiché. `_scheduleWidgetPush(force)` pousse immédiatement.
- **`digest_provider.dart`** — `syncWidgetFromRefresh()` : recharge si `_normalDigest == null` puis re-pousse.
- 3 tests de régression `refreshForWidget`.

## Fix 2 — Clic sur un article ouvre le reader même déjà dans un article (chaînage)

Le clic article du widget utilisait `router.go`, qui réutilise en place la route `content/:id` courante : quand un reader était déjà ouvert, le tap n'ouvrait pas le nouvel article.

- **`deep_link_service.dart`** — cas `article` : `router.go` → **`router.push`**. Le reader s'**empile** par-dessus l'écran courant (y compris un reader déjà ouvert), ce qui permet d'**enchaîner la lecture** depuis le widget (le retour ramène à l'article précédent). Aligne le comportement sur la navigation in-app (cartes feed, deep-reco). Les autres cibles widget (digest/feed/veille/grille) gardent `go` volontairement (atterrissage sur un onglet).
- 3 tests de régression (routeur synthétique) — 2e article empilé sur le 1er + retour, côté Flux et Essentiel, + ouverture depuis l'accueil. **Vérifié qu'ils échouent sous l'ancien `go`.**

---

## Vérification

- `flutter test` deep_link_service (26/26) + feed_provider_widget_refresh (3/3) verts.
- `flutter analyze` (fichiers touchés) → propre / uniquement des `info avoid_print` pré-existants.
- Suite complète : **1495 pass / 23 fail** — les 23 échecs sont **identiques sur `main` sans ce diff** (pré-existants, pollution thème inter-fichiers), **zéro régression**.
- Simplify : churn `dart format` retiré de digest_provider ; dédup corps push + suppression d'un double push widget.

## Différé (décision PO)

- **Étape 1** — repro device (mécanisme du push 1-item). **Étape 3** — rendu natif Kotlin si la repro pointe dessus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)