### PR TITLE
fix(serein): persiste le mode apaisé au redémarrage (miroir Hive par utilisateur)

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,8 +1,14 @@
 {
   "unreleased": [
     {
+      "tag": "Serein",
+      "summary": "Le mode de lecture apaisé reste activé au redémarrage de l'app : plus besoin de le réactiver chaque matin."
+    },
+    {
       "tag": "Lecture",
       "summary": "L'écran de lecture s'allège : barres flottantes translucides qui laissent transparaître l'article."
+    },
+    {
       "tag": "Widget",
       "summary": "Le bouton rafraîchir du widget d'accueil répare désormais l'Essentiel et le Flux d'un coup, même après un blocage."
     },

--- a/apps/mobile/lib/features/digest/providers/digest_provider.dart
+++ b/apps/mobile/lib/features/digest/providers/digest_provider.dart
@@ -205,7 +205,10 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
           final digest = await repository.getDigest(date: date);
           _normalDigest = digest;
           _cachedDate = _todayDateString;
-          ref.read(sereinToggleProvider.notifier).initFromApi(false);
+          // Le fallback single-digest ne porte aucun flag serein : il lève
+          // juste le loading si rien n'est encore connu, sans persister ni
+          // écraser un miroir local ON.
+          ref.read(sereinToggleProvider.notifier).markLoadedFromFallback();
           _maybeScheduleStaleFallbackRefetch();
           return digest;
         } catch (_) {

--- a/apps/mobile/lib/features/digest/providers/serein_toggle_provider.dart
+++ b/apps/mobile/lib/features/digest/providers/serein_toggle_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../../core/auth/auth_state.dart';
 import 'digest_provider.dart';
@@ -24,29 +25,70 @@ class SereinToggleState {
 
 final sereinToggleProvider =
     StateNotifierProvider<SereinToggleNotifier, SereinToggleState>((ref) {
-  // Rebuild a fresh notifier (back to isLoading:true) whenever the
-  // authenticated user changes — logout, then a different account on the same
-  // device. Otherwise the initFromApi guard below would block the next user's
-  // server preference from ever applying and they'd inherit the previous
-  // user's toggle.
-  ref.watch(authStateProvider.select((s) => s.user?.id));
-  return SereinToggleNotifier(ref);
+  // Rebuild a fresh notifier whenever the authenticated user changes — logout,
+  // then a different account on the same device. The local Hive mirror is
+  // namespaced per user (`serein_enabled:$userId`) so the boot state is
+  // restored synchronously for the CURRENT account, and userB never inherits
+  // userA's preference. The server sync (initFromApi) still reconciles
+  // cross-device.
+  final userId = ref.watch(authStateProvider.select((s) => s.user?.id));
+  return SereinToggleNotifier(ref, userId);
 });
 
 class SereinToggleNotifier extends StateNotifier<SereinToggleState> {
   final Ref _ref;
+  final String? _userId;
 
-  SereinToggleNotifier(this._ref) : super(const SereinToggleState());
+  /// True once the server preference has been reconciled once, OR the user has
+  /// made an explicit choice (`toggle`). Decoupled from [isLoading] because the
+  /// state is no longer loading at boot as soon as a local mirror exists — so
+  /// we can't reuse `!isLoading` as the one-shot guard anymore.
+  bool _serverReconciled = false;
+
+  SereinToggleNotifier(this._ref, this._userId)
+      : super(_initialState(_userId));
+
+  static const String _boxName = 'settings';
+
+  static String _key(String userId) => 'serein_enabled:$userId';
+
+  /// Synchronous boot state, restored from the per-user Hive mirror written on
+  /// [toggle] / [initFromApi] / [commitFromOnboarding]. No user or an
+  /// unopened box (unit tests) → legacy `enabled:false, isLoading:true`.
+  static SereinToggleState _initialState(String? userId) {
+    if (userId == null || !Hive.isBoxOpen(_boxName)) {
+      return const SereinToggleState();
+    }
+    final saved = Hive.box<dynamic>(_boxName).get(_key(userId)) as bool?;
+    if (saved == null) return const SereinToggleState();
+    return SereinToggleState(enabled: saved, isLoading: false);
+  }
+
+  void _persistLocal(bool value) {
+    if (_userId == null || !Hive.isBoxOpen(_boxName)) return;
+    Hive.box<dynamic>(_boxName).put(_key(_userId!), value);
+  }
 
   /// Sync with the server preference returned by /digest/both.
   ///
-  /// Only syncs on the FIRST load (while still [isLoading]). Once the toggle
-  /// has stabilised, a digest re-fetch (scroll, navigation to Actus du jour,
-  /// stale-fallback refresh) must NEVER overwrite the user's current choice —
-  /// otherwise serein silently flips back OFF mid-session.
+  /// Reconciles only ONCE. Once the toggle has stabilised — reconciled with the
+  /// server or explicitly toggled — a digest re-fetch (scroll, navigation to
+  /// Actus du jour, stale-fallback refresh) must NEVER overwrite the current
+  /// choice, otherwise serein silently flips back OFF mid-session.
   void initFromApi(bool sereinEnabled) {
-    if (!state.isLoading) return;
+    if (_serverReconciled) return;
+    _serverReconciled = true;
     state = SereinToggleState(enabled: sereinEnabled, isLoading: false);
+    _persistLocal(sereinEnabled);
+  }
+
+  /// Single-digest 404 fallback: it carries no serein flag, so just lift
+  /// [isLoading] when nothing is known yet. It never persists the local mirror
+  /// nor marks the reconciliation done — a real sync via [initFromApi] can
+  /// still arrive and set the actual value.
+  void markLoadedFromFallback() {
+    if (_serverReconciled || !state.isLoading) return;
+    state = state.copyWith(isLoading: false);
   }
 
   /// Change the local view mode without persisting the preference.
@@ -57,6 +99,15 @@ class SereinToggleNotifier extends StateNotifier<SereinToggleState> {
     state = state.copyWith(enabled: enabled);
   }
 
+  /// Persist the onboarding "serein" choice locally so it survives the very
+  /// first cold start (before /digest/both is ever hit). The server already
+  /// persisted it via save_onboarding, so this only writes the local mirror and
+  /// does not mark the reconciliation done — a later server sync still applies.
+  void commitFromOnboarding(bool enabled) {
+    state = state.copyWith(enabled: enabled, isLoading: false);
+    _persistLocal(enabled);
+  }
+
   /// Instant toggle — UI flips immediately, preference saved in background.
   Future<void> toggle() async {
     final newValue = !state.enabled;
@@ -64,10 +115,16 @@ class SereinToggleNotifier extends StateNotifier<SereinToggleState> {
     // 1. Immediate UI update
     state = state.copyWith(enabled: newValue);
 
-    // 2. Haptic
+    // 2. An explicit choice freezes any later server reconciliation and is
+    //    mirrored locally right away — so it survives a silently-failed PUT
+    //    and the next cold start regardless of the network round-trip.
+    _serverReconciled = true;
+    _persistLocal(newValue);
+
+    // 3. Haptic
     HapticFeedback.lightImpact();
 
-    // 3. Persist preference (fire-and-forget)
+    // 4. Persist preference server-side (fire-and-forget)
     try {
       final repository = _ref.read(digestRepositoryProvider);
       await repository.updatePreference(
@@ -75,7 +132,8 @@ class SereinToggleNotifier extends StateNotifier<SereinToggleState> {
         value: newValue.toString(),
       );
     } catch (_) {
-      // Silent fail — preference retried next session
+      // Silent fail — the local mirror already holds the choice; the server
+      // preference is retried next session.
     }
   }
 }

--- a/apps/mobile/lib/features/onboarding/providers/conclusion_notifier.dart
+++ b/apps/mobile/lib/features/onboarding/providers/conclusion_notifier.dart
@@ -133,11 +133,11 @@ class ConclusionNotifier extends StateNotifier<ConclusionState> {
         await _saveProfileLocally(result.profile!);
         // Pré-règle le mode serein dès l'entrée dans le feed depuis le choix
         // d'onboarding, sans attendre /digest/both. La préférence est déjà
-        // persistée côté serveur (save_onboarding ⇒ serein_enabled='true'), et
-        // initFromApi reste idempotent (sync uniquement au 1er chargement), donc
-        // ce pré-réglage n'est jamais écrasé au scroll / refetch.
+        // persistée côté serveur (save_onboarding ⇒ serein_enabled='true') ;
+        // `commitFromOnboarding` écrit en plus le miroir local Hive pour que le
+        // choix survive au 1er cold start (avant que /digest/both ait répondu).
         if (answers.digestMode == 'serein') {
-          _ref.read(sereinToggleProvider.notifier).setEnabledLocal(true);
+          _ref.read(sereinToggleProvider.notifier).commitFromOnboarding(true);
         }
         await _ref.read(onboardingProvider.notifier).clearSavedData();
         await _invalidatePostOnboardingState();

--- a/apps/mobile/test/features/digest/serein_toggle_provider_test.dart
+++ b/apps/mobile/test/features/digest/serein_toggle_provider_test.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
 
 import 'package:facteur/core/auth/auth_state.dart' as app_auth;
@@ -39,7 +42,47 @@ ProviderContainer _container(_FakeAuthNotifier auth) {
   return container;
 }
 
+String _key(String userId) => 'serein_enabled:$userId';
+
 void main() {
+  // toggle() emits haptic feedback via a platform channel → the binding must
+  // be initialised even for these unit tests.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp();
+    Hive.init(tempDir.path);
+    await Hive.openBox<dynamic>('settings');
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+  });
+
+  group('SereinToggleNotifier — restauration synchrone depuis Hive', () {
+    test('un miroir ON pré-écrit est lu au boot, sans initFromApi', () {
+      // Régression du bug : au cold start home (FluxContinuScreen ne construit
+      // jamais digestProvider), l'état doit déjà être serein.
+      Hive.box<dynamic>('settings').put(_key('userA'), true);
+
+      final container = _container(_FakeAuthNotifier('userA'));
+      final state = container.read(sereinToggleProvider);
+
+      expect(state.enabled, isTrue);
+      expect(state.isLoading, isFalse);
+    });
+
+    test('pas de miroir → legacy loading:true (comportement conservé)', () {
+      final container = _container(_FakeAuthNotifier('userA'));
+      final state = container.read(sereinToggleProvider);
+
+      expect(state.enabled, isFalse);
+      expect(state.isLoading, isTrue);
+    });
+  });
+
   group('SereinToggleNotifier.initFromApi idempotency', () {
     test('first call syncs with the server value and clears loading', () {
       final container = _container(_FakeAuthNotifier('userA'));
@@ -63,6 +106,14 @@ void main() {
       expect(container.read(sereinToggleProvider).enabled, isTrue);
     });
 
+    test('an authoritative sync also persists the local mirror', () {
+      final container = _container(_FakeAuthNotifier('userA'));
+
+      container.read(sereinToggleProvider.notifier).initFromApi(true);
+
+      expect(Hive.box<dynamic>('settings').get(_key('userA')), isTrue);
+    });
+
     test('setEnabledLocal keeps isLoading so the first sync still confirms', () {
       final container = _container(_FakeAuthNotifier('userA'));
       final notifier = container.read(sereinToggleProvider.notifier);
@@ -76,6 +127,102 @@ void main() {
       notifier.initFromApi(true);
       expect(container.read(sereinToggleProvider).enabled, isTrue);
       expect(container.read(sereinToggleProvider).isLoading, isFalse);
+    });
+
+    test('setEnabledLocal ne persiste PAS le miroir local', () {
+      final container = _container(_FakeAuthNotifier('userA'));
+      container.read(sereinToggleProvider.notifier).setEnabledLocal(true);
+
+      expect(Hive.box<dynamic>('settings').get(_key('userA')), isNull);
+    });
+  });
+
+  group('SereinToggleNotifier.initFromApi — fallback non autoritatif', () {
+    test('ne persiste pas et n\'écrase pas un miroir local ON', () {
+      Hive.box<dynamic>('settings').put(_key('userA'), true);
+      final container = _container(_FakeAuthNotifier('userA'));
+
+      // Le fallback single-digest (404) ne porte aucun flag serein.
+      container
+          .read(sereinToggleProvider.notifier)
+          .markLoadedFromFallback();
+
+      // Le miroir ON reste ON, la clé Hive n'est pas touchée.
+      expect(container.read(sereinToggleProvider).enabled, isTrue);
+      expect(Hive.box<dynamic>('settings').get(_key('userA')), isTrue);
+    });
+
+    test('lève juste isLoading si aucune valeur connue, sans persister', () {
+      final container = _container(_FakeAuthNotifier('userA'));
+      expect(container.read(sereinToggleProvider).isLoading, isTrue);
+
+      container
+          .read(sereinToggleProvider.notifier)
+          .markLoadedFromFallback();
+
+      expect(container.read(sereinToggleProvider).isLoading, isFalse);
+      expect(container.read(sereinToggleProvider).enabled, isFalse);
+      // Non autoritatif → pas de persistance.
+      expect(Hive.box<dynamic>('settings').get(_key('userA')), isNull);
+    });
+
+    test('une vraie sync autoritaire peut encore arriver après le fallback', () {
+      final container = _container(_FakeAuthNotifier('userA'));
+      final notifier = container.read(sereinToggleProvider.notifier);
+
+      notifier.markLoadedFromFallback(); // fallback
+      notifier.initFromApi(true); // vraie sync serveur
+
+      expect(container.read(sereinToggleProvider).enabled, isTrue);
+      expect(Hive.box<dynamic>('settings').get(_key('userA')), isTrue);
+    });
+  });
+
+  group('SereinToggleNotifier.toggle', () {
+    test('persiste le miroir local et survit à un restart', () {
+      final container = _container(_FakeAuthNotifier('userA'));
+      container.read(sereinToggleProvider.notifier).toggle();
+
+      expect(container.read(sereinToggleProvider).enabled, isTrue);
+      expect(Hive.box<dynamic>('settings').get(_key('userA')), isTrue);
+
+      // Un 2e container (redémarrage) relit la valeur persistée.
+      final restarted = _container(_FakeAuthNotifier('userA'));
+      final state = restarted.read(sereinToggleProvider);
+      expect(state.enabled, isTrue);
+      expect(state.isLoading, isFalse);
+    });
+
+    test('gèle la réconciliation serveur ultérieure', () {
+      final container = _container(_FakeAuthNotifier('userA'));
+      final notifier = container.read(sereinToggleProvider.notifier);
+
+      notifier.toggle(); // choix explicite ON
+      notifier.initFromApi(false); // sync tardive → ignorée
+
+      expect(container.read(sereinToggleProvider).enabled, isTrue);
+    });
+  });
+
+  group('SereinToggleNotifier.commitFromOnboarding', () {
+    test('persiste le miroir local et lève loading', () {
+      final container = _container(_FakeAuthNotifier('userA'));
+      container.read(sereinToggleProvider.notifier).commitFromOnboarding(true);
+
+      expect(container.read(sereinToggleProvider).enabled, isTrue);
+      expect(container.read(sereinToggleProvider).isLoading, isFalse);
+      expect(Hive.box<dynamic>('settings').get(_key('userA')), isTrue);
+    });
+
+    test('ne marque pas reconciled → une sync serveur peut encore corriger', () {
+      final container = _container(_FakeAuthNotifier('userA'));
+      final notifier = container.read(sereinToggleProvider.notifier);
+
+      notifier.commitFromOnboarding(true);
+      // La préférence serveur fait autorité pour la réconciliation.
+      notifier.initFromApi(false);
+
+      expect(container.read(sereinToggleProvider).enabled, isFalse);
     });
   });
 
@@ -93,14 +240,39 @@ void main() {
       auth.setUser(null);
       auth.setUser('userB');
 
-      // The notifier is rebuilt fresh → the guard no longer blocks the new
-      // user's sync, so userB's OFF preference applies correctly.
+      // The notifier is rebuilt fresh for userB (whose mirror is absent) → it
+      // does not inherit userA's ON preference.
       final fresh = container.read(sereinToggleProvider);
       expect(fresh.isLoading, isTrue);
       expect(fresh.enabled, isFalse);
 
       container.read(sereinToggleProvider.notifier).initFromApi(false);
       expect(container.read(sereinToggleProvider).enabled, isFalse);
+    });
+
+    test('isolation multi-compte : la sync de B ne touche pas la clé de A', () {
+      final auth = _FakeAuthNotifier('userA');
+      final container = _container(auth);
+
+      container.read(sereinToggleProvider.notifier).toggle(); // A → ON persisté
+      expect(Hive.box<dynamic>('settings').get(_key('userA')), isTrue);
+
+      auth.setUser(null);
+      auth.setUser('userB');
+      // B réconcilie OFF (sa préférence) : sa propre clé est écrite, celle de A
+      // reste intacte.
+      container.read(sereinToggleProvider.notifier).initFromApi(false);
+
+      expect(container.read(sereinToggleProvider).enabled, isFalse);
+      expect(Hive.box<dynamic>('settings').get(_key('userB')), isFalse);
+      expect(Hive.box<dynamic>('settings').get(_key('userA')), isTrue);
+
+      // Re-login A → serein ON restauré sans round-trip.
+      auth.setUser(null);
+      auth.setUser('userA');
+      final backToA = container.read(sereinToggleProvider);
+      expect(backToA.enabled, isTrue);
+      expect(backToA.isLoading, isFalse);
     });
   });
 }

--- a/apps/mobile/test/features/feed/widgets/pin_subjects_sheet_test.dart
+++ b/apps/mobile/test/features/feed/widgets/pin_subjects_sheet_test.dart
@@ -68,7 +68,7 @@ class _NoGrille implements GrilleRepository {
 }
 
 class _StubSerein extends SereinToggleNotifier {
-  _StubSerein(super.ref) {
+  _StubSerein(Ref ref) : super(ref, null) {
     state = const SereinToggleState(enabled: false, isLoading: false);
   }
 }

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_progressive_fanout_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_progressive_fanout_test.dart
@@ -130,7 +130,7 @@ void main() {
         userInterestsProvider.overrideWith(
           () => _StubUserInterestsNotifier(interests),
         ),
-        sereinToggleProvider.overrideWith((ref) => SereinToggleNotifier(ref)),
+        sereinToggleProvider.overrideWith((ref) => SereinToggleNotifier(ref, null)),
         displayModeSpecProvider.overrideWithValue(DisplayModeSpec.normal),
       ],
     );

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:facteur/core/auth/auth_state.dart' as app_auth;
 import 'package:facteur/features/digest/models/digest_models.dart';
 import 'package:facteur/features/digest/models/dual_digest_response.dart';
 import 'package:facteur/features/digest/providers/digest_provider.dart';
@@ -28,6 +29,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
 
 import 'flux_continu_settle.dart';
 
@@ -37,6 +39,29 @@ class _MockFeedRepository extends Mock implements FeedRepository {}
 
 class _MockFluxContinuRepository extends Mock
     implements FluxContinuRepository {}
+
+class _MockEssentielRepository extends Mock implements EssentielRepository {}
+
+/// Minimal auth notifier that reports a fixed signed-in user id, so the real
+/// [sereinToggleProvider] keys its Hive mirror by that id.
+class _FakeAuthNotifier extends StateNotifier<app_auth.AuthState>
+    implements app_auth.AuthStateNotifier {
+  _FakeAuthNotifier(String userId)
+      : super(
+          app_auth.AuthState(
+            user: supabase.User(
+              id: userId,
+              appMetadata: const {},
+              userMetadata: const {},
+              aud: 'authenticated',
+              createdAt: '2023-01-01',
+            ),
+          ),
+        );
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
 
 class _StubEssentielRepository implements EssentielRepository {
   @override
@@ -177,7 +202,7 @@ void main() {
         ),
         grilleRepositoryProvider.overrideWithValue(_NoGrilleRepository()),
         userInterestsProvider.overrideWith(() => userInterestsNotifier),
-        sereinToggleProvider.overrideWith((ref) => SereinToggleNotifier(ref)),
+        sereinToggleProvider.overrideWith((ref) => SereinToggleNotifier(ref, null)),
         // Le cap de fit lit displayModeSpecProvider même sans mesure (fallback
         // référence) ⇒ il faut court-circuiter la box Hive 'settings' (non
         // ouverte ici), comme makeFitContainer.
@@ -867,7 +892,7 @@ void main() {
               () => _StubUserInterestsNotifier(_interestsState()),
             ),
             sereinToggleProvider.overrideWith(
-              (ref) => SereinToggleNotifier(ref),
+              (ref) => SereinToggleNotifier(ref, null),
             ),
             displayModeSpecProvider.overrideWithValue(DisplayModeSpec.normal),
           ],
@@ -944,7 +969,7 @@ void main() {
           // The real serein toggle watches authStateProvider → Supabase.instance
           // (uninitialized in unit tests). Override with a notifier that skips
           // the auth watch so the provider build doesn't blow up.
-          sereinToggleProvider.overrideWith((ref) => SereinToggleNotifier(ref)),
+          sereinToggleProvider.overrideWith((ref) => SereinToggleNotifier(ref, null)),
           // Le cap de fit lit displayModeSpecProvider (box Hive 'settings' non
           // ouverte ici) ⇒ court-circuit.
           displayModeSpecProvider.overrideWithValue(DisplayModeSpec.normal),
@@ -1112,7 +1137,7 @@ void main() {
                   favorites: const [ThemeFavoriteRef(slug: 'tech')]),
             ),
           ),
-          sereinToggleProvider.overrideWith((ref) => SereinToggleNotifier(ref)),
+          sereinToggleProvider.overrideWith((ref) => SereinToggleNotifier(ref, null)),
           // La box Hive 'settings' n'est pas ouverte ici ⇒ on court-circuite le
           // spec (lu par le cap dynamique) plutôt que de la faire planter.
           displayModeSpecProvider.overrideWithValue(spec),
@@ -1475,6 +1500,55 @@ void main() {
           finalState.sections.whereType<FeedThemeSection>(),
           isNotEmpty,
         );
+      },
+    );
+  });
+
+  group('FluxContinuNotifier — persistance serein au cold start', () {
+    test(
+      'un miroir Hive serein ON pilote isSerene=true et fetch(serein:true) '
+      'sans passer par digestProvider',
+      () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+
+        // Miroir local serein ON pré-écrit (comme après un toggle / restart),
+        // keyé par l'utilisateur signé.
+        const uid = 'user-serene-1';
+        final settings = Hive.isBoxOpen('settings')
+            ? Hive.box<dynamic>('settings')
+            : await Hive.openBox<dynamic>('settings');
+        await settings.put('serein_enabled:$uid', true);
+        addTearDown(() => settings.delete('serein_enabled:$uid'));
+
+        final essentielRepo = _MockEssentielRepository();
+        when(() => essentielRepo.fetch(serein: any(named: 'serein')))
+            .thenAnswer((_) async => const <EssentielArticle>[]);
+
+        final container = ProviderContainer(
+          overrides: [
+            app_auth.authStateProvider
+                .overrideWith((ref) => _FakeAuthNotifier(uid)),
+            digestRepositoryProvider.overrideWithValue(digestRepo),
+            feedRepositoryProvider.overrideWithValue(feedRepo),
+            fluxContinuRepositoryProvider.overrideWithValue(fluxRepo),
+            essentielRepositoryProvider.overrideWithValue(essentielRepo),
+            grilleRepositoryProvider.overrideWithValue(_NoGrilleRepository()),
+            userInterestsProvider.overrideWith(
+              () => _StubUserInterestsNotifier(_interestsState()),
+            ),
+            displayModeSpecProvider.overrideWithValue(DisplayModeSpec.normal),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        // La préférence persistée est lue en synchrone, sans /digest/both.
+        expect(container.read(sereinToggleProvider).enabled, isTrue);
+
+        final state = await settle(container);
+
+        expect(state.isSerene, isTrue);
+        verify(() => essentielRepo.fetch(serein: true)).called(1);
+        verifyNever(() => essentielRepo.fetch(serein: false));
       },
     );
   });

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_sources_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_sources_test.dart
@@ -190,7 +190,7 @@ void main() {
             .overrideWith(() => _StubUserSourcesNotifier(catalog)),
         // Évite la chaîne authStateProvider → Supabase.instance (non initialisé
         // en test). Notifier réel mais sans le `ref.watch(authStateProvider)`.
-        sereinToggleProvider.overrideWith((ref) => SereinToggleNotifier(ref)),
+        sereinToggleProvider.overrideWith((ref) => SereinToggleNotifier(ref, null)),
         // Le cap de fit lit displayModeSpecProvider (box Hive 'settings' non
         // ouverte en test) ⇒ court-circuit.
         displayModeSpecProvider.overrideWithValue(DisplayModeSpec.normal),

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_tournee_order_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_tournee_order_test.dart
@@ -308,7 +308,7 @@ void main() {
         veilleActiveConfigProvider.overrideWith(
           () => _StubVeilleActiveConfigNotifier(veilleCfg),
         ),
-        sereinToggleProvider.overrideWith((ref) => SereinToggleNotifier(ref)),
+        sereinToggleProvider.overrideWith((ref) => SereinToggleNotifier(ref, null)),
         // Le cap de fit lit displayModeSpecProvider (box Hive 'settings' non
         // ouverte en test) ⇒ court-circuit.
         displayModeSpecProvider.overrideWithValue(DisplayModeSpec.normal),

--- a/apps/mobile/test/features/flux_continu/widgets/manage_favorites_sheet_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/manage_favorites_sheet_test.dart
@@ -96,7 +96,7 @@ class _FakeGrilleRepository implements GrilleRepository {
 }
 
 class _StubSereinToggleNotifier extends SereinToggleNotifier {
-  _StubSereinToggleNotifier(super.ref, bool enabled) {
+  _StubSereinToggleNotifier(Ref ref, bool enabled) : super(ref, null) {
     state = SereinToggleState(enabled: enabled, isLoading: false);
   }
 }

--- a/apps/mobile/test/features/flux_continu/widgets/personalisation_cta_card_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/personalisation_cta_card_test.dart
@@ -69,7 +69,7 @@ class _FakeGrilleRepository implements GrilleRepository {
 }
 
 class _StubSerein extends SereinToggleNotifier {
-  _StubSerein(super.ref) {
+  _StubSerein(Ref ref) : super(ref, null) {
     state = const SereinToggleState(enabled: false, isLoading: false);
   }
 }

--- a/apps/mobile/test/features/flux_continu/widgets/tournee_composer_sheet_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/tournee_composer_sheet_test.dart
@@ -66,7 +66,7 @@ class _NoGrille implements GrilleRepository {
 }
 
 class _StubSerein extends SereinToggleNotifier {
-  _StubSerein(super.ref) {
+  _StubSerein(Ref ref) : super(ref, null) {
     state = const SereinToggleState(enabled: false, isLoading: false);
   }
 }

--- a/apps/mobile/test/features/notif_du_jour/notif_du_jour_card_test.dart
+++ b/apps/mobile/test/features/notif_du_jour/notif_du_jour_card_test.dart
@@ -16,7 +16,7 @@ import 'package:facteur/features/notif_du_jour/providers/notif_du_jour_provider.
 import 'package:facteur/features/notif_du_jour/widgets/notif_du_jour_card.dart';
 
 class _FakeSerein extends SereinToggleNotifier {
-  _FakeSerein(super.ref) {
+  _FakeSerein(Ref ref) : super(ref, null) {
     initFromApi(false);
   }
 

--- a/apps/mobile/test/features/notif_du_jour/notif_du_jour_provider_test.dart
+++ b/apps/mobile/test/features/notif_du_jour/notif_du_jour_provider_test.dart
@@ -72,7 +72,7 @@ ProviderContainer _container({
       if (veilleLoaded)
         veilleActiveConfigProvider.overrideWith(() => _FakeVeille(veille)),
       sereinToggleProvider.overrideWith((ref) {
-        final n = SereinToggleNotifier(ref);
+        final n = SereinToggleNotifier(ref, null);
         if (!sereinLoading) n.initFromApi(sereinEnabled);
         return n;
       }),


### PR DESCRIPTION
## Quoi
Le mode de lecture « apaisé » (serein) repartait **OFF à chaque redémarrage** de l'app : l'état n'était restauré que via `/digest/both`, et un re-fetch (scroll, navigation, stale-fallback) pouvait le rebasculer OFF en cours de session.

Cette PR ajoute un **miroir local Hive namespacé par utilisateur** (`serein_enabled:$userId`) restauré synchroniquement au boot, avec réconciliation serveur one-shot.

## Pourquoi
Bug user-visible : l'utilisateur devait réactiver le mode apaisé chaque matin. La préférence était bien persistée côté serveur mais jamais côté client au cold start, et le garde `!isLoading` sautait dès qu'un miroir local existait.

## Comment
- Miroir Hive `serein_enabled:$userId` restauré au boot (`_initialState`) ; userB n'hérite jamais du choix de userA.
- `_serverReconciled` remplace le garde `!isLoading` (découplé, car l'état n'est plus « loading » au boot dès qu'un miroir existe).
- `initFromApi` recentré sur la sync **autoritaire** (persiste + fige) ; nouveau `markLoadedFromFallback()` dédié au fallback 404 single-digest (lève juste `isLoading`, ne persiste pas, laisse une vraie sync arriver ensuite).
- `commitFromOnboarding` écrit le miroir dès le choix d'onboarding, avant le 1er `/digest/both`.

## Comment ça a été vérifié
- [x] `flutter test` sur tous les fichiers touchés — **348 tests OK** (serein persistance cold-start, isolation multi-compte, fallback non-autoritatif, sync autoritaire)
- [x] `flutter analyze` clean sur les 3 fichiers source (seul reste un `unawaited_futures` pré-existant sur `HapticFeedback`)
- [x] `/simplify` passé (split `initFromApi`/`markLoadedFromFallback`, suppression du flag `authoritative` mort)
- [x] Échecs restants de la suite complète = mobiles pré-existants (bookmark, feed_sources, notification, perspectives, widget_test), non liés à ce diff et non exécutés en CI

## Zones à risque
- `SereinToggleNotifier` : nouveau paramètre `userId` au constructeur (call sites de test mis à jour).
- Accès direct à la box Hive `settings` (convention établie du repo, cf. theme/display_mode/paid_content providers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)