### PR TITLE
fix(rituel): lettre du matin sautée au cold-boot (device sans cache Hive)

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -2,6 +2,10 @@
   "unreleased": [
     {
       "tag": "Rituel",
+      "summary": "Ta lettre du matin s'affiche même au tout premier lancement de la journée, sans passer directement au flux."
+    },
+    {
+      "tag": "Rituel",
       "summary": "En ouvrant ta lettre du matin, ta flamme grandit et ta série s'incrémente : une petite récompense pour être revenu aujourd'hui."
     },
     {
@@ -43,6 +47,8 @@
     {
       "tag": "Ouverture",
       "summary": "Chaque matin, ton édition du jour t'accueille comme une enveloppe cachetée : un bonjour, la date, et l'aperçu coloré des sections qui t'attendent, à personnaliser d'un geste."
+    },
+    {
       "tag": "Serein",
       "summary": "Le mode de lecture apaisé reste activé au redémarrage de l'app : plus besoin de le réactiver chaque matin."
     },

--- a/apps/mobile/lib/features/flux_continu/screens/morning_ritual_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/morning_ritual_screen.dart
@@ -19,6 +19,7 @@ import 'package:facteur/features/flux_continu/models/flux_continu_models.dart';
 import 'package:facteur/features/flux_continu/providers/morning_ritual_qa_provider.dart';
 import 'package:facteur/features/flux_continu/providers/pending_feed_section_provider.dart';
 import 'package:facteur/features/flux_continu/providers/selected_edition_date_provider.dart';
+import 'package:facteur/features/flux_continu/services/flux_continu_cache_service.dart';
 import 'package:facteur/features/flux_continu/services/tournee_progress_service.dart';
 import 'package:facteur/features/flux_continu/utils/morning_ritual_format.dart';
 import 'package:facteur/features/flux_continu/utils/theme_color_mapping.dart';
@@ -69,9 +70,13 @@ class _MorningRitualScreenState extends ConsumerState<MorningRitualScreen>
   static const Duration _editorialReveal = Duration(milliseconds: 600);
 
   /// Plafond de résilience : au-delà, repli vers le feed sans marquer « vu ».
-  /// Plus large en sortie d'onboarding (édition calculée à froid).
-  Duration get _maxWaitFor =>
-      widget.fromOnboarding ? const Duration(seconds: 10) : const Duration(seconds: 6);
+  /// Plus large en sortie d'onboarding (édition calculée à froid). Le cas
+  /// cold-boot (aucun snapshot Hive) élargit le plafond à part, via
+  /// [_maybeExtendForColdBoot] (lecture Hive asynchrone, hors du chemin chaud).
+  Duration get _maxWaitFor => resolveMorningRitualMaxWait(
+        fromOnboarding: widget.fromOnboarding,
+        coldBoot: false,
+      );
 
   Timer? _floorTimer;
   Timer? _maxWaitTimer;
@@ -99,6 +104,9 @@ class _MorningRitualScreenState extends ConsumerState<MorningRitualScreen>
       _maybeReveal();
     });
     _maxWaitTimer = Timer(_maxWaitFor, _forwardIfNotReady);
+    // Élargit le plafond aux seuls devices genuinement froids (lecture Hive
+    // asynchrone, non bloquante — le plafond chaud tourne déjà ci-dessus).
+    unawaited(_maybeExtendForColdBoot());
     _exitController = AnimationController(
       vsync: this,
       duration: FacteurDurations.slow,
@@ -122,6 +130,36 @@ class _MorningRitualScreenState extends ConsumerState<MorningRitualScreen>
     _maxWaitTimer?.cancel();
     _exitController.dispose();
     super.dispose();
+  }
+
+  /// Sur un device genuinement froid (aucun snapshot Hive jamais écrit), la
+  /// chaîne auth-refresh + 3 appels réseau concurrents peut dépasser le plafond
+  /// chaud de 6 s → le rituel serait silencieusement sauté. On étend alors le
+  /// plafond à 12 s, mesuré depuis le mount (pas depuis la détection, pour ne pas
+  /// cumuler la latence de la lecture Hive). Fail-safe : toute erreur de lecture
+  /// → on garde le plafond actuel (jamais d'extension). Ne touche pas au cas
+  /// onboarding (déjà 10 s).
+  Future<void> _maybeExtendForColdBoot() async {
+    if (widget.fromOnboarding) return;
+    FluxContinuSnapshot? snapshot;
+    try {
+      snapshot = await FluxContinuCacheService().readLatest();
+    } catch (_) {
+      return; // fail-safe → comportement actuel (6 s), jamais fail-extend
+    }
+    if (snapshot != null) return; // cache présent → device chaud, 6 s inchangé
+    if (!mounted || _phase != _Phase.loading) return;
+    final coldMax = resolveMorningRitualMaxWait(
+      fromOnboarding: false,
+      coldBoot: true,
+    );
+    final remaining = coldMax - DateTime.now().difference(_mountedAt);
+    _maxWaitTimer?.cancel();
+    if (remaining <= Duration.zero) {
+      _forwardIfNotReady();
+    } else {
+      _maxWaitTimer = Timer(remaining, _forwardIfNotReady);
+    }
   }
 
   /// Révèle le rituel dès que les deux conditions sont réunies : édition prête

--- a/apps/mobile/lib/features/flux_continu/utils/morning_ritual_format.dart
+++ b/apps/mobile/lib/features/flux_continu/utils/morning_ritual_format.dart
@@ -41,6 +41,18 @@ bool isEditionReady(
   return true;
 }
 
+/// Plafond de résilience du loader du rituel matinal avant repli vers le feed.
+/// Onboarding : édition calculée à froid → 10 s (déjà validé). Cold-boot (aucun
+/// snapshot Hive) : chaîne auth-refresh + 3 appels réseau concurrents vers un
+/// backend mono-worker → 12 s. Cas chaud (cache existant) : 6 s, inchangé.
+Duration resolveMorningRitualMaxWait({
+  required bool fromOnboarding,
+  required bool coldBoot,
+}) {
+  if (fromOnboarding) return const Duration(seconds: 10);
+  return coldBoot ? const Duration(seconds: 12) : const Duration(seconds: 6);
+}
+
 /// Jour calendaire (`YYYY-MM-DD`) d'une `targetDate` éditoriale, à partir de ses
 /// composantes brutes (aucune conversion tz : c'est un libellé, pas un instant).
 String editionDayKey(DateTime date) {

--- a/apps/mobile/test/features/flux_continu/utils/morning_ritual_format_test.dart
+++ b/apps/mobile/test/features/flux_continu/utils/morning_ritual_format_test.dart
@@ -144,4 +144,33 @@ void main() {
     });
   });
 
+  // ---------------------------------------------------------------------------
+  // resolveMorningRitualMaxWait
+  // ---------------------------------------------------------------------------
+  group('resolveMorningRitualMaxWait', () {
+    test('chaud (cache Hive présent) → 6 s', () {
+      expect(
+        resolveMorningRitualMaxWait(fromOnboarding: false, coldBoot: false),
+        const Duration(seconds: 6),
+      );
+    });
+
+    test('froid (aucun cache) → 12 s', () {
+      expect(
+        resolveMorningRitualMaxWait(fromOnboarding: false, coldBoot: true),
+        const Duration(seconds: 12),
+      );
+    });
+
+    test('onboarding → 10 s, quel que soit coldBoot', () {
+      expect(
+        resolveMorningRitualMaxWait(fromOnboarding: true, coldBoot: false),
+        const Duration(seconds: 10),
+      );
+      expect(
+        resolveMorningRitualMaxWait(fromOnboarding: true, coldBoot: true),
+        const Duration(seconds: 10),
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Quoi

Sur un device jamais ouvert le jour même (aucun cache Hive `flux_continu_cache`, ex. Chrome sur Mac), la lettre du Rituel matinal ne s'affichait pas : elle était silencieusement remplacée par un repli vers le feed. `MorningRitualScreen` imposait un plafond de résilience de **6 s** ; sur un cold-start réel (auth-refresh Supabase jusqu'à 3 s + 3 appels réseau concurrents vers un backend mono-worker), ce plafond est dépassé → lettre jamais vue ce matin-là.

- Extrait la sélection du plafond dans `resolveMorningRitualMaxWait` (**pure, testable**, colocalisée avec `isEditionReady`) : onboarding 10 s, chaud 6 s, froid 12 s.
- `_maybeExtendForColdBoot` : lecture Hive **async non bloquante** ; si aucun snapshot n'a jamais été écrit (device genuinement froid) et l'écran est toujours en `loading`, étend le plafond à 12 s **mesuré depuis le mount**. Fail-safe : toute erreur de lecture → on garde 6 s (jamais d'extension).
- Cas **chaud** (6 s) et **onboarding** (10 s) strictement inchangés. Le repli ne marque toujours pas « vu » (décision PO #4 : le rituel revient au prochain open).
- Répare `changelog.json` (JSON invalide sur `main`, entrées « Ouverture »/« Serein » fusionnées) + ajoute une entrée « Rituel ».

## Pourquoi

Bug user-visible bloquant introduit **sur cette branche** (commit `a88bd328`, mécanisme `MorningRitualScreen` + gate `postAuthHomePath`) — pas une régression `main`. La lettre du matin, cœur du rituel, était sautée au tout premier lancement de la journée.

## Comment ça a été vérifié

- [x] `flutter test` du fichier pur : 16 tests OK (dont les 3 nouveaux cas `resolveMorningRitualMaxWait` : chaud→6 s, froid→12 s, onboarding→10 s quel que soit `coldBoot`)
- [x] `flutter analyze` sur les fichiers touchés : 0 issue
- [x] `changelog_asset_test` : vert après réparation du JSON
- [x] Suite complète : les échecs restants sont pré-existants et sans rapport (topic_chip, notification, bookmark, feed_sources, perspectives intros, widget_test smoke — non lancés en CI), aucun dans `flux_continu`/rituel
- [x] `/simplify` passé (diff ~30 lignes, déjà propre)

## Hors scope

**Retry-on-resume (`WidgetsBindingObserver`).** Le bug rapporté est un cold-miss en session unique, réglé par l'extension du plafond. Router le retour vers `/edition` au `resume` exigerait de modifier `routes.dart`/`postAuthHomePath` (le redirect GoRouter ne se ré-exécute qu'au changement d'`authStateProvider`) — changement plus large qu'un bug fix.

## Zones à risque

`MorningRitualScreen` (timers/lifecycle). Aucun changement backend, aucune migration Alembic. `FluxContinuCacheService.readLatest` réutilisé en lecture seule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)