### PR TITLE
feat: app update modal + topic chip in digest cards + badge spacing (#333)

### DIFF
--- a/docs/bugs/bug-clustering-sans-filtre-temporel.md
+++ b/docs/bugs/bug-clustering-sans-filtre-temporel.md
@@ -1,0 +1,115 @@
+# Bug: Clustering "couverture médiatique" sans filtre temporel
+
+## Statut
+- [x] En cours d'investigation
+- [x] En cours de correction
+- [x] Corrigé (date: 2026-07-14)
+
+## Sévérité
+- 🟡 Moyenne
+
+## Description
+
+Le clustering qui regroupe les articles par sujet (base des "Sujets du jour" /
+détection trending = la "couverture médiatique" d'un sujet par plusieurs
+sources) ne vérifiait jamais l'écart temporel entre deux articles avant de
+les fusionner dans le même cluster. La fusion se fait uniquement sur la
+similarité Jaccard des titres (`ImportanceDetector.build_topic_clusters`,
+seuil `ScoringWeights.TOPIC_CLUSTER_THRESHOLD = 0.45`, tokenisation déléguée
+à `app/services/text_similarity.py`).
+
+Concrètement : si deux articles partagent assez de mots-clés de titre (sujet
+récurrent, marronnier, dépêche republiée, gros titre générique...), ils
+étaient regroupés dans le même "sujet" **quel que soit l'écart entre leurs
+dates de publication**, tant qu'ils se trouvent dans le pool de candidats
+fourni par l'appelant.
+
+Ce n'était pas visible en prod car chaque appelant limite déjà la fenêtre de
+récupération des contenus (7j pour le digest "sujets du jour" via
+`DigestSelector._get_candidates(hours_lookback=168)`, ~48h pour le pipeline
+éditorial). Mais rien dans `build_topic_clusters` lui-même n'empêchait de
+mélanger un article du jour 1 et un article du jour 7, et toute évolution
+future élargissant/supprimant ce filtre amont aurait réintroduit
+silencieusement des clusters mêlant des sujets sans rapport temporel.
+
+## Cause racine
+
+`ImportanceDetector.build_topic_clusters()`
+(`packages/api/app/services/briefing/importance_detector.py`) ne comparait
+que les tokens de titre (similarité Jaccard) pour décider si un contenu
+rejoint un cluster existant. Aucun champ temporel n'était lu ni comparé
+pendant la boucle de clustering.
+
+Le filtrage temporel n'existait qu'**en amont**, côté appelants
+(`DigestSelector._get_candidates`, docstring `compute_global_context`), pas
+dans la fonction de clustering elle-même — ce n'était pas une garantie
+structurelle de l'algorithme.
+
+## Solution
+
+Ajout d'un filtre temporel **dans** `build_topic_clusters`, indépendant des
+appelants :
+
+1. **`packages/api/app/services/recommendation/scoring_config.py`**
+   Nouvelle constante à côté de `TOPIC_CLUSTER_THRESHOLD` /
+   `TOPIC_CLUSTER_MIN_TOKENS` / `TOPIC_CLUSTER_MAX_TOKENS` :
+   `TOPIC_CLUSTER_MAX_TIME_GAP_HOURS = 720` (30 jours). Valeur volontairement
+   large pour ne rien changer côté digest/éditorial (fenêtres amont ≤ 7j) :
+   garde-fou structurel, pas un resserrement du comportement actuel.
+
+2. **`packages/api/app/services/briefing/importance_detector.py`**
+   - `build_topic_clusters()` accepte un nouveau paramètre optionnel
+     `max_time_gap_hours` (défaut : la constante ci-dessus), surchargeable
+     comme `similarity_threshold`.
+   - Chaque cluster en cours de construction garde en mémoire ses bornes
+     temporelles (`min_published_at` / `max_published_at`).
+   - Un contenu candidat ne peut rejoindre un cluster que si son
+     `published_at` est à ≤ `max_time_gap_hours` de la borne la plus proche
+     du cluster (`_within_time_gap`), en plus du critère Jaccard existant.
+   - Fail-open : si le contenu ou le cluster n'a pas de date exploitable
+     (`published_at` absent/`None`, ou mock sans date réelle), le filtre
+     temporel ne bloque pas la fusion — comportement historique préservé.
+   - Gestion tz-aware/naive (`_normalize_published_at`), alignée avec le
+     pattern déjà utilisé ailleurs dans le digest (ex.
+     `TopicSelector._best_recency_bonus`).
+   - N'affecte pas la logique de "fold" des agrégateurs (Reddit) ni le
+     comptage par `source_domains` ajoutés depuis (Phase 2 de
+     `build_topic_clusters`, indépendante de la Phase 1 modifiée ici).
+
+3. **Tests** (`packages/api/tests/test_importance_detector.py`,
+   classe `TestBuildTopicClustersTimeGap`)
+   - Cas nominal : deux articles proches dans le temps + titres similaires →
+     même cluster (comportement actuel inchangé).
+   - Cas régression : deux articles à >30 jours d'écart + titres très
+     similaires → clusters séparés.
+   - Override de `max_time_gap_hours` (fenêtre resserrée à 6h).
+   - Fail-open : contenu sans `published_at` → pas de blocage, pas de crash.
+   - `published_at` naive (sans tzinfo) → pas de crash.
+   - Suite `TestAggregatorFold` existante (fold Reddit) toujours verte, non
+     affectée par ce changement.
+
+## Fichiers concernés
+- `packages/api/app/services/recommendation/scoring_config.py`
+- `packages/api/app/services/briefing/importance_detector.py`
+- `packages/api/tests/test_importance_detector.py`
+
+## Hors scope
+
+- `StoryService.cluster_hybrid` (`packages/api/app/services/story_service.py`,
+  si présent sur cette base) : clustering distinct, sans appelant identifié
+  dans la codebase — non traité ici.
+- `DeepMatcher` (`packages/api/app/services/editorial/deep_matcher.py`) est
+  volontairement **sans limite de temps** ("No time limit on deep articles,
+  can be months old") — choix produit assumé (articles de fond), pas un bug.
+
+## Notes
+Demande utilisateur : "AJOUTER UN FILTRE TEMPOREL (même large, par exemple
+d'1 mois ?) lors du clustering" — valeur par défaut : 30 jours (720h),
+configurable via `ScoringWeights.TOPIC_CLUSTER_MAX_TIME_GAP_HOURS`.
+
+**Note process** : la première itération de ce correctif avait été
+développée par erreur sur une branche partie de `staging` (au lieu de
+`main`), sur une version de `importance_detector.py` significativement plus
+ancienne (avant l'extraction de `text_similarity.py` et l'ajout du fold
+agrégateurs/`source_domains`). La branche a été réinitialisée sur `main` et
+le correctif refait contre le code actuel.

--- a/packages/api/app/services/briefing/importance_detector.py
+++ b/packages/api/app/services/briefing/importance_detector.py
@@ -12,6 +12,7 @@ Architecture: Ce module est DÉCOUPLÉ du ScoringEngine. Il consomme les contenu
 bruts et produit des clusters/flags d'importance utilisés par TopicSelector et Top3Selector.
 """
 
+import datetime
 from collections import Counter
 from dataclasses import dataclass, field
 from urllib.parse import urlparse
@@ -137,10 +138,68 @@ class ImportanceDetector:
         """Délègue à `text_similarity.jaccard_similarity` (méthode conservée pour compat)."""
         return _jaccard_similarity(tokens_a, tokens_b)
 
+    @staticmethod
+    def _normalize_published_at(
+        published_at: object,
+    ) -> datetime.datetime | None:
+        """Retourne un datetime tz-aware valide, ou None si non exploitable."""
+        if not isinstance(published_at, datetime.datetime):
+            return None
+        if published_at.tzinfo is None:
+            return published_at.replace(tzinfo=datetime.UTC)
+        return published_at
+
+    def _within_time_gap(
+        self,
+        published_at: datetime.datetime | None,
+        cluster: dict,
+        max_gap_hours: float,
+    ) -> bool:
+        """True si published_at est à ≤ max_gap_hours d'une borne du cluster.
+
+        Fail-open : si l'une des deux dates est inconnue/non exploitable, le
+        filtre temporel ne bloque pas la fusion (comportement historique
+        préservé pour les contenus sans date fiable).
+        """
+        if published_at is None:
+            return True
+
+        cluster_min = cluster["min_published_at"]
+        cluster_max = cluster["max_published_at"]
+        if cluster_min is None or cluster_max is None:
+            return True
+
+        if published_at < cluster_min:
+            gap = cluster_min - published_at
+        elif published_at > cluster_max:
+            gap = published_at - cluster_max
+        else:
+            return True
+
+        return gap.total_seconds() / 3600 <= max_gap_hours
+
+    @staticmethod
+    def _update_cluster_bounds(
+        cluster: dict, published_at: datetime.datetime | None
+    ) -> None:
+        if published_at is None:
+            return
+        if (
+            cluster["min_published_at"] is None
+            or published_at < cluster["min_published_at"]
+        ):
+            cluster["min_published_at"] = published_at
+        if (
+            cluster["max_published_at"] is None
+            or published_at > cluster["max_published_at"]
+        ):
+            cluster["max_published_at"] = published_at
+
     def build_topic_clusters(
         self,
         contents: list[Content],
         similarity_threshold: float | None = None,
+        max_time_gap_hours: float | None = None,
     ) -> list[TopicCluster]:
         """Cluster tous les contenus par similarité de titre.
 
@@ -150,9 +209,17 @@ class ImportanceDetector:
         Algorithme identique à detect_trending_clusters mais retourne
         la structure complète au lieu de filtrer sur le trending.
 
+        Un contenu ne peut rejoindre un cluster existant que si son
+        published_at reste à ≤ max_time_gap_hours de la borne temporelle la
+        plus proche du cluster (garde-fou contre les faux clusters entre
+        sujets récurrents publiés à des dates très éloignées). Les contenus
+        sans date exploitable ne sont pas soumis à ce filtre.
+
         Args:
             contents: Liste des contenus à analyser
             similarity_threshold: Seuil Jaccard override (default: self.similarity_threshold)
+            max_time_gap_hours: Écart temporel max override
+                (default: ScoringWeights.TOPIC_CLUSTER_MAX_TIME_GAP_HOURS)
 
         Returns:
             Liste de TopicCluster triée par taille décroissante
@@ -166,15 +233,25 @@ class ImportanceDetector:
             else self.similarity_threshold
         )
 
+        from app.services.recommendation.scoring_config import ScoringWeights
+
+        max_gap_hours = (
+            max_time_gap_hours
+            if max_time_gap_hours is not None
+            else ScoringWeights.TOPIC_CLUSTER_MAX_TIME_GAP_HOURS
+        )
+
         # Phase 1: Clustering Jaccard (même algo que detect_trending_clusters)
         raw_clusters: list[dict] = []
-
-        from app.services.recommendation.scoring_config import ScoringWeights
 
         for content in contents:
             tokens = self.normalize_title(content.title)
             if not tokens:
                 continue
+
+            published_at = self._normalize_published_at(
+                getattr(content, "published_at", None)
+            )
 
             # Minimum token constraint: very short titles become singletons
             if len(tokens) < ScoringWeights.TOPIC_CLUSTER_MIN_TOKENS:
@@ -182,6 +259,8 @@ class ImportanceDetector:
                     {
                         "tokens": tokens,
                         "contents": [content],
+                        "min_published_at": published_at,
+                        "max_published_at": published_at,
                     }
                 )
                 continue
@@ -190,6 +269,9 @@ class ImportanceDetector:
             best_similarity = 0.0
 
             for cluster in raw_clusters:
+                if not self._within_time_gap(published_at, cluster, max_gap_hours):
+                    continue
+
                 sim = self.jaccard_similarity(tokens, cluster["tokens"])
                 if sim > best_similarity and sim >= threshold:
                     best_similarity = sim
@@ -201,11 +283,14 @@ class ImportanceDetector:
                 merged = matched_cluster["tokens"] | tokens
                 if len(merged) <= ScoringWeights.TOPIC_CLUSTER_MAX_TOKENS:
                     matched_cluster["tokens"] = merged
+                self._update_cluster_bounds(matched_cluster, published_at)
             else:
                 raw_clusters.append(
                     {
                         "tokens": tokens,
                         "contents": [content],
+                        "min_published_at": published_at,
+                        "max_published_at": published_at,
                     }
                 )
 

--- a/packages/api/app/services/recommendation/scoring_config.py
+++ b/packages/api/app/services/recommendation/scoring_config.py
@@ -250,6 +250,14 @@ class ScoringWeights:
     # Maximum de tokens par cluster (évite la dérive par union successive).
     TOPIC_CLUSTER_MAX_TOKENS = 15
 
+    # Écart temporel maximum (en heures) entre un article candidat et la borne
+    # temporelle la plus proche d'un cluster pour autoriser la fusion.
+    # 720h = 30 jours — filtre volontairement large : garde-fou structurel
+    # contre les faux clusters entre sujets récurrents/marronniers éloignés
+    # dans le temps, sans resserrer le comportement actuel (fenêtres amont
+    # déjà ≤ 7j pour le digest, ≤ 48h pour l'éditorial).
+    TOPIC_CLUSTER_MAX_TIME_GAP_HOURS = 720
+
     # --- EXPLICIT FEEDBACK LAYER (Like & Bookmark signals) ---
 
     # Delta applied to user_subtopics.weight when liking/unliking content.

--- a/packages/api/tests/test_importance_detector.py
+++ b/packages/api/tests/test_importance_detector.py
@@ -5,6 +5,7 @@ Valide le clustering Jaccard et la détection de sujets tendance.
 """
 
 import uuid
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
 import pytest
@@ -262,6 +263,123 @@ class TestDetectTrendingClusters:
         trending = detector.detect_trending_clusters([])
 
         assert trending == set()
+
+
+class TestBuildTopicClustersTimeGap:
+    """Tests pour le filtre temporel de build_topic_clusters."""
+
+    def _create_mock_content(
+        self,
+        title: str,
+        published_at=None,
+        source_id: uuid.UUID = None,
+    ) -> MagicMock:
+        """Helper pour créer un mock Content avec une date de publication."""
+        mock = MagicMock()
+        mock.id = uuid.uuid4()
+        mock.source_id = source_id or uuid.uuid4()
+        mock.title = title
+        mock.guid = str(uuid.uuid4())
+        mock.url = f"https://source-{mock.source_id}.fr/article"
+        mock.published_at = published_at
+        mock.theme = None
+        mock.source = None
+        return mock
+
+    def test_close_in_time_same_cluster(self):
+        """Deux articles proches dans le temps + titres similaires → même cluster."""
+
+        detector = ImportanceDetector(similarity_threshold=0.4)
+        now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+        contents = [
+            self._create_mock_content("Macron annonce réforme fiscale majeure", now),
+            self._create_mock_content(
+                "Macron réforme fiscale annonce Bercy", now + timedelta(days=2)
+            ),
+        ]
+
+        clusters = detector.build_topic_clusters(contents)
+
+        assert len(clusters) == 1
+        assert len(clusters[0].contents) == 2
+
+    def test_beyond_max_gap_separate_clusters(self):
+        """Deux articles à >30 jours d'écart + titres similaires → clusters séparés."""
+
+        detector = ImportanceDetector(similarity_threshold=0.4)
+        now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+        contents = [
+            self._create_mock_content("Macron annonce réforme fiscale majeure", now),
+            self._create_mock_content(
+                "Macron réforme fiscale annonce Bercy", now + timedelta(days=45)
+            ),
+        ]
+
+        clusters = detector.build_topic_clusters(contents)
+
+        assert len(clusters) == 2
+        assert all(len(c.contents) == 1 for c in clusters)
+
+    def test_custom_max_time_gap_hours_override(self):
+        """max_time_gap_hours override permet de resserrer/élargir le filtre."""
+
+        detector = ImportanceDetector(similarity_threshold=0.4)
+        now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+        contents = [
+            self._create_mock_content("Macron annonce réforme fiscale majeure", now),
+            self._create_mock_content(
+                "Macron réforme fiscale annonce Bercy", now + timedelta(hours=12)
+            ),
+        ]
+
+        # Fenêtre resserrée à 6h : l'écart de 12h dépasse le seuil.
+        clusters = detector.build_topic_clusters(contents, max_time_gap_hours=6)
+
+        assert len(clusters) == 2
+
+    def test_missing_published_at_fails_open(self):
+        """Contenu sans date exploitable : le filtre temporel ne bloque pas la fusion."""
+
+        detector = ImportanceDetector(similarity_threshold=0.4)
+
+        contents = [
+            self._create_mock_content(
+                "Macron annonce réforme fiscale majeure", published_at=None
+            ),
+            self._create_mock_content(
+                "Macron réforme fiscale annonce Bercy",
+                published_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+            ),
+        ]
+
+        clusters = detector.build_topic_clusters(contents)
+
+        assert len(clusters) == 1
+        assert len(clusters[0].contents) == 2
+
+    def test_naive_datetime_is_handled(self):
+        """Un published_at naive (sans tzinfo) ne doit pas lever d'exception."""
+
+        detector = ImportanceDetector(similarity_threshold=0.4)
+        now_naive = datetime(2026, 6, 1)
+
+        contents = [
+            self._create_mock_content(
+                "Macron annonce réforme fiscale majeure", now_naive
+            ),
+            self._create_mock_content(
+                "Macron réforme fiscale annonce Bercy",
+                now_naive + timedelta(days=2),
+            ),
+        ]
+
+        clusters = detector.build_topic_clusters(contents)
+
+        assert len(clusters) == 1
+        assert len(clusters[0].contents) == 2
 
 
 class TestIdentifyUneContents:


### PR DESCRIPTION
- Show update modal on digest launch when an update is available
- Replace onNotInterested with topicChipWidget in topic section cards
- Increase badge bottom padding (6→14px) in carousels and topic sections
- Add badge height constant for accurate card height computation
- Bump transitive dependency versions in pubspec.lock

Co-authored-by: Laurin Boujon <laurinboujon@mbp-de-laurin.home>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>