### PR TITLE
fix(abonnements): connexion premium fiabilisée + finition du flux

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Abonnements",
+      "summary": "Connecter un abonnement est plus clair : titre au nom du média, écran de vérification guidé, et un message d'aide quand une page ne se charge pas."
+    },
+    {
       "tag": "Rituel",
       "summary": "Ta lettre du matin s'affiche même au tout premier lancement de la journée, sans passer directement au flux."
     },

--- a/apps/mobile/lib/features/sources/models/source_model.dart
+++ b/apps/mobile/lib/features/sources/models/source_model.dart
@@ -40,9 +40,31 @@ class PremiumConnection {
   bool get isUsable => enabled && loginUrl.isNotEmpty && testUrl.isNotEmpty;
 }
 
-/// Connexion existante si utilisable, sinon flux générique (login=test=home)
-/// dès qu'il y a une URL http(s) valide ; `null` sinon. Cœur partagé par
-/// [resolvePremiumConnection] et [forceGenericConnection].
+/// Réduit une URL à l'origine du site (`scheme://host[:port]/`).
+///
+/// Beaucoup de sources stockent dans `source.url` l'URL de leur **flux** RSS
+/// (`/rss.xml`, `/feed/`…) : ouverte telle quelle dans la WebView de connexion,
+/// elle affiche du XML brut au lieu d'une page (bug « Cerveau & Psycho »).
+/// Normaliser vers l'origine répare toutes ces sources d'un coup.
+///
+/// Idempotent (`/rss.xml` → `/`, `/` → `/`), port préservé ; renvoie `null` si
+/// l'URL n'est pas une URL http(s) exploitable (même contrat que le jumeau
+/// back-end `origin_url` — un flux de connexion ne s'ouvre qu'en http(s)).
+String? siteRootFor(String url) {
+  final uri = Uri.tryParse(url.trim());
+  if (uri == null || uri.host.isEmpty) return null;
+  if (uri.scheme != 'http' && uri.scheme != 'https') return null;
+  return Uri(
+    scheme: uri.scheme,
+    host: uri.host,
+    port: uri.hasPort ? uri.port : null,
+    path: '/',
+  ).toString();
+}
+
+/// Connexion existante si utilisable, sinon flux générique (login=test=origine
+/// du site) dès qu'il y a une URL http(s) valide ; `null` sinon. Cœur partagé
+/// par [resolvePremiumConnection] et [forceGenericConnection].
 PremiumConnection? _genericConnectionFor(Source source) {
   final existing = source.premiumConnection;
   if (existing != null && existing.isUsable) return existing;
@@ -50,9 +72,15 @@ PremiumConnection? _genericConnectionFor(Source source) {
   final url = source.url?.trim() ?? '';
   if (!url.startsWith('http://') && !url.startsWith('https://')) return null;
 
+  // On synthétise le flux générique sur l'**origine** du site, jamais sur
+  // l'URL brute (souvent un flux RSS). La branche `existing.isUsable` ci-dessus
+  // n'est pas touchée : les connexions curées/explicites portent de vraies URLs.
+  final origin = siteRootFor(url);
+  if (origin == null) return null;
+
   return PremiumConnection(
-    loginUrl: url,
-    testUrl: url,
+    loginUrl: origin,
+    testUrl: origin,
     displayHint:
         'Connecte-toi à ton compte sur le site du média, puis reviens lire '
         'tes articles.',

--- a/apps/mobile/lib/features/sources/widgets/premium_source_connection.dart
+++ b/apps/mobile/lib/features/sources/widgets/premium_source_connection.dart
@@ -13,7 +13,12 @@ import 'premium_web_view.dart';
 import 'source_logo_avatar.dart';
 
 typedef PremiumWebViewBuilder = Widget Function(
-    BuildContext context, String url, ValueChanged<WebUri?>? onLoadStop);
+  BuildContext context,
+  String url,
+  ValueChanged<WebUri?>? onLoadStop, {
+  VoidCallback? onPaywallDetected,
+  ValueChanged<int?>? onLoadError,
+});
 
 /// Nombre de pills affichées dans les WebView steps : login → vérification →
 /// terminé. Les écrans intro/succès ne portent pas de pills.
@@ -57,6 +62,18 @@ class _PremiumSourceConnectionState
   /// CTA du step 1 pour ne pas inviter à cliquer avant d'avoir navigué.
   bool _loginNavigated = false;
 
+  /// Étape 2 : la sonde paywall (`PremiumWebView.detectPaywall`) a repéré un
+  /// article encore réservé → bannière d'avertissement **non bloquante**.
+  bool _paywallWarning = false;
+
+  /// La frame principale n'a pas pu charger (404 / erreur transport) → encart de
+  /// guidage en overlay. Reset à chaque transition d'étape.
+  bool _loadError = false;
+
+  /// Bumpé au « Réessayer » pour reconstruire la WebView (nouvelle `ValueKey`
+  /// → `onWebViewCreated` rejoue le chargement).
+  int _webViewEpoch = 0;
+
   PremiumConnection get _connection =>
       widget.connection ?? widget.source.premiumConnection!;
 
@@ -85,10 +102,31 @@ class _PremiumSourceConnectionState
     }
   }
 
+  /// Entre dans une étape WebView en repartant d'un état propre : les bannières
+  /// transitoires (`_paywallWarning`, `_loadError`) sont les seules à reset ici
+  /// et au « Réessayer ». Centralisé pour garder l'invariant en un point.
+  void _goToStep(int next) {
+    setState(() {
+      _step = next;
+      _paywallWarning = false;
+      _loadError = false;
+    });
+  }
+
+  /// Reconstruit la WebView de l'étape courante (« Réessayer » de l'overlay
+  /// d'erreur) en changeant sa `ValueKey`, ce qui rejoue `onWebViewCreated`.
+  void _retryWebView() {
+    setState(() {
+      _loadError = false;
+      _webViewEpoch++;
+    });
+  }
+
   Future<void> _confirm() async {
     setState(() {
       _saving = true;
       _error = null;
+      _paywallWarning = false;
     });
     try {
       // Session validée par l'utilisateur : on capture les cookies du média
@@ -116,33 +154,72 @@ class _PremiumSourceConnectionState
     final colors = context.facteurColors;
     return Scaffold(
       backgroundColor: colors.backgroundPrimary,
-      appBar: AppBar(
-        backgroundColor: colors.backgroundPrimary,
-        elevation: 0,
-        leading: IconButton(
-          icon: Icon(PhosphorIcons.x(), color: colors.textPrimary),
-          onPressed: () => Navigator.of(context).pop(),
-        ),
-        title: Text(
-          widget.source.name,
-          style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                color: colors.textPrimary,
-                fontWeight: FontWeight.w700,
-              ),
-        ),
-      ),
+      appBar: _buildAppBar(context, colors),
       body: SafeArea(child: _buildStep(context, colors)),
     );
+  }
+
+  /// AppBar unifié : sur les étapes WebView (1 & 2) il fusionne le chrome — titre
+  /// « Connecter {source} », barre d'étapes (pills) et raccourci navigateur
+  /// externe — pour rendre toute la hauteur à la WebView. Sur intro/succès, seul
+  /// le titre (nom de la source), sans pills.
+  PreferredSizeWidget _buildAppBar(BuildContext context, FacteurColors colors) {
+    final isWebViewStep = _step == 1 || _step == 2;
+    final titleText =
+        isWebViewStep ? 'Connecter ${widget.source.name}' : widget.source.name;
+    return AppBar(
+      backgroundColor: colors.backgroundPrimary,
+      elevation: 0,
+      leading: IconButton(
+        icon: Icon(PhosphorIcons.x(), color: colors.textPrimary),
+        onPressed: () => Navigator.of(context).pop(),
+      ),
+      title: Text(
+        titleText,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+              color: colors.textPrimary,
+              fontWeight: FontWeight.w700,
+            ),
+      ),
+      actions: isWebViewStep ? _appBarStepActions(colors) : null,
+    );
+  }
+
+  List<Widget> _appBarStepActions(FacteurColors colors) {
+    // Le label d'étape ('Connexion'/'Vérification') reste porté par la
+    // sémantique des pills (a11y + tests `find.bySemanticsLabel`).
+    final stepLabel = _step == 1 ? 'Connexion' : 'Vérification';
+    final externalUrl = _step == 1 ? _connection.loginUrl : _connection.testUrl;
+    return [
+      Center(
+        child: Semantics(
+          label: stepLabel,
+          child: SizedBox(
+            width: 72,
+            child: _PremiumStepPills(
+              totalSteps: _kTotalSteps,
+              currentStep: _step,
+            ),
+          ),
+        ),
+      ),
+      IconButton(
+        onPressed: () => _openExternal(externalUrl),
+        icon: Icon(PhosphorIcons.arrowSquareOut(), size: 20),
+        color: colors.textPrimary,
+        tooltip: 'Ouvrir dans le navigateur externe',
+      ),
+      const SizedBox(width: FacteurSpacing.space2),
+    ];
   }
 
   Widget _buildStep(BuildContext context, FacteurColors colors) {
     switch (_step) {
       case 1:
         return _WebViewStep(
-          key: const ValueKey('premium-webview-login'),
-          title: 'Connexion',
-          stepIndex: 1,
-          totalSteps: _kTotalSteps,
+          key: ValueKey('premium-webview-login-$_webViewEpoch'),
           url: _connection.loginUrl,
           source: widget.source,
           sessionStore: _sessionStore,
@@ -150,24 +227,32 @@ class _PremiumSourceConnectionState
           webViewBuilder: widget.webViewBuilder,
           showAction: _loginNavigated,
           onLoadStop: _handleLoginNavigation,
-          onAction: () => setState(() => _step = 2),
+          onAction: () => _goToStep(2),
           onOpenExternal: () => _openExternal(_connection.loginUrl),
+          loadError: _loadError,
+          onLoadError: (_) => setState(() => _loadError = true),
+          onRetry: _retryWebView,
         );
       case 2:
         return _WebViewStep(
-          key: const ValueKey('premium-webview-test'),
-          title: 'Vérification',
-          stepIndex: 2,
-          totalSteps: _kTotalSteps,
+          key: ValueKey('premium-webview-test-$_webViewEpoch'),
           url: _connection.testUrl,
           source: widget.source,
           sessionStore: _sessionStore,
           actionLabel: 'Je suis connecté(e)',
           webViewBuilder: widget.webViewBuilder,
+          instruction:
+              'Ouvre un article réservé aux abonnés et vérifie qu’il '
+              's’affiche en entier.',
+          paywallWarning: _paywallWarning,
+          onPaywallDetected: () => setState(() => _paywallWarning = true),
           onAction: _saving ? null : _confirm,
           onOpenExternal: () => _openExternal(_connection.testUrl),
           isLoading: _saving,
           error: _error,
+          loadError: _loadError,
+          onLoadError: (_) => setState(() => _loadError = true),
+          onRetry: _retryWebView,
         );
       case 3:
         return Padding(
@@ -222,7 +307,7 @@ class _PremiumSourceConnectionState
               Center(child: SourceLogoAvatar(source: widget.source, size: 72)),
               const SizedBox(height: FacteurSpacing.space6),
               Text(
-                'Connecter votre abonnement',
+                'Connecter ${widget.source.name}',
                 textAlign: TextAlign.center,
                 style: Theme.of(context).textTheme.headlineSmall?.copyWith(
                       color: colors.textPrimary,
@@ -244,7 +329,7 @@ class _PremiumSourceConnectionState
                 label: 'Commencer',
                 type: FacteurButtonType.primary,
                 icon: PhosphorIcons.link(),
-                onPressed: () => setState(() => _step = 1),
+                onPressed: () => _goToStep(1),
               ),
             ],
           ),
@@ -254,9 +339,6 @@ class _PremiumSourceConnectionState
 }
 
 class _WebViewStep extends StatelessWidget {
-  final String title;
-  final int stepIndex; // 1-based
-  final int totalSteps;
   final String url;
   final Source source;
   final PremiumSessionStore sessionStore;
@@ -265,6 +347,24 @@ class _WebViewStep extends StatelessWidget {
   final ValueChanged<WebUri?>? onLoadStop;
   final VoidCallback? onAction;
   final VoidCallback onOpenExternal;
+
+  /// Consigne discrète rendue juste au-dessus de la WebView (étape de
+  /// vérification). `null` à l'étape de login → aucune ligne.
+  final String? instruction;
+
+  /// Remonté quand la sonde paywall repère un article encore réservé. Non nul
+  /// ⇒ la sonde est injectée dans la WebView (étape de vérification).
+  final VoidCallback? onPaywallDetected;
+
+  /// Affiche la bannière « article encore réservé » (non bloquante, le CTA reste
+  /// actif : on informe, on ne bloque pas).
+  final bool paywallWarning;
+
+  /// Échec de chargement de la frame principale (404 / transport) → overlay de
+  /// guidage par-dessus la WebView. [onRetry] recharge la page.
+  final ValueChanged<int?>? onLoadError;
+  final bool loadError;
+  final VoidCallback? onRetry;
 
   /// Masque le CTA principal tant qu'il n'a pas de sens (step login avant que
   /// l'utilisateur ait navigué). Un `SizedBox` prend sa place pour éviter un
@@ -275,9 +375,6 @@ class _WebViewStep extends StatelessWidget {
 
   const _WebViewStep({
     super.key,
-    required this.title,
-    required this.stepIndex,
-    required this.totalSteps,
     required this.url,
     required this.source,
     required this.sessionStore,
@@ -286,6 +383,12 @@ class _WebViewStep extends StatelessWidget {
     required this.onOpenExternal,
     this.webViewBuilder,
     this.onLoadStop,
+    this.instruction,
+    this.onPaywallDetected,
+    this.paywallWarning = false,
+    this.onLoadError,
+    this.loadError = false,
+    this.onRetry,
     this.showAction = true,
     this.isLoading = false,
     this.error,
@@ -294,47 +397,67 @@ class _WebViewStep extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
-    final webView = webViewBuilder?.call(context, url, onLoadStop) ??
+    final webView = webViewBuilder?.call(
+          context,
+          url,
+          onLoadStop,
+          onPaywallDetected: onPaywallDetected,
+          onLoadError: onLoadError,
+        ) ??
         PremiumWebView(
           source: source,
           url: WebUri(url),
           sessionStore: sessionStore,
           enableScrollBridge: false,
+          // La sonde n'a de sens qu'à l'étape de vérification, signalée par un
+          // callback non nul.
+          detectPaywall: onPaywallDetected != null,
           onLoadStop: onLoadStop,
+          onPaywallDetected: onPaywallDetected,
+          onLoadError: onLoadError,
         );
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Padding(
-          padding: const EdgeInsets.fromLTRB(
-            FacteurSpacing.space4,
-            FacteurSpacing.space2,
-            FacteurSpacing.space4,
-            FacteurSpacing.space3,
+        if (instruction != null)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              FacteurSpacing.space4,
+              FacteurSpacing.space2,
+              FacteurSpacing.space4,
+              FacteurSpacing.space2,
+            ),
+            child: Text(
+              instruction!,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: colors.textSecondary,
+                  ),
+            ),
           ),
-          child: Row(
+        Expanded(
+          child: Stack(
             children: [
-              Expanded(
-                child: Semantics(
-                  label: title,
-                  child: _PremiumStepPills(
-                    totalSteps: totalSteps,
-                    currentStep: stepIndex,
+              Positioned.fill(child: webView),
+              if (loadError)
+                Positioned.fill(
+                  child: _LoadErrorGuidance(
+                    onOpenExternal: onOpenExternal,
+                    onRetry: onRetry,
                   ),
                 ),
-              ),
-              const SizedBox(width: FacteurSpacing.space2),
-              IconButton(
-                onPressed: onOpenExternal,
-                icon: Icon(PhosphorIcons.arrowSquareOut(), size: 20),
-                tooltip: 'Ouvrir dans le navigateur externe',
-                padding: EdgeInsets.zero,
-                constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
-              ),
             ],
           ),
         ),
-        Expanded(child: webView),
+        if (paywallWarning)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 10, 16, 0),
+            child: Text(
+              'Cet article semble encore réservé. Ta session n’est '
+              'peut-être pas active.',
+              textAlign: TextAlign.center,
+              style: TextStyle(color: colors.warning),
+            ),
+          ),
         if (error != null)
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 10, 16, 0),
@@ -346,7 +469,12 @@ class _WebViewStep extends StatelessWidget {
           ),
         if (showAction)
           Padding(
-            padding: const EdgeInsets.all(FacteurSpacing.space4),
+            padding: const EdgeInsets.fromLTRB(
+              FacteurSpacing.space4,
+              FacteurSpacing.space2,
+              FacteurSpacing.space4,
+              FacteurSpacing.space3,
+            ),
             child: FacteurButton(
               label: isLoading ? 'Connexion...' : actionLabel,
               type: FacteurButtonType.primary,
@@ -355,8 +483,73 @@ class _WebViewStep extends StatelessWidget {
             ),
           )
         else
-          const SizedBox(height: FacteurSpacing.space4),
+          const SizedBox(height: FacteurSpacing.space2),
       ],
+    );
+  }
+}
+
+/// Encart de guidage affiché en overlay quand la page ne se charge pas (404 /
+/// erreur transport). Non destructif : la WebView reste dessous, l'utilisateur
+/// garde l'échappatoire navigateur et peut réessayer.
+class _LoadErrorGuidance extends StatelessWidget {
+  final VoidCallback onOpenExternal;
+  final VoidCallback? onRetry;
+
+  const _LoadErrorGuidance({required this.onOpenExternal, this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Container(
+      color: colors.backgroundPrimary,
+      padding: const EdgeInsets.all(FacteurSpacing.space6),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Icon(
+            PhosphorIcons.warningCircle(),
+            size: 48,
+            color: colors.textSecondary,
+          ),
+          const SizedBox(height: FacteurSpacing.space4),
+          Text(
+            'La page ne s’est pas chargée',
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  color: colors.textPrimary,
+                  fontWeight: FontWeight.w700,
+                ),
+          ),
+          const SizedBox(height: FacteurSpacing.space2),
+          Text(
+            'Ouvre le site du média et appuie sur « Se connecter », ou '
+            'ouvre-le dans ton navigateur.',
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: colors.textSecondary,
+                  height: 1.4,
+                ),
+          ),
+          const SizedBox(height: FacteurSpacing.space6),
+          FacteurButton(
+            label: 'Ouvrir dans le navigateur',
+            type: FacteurButtonType.primary,
+            icon: PhosphorIcons.arrowSquareOut(),
+            onPressed: onOpenExternal,
+          ),
+          if (onRetry != null) ...[
+            const SizedBox(height: FacteurSpacing.space2),
+            FacteurButton(
+              label: 'Réessayer',
+              type: FacteurButtonType.secondary,
+              icon: PhosphorIcons.arrowClockwise(),
+              onPressed: onRetry,
+            ),
+          ],
+        ],
+      ),
     );
   }
 }

--- a/apps/mobile/lib/features/sources/widgets/premium_web_view.dart
+++ b/apps/mobile/lib/features/sources/widgets/premium_web_view.dart
@@ -47,6 +47,7 @@ class PremiumWebView extends StatefulWidget {
     this.onProgress,
     this.onScrollY,
     this.onPaywallDetected,
+    this.onLoadError,
     this.gestureRecognizers,
   });
 
@@ -71,6 +72,11 @@ class PremiumWebView extends StatefulWidget {
   final ValueChanged<double>? onProgress;
   final ValueChanged<double>? onScrollY;
   final VoidCallback? onPaywallDetected;
+
+  /// Échec de chargement de la **frame principale** (page cassée). `int` = code
+  /// HTTP quand connu (>= 400), `null` pour une erreur de transport. Les échecs
+  /// de sous-ressources (favicon, pubs, trackers) sont ignorés.
+  final ValueChanged<int?>? onLoadError;
   final Set<Factory<OneSequenceGestureRecognizer>>? gestureRecognizers;
 
   @override
@@ -106,6 +112,19 @@ class _PremiumWebViewState extends State<PremiumWebView> {
       onWebViewCreated: _handleCreated,
       onLoadStart: (controller, url) => widget.onLoadStart?.call(url),
       onLoadStop: _handleLoadStop,
+      onReceivedError: (controller, request, error) {
+        // Frame principale uniquement : un favicon/tracker qui échoue ne casse
+        // pas la page. Erreur de transport → pas de code HTTP (`null`).
+        if (request.isForMainFrame ?? false) {
+          widget.onLoadError?.call(null);
+        }
+      },
+      onReceivedHttpError: (controller, request, errorResponse) {
+        final status = errorResponse.statusCode ?? 0;
+        if ((request.isForMainFrame ?? false) && status >= 400) {
+          widget.onLoadError?.call(status);
+        }
+      },
     );
   }
 

--- a/apps/mobile/test/features/sources/models/source_model_test.dart
+++ b/apps/mobile/test/features/sources/models/source_model_test.dart
@@ -32,8 +32,25 @@ void main() {
 
       expect(connection, isNotNull);
       expect(connection!.isGeneric, isTrue);
-      expect(connection.loginUrl, 'https://example.com');
-      expect(connection.testUrl, 'https://example.com');
+      // Le flux générique est synthétisé sur l'origine du site (slash final).
+      expect(connection.loginUrl, 'https://example.com/');
+      expect(connection.testUrl, 'https://example.com/');
+    });
+
+    test('normalizes a feed URL to the site origin (bug Cerveau & Psycho)', () {
+      final source = Source(
+        id: 'feed',
+        name: 'Cerveau & Psycho',
+        type: SourceType.article,
+        url: 'https://www.cerveauetpsycho.fr/rss.xml',
+        hasPaywall: true,
+      );
+
+      final connection = resolvePremiumConnection(source);
+
+      expect(connection, isNotNull);
+      expect(connection!.loginUrl, 'https://www.cerveauetpsycho.fr/');
+      expect(connection.testUrl, 'https://www.cerveauetpsycho.fr/');
     });
 
     test('rejects free sources and paid sources without a valid URL', () {
@@ -85,8 +102,9 @@ void main() {
 
       expect(connection, isNotNull);
       expect(connection!.isGeneric, isTrue);
-      expect(connection.loginUrl, 'https://nytimes.com');
-      expect(connection.testUrl, 'https://nytimes.com');
+      // Origine du site (slash final), jamais l'URL brute.
+      expect(connection.loginUrl, 'https://nytimes.com/');
+      expect(connection.testUrl, 'https://nytimes.com/');
     });
 
     test('returns null without a valid http(s) url', () {

--- a/apps/mobile/test/features/sources/widgets/premium_source_connection_test.dart
+++ b/apps/mobile/test/features/sources/widgets/premium_source_connection_test.dart
@@ -91,9 +91,12 @@ void main() {
             onConnected: () async {
               connected = true;
             },
-            // Le builder de test bypass PremiumWebView : on expose un bouton qui
-            // déclenche onLoadStop pour simuler une navigation dans la WebView.
-            webViewBuilder: (_, url, onLoadStop) => Column(
+            // Le builder de test bypass PremiumWebView : on expose des boutons
+            // qui déclenchent onLoadStop / onPaywallDetected / onLoadError pour
+            // simuler les événements de la WebView.
+            webViewBuilder: (_, url, onLoadStop,
+                    {onPaywallDetected, onLoadError}) =>
+                Column(
               children: [
                 Text(url),
                 TextButton(
@@ -108,7 +111,7 @@ void main() {
       ),
     );
 
-    expect(find.text('Connecter votre abonnement'), findsOneWidget);
+    expect(find.text('Connecter Premium Source'), findsOneWidget);
 
     await tester.ensureVisible(find.text('Commencer'));
     await tester.tap(find.text('Commencer'));
@@ -141,5 +144,181 @@ void main() {
     expect(await store.hasSession(source), isTrue);
 
     semantics.dispose();
+  });
+
+  testWidgets(
+      'step 2 shows a non-blocking paywall warning on onPaywallDetected '
+      'without disabling the confirm CTA', (tester) async {
+    final jar = _FakeCookieJar();
+    jar.store['example.com'] = [Cookie(name: 'sid', value: 'abc')];
+    final store = PremiumSessionStore(
+      jar: jar,
+      secureStore: _InMemorySecureStore(),
+    );
+    final source = Source(
+      id: 'source-id',
+      name: 'Premium Source',
+      type: SourceType.article,
+      url: 'https://example.com',
+      premiumConnection: const PremiumConnection(
+        loginUrl: 'https://example.com/login',
+        testUrl: 'https://example.com/test',
+      ),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [premiumSessionStoreProvider.overrideWithValue(store)],
+        child: MaterialApp(
+          theme: FacteurTheme.lightTheme,
+          home: PremiumSourceConnection(
+            source: source,
+            onConnected: () async {},
+            webViewBuilder: (_, url, onLoadStop,
+                    {onPaywallDetected, onLoadError}) =>
+                Column(
+              children: [
+                TextButton(
+                  onPressed: () =>
+                      onLoadStop?.call(WebUri('https://example.com/x')),
+                  child: const Text('simulate-navigation'),
+                ),
+                TextButton(
+                  onPressed: () => onPaywallDetected?.call(),
+                  child: const Text('simulate-paywall'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // intro → step 1 → navigation → step 2
+    await tester.tap(find.text('Commencer'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('simulate-navigation'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Continuer'));
+    await tester.pumpAndSettle();
+
+    // Consigne de l'étape 2 rendue, pas encore de warning.
+    expect(
+      find.textContaining('Ouvre un article réservé aux abonnés'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('semble encore réservé'), findsNothing);
+
+    // La sonde remonte un paywall → bannière visible, CTA toujours actif.
+    await tester.tap(find.text('simulate-paywall'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('semble encore réservé'), findsOneWidget);
+
+    await tester.ensureVisible(find.text('Je suis connecté(e)'));
+    await tester.tap(find.text('Je suis connecté(e)'));
+    await tester.pumpAndSettle();
+    // Le CTA n'était pas bloqué : la connexion aboutit malgré le warning.
+    expect(find.text('Abonnement connecté'), findsOneWidget);
+  });
+
+  testWidgets(
+      'a failed page load surfaces the guidance overlay, and Retry clears it',
+      (tester) async {
+    final store = PremiumSessionStore(
+      jar: _FakeCookieJar(),
+      secureStore: _InMemorySecureStore(),
+    );
+    final source = Source(
+      id: 'source-id',
+      name: 'Premium Source',
+      type: SourceType.article,
+      url: 'https://example.com',
+      premiumConnection: const PremiumConnection(
+        loginUrl: 'https://example.com/login',
+        testUrl: 'https://example.com/test',
+      ),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [premiumSessionStoreProvider.overrideWithValue(store)],
+        child: MaterialApp(
+          theme: FacteurTheme.lightTheme,
+          home: PremiumSourceConnection(
+            source: source,
+            onConnected: () async {},
+            webViewBuilder: (_, url, onLoadStop,
+                    {onPaywallDetected, onLoadError}) =>
+                Column(
+              children: [
+                TextButton(
+                  onPressed: () => onLoadError?.call(404),
+                  child: const Text('simulate-error'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Commencer'));
+    await tester.pumpAndSettle();
+    // Pas d'overlay tant que la page charge.
+    expect(find.text('Réessayer'), findsNothing);
+
+    await tester.tap(find.text('simulate-error'));
+    await tester.pumpAndSettle();
+    expect(find.text('La page ne s’est pas chargée'), findsOneWidget);
+    expect(find.text('Réessayer'), findsOneWidget);
+
+    // « Réessayer » efface l'overlay (et reconstruit la WebView).
+    await tester.tap(find.text('Réessayer'));
+    await tester.pumpAndSettle();
+    expect(find.text('La page ne s’est pas chargée'), findsNothing);
+  });
+
+  group('siteRootFor + generic connection origin normalization', () {
+    test('reduces a feed URL to the site origin', () {
+      expect(
+        siteRootFor('https://www.cerveauetpsycho.fr/rss.xml'),
+        'https://www.cerveauetpsycho.fr/',
+      );
+      expect(siteRootFor('https://example.com/feed/'), 'https://example.com/');
+    });
+
+    test('is idempotent on an already-root URL and adds the trailing slash', () {
+      expect(siteRootFor('https://example.com/'), 'https://example.com/');
+      expect(siteRootFor('https://example.com'), 'https://example.com/');
+    });
+
+    test('preserves scheme and port', () {
+      expect(
+        siteRootFor('http://localhost:8080/x/y'),
+        'http://localhost:8080/',
+      );
+    });
+
+    test('returns null for non-http(s) / hostless / invalid URLs', () {
+      expect(siteRootFor('not a url'), isNull);
+      expect(siteRootFor(''), isNull);
+      expect(siteRootFor('mailto:foo@bar.com'), isNull);
+      // Même contrat http(s)-only que le back-end `origin_url`.
+      expect(siteRootFor('ftp://weird-host/x'), isNull);
+    });
+
+    test('forceGenericConnection normalizes a feed URL to the origin', () {
+      final source = Source(
+        id: 's',
+        name: 'Cerveau & Psycho',
+        type: SourceType.article,
+        url: 'https://www.cerveauetpsycho.fr/rss.xml',
+      );
+      final conn = forceGenericConnection(source);
+      expect(conn, isNotNull);
+      expect(conn!.loginUrl, 'https://www.cerveauetpsycho.fr/');
+      expect(conn.testUrl, 'https://www.cerveauetpsycho.fr/');
+      expect(conn.isGeneric, isTrue);
+    });
   });
 }

--- a/packages/api/app/schemas/source.py
+++ b/packages/api/app/schemas/source.py
@@ -112,6 +112,7 @@ class PremiumConnectionResponse(BaseModel):
         from app.services.premium_curated_sources import (
             domain_key,
             is_paywalled_source,
+            origin_url,
         )
 
         config = getattr(source, "premium_connection_config", None)
@@ -142,12 +143,16 @@ class PremiumConnectionResponse(BaseModel):
                 )
 
         if is_paywalled_source(source, curated_map=curated_map):
-            clean_url = url.strip() if isinstance(url, str) else ""
-            if clean_url.startswith(("http://", "https://")):
+            # On synthétise le flux générique sur l'**origine** du site, jamais
+            # sur l'URL brute (souvent un flux RSS : `/rss.xml`, `/feed/`…) qui
+            # ouvrirait du XML dans la WebView. `origin_url` renvoie "" pour tout
+            # ce qui n'est pas http(s) exploitable (subsume l'ancienne garde).
+            origin = origin_url(url)
+            if origin:
                 return cls(
                     enabled=True,
-                    login_url=clean_url,
-                    test_url=clean_url,
+                    login_url=origin,
+                    test_url=origin,
                     display_hint=(
                         "Connecte-toi à ton compte sur le site du média, "
                         "puis reviens lire tes articles."

--- a/packages/api/app/services/premium_curated_sources.py
+++ b/packages/api/app/services/premium_curated_sources.py
@@ -47,6 +47,24 @@ def domain_key(url: str | None) -> str:
     return ".".join(labels[-2:])
 
 
+def origin_url(url: str | None) -> str:
+    """Réduit une URL à l'origine du site (``scheme://netloc/``).
+
+    ``https://www.cerveauetpsycho.fr/rss.xml`` → ``https://www.cerveauetpsycho.fr/``.
+    Beaucoup de sources stockent dans ``url`` l'URL de leur **flux** RSS
+    (``/rss.xml``, ``/feed/``…) ; ouverte telle quelle dans la WebView de
+    connexion, elle affiche du XML brut au lieu d'une page. Normaliser vers
+    l'origine répare toutes ces sources d'un coup. Renvoie ``""`` si l'URL n'est
+    pas une URL http(s) exploitable (mêmes garanties que ``domain_key``).
+    """
+    if not isinstance(url, str):
+        return ""
+    parts = urlsplit(url.strip())
+    if parts.scheme not in ("http", "https") or not parts.netloc:
+        return ""
+    return f"{parts.scheme}://{parts.netloc}/"
+
+
 # Config curée : login_url = page de connexion du média ; test_url = page chargée
 # pour vérifier que la session est active (idéalement un article abonné
 # "evergreen", à défaut la home du média). display_hint = consigne affichée à

--- a/packages/api/tests/test_premium_discoverability.py
+++ b/packages/api/tests/test_premium_discoverability.py
@@ -17,6 +17,7 @@ from app.services.premium_curated_sources import (
     PREMIUM_CURATED_MAP,
     domain_key,
     is_paywalled_source,
+    origin_url,
 )
 from app.services.source_service import SourceService
 
@@ -47,6 +48,29 @@ def test_domain_key_handles_multipart_tld_and_invalids():
     assert domain_key(None) == ""
     assert domain_key("   ") == ""
     assert domain_key("https://") == ""
+
+
+# ─── origin_url ───────────────────────────────────────────────────
+
+
+def test_origin_url_reduces_to_site_origin():
+    assert (
+        origin_url("https://www.cerveauetpsycho.fr/rss.xml")
+        == "https://www.cerveauetpsycho.fr/"
+    )
+    assert origin_url("https://example.com/feed/") == "https://example.com/"
+    # Idempotent + ajoute le slash final manquant.
+    assert origin_url("https://example.com/") == "https://example.com/"
+    assert origin_url("https://example.com") == "https://example.com/"
+    # Port préservé.
+    assert origin_url("http://localhost:8080/x/y") == "http://localhost:8080/"
+
+
+def test_origin_url_rejects_non_http_and_invalid():
+    assert origin_url(None) == ""
+    assert origin_url("") == ""
+    assert origin_url("ftp://weird-host/x") == ""
+    assert origin_url("mailto:foo@bar.com") == ""
 
 
 # ─── from_source : priorité config > map > générique > None ────────
@@ -99,7 +123,9 @@ def test_from_source_english_titles_are_curated_not_generic(url, domain):
     assert resp.test_url == MAP[domain]["test_url"]
 
 
-def test_from_source_paywall_config_only_is_generic_using_source_url():
+def test_from_source_paywall_config_only_is_generic_using_site_origin():
+    # L'URL de la source est un article ; le flux générique doit pointer sur
+    # l'origine du site, jamais sur l'URL brute (article ou flux RSS).
     src = _stub(
         url="https://unknown-paper.example/news/x",
         paywall_config={"keywords": ["réservé aux abonnés"]},
@@ -107,8 +133,22 @@ def test_from_source_paywall_config_only_is_generic_using_source_url():
     resp = PremiumConnectionResponse.from_source(src, curated_map=MAP)
     assert resp is not None
     assert resp.is_generic is True
-    assert resp.login_url == "https://unknown-paper.example/news/x"
+    assert resp.login_url == "https://unknown-paper.example/"
     assert resp.test_url == resp.login_url
+
+
+def test_from_source_generic_normalizes_feed_url_to_origin():
+    # Bug « Cerveau & Psycho » : ``url`` = URL du flux RSS. Sans normalisation la
+    # WebView ouvrait du XML brut ; on doit résoudre vers l'origine du site.
+    src = _stub(
+        url="https://www.cerveauetpsycho.fr/rss.xml",
+        paywall_config={"keywords": ["réservé aux abonnés"]},
+    )
+    resp = PremiumConnectionResponse.from_source(src, curated_map=MAP)
+    assert resp is not None
+    assert resp.is_generic is True
+    assert resp.login_url == "https://www.cerveauetpsycho.fr/"
+    assert resp.test_url == "https://www.cerveauetpsycho.fr/"
 
 
 def test_from_source_disabled_config_blocks_curated_and_generic_fallback():


### PR DESCRIPTION
## Contexte

La connexion d'une source payante (WebView login → vérification → succès) marchait « sur le papier » mais ratait en pratique et faisait cheap. Deux problèmes PO :

1. Flux sans guidage ni finition (étape 2 charge la home sans consigne, bandeaux épais, titre générique).
2. Reconnexion de **Cerveau & Psycho** ouvrait du **XML brut** : `sources.url` = `…/rss.xml` (URL du flux), et le fallback générique faisait `loginUrl = testUrl = url`. **81/405 sources** stockent une URL de flux.

Tous les points d'entrée (subscriptions, banner reconnexion, source-detail, onboarding) passent par le **même** widget + les mêmes helpers → un fix widget + un fix helper couvrent tout.

## Changements

**A. Fix racine — origine du site.** Normalise l'URL de connexion **générique** vers `scheme://host/`. Répare Cerveau & Psycho **et ~80 autres** d'un coup.
- Mobile : `siteRootFor` (`source_model.dart`), utilisé seulement dans la branche générique de `_genericConnectionFor` (les connexions curées/explicites ne sont pas réduites).
- Backend : `origin_url` (`premium_curated_sources.py`), utilisé dans le fallback générique de `PremiumConnectionResponse.from_source` (map curée + branche explicite intactes). Contrat http(s)-only aligné entre les deux jumeaux.
- Host préservé ⇒ capture/restore cookies (`PremiumSessionStore`, clé par host) inchangées.

**B. Étape 2 « Vérification » qui guide et vérifie.** Consigne discrète (« Ouvre un article réservé aux abonnés… ») + réutilise la sonde paywall existante (`detectPaywall`) → bannière d'avertissement **non bloquante** (le CTA reste actif). Pas d'auto-sélection d'article JS (fragile, différée).

**C. Chrome fusionné dans l'AppBar.** Titre « Connecter {média} » (ellipsis), pills d'étapes + bouton navigateur externe dans les `actions` ; rangée header interne supprimée ; footer plus fin → plus de hauteur WebView. Labels a11y `Connexion`/`Vérification` conservés.

**D. Garde-fou page cassée.** `onReceivedError` / `onReceivedHttpError` (frame principale uniquement, HTTP ≥ 400) → overlay de guidage non destructif (WebView dessous) avec « Ouvrir dans le navigateur » + « Réessayer » (rebuild via bump de `ValueKey`).

+ Entrée `changelog.json` (tag `Abonnements`).

## Vérification

- **Mobile** : `flutter analyze` propre ; `flutter test test/features/sources/` **140 verts**, dont : `siteRootFor` (flux→origine, http(s)-only, idempotent), `_genericConnectionFor`/`forceGenericConnection` sur URL de flux, warning paywall non bloquant, overlay d'erreur + Réessayer, titre « Connecter {média} ».
- **Backend** : `pytest tests/test_premium_discoverability.py tests/test_premium_source_connection.py` **verts** (27), incl. `origin_url` + normalisation d'une URL de flux vers l'origine, map curée inchangée. `ruff` propre.
- **On-device (à faire par le PO)** : le login WebView média est **natif-only** (pas de web/Playwright). Reconnecter Cerveau & Psycho → doit ouvrir `cerveauetpsycho.fr` (plus de XML) ; connecter Le Monde → titre + chrome fin + consigne étape 2 ; forcer un 404 → overlay de guidage.

## Migration / risque

Aucun changement DB, **aucune migration Alembic**. Change additif (nouveau param optionnel `onLoadError` sur `PremiumWebView`, consommé aussi par le reader sans impact).

## Suivi (hors PR, notés au review qualité)

- Corriger `Source.url` à la création (stocker le lien du site, pas le flux) pour que la normalisation devienne un simple filet de sécurité.
- Enrichir les `test_url` curés vers de vrais articles evergreen.
- Overlay d'erreur : envisager un reset sur `onLoadStop` réussi (à valider on-device pour l'ordre des callbacks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
