### PR TITLE
feat(rituel): Lettre du jour « Rattrapage » — Tout lire hebdo + bonnes de toute la semaine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,19 +81,6 @@ Après le GO utilisateur, implémente et teste en autonomie :
 | `pre-bash-no-staging.sh` | Avant Bash | Bloque `gh pr create` sans `--base main` |
 | `stop-verify-tests.sh` | Avant fin réponse | Bloque si tests échouent |
 
-## Changelog utilisateur
-
-Si ta PR dépasse **400 lignes de diff** OU si elle livre un changement user-visible important (nouvelle feature, refonte UX, fix d'un bug bloquant connu), ajoute une entrée dans `apps/mobile/assets/changelog.json` (clé `unreleased`) :
-
-```json
-{ "tag": "Perspectives", "summary": "Clustering plus pertinent dans les perspectives." }
-```
-
-- `tag` : **1-2 mots max**, orienté feature (ex: « Perspectives », « Tournée », « Onboarding »). Sert au bandeau cumulatif en haut du Flâner.
-- `summary` : **1 phrase courte** sur la **valeur user** (pas la techno). Sert à la modal « Quoi de neuf » (bullet point).
-
-L'agent peut **by-passer la règle des 400 lignes** si elle ne reflète pas l'impact réel (gros refactor invisible / petit fix UX très visible). Le script `scripts/promote_changelog.py --version X.Y.Z` déplace `unreleased` → `released` au moment du bump de version.
-
 ## Outillage UI/E2E & MCP Servers
 
 **Tests UI/E2E** : **Playwright Agent CLI** (`playwright-cli`, épinglé dans `package.json`).

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Rattrapage",
+      "summary": "« Cette semaine » : accès Tout lire par section et bonnes nouvelles de toute la semaine."
+    },
+    {
       "tag": "Rituel",
       "summary": "Ta lettre du matin s'affiche même au tout premier lancement de la journée, sans passer directement au flux."
     },

--- a/apps/mobile/lib/config/routes.dart
+++ b/apps/mobile/lib/config/routes.dart
@@ -429,6 +429,11 @@ final routerProvider = Provider<GoRouter>((ref) {
                     pageBuilder: (context, state) {
                       final key = state.pathParameters['key']!;
                       final section = state.extra as DigestTopicSection?;
+                      // `src=week` → « Tout lire » de la rétro hebdo : la page
+                      // épingle l'agrégat passé en `extra` au lieu de résoudre
+                      // le feed du jour (cf. DigestSectionScreen.pinToInitial).
+                      final pinToInitial =
+                          state.uri.queryParameters['src'] == 'week';
                       return FullSwipeCupertinoPage(
                         key: state.pageKey,
                         transitionDurationOverride:
@@ -437,6 +442,7 @@ final routerProvider = Provider<GoRouter>((ref) {
                         child: DigestSectionScreen(
                           sectionKeyValue: key,
                           initialSection: section,
+                          pinToInitial: pinToInitial,
                         ),
                       );
                     },

--- a/apps/mobile/lib/features/flux_continu/providers/edition_essentiel_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/edition_essentiel_provider.dart
@@ -39,6 +39,16 @@ class EditionEssentielState {
   /// indépendamment du toggle. Vide si le jour n'a pas de variante sereine.
   final List<DigestTopic> bonnesTopics;
 
+  /// Agrégat hebdo **complet** (non plafonné à l'aperçu inline) des « Actus de
+  /// la semaine », pour la page « Tout lire » (`DigestSectionScreen` épinglé).
+  /// Vide hors vue hebdo (le single-day rend tout inline). Cf.
+  /// [kEditionWeekSeeAllMaxTopics].
+  final List<DigestTopic> topicsAll;
+
+  /// Agrégat hebdo **complet** des « Bonnes Nouvelles », pour la page « Tout
+  /// lire ». Vide hors vue hebdo.
+  final List<DigestTopic> bonnesAll;
+
   final QuoteResponse? quote;
 
   /// Aucune lettre propre à servir pour ce jour : soit le backend n'a servi
@@ -57,6 +67,8 @@ class EditionEssentielState {
     this.heroArticles = const [],
     this.topics = const [],
     this.bonnesTopics = const [],
+    this.topicsAll = const [],
+    this.bonnesAll = const [],
     this.quote,
     this.isStaleOrEmpty = false,
     this.isWeek = false,
@@ -66,8 +78,17 @@ class EditionEssentielState {
 /// Concurrence du fan-out « Cette semaine » (≤ N jours en vol à la fois).
 const int kEditionWeekConcurrency = 3;
 
-/// Plafond de l'agrégation hebdo des topics (« Actus de la semaine »).
+/// Plafond de l'agrégation hebdo des topics (« Actus de la semaine ») — aperçu
+/// inline dans la lettre.
 const int kEditionWeekMaxTopics = 6;
+
+/// Plafond de l'agrégat **complet** « Tout lire » (page section hebdo) — borne
+/// haute anti-emballement, plus large que l'aperçu inline.
+const int kEditionWeekSeeAllMaxTopics = 20;
+
+/// Nombre de sujets montrés **inline** en vue hebdo avant le footer/bandeau
+/// « Tout lire » (aperçu court ; le reste s'ouvre dans la page section).
+const int kEditionWeekInlinePreview = 4;
 
 /// Plafond d'articles **par jour** entrant dans le pool héros hebdo — borne le
 /// candidat-pool avant dédup/tri/cap.
@@ -195,21 +216,35 @@ class EditionEssentielNotifier extends AsyncNotifier<EditionEssentielState> {
     final hero = results[0] as List<EssentielArticle>?;
     final dual = results[1] as DualDigestResponse?;
 
+    // « Bonnes Nouvelles » (serein) captées **indépendamment** du garde
+    // héros/normal ci-dessous : un jour dont le digest **normal** est vide ou
+    // périmé peut tout de même porter une variante **sereine** valide — on ne
+    // veut pas perdre ses bonnes dans l'agrégat hebdo (bug « seulement hier »).
+    // Un fallback cloné serein reste écarté (jamais présenter les bonnes d'un
+    // autre jour comme celles de ce jour).
+    final sereinDigest = dual?.serein;
+    final bonnesTopics = (sereinDigest != null && !sereinDigest.isStaleFallback)
+        ? _nonEmptyTopics(sereinDigest.topics)
+        : const <DigestTopic>[];
+
     final digest = serein
         ? (dual?.serein ?? dual?.normal)
         : (dual?.normal ?? dual?.serein);
 
     // Mitigation client : ne jamais présenter un fallback cloné (qui peut être
-    // le contenu d'un AUTRE jour) comme la lettre du jour demandé.
+    // le contenu d'un AUTRE jour) comme la lettre du jour demandé. Ce garde ne
+    // court-circuite que le héros + les Actus normales : les bonnes sereines,
+    // elles, sont déjà captées ci-dessus (elles alimentent l'agrégat hebdo ; le
+    // rendu single-day reste, lui, gardé par `isStaleOrEmpty`).
     if (digest == null ||
         digest.isStaleFallback ||
         hero == null ||
         hero.isEmpty) {
-      const data = _DayData(
-        heroArticles: [],
-        topics: [],
-        normalTopics: [],
-        bonnesTopics: [],
+      final data = _DayData(
+        heroArticles: const [],
+        topics: const [],
+        normalTopics: const [],
+        bonnesTopics: bonnesTopics,
         quote: null,
         isStaleOrEmpty: true,
       );
@@ -227,7 +262,7 @@ class EditionEssentielNotifier extends AsyncNotifier<EditionEssentielState> {
       heroArticles: hero,
       topics: topics,
       normalTopics: _nonEmptyTopics(dual?.normal?.topics),
-      bonnesTopics: _nonEmptyTopics(dual?.serein?.topics),
+      bonnesTopics: bonnesTopics,
       quote: digest.quote,
       isStaleOrEmpty: false,
     );
@@ -286,10 +321,15 @@ class EditionEssentielNotifier extends AsyncNotifier<EditionEssentielState> {
     ];
     for (var i = 0; i < pastDates.length; i++) {
       final d = dayResults[i];
+      // Bonnes Nouvelles (serein) : agrégées de **chaque** jour dont les bonnes
+      // sont non vides, indépendamment de l'état héros/normal du jour. Un jour
+      // au digest normal périmé mais serein valide contribue quand même ses
+      // bonnes (correctif « seulement hier »). Placé AVANT le `continue`.
+      allBonnes.addAll(d.bonnesTopics);
+      // Pool héros + Actus normales : gardés au digest normal frais du jour.
       if (d.isStaleOrEmpty || d.heroArticles.isEmpty) continue;
       pool.addAll(d.heroArticles.take(kEditionWeekMaxArticlesPerDay));
       allTopics.addAll(d.normalTopics);
-      allBonnes.addAll(d.bonnesTopics);
     }
     final deduped = _dedupArticlesById(pool);
 
@@ -306,14 +346,25 @@ class EditionEssentielNotifier extends AsyncNotifier<EditionEssentielState> {
       });
     final hero = heroSource.take(kEditionWeekSpineMax).toList(growable: false);
 
-    final topics = _dedupAndRankTopics(allTopics);
-    final bonnes = _dedupAndRankTopics(allBonnes);
+    // Agrégat complet « Tout lire » (cap 20) dédupé/trié **une fois** ; l'aperçu
+    // inline (cap 6) en est simplement le préfixe (même dédup/tri, cap plus
+    // petit) — évite de relancer le tri deux fois par liste.
+    final topicsAll =
+        _dedupAndRankTopics(allTopics, cap: kEditionWeekSeeAllMaxTopics);
+    final bonnesAll =
+        _dedupAndRankTopics(allBonnes, cap: kEditionWeekSeeAllMaxTopics);
+    final topics =
+        topicsAll.take(kEditionWeekMaxTopics).toList(growable: false);
+    final bonnes =
+        bonnesAll.take(kEditionWeekMaxTopics).toList(growable: false);
 
     return EditionEssentielState(
       selection: const EditionWeek(),
       heroArticles: hero,
       topics: topics,
       bonnesTopics: bonnes,
+      topicsAll: topicsAll,
+      bonnesAll: bonnesAll,
       quote: null, // pas de citation unique pour une rétro hebdo
       isStaleOrEmpty: hero.isEmpty && topics.isEmpty,
       isWeek: true,
@@ -351,8 +402,12 @@ class EditionEssentielNotifier extends AsyncNotifier<EditionEssentielState> {
   }
 
   /// Dédup par `topicId` (fallback `label`) puis re-tri par `topicScore` desc,
-  /// `rank` asc en départage, top N.
-  List<DigestTopic> _dedupAndRankTopics(List<DigestTopic> all) {
+  /// `rank` asc en départage, top [cap] (aperçu inline par défaut,
+  /// [kEditionWeekSeeAllMaxTopics] pour l'agrégat « Tout lire »).
+  List<DigestTopic> _dedupAndRankTopics(
+    List<DigestTopic> all, {
+    int cap = kEditionWeekMaxTopics,
+  }) {
     final seen = <String>{};
     final deduped = <DigestTopic>[];
     for (final t in all) {
@@ -365,7 +420,7 @@ class EditionEssentielNotifier extends AsyncNotifier<EditionEssentielState> {
       if (byScore != 0) return byScore;
       return a.rank.compareTo(b.rank);
     });
-    return deduped.take(kEditionWeekMaxTopics).toList(growable: false);
+    return deduped.take(cap).toList(growable: false);
   }
 }
 

--- a/apps/mobile/lib/features/flux_continu/screens/digest_section_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/digest_section_screen.dart
@@ -28,10 +28,18 @@ class DigestSectionScreen extends ConsumerStatefulWidget {
   /// empty page during the slide-in transition.
   final DigestTopicSection? initialSection;
 
+  /// « Tout lire » de la rétro hebdo (« Cette semaine ») : rend [initialSection]
+  /// **tel quel** (agrégat de la semaine épinglé) au lieu de résoudre le feed
+  /// **du jour** via [fluxContinuProvider]. Sans ce flag, un « Tout lire » hebdo
+  /// afficherait par erreur le contenu d'aujourd'hui (même `sectionKey`
+  /// `essentiel`/`bonnes`). Câblé par le query param `src=week` (cf. routes.dart).
+  final bool pinToInitial;
+
   const DigestSectionScreen({
     super.key,
     required this.sectionKeyValue,
     this.initialSection,
+    this.pinToInitial = false,
   });
 
   @override
@@ -53,6 +61,9 @@ class _DigestSectionScreenState extends ConsumerState<DigestSectionScreen> {
   }
 
   DigestTopicSection? _resolveSection() {
+    // Vue hebdo épinglée : on ne résout jamais le feed du jour, l'agrégat de la
+    // semaine passé en `extra` est la seule source de vérité.
+    if (widget.pinToInitial) return widget.initialSection;
     final state = ref.watch(fluxContinuProvider).valueOrNull;
     if (state == null) return widget.initialSection;
     for (final s in state.sections) {
@@ -132,7 +143,9 @@ class _DigestSectionScreenState extends ConsumerState<DigestSectionScreen> {
 
   Widget _buildBody(DigestTopicSection section) {
     final state = ref.watch(fluxContinuProvider).valueOrNull;
-    final next = state == null
+    // En vue hebdo épinglée, pas de « Sujet suivant » : il pointerait vers une
+    // section du feed **du jour** (rupture de contexte). Seul « Retour » reste.
+    final next = widget.pinToInitial || state == null
         ? null
         : nextSectionAfter(state.sections, widget.sectionKeyValue);
     return CustomScrollView(

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -1537,29 +1537,54 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   /// de swipe). Réutilise `SectionBlock`. `blurb`/`illustrationAsset` reproduisent
   /// le `SectionBanner` de la lettre du jour (parité visuelle). `null` si la
   /// liste est vide (no-op).
+  ///
+  /// En vue hebdo, [previewCount] borne l'aperçu inline et câble « Tout lire »
+  /// (bandeau + footer) vers la page section épinglée ([_openWeekSection]) dès
+  /// qu'il y a plus de sujets que l'aperçu. Hors hebdo ([previewCount] `null`),
+  /// tous les sujets se rendent inline sans « Tout lire ».
   Widget? _topicSectionSliver(
     BuildContext context, {
     required SectionKind kind,
     required String label,
     required Color accent,
     required List<DigestTopic> topics,
+    int? previewCount,
     String? blurb,
     String? illustrationAsset,
   }) {
     if (topics.isEmpty) return null;
+    final section = DigestTopicSection(
+      kind: kind,
+      label: label,
+      accent: accent,
+      coreVisibleCount: previewCount ?? topics.length,
+      topics: topics,
+      blurb: blurb,
+      illustrationAsset: illustrationAsset,
+    );
+    // « Tout lire » seulement s'il reste des sujets au-delà de l'aperçu (sinon
+    // la page section afficherait exactement le même contenu que l'inline).
+    final onSeeAll = previewCount != null && topics.length > previewCount
+        ? () => _openWeekSection(context, section)
+        : null;
     return SliverToBoxAdapter(
       child: SectionBlock(
-        section: DigestTopicSection(
-          kind: kind,
-          label: label,
-          accent: accent,
-          coreVisibleCount: topics.length,
-          topics: topics,
-          blurb: blurb,
-          illustrationAsset: illustrationAsset,
-        ),
+        section: section,
         onTapArticle: (a) => _openArticle(context, a),
+        onSeeAll: onSeeAll,
       ),
+    );
+  }
+
+  /// Ouvre la page section (`DigestSectionScreen`) **épinglée** sur l'agrégat
+  /// hebdo (query `src=week`) : le contenu affiché est la [section] passée en
+  /// `extra` (la semaine complète), pas le feed du jour. Utilisé par « Tout
+  /// lire » de « Cette semaine ». Push simple (pas de restauration de scroll du
+  /// feed du jour : la vue hebdo a son propre contrôleur, sans snap).
+  void _openWeekSection(BuildContext context, DigestTopicSection section) {
+    context.push(
+      '${RoutePaths.fluxContinu}/section/${sectionKey(section)}?src=week',
+      extra: section,
     );
   }
 
@@ -1595,12 +1620,16 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       );
     }
 
+    // En vue hebdo : agrégat **complet** (`topicsAll`/`bonnesAll`) + aperçu
+    // borné (`kEditionWeekInlinePreview`) → « Tout lire » ouvre le reste. En
+    // jour unique : liste du jour rendue intégralement inline (pas de préview).
     final actus = _topicSectionSliver(
       context,
       kind: SectionKind.essentiel,
       label: edition.isWeek ? 'Actus de la semaine' : 'Actus du jour',
       accent: colors.sectionEssentiel,
-      topics: edition.topics,
+      topics: edition.isWeek ? edition.topicsAll : edition.topics,
+      previewCount: edition.isWeek ? kEditionWeekInlinePreview : null,
       blurb: 'Les sujets les + couverts en France.',
       illustrationAsset: 'assets/notifications/facteur_avatar.png',
     );
@@ -1611,7 +1640,8 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       kind: SectionKind.bonnes,
       label: 'Bonnes Nouvelles',
       accent: colors.sectionBonnes,
-      topics: edition.bonnesTopics,
+      topics: edition.isWeek ? edition.bonnesAll : edition.bonnesTopics,
+      previewCount: edition.isWeek ? kEditionWeekInlinePreview : null,
       blurb: 'Un peu de douceur...',
       illustrationAsset: 'assets/notifications/facteur_goodnews.png',
     );

--- a/apps/mobile/lib/features/flux_continu/screens/morning_ritual_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/morning_ritual_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart' show HapticFeedback;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import 'package:facteur/config/constants.dart';
 import 'package:facteur/config/routes.dart';
@@ -830,10 +831,13 @@ class _CarouselNavRow extends StatelessWidget {
   }
 }
 
-/// Affordance « lettre voisine » : chevron + libellé, en petite typo tertiaire.
-/// Borné (`Flexible` + `maxLines: 1` + ellipsis) pour ne jamais crop/overflow sur
-/// 360–390px. [isLeft] pose le chevron à gauche (← plus ancien) ou à droite
-/// (plus récent →).
+/// Affordance « lettre voisine » : reprend le traitement de la double-flèche
+/// « Rattraper » ([EditionRewindTrigger]) — glyphe Phosphor ⏪/⏩ **en couleur
+/// `primary`** + libellé date en `primary` poids fort (au lieu du chevron gris
+/// peu lisible). Borné (`Flexible` + `maxLines: 1` + ellipsis) pour ne jamais
+/// crop/overflow sur 360–390px. [isLeft] = lettre plus **ancienne** (⏪ à
+/// gauche) ; sinon lettre plus **récente** (⏩ à droite). Haptique de sélection
+/// au tap (miroir de [EditionRewindTrigger]).
 class _NeighborCta extends StatelessWidget {
   final String label;
   final bool isLeft;
@@ -848,18 +852,20 @@ class _NeighborCta extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
-    final chevron = Icon(
-      isLeft ? Icons.chevron_left_rounded : Icons.chevron_right_rounded,
-      size: 16,
-      color: colors.textTertiary,
+    final glyph = Icon(
+      isLeft
+          ? PhosphorIcons.rewind(PhosphorIconsStyle.fill)
+          : PhosphorIcons.fastForward(PhosphorIconsStyle.fill),
+      size: 15,
+      color: colors.primary,
     );
     final text = Flexible(
       child: Text(
         label,
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
-        style: FacteurTypography.bodySmall(colors.textTertiary)
-            .copyWith(fontSize: 11.5, fontWeight: FontWeight.w600),
+        style: FacteurTypography.bodySmall(colors.primary)
+            .copyWith(fontSize: 11.5, fontWeight: FontWeight.w700),
       ),
     );
     return Semantics(
@@ -867,14 +873,17 @@ class _NeighborCta extends StatelessWidget {
       label: isLeft ? 'Lettre précédente : $label' : 'Lettre suivante : $label',
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
-        onTap: onTap,
+        onTap: () {
+          HapticFeedback.selectionClick();
+          onTap();
+        },
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: isLeft
-                ? [chevron, const SizedBox(width: 2), text]
-                : [text, const SizedBox(width: 2), chevron],
+                ? [glyph, const SizedBox(width: 4), text]
+                : [text, const SizedBox(width: 4), glyph],
           ),
         ),
       ),
@@ -1105,32 +1114,35 @@ class _SectionRow extends StatelessWidget {
       label: '${section.label}, $meta',
       child: InkWell(
         onTap: onTap,
-        borderRadius: BorderRadius.circular(15),
+        borderRadius: BorderRadius.circular(FacteurRadius.large),
         child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+          padding: const EdgeInsets.symmetric(
+            horizontal: FacteurSpacing.space4,
+            vertical: FacteurSpacing.space3,
+          ),
           decoration: BoxDecoration(
             color: section.accent.withValues(alpha: 0.10),
-            borderRadius: BorderRadius.circular(15),
+            borderRadius: BorderRadius.circular(FacteurRadius.large),
           ),
           child: Row(
             children: [
               Container(
-                width: 42,
-                height: 42,
+                width: 40,
+                height: 40,
                 alignment: Alignment.center,
                 decoration: BoxDecoration(
                   color: colors.surface,
-                  borderRadius: BorderRadius.circular(12),
+                  borderRadius: BorderRadius.circular(FacteurRadius.medium),
                   border: Border.all(
                     color: colors.textTertiary.withValues(alpha: 0.10),
                   ),
                 ),
                 child: Text(
                   sectionEmoji(section),
-                  style: const TextStyle(fontSize: 21),
+                  style: const TextStyle(fontSize: 20),
                 ),
               ),
-              const SizedBox(width: 13),
+              const SizedBox(width: FacteurSpacing.space3),
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,

--- a/apps/mobile/test/features/flux_continu/providers/edition_essentiel_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/edition_essentiel_provider_test.dart
@@ -258,7 +258,10 @@ void main() {
       expect(state.bonnesTopics, isEmpty);
     });
 
-    test('stale → bonnesTopics vide même si serein présent', () async {
+    test(
+        'normal stale mais serein valide → jour stale, mais bonnes captées '
+        '(Change 4 : alimentent l\'agrégat hebdo ; le rendu single-day reste '
+        'gardé par isStaleOrEmpty)', () async {
       final date = DateTime(2026, 6, 20);
       final key = editionDayKey(date);
       final container = makeContainer(
@@ -266,8 +269,8 @@ void main() {
           key: [_hero('h1')],
         },
         dualByDay: {
-          // Le digest **pické** (normal, toggle off) est stale ⇒ jour traité
-          // comme sans lettre : aucune section, Bonnes incluses.
+          // Le digest **pické** (normal, toggle off) est stale ⇒ jour stale
+          // pour le héros/Actus… mais le serein est valide.
           key: _dualS(
             _digest(topics: [_topic('t1')], stale: true),
             serein: _digest(topics: [_topic('bn1')]),
@@ -279,7 +282,41 @@ void main() {
           EditionPastDay(date);
 
       final state = await container.read(editionEssentielProvider.future);
+      // Le jour reste « sans lettre » pour le rendu single-day (héros + Actus
+      // absents ⇒ empty-state affiché).
       expect(state.isStaleOrEmpty, isTrue);
+      expect(state.heroArticles, isEmpty);
+      expect(state.topics, isEmpty);
+      // Change 4 — les bonnes sereines sont désormais captées même quand le
+      // digest normal est périmé : c'est ce qui permet à un tel jour de
+      // contribuer ses bonnes à « Cette semaine » (avant, elles étaient
+      // perdues).
+      expect(state.bonnesTopics.map((t) => t.topicId), ['bn1']);
+    });
+
+    test('serein aussi stale (fallback cloné) → bonnesTopics vide', () async {
+      final date = DateTime(2026, 6, 20);
+      final key = editionDayKey(date);
+      final container = makeContainer(
+        heroByDay: {
+          key: [_hero('h1')],
+        },
+        dualByDay: {
+          // Digest normal valide mais serein = fallback cloné ⇒ ne jamais
+          // présenter les bonnes d'un autre jour.
+          key: _dualS(
+            _digest(topics: [_topic('t1')]),
+            serein: _digest(topics: [_topic('bn1')], stale: true),
+          ),
+        },
+      );
+      addTearDown(container.dispose);
+      container.read(selectedEditionDateProvider.notifier).state =
+          EditionPastDay(date);
+
+      final state = await container.read(editionEssentielProvider.future);
+      expect(state.isStaleOrEmpty, isFalse);
+      expect(state.topics.map((t) => t.topicId), ['t1']);
       expect(state.bonnesTopics, isEmpty);
     });
   });
@@ -425,6 +462,88 @@ void main() {
       final state = await container.read(editionEssentielProvider.future);
       // bn1 dédupliqué (1ʳᵉ occurrence gardée) ; tri topicScore desc : bn2, bn1.
       expect(state.bonnesTopics.map((t) => t.topicId), ['bn2', 'bn1']);
+    });
+
+    test(
+        'Change 4 — un jour au normal périmé mais serein valide contribue ses '
+        'bonnes à l\'agrégat hebdo (bug « seulement hier »)', () async {
+      final today = editionTodayDate();
+      DateTime past(int i) => DateTime(today.year, today.month, today.day - i);
+      final k1 = editionDayKey(past(1)); // digest normal frais
+      final k2 = editionDayKey(past(2)); // normal périmé, serein valide
+      final container = makeContainer(
+        heroByDay: {
+          k1: [_hero('a', rank: 1)],
+          k2: [_hero('b', rank: 2)],
+        },
+        dualByDay: {
+          k1: _dualS(
+            _digest(topics: [_topic('t1')]),
+            serein: _digest(topics: [_topic('bnFresh', score: 1)]),
+          ),
+          k2: _dualS(
+            _digest(topics: [_topic('t2')], stale: true),
+            serein: _digest(topics: [_topic('bnStaleDay', score: 5)]),
+          ),
+        },
+      );
+      addTearDown(container.dispose);
+      container.read(selectedEditionDateProvider.notifier).state =
+          const EditionWeek();
+
+      final state = await container.read(editionEssentielProvider.future);
+      // k2 (normal périmé) ne contribue PAS au héros ni aux Actus…
+      expect(state.heroArticles.map((a) => a.contentId), ['a']);
+      expect(state.topics.map((t) => t.topicId), ['t1']);
+      // … mais SES bonnes sereines rejoignent bien l'agrégat hebdo. Avant le
+      // correctif, le `continue` sur le jour stale les jetait → « seulement
+      // hier ». Tri score desc : bnStaleDay(5), bnFresh(1).
+      expect(
+        state.bonnesTopics.map((t) => t.topicId),
+        ['bnStaleDay', 'bnFresh'],
+      );
+    });
+
+    test(
+        'Change 3 — agrégats « Tout lire » (topicsAll/bonnesAll) plus larges '
+        'que l\'aperçu inline (cap 6)', () async {
+      final today = editionTodayDate();
+      final k1 = editionDayKey(DateTime(today.year, today.month, today.day - 1));
+      // 8 topics normaux + 8 bonnes sereines distincts (score décroissant pour
+      // un tri déterministe) → l'inline plafonne à 6, « Tout lire » en garde 8.
+      final normalTopics = [
+        for (var i = 0; i < 8; i++) _topic('n$i', score: (8 - i).toDouble()),
+      ];
+      final sereinTopics = [
+        for (var i = 0; i < 8; i++) _topic('s$i', score: (8 - i).toDouble()),
+      ];
+      final container = makeContainer(
+        heroByDay: {
+          k1: [_hero('a', rank: 1)],
+        },
+        dualByDay: {
+          k1: _dualS(
+            _digest(topics: normalTopics),
+            serein: _digest(topics: sereinTopics),
+          ),
+        },
+      );
+      addTearDown(container.dispose);
+      container.read(selectedEditionDateProvider.notifier).state =
+          const EditionWeek();
+
+      final state = await container.read(editionEssentielProvider.future);
+      // Aperçu inline plafonné (kEditionWeekMaxTopics = 6).
+      expect(state.topics, hasLength(kEditionWeekMaxTopics));
+      expect(state.bonnesTopics, hasLength(kEditionWeekMaxTopics));
+      // Agrégat « Tout lire » : les 8 (sous le cap large 20).
+      expect(state.topicsAll, hasLength(8));
+      expect(state.bonnesAll, hasLength(8));
+      // Superset ordonné : l'inline est le préfixe de l'agrégat complet.
+      expect(
+        state.topicsAll.take(kEditionWeekMaxTopics).map((t) => t.topicId),
+        state.topics.map((t) => t.topicId),
+      );
     });
   });
 }

--- a/apps/mobile/test/features/flux_continu/screens/digest_section_screen_test.dart
+++ b/apps/mobile/test/features/flux_continu/screens/digest_section_screen_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/digest/models/digest_models.dart';
+import 'package:facteur/features/flux_continu/models/flux_continu_models.dart';
+import 'package:facteur/features/flux_continu/providers/flux_continu_provider.dart';
+import 'package:facteur/features/flux_continu/screens/digest_section_screen.dart';
+import 'package:facteur/features/settings/models/display_mode_spec.dart';
+import 'package:facteur/features/settings/providers/display_mode_provider.dart';
+
+/// Rétro hebdo « Tout lire » (Change 3) : `DigestSectionScreen` en mode épinglé
+/// (`pinToInitial`) doit rendre l'agrégat de la **semaine** passé en
+/// `initialSection`, jamais résoudre la section homonyme du feed **du jour**
+/// (même `sectionKey` `bonnes`).
+
+DigestTopicSection _bonnesSection({
+  required String label,
+  required String leadTitle,
+  required String leadId,
+}) {
+  return DigestTopicSection(
+    kind: SectionKind.bonnes,
+    label: label,
+    accent: const Color(0xFF2E7D32),
+    coreVisibleCount: 4,
+    topics: [
+      DigestTopic(
+        topicId: leadId,
+        label: 'topic-$leadId',
+        topicScore: 1,
+        rank: 1,
+        articles: [DigestItem(contentId: leadId, title: leadTitle)],
+      ),
+    ],
+  );
+}
+
+/// Feed du jour **résolu** (non-loading) contenant une section `bonnes` dont le
+/// contenu diffère de l'agrégat hebdo → prouve que l'épinglage ignore le live.
+class _TodayFluxNotifier extends FluxContinuNotifier {
+  @override
+  Future<FluxContinuState> build() async => FluxContinuState(
+        isLoading: false,
+        sections: [
+          _bonnesSection(
+            label: 'Bonnes Nouvelles',
+            leadTitle: 'title-today',
+            leadId: 'today-1',
+          ),
+        ],
+      );
+}
+
+Widget _wrap(Widget child, {required List<Override> overrides}) {
+  return ProviderScope(
+    overrides: [
+      displayModeSpecProvider.overrideWith((ref) => DisplayModeSpec.normal),
+      ...overrides,
+    ],
+    child: MaterialApp(
+      theme: ThemeData(extensions: [FacteurPalettes.light]),
+      home: child,
+    ),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  testWidgets(
+      'pinToInitial=true → rend l\'agrégat hebdo (initialSection), ignore la '
+      'section homonyme du feed du jour', (tester) async {
+    final week = _bonnesSection(
+      label: 'Bonnes Nouvelles de la semaine',
+      leadTitle: 'title-week',
+      leadId: 'week-1',
+    );
+    await tester.pumpWidget(_wrap(
+      DigestSectionScreen(
+        sectionKeyValue: 'bonnes',
+        initialSection: week,
+        pinToInitial: true,
+      ),
+      overrides: [
+        fluxContinuProvider.overrideWith(_TodayFluxNotifier.new),
+      ],
+    ));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    // Titre + contenu de la semaine, pas du jour.
+    expect(find.text('title-week'), findsOneWidget);
+    expect(find.text('title-today'), findsNothing);
+    expect(find.text('Bonnes Nouvelles de la semaine'), findsWidgets);
+    // Pas de « Sujet suivant » (rupture vers le feed du jour) : seul « Retour ».
+    expect(find.textContaining('Sujet suivant'), findsNothing);
+    expect(find.text('Retour à la Tournée'), findsWidgets);
+  });
+
+  testWidgets(
+      'pinToInitial=false (chemin actuel) → résout la section du feed du jour',
+      (tester) async {
+    // initialSection = snapshot hebdo, mais sans épinglage le feed du jour
+    // résolu prend le dessus (comportement inchangé du « Tout lire » du jour).
+    final week = _bonnesSection(
+      label: 'Bonnes Nouvelles de la semaine',
+      leadTitle: 'title-week',
+      leadId: 'week-1',
+    );
+    await tester.pumpWidget(_wrap(
+      DigestSectionScreen(
+        sectionKeyValue: 'bonnes',
+        initialSection: week,
+      ),
+      overrides: [
+        fluxContinuProvider.overrideWith(_TodayFluxNotifier.new),
+      ],
+    ));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(find.text('title-today'), findsOneWidget);
+    expect(find.text('title-week'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Quoi
Correctifs UX sur la rétro hebdo « Cette semaine » de la Lettre du jour.

- **Change 3 — « Tout lire » hebdo** : nouveaux agrégats complets `topicsAll` / `bonnesAll` (cap 20) dans `EditionEssentielState`, distincts de l'aperçu inline (cap 6, borné à 4 sujets en vue hebdo). Le bandeau/footer « Tout lire » ouvre `DigestSectionScreen` **épinglé** (`pinToInitial`, query `src=week`) sur l'agrégat de la semaine, au lieu de résoudre par erreur le feed **du jour** (même `sectionKey`).
- **Change 4 — bug « seulement hier »** : les Bonnes Nouvelles sereines sont désormais captées même quand le digest **normal** du jour est périmé (`bonnesTopics` sorti du garde héros/normal, `addAll` placé avant le `continue` du fan-out hebdo). Un fallback cloné serein reste écarté (jamais présenter les bonnes d'un autre jour).
- **Rituel matinal** : l'affordance « lettre voisine » (`_NeighborCta`) reprend la double-flèche Phosphor ⏪/⏩ couleur `primary` + haptique de sélection (miroir de `EditionRewindTrigger`) ; `_SectionRow` aligné sur les tokens `FacteurRadius` / `FacteurSpacing`.

## Pourquoi
La rétro hebdo n'exposait qu'un aperçu tronqué sans accès au reste des sujets, et perdait les bonnes nouvelles des jours au digest normal périmé (elles n'apparaissaient que « pour hier »). Le « Tout lire » hebdo affichait par erreur le contenu du jour.

## Comment ça a été vérifié
- [x] `flutter test test/features/flux_continu/` : 17/17 verts (provider + nouveau widget test `digest_section_screen_test`)
- [x] Suite complète `flutter test` : 1627 verts ; les 23 échecs sont pré-existants et hors diff (custom_topics, notification, bookmark, feed_sources, perspectives, smoke) — aucun dans flux_continu
- [x] `flutter analyze` sur les fichiers touchés : clean (3 `info` pré-existants dans routes.dart hors région modifiée)
- [x] `/simplify` passé : consolidation dédup/tri (4 passes → 2, agrégat calculé une fois, aperçu = préfixe), zéro changement de comportement
- Pas de Playwright : flux hebdo dépendant de données digest multi-jours difficile à câbler sur le build web ; la couverture widget/unit (épinglage + agrégats + bug « seulement hier ») est le filet réel.

## Zones à risque
- Navigation `DigestSectionScreen` épinglé via `extra` + query `src=week` : entrée push-only. `extra` n'est pas sérialisé → un reload web / restauration profonde perdrait la section (rendrait un empty-state, sans recovery live). Acceptable pour un point d'entrée push, à surveiller.
- Aucun changement back-end, aucune migration Alembic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)