### PR TITLE
fix(infra): garde-fou drift migration sur /api/health/ready (503 direction-aware)

### DIFF
--- a/packages/api/app/checks.py
+++ b/packages/api/app/checks.py
@@ -1,4 +1,5 @@
 import os
+from functools import lru_cache
 
 import structlog
 from alembic.config import Config
@@ -92,3 +93,63 @@ async def check_migrations_up_to_date():
         raise RuntimeError(error_msg)
 
     logger.info("startup_check_migrations_ok")
+
+
+@lru_cache(maxsize=1)
+def _code_head_and_ancestors() -> tuple[str | None, frozenset[str]]:
+    """Code-side head revision + the full set of its ancestors (incl. head).
+
+    Derived only from the Alembic script files bundled in this image, so it is
+    static per process — memoised. Raises on config error (caller catches).
+    """
+    alembic_cfg = Config(_ALEMBIC_INI_PATH)
+    script_directory = script.ScriptDirectory.from_config(alembic_cfg)
+    heads = script_directory.get_heads()
+    head_rev = heads[0] if heads else None
+    if head_rev is None:
+        return None, frozenset()
+    ancestors = frozenset(
+        rev.revision for rev in script_directory.iterate_revisions(head_rev, "base")
+    )
+    return head_rev, ancestors
+
+
+async def get_migration_readiness() -> dict[str, str | bool | None]:
+    """Direction-aware migration drift status for the readiness probe.
+
+    Returns ``{"behind": bool, "head": str|None, "current": str|None}``.
+
+    ``behind=True`` **only** when the DB current revision is a *strict ancestor*
+    of the code head — i.e. migrations this deployed image expects have not been
+    applied yet (the "pending migrations" failure mode that makes every query on
+    the new schema 500). A drifted container should then be pulled out of the
+    load balancer.
+
+    ``behind=False`` when ``current == head`` (fine) **or** when ``current`` is
+    *ahead of* / unrelated to the code head. The latter is the normal
+    expand-contract window: the prod backend runs last week's code (old head) on
+    a shared DB whose ``current`` has already been advanced by staging — 503-ing
+    prod then would cause an outage, so we must stay ready. Any config/DB error
+    also returns ``behind=False`` (fail-open — never take traffic down because
+    this check itself hiccuped).
+    """
+    try:
+        head_rev, ancestors = _code_head_and_ancestors()
+    except Exception as e:
+        logger.warning("readiness_migration_check_config_error", error=str(e))
+        return {"behind": False, "head": None, "current": None}
+
+    try:
+        async with engine.connect() as conn:
+            current_rev = await conn.run_sync(_get_current_revision_sync)
+    except Exception as e:
+        logger.warning("readiness_migration_check_db_error", error=str(e))
+        return {"behind": False, "head": head_rev, "current": None}
+
+    if head_rev is None or current_rev == head_rev:
+        return {"behind": False, "head": head_rev, "current": current_rev}
+
+    # DB is behind code iff its current revision is a *strict* ancestor of head.
+    # (current ahead of / unrelated to head → not in `ancestors` → stays ready.)
+    behind = current_rev in ancestors and current_rev != head_rev
+    return {"behind": behind, "head": head_rev, "current": current_rev}

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -610,6 +610,40 @@ async def readiness_check(db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
             },
         )
 
+    # 🛡️ MIGRATION DRIFT: pull a drifted container OUT of the load balancer.
+    # Incident 2026-07-14 : la colonne `sources.coverage_themes` (migration cv01)
+    # n'avait jamais été appliquée sur la DB partagée → tout `select(Source)` en
+    # 500, mais /health (liveness) restait 200 et l'ancien /ready (SELECT 1 seul)
+    # aussi → Railway continuait de router du trafic vers un conteneur en drift.
+    # On 503 UNIQUEMENT quand la DB est EN RETARD sur le code (migrations non
+    # appliquées) — jamais quand elle est en avance (fenêtre expand-contract :
+    # prod tourne l'ancien code sur une DB déjà avancée par staging). Fail-open.
+    from app.checks import get_migration_readiness
+
+    migration_status = await get_migration_readiness()
+    if migration_status["behind"]:
+        from fastapi.responses import JSONResponse
+
+        logger.critical(
+            "readiness_migration_drift",
+            head=migration_status["head"],
+            current=migration_status["current"],
+            hint="DB behind code head — pending migrations. Pulling container out of LB.",
+        )
+        return JSONResponse(
+            status_code=503,
+            content={
+                "status": "not_ready",
+                "version": settings.app_version,
+                "database": db_status,
+                "migrations": "pending",
+                "migration_head": migration_status["head"],
+                "migration_current": migration_status["current"],
+                "environment": settings.environment,
+                "probe": "readiness",
+            },
+        )
+
     return {
         "status": "ready",
         "version": settings.app_version,

--- a/packages/api/tests/test_health_readiness_migrations.py
+++ b/packages/api/tests/test_health_readiness_migrations.py
@@ -1,0 +1,170 @@
+"""Tests for the migration-drift guard on /api/health/ready.
+
+Incident 2026-07-14 : la migration `cv01` (colonne `sources.coverage_themes`)
+n'avait jamais été appliquée sur la DB partagée. Tout `select(Source)` renvoyait
+500, mais /api/health (liveness) restait 200 et l'ancien /api/health/ready
+(un simple `SELECT 1`) aussi → Railway continuait de router du trafic vers un
+conteneur en drift. Ce garde-fou sort un conteneur en retard de schéma du load
+balancer (503), **sans** casser prod pendant la fenêtre expand-contract (DB en
+avance sur l'ancien code prod → doit rester ready).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.checks import get_migration_readiness
+from app.database import get_db
+from app.main import app
+
+
+def _fake_engine(current_rev: str | None, *, raise_on_connect: bool = False):
+    """Build a mock engine whose `connect()` yields a conn returning current_rev."""
+
+    class _FakeConn:
+        async def run_sync(self, _fn):
+            return current_rev
+
+    class _FakeConnectCtx:
+        async def __aenter__(self):
+            if raise_on_connect:
+                raise RuntimeError("db down")
+            return _FakeConn()
+
+        async def __aexit__(self, *_a):
+            return False
+
+    engine = MagicMock()
+    engine.connect.return_value = _FakeConnectCtx()
+    return engine
+
+
+# --- Unit: direction-aware decision -------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_behind_true_when_current_is_strict_ancestor():
+    """The incident case: DB at ue01, code head at me01 → behind=True."""
+    head = "me01_media_eval_tables"
+    ancestors = frozenset(
+        {head, "cv01_source_coverage_themes", "ue01_user_entity_affinity"}
+    )
+    with (
+        patch("app.checks._code_head_and_ancestors", return_value=(head, ancestors)),
+        patch("app.checks.engine", _fake_engine("ue01_user_entity_affinity")),
+    ):
+        status = await get_migration_readiness()
+    assert status["behind"] is True
+    assert status["head"] == head
+    assert status["current"] == "ue01_user_entity_affinity"
+
+
+@pytest.mark.asyncio
+async def test_behind_false_when_current_equals_head():
+    head = "me01_media_eval_tables"
+    ancestors = frozenset({head, "cv01_source_coverage_themes"})
+    with (
+        patch("app.checks._code_head_and_ancestors", return_value=(head, ancestors)),
+        patch("app.checks.engine", _fake_engine(head)),
+    ):
+        status = await get_migration_readiness()
+    assert status["behind"] is False
+
+
+@pytest.mark.asyncio
+async def test_behind_false_when_db_ahead_of_code_expand_contract():
+    """Expand-contract window: prod runs OLD code (head=cv01) on a DB already
+    advanced by staging (current=me01, NOT an ancestor of cv01). Must stay ready
+    — 503-ing here would take prod down every weekly cycle."""
+    head = "cv01_source_coverage_themes"
+    ancestors = frozenset({head, "ue01_user_entity_affinity"})  # me01 absent
+    with (
+        patch("app.checks._code_head_and_ancestors", return_value=(head, ancestors)),
+        patch("app.checks.engine", _fake_engine("me01_media_eval_tables")),
+    ):
+        status = await get_migration_readiness()
+    assert status["behind"] is False
+
+
+@pytest.mark.asyncio
+async def test_fail_open_on_db_error():
+    head = "me01_media_eval_tables"
+    ancestors = frozenset({head})
+    with (
+        patch("app.checks._code_head_and_ancestors", return_value=(head, ancestors)),
+        patch("app.checks.engine", _fake_engine(None, raise_on_connect=True)),
+    ):
+        status = await get_migration_readiness()
+    assert status["behind"] is False
+
+
+@pytest.mark.asyncio
+async def test_fail_open_on_config_error():
+    with patch(
+        "app.checks._code_head_and_ancestors",
+        side_effect=RuntimeError("no alembic.ini"),
+    ):
+        status = await get_migration_readiness()
+    assert status["behind"] is False
+
+
+# --- Endpoint: 503 vs 200 -----------------------------------------------------
+
+
+async def _override_db_ok():
+    session = MagicMock()
+    session.execute = AsyncMock()  # SELECT 1 succeeds
+    yield session
+
+
+@pytest.mark.asyncio
+async def test_readiness_returns_503_on_migration_drift():
+    app.dependency_overrides[get_db] = _override_db_ok
+    try:
+        with patch(
+            "app.checks.get_migration_readiness",
+            AsyncMock(
+                return_value={
+                    "behind": True,
+                    "head": "me01_media_eval_tables",
+                    "current": "ue01_user_entity_affinity",
+                }
+            ),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as ac:
+                resp = await ac.get("/api/health/ready")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["status"] == "not_ready"
+    assert body["migrations"] == "pending"
+    assert body["migration_current"] == "ue01_user_entity_affinity"
+    assert body["migration_head"] == "me01_media_eval_tables"
+
+
+@pytest.mark.asyncio
+async def test_readiness_returns_200_when_up_to_date():
+    app.dependency_overrides[get_db] = _override_db_ok
+    try:
+        with patch(
+            "app.checks.get_migration_readiness",
+            AsyncMock(
+                return_value={
+                    "behind": False,
+                    "head": "me01_media_eval_tables",
+                    "current": "me01_media_eval_tables",
+                }
+            ),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as ac:
+                resp = await ac.get("/api/health/ready")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ready"


### PR DESCRIPTION
## Quoi
Ajoute un garde-fou de **drift de migration** à la readiness probe `/api/health/ready` : le conteneur renvoie **503** (sorti du load balancer) **uniquement** quand la DB est **en retard** sur le head Alembic du code (migrations en attente), et reste **200** quand elle est en avance/non liée (fenêtre expand-contract). Fail-open sur toute erreur config/DB.

## Pourquoi
Incident 2026-07-14 : la migration `cv01` (`sources.coverage_themes`) n'avait jamais été appliquée sur la DB partagée → tout `select(Source)` renvoyait 500, mais `/api/health` (liveness) **et** l'ancien `/api/health/ready` (simple `SELECT 1`) restaient **200** → Railway continuait de router du trafic vers un conteneur en drift. Ce garde-fou détecte le retard de schéma et sort le conteneur du LB, **sans** casser prod pendant la fenêtre expand-contract (prod tourne l'ancien code sur une DB déjà avancée par staging → doit rester ready, sinon outage à chaque release hebdo).

## Comment ça a été vérifié
- [x] `pytest tests/test_health_readiness_migrations.py` → **7 passed** (cas incident, égal, avance expand-contract, fail-open DB, fail-open config, endpoint 503, endpoint 200)
- [x] Suite complète : **1799 passed** (les 446 `error` = creds DB locales `postgres@54322` rotées, env-only, sans lien avec ce diff — mocks purs ici, pas de DB)
- [x] `ruff format` + `ruff check` OK sur les 3 fichiers
- [x] Aucune migration Alembic ajoutée (1 head inchangé)
- [x] `/simplify` : diff déjà propre (imports inline volontaires — idiome local de l'endpoint + cible de patch des tests)

## Zones à risque
Readiness probe (zone Infra guardrail). Mitigation : garde **fail-open** et ne 503 que sur retard *strict* ; le cas « DB en avance » (expand-contract) est explicitement testé pour rester ready → les releases hebdo prod ne sont jamais coupées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)