### PR TITLE
fix(essentiel): snap 1-buzz + long-press grow nudge + sondage NPS rarefié

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Essentiel",
+      "summary": "Défilement affiné : une seule vibration à l'arrivée sur une section, un maintien appui qui fait respirer la carte, et un sondage bien plus rare."
+    },
+    {
       "tag": "Rattrapage",
       "summary": "« Cette semaine » : accès Tout lire par section et bonnes nouvelles de toute la semaine."
     },

--- a/apps/mobile/lib/core/nudges/nudge_registry.dart
+++ b/apps/mobile/lib/core/nudges/nudge_registry.dart
@@ -114,15 +114,16 @@ class NudgeRegistry {
       frequency: NudgeFrequency.once,
     ),
 
-    // Story 14.3 — well-informed NPS. Cooldown porté à 5j (skip) ; le
-    // provider impose en plus un cooldown 14j après une vraie soumission.
+    // Story 14.3 — well-informed NPS. Cooldown porté à 21j (skip) ; le
+    // provider impose en plus un cooldown 60j après une vraie soumission, et un
+    // tirage aléatoire quotidien (~1 jour sur 7) pour rarefier sans biais.
     const Nudge(
       id: NudgeIds.wellInformedPoll,
       surface: NudgeSurface.digest,
       placement: NudgePlacement.inlineBanner,
       priority: NudgePriority.low,
       frequency: NudgeFrequency.cooldown,
-      cooldown: Duration(days: 5),
+      cooldown: Duration(days: 21),
     ),
 
     // Story web.1 — iOS Safari "Ajouter à l'écran d'accueil". Cooldown 7j

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -141,6 +141,14 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   final ValueNotifier<bool> _stickyVisible = ValueNotifier(false);
   final ValueNotifier<int> _activeIndex = ValueNotifier(0);
 
+  /// Active section index captured at the *start* of the current scroll
+  /// gesture. The section haptic is now emitted once, at settle
+  /// (`ScrollEndNotification`), only when the gesture actually changed section
+  /// vs. this snapshot — so a drag-then-snapback (which flips `_activeIndex`
+  /// mid-drag then recadres the origin section) fires **zero** buzz instead of
+  /// two. `null` until the first gesture starts.
+  int? _gestureStartActiveIndex;
+
   final List<GlobalKey> _sectionKeys = [];
 
   // Clés dédiées aux cartes virtuelles qui ont désormais un onglet sticky.
@@ -339,14 +347,11 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
       }
     }
     if (_activeIndex.value != activeAt) {
-      // Strong section haptic when the active tab flips section under the
-      // sticky bar. Gated on visibility so we don't buzz during the initial
-      // layout / top-of-page scroll, before the sticky is even revealed. The
-      // snap's one-step cap (cf. resolveSnapTarget) keeps a fling to a single
-      // boundary crossing, so this fires exactly once per step.
-      if (_stickyVisible.value) {
-        unawaited(_triggerSectionChangeHaptic());
-      }
+      // Visual-only tab tracking here. The section haptic used to fire on this
+      // per-frame flip, which double-buzzed a drag-then-snapback (flip N→N+1
+      // mid-drag, then N+1→N on the pull-back). It now fires once at settle —
+      // see `_onScrollNotification` (`ScrollEndNotification`), gated on a real
+      // change of section across the whole gesture.
       _activeIndex.value = activeAt;
       _alignTabsToActive(activeAt);
     }
@@ -369,6 +374,21 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   bool _onScrollNotification(ScrollNotification n) {
     if (n is ScrollStartNotification) {
       _scheduleAnchorRecompute();
+      // Snapshot the section we start on. The settle handler compares against
+      // it so a gesture that nets no section change (drag-puis-snapback) stays
+      // silent.
+      _gestureStartActiveIndex = _activeIndex.value;
+    } else if (n is ScrollEndNotification) {
+      // One buzz per gesture, at rest: only when the sticky bar is visible
+      // (skip the initial top-of-page scroll) and the settle landed on a
+      // different section than the gesture started on. Covers both the reader's
+      // fling/snap and programmatic tab nav (which also settles here).
+      if (_stickyVisible.value &&
+          _gestureStartActiveIndex != null &&
+          _activeIndex.value != _gestureStartActiveIndex) {
+        unawaited(_triggerSectionChangeHaptic());
+      }
+      _gestureStartActiveIndex = _activeIndex.value;
     }
     return false;
   }

--- a/apps/mobile/lib/features/flux_continu/utils/section_snap.dart
+++ b/apps/mobile/lib/features/flux_continu/utils/section_snap.dart
@@ -13,7 +13,7 @@ const double kSnapEpsilon = 1.0;
 /// more than this margin past the edge before the section actually switches.
 /// Larger ⇒ harder to switch sections (more « collant » à la carte courante);
 /// smaller ⇒ switches more readily. 0 reverts to the pure edge-triggered feel.
-const double kSectionEdgeMargin = 120.0;
+const double kSectionEdgeMargin = 160.0;
 
 /// px/s. **The only knob for the UP-only fast-rewind exception** — tune it à
 /// l'œil sur device. Snap is now the default *both* ways (a slow upward scroll

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -7,8 +7,6 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
-import '../../../widgets/article_preview_modal.dart';
-import '../../detail/content_preview_mapper.dart';
 import '../../tour/tour_anchors.dart';
 import '../../settings/models/display_mode_spec.dart';
 import '../../settings/providers/display_mode_provider.dart';
@@ -18,6 +16,7 @@ import '../providers/selected_edition_date_provider.dart';
 import '../providers/weather_provider.dart';
 import '../utils/theme_color_mapping.dart';
 import 'edition_timeline_sheet.dart';
+import 'long_press_grow.dart';
 import 'weather_condition_icon.dart';
 import 'weather_detail_sheet.dart';
 
@@ -535,8 +534,7 @@ class _LeadTile extends StatelessWidget {
     final chipAccent = _accentFor(article, accent);
     return Material(
       color: Colors.transparent,
-      child: _ArticlePreviewGesture(
-        article: article,
+      child: LongPressGrowNudge(
         child: InkWell(
         onTap: onTap,
         borderRadius: BorderRadius.circular(FacteurRadius.medium),
@@ -618,8 +616,7 @@ class _MediumTile extends StatelessWidget {
     final colors = Theme.of(context).extension<FacteurColors>()!;
     return Material(
       color: Colors.transparent,
-      child: _ArticlePreviewGesture(
-        article: article,
+      child: LongPressGrowNudge(
         child: InkWell(
         onTap: onTap,
         borderRadius: BorderRadius.circular(FacteurRadius.small),
@@ -677,29 +674,6 @@ class _MediumTile extends StatelessWidget {
         ),
         ),
       ),
-    );
-  }
-}
-
-/// Aperçu au long-press, partagé par [_LeadTile] et [_MediumTile] (cf.
-/// flux_continu_article_card.dart). Pas de swipe (choix PO) ni d'haptique
-/// (cohérence FluxContinuArticleCard). Les tuiles vivent dans un scroll
-/// vertical → pas de conflit d'arène, le long-press gagne de façon fiable.
-class _ArticlePreviewGesture extends StatelessWidget {
-  final EssentielArticle article;
-  final Widget child;
-
-  const _ArticlePreviewGesture({required this.article, required this.child});
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onLongPressStart: (_) =>
-          ArticlePreviewOverlay.show(context, article.toPreviewContent()),
-      onLongPressMoveUpdate: (d) =>
-          ArticlePreviewOverlay.updateScroll(d.localOffsetFromOrigin.dy),
-      onLongPressEnd: (_) => ArticlePreviewOverlay.dismiss(),
-      child: child,
     );
   }
 }

--- a/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
@@ -6,7 +6,6 @@ import 'package:timeago/timeago.dart' as timeago;
 
 import '../../../config/theme.dart';
 import '../../../config/topic_labels.dart';
-import '../../../widgets/article_preview_modal.dart';
 import '../../../widgets/design/facteur_image.dart';
 import '../../digest/models/digest_models.dart';
 import '../../digest/widgets/divergence_inline_badge.dart';
@@ -16,6 +15,7 @@ import '../../feed/widgets/swipe_to_open_card.dart';
 import '../../settings/models/display_mode_spec.dart';
 import '../../settings/providers/display_mode_provider.dart';
 import '../../sources/models/source_model.dart';
+import 'long_press_grow.dart';
 
 /// Unified view-model that hides the DigestItem vs Content split from the
 /// rendering layer. Both types carry the fields needed to display a Flux
@@ -173,19 +173,8 @@ class _FluxContinuArticleCardState
               color: colors.surface,
               borderRadius: cardRadius,
               elevation: 0,
-              child: GestureDetector(
-                onLongPressStart: (_) {
-                  widget.onLongPressConversion?.call();
-                  ArticlePreviewOverlay.show(
-                    context,
-                    articleToContent(widget.article),
-                  );
-                },
-                onLongPressMoveUpdate: (details) =>
-                    ArticlePreviewOverlay.updateScroll(
-                  details.localOffsetFromOrigin.dy,
-                ),
-                onLongPressEnd: (_) => ArticlePreviewOverlay.dismiss(),
+              child: LongPressGrowNudge(
+                onLongPress: () => widget.onLongPressConversion?.call(),
                 child: InkWell(
                   onTap: widget.onTap,
                   borderRadius: cardRadius,
@@ -385,9 +374,9 @@ class _FluxContinuArticleCardState
       type == ContentType.video || type == ContentType.youtube;
 }
 
-/// Adapter producing a synthetic [Content] suitable for [ArticlePreviewOverlay]
-/// or [TopicChip.showArticleSheet] regardless of the source type. [DigestItem]
-/// carries every field needed by the preview except the rich [Source] object —
+/// Adapter producing a synthetic [Content] suitable for
+/// `TopicChip.showArticleSheet` regardless of the source type. [DigestItem]
+/// carries every field needed by the sheet except the rich [Source] object —
 /// a minimal [Source] is built from its [SourceMini]. Exposed as top-level so
 /// the screen can reuse it when resolving an inline-feedback chip on a digest
 /// lead.

--- a/apps/mobile/lib/features/flux_continu/widgets/long_press_grow.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/long_press_grow.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+/// « Nudge grow » au long-press, remplaçant l'ancien aperçu flottant plein
+/// écran (`ArticlePreviewOverlay`) sur les cartes Essentiel / Flux : la carte
+/// grossit brièvement puis revient (1.0 → 1.06 → 1.0), sans overlay.
+///
+/// **Pas d'haptique** (choix de cohérence : le seul buzz de l'écran Essentiel
+/// reste le snap de section). Transposé du pulse `_WeatherBadge`
+/// (`essentiel_hi_fi_card.dart`) — même grain de courbe, départ à 1.0.
+class LongPressGrowNudge extends StatefulWidget {
+  const LongPressGrowNudge({
+    super.key,
+    required this.child,
+    this.onLongPress,
+  });
+
+  final Widget child;
+
+  /// Hook analytics-only (ex. `onLongPressConversion`). Aucune action visuelle :
+  /// le grow est piloté en interne.
+  final VoidCallback? onLongPress;
+
+  @override
+  State<LongPressGrowNudge> createState() => _LongPressGrowNudgeState();
+}
+
+class _LongPressGrowNudgeState extends State<LongPressGrowNudge>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _scale;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 260),
+    );
+    _scale = TweenSequence<double>([
+      TweenSequenceItem(
+        tween: Tween(begin: 1.0, end: 1.06)
+            .chain(CurveTween(curve: Curves.easeOutCubic)),
+        weight: 55,
+      ),
+      TweenSequenceItem(
+        tween: Tween(begin: 1.06, end: 1.0)
+            .chain(CurveTween(curve: Curves.easeInOutCubic)),
+        weight: 45,
+      ),
+    ]).animate(_controller);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _play() {
+    widget.onLongPress?.call();
+    _controller.forward(from: 0);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onLongPressStart: (_) => _play(),
+      child: ScaleTransition(scale: _scale, child: widget.child),
+    );
+  }
+}

--- a/apps/mobile/lib/features/notif_du_jour/providers/notif_du_jour_provider.dart
+++ b/apps/mobile/lib/features/notif_du_jour/providers/notif_du_jour_provider.dart
@@ -92,7 +92,9 @@ final notifDuJourQueueProvider = Provider<List<String>>((ref) {
     candidates.add(const NotifCandidate(NotifDuJourIds.notifRenudge, 0.9));
   }
   if (ref.watch(wellInformedShouldShowProvider).valueOrNull ?? false) {
-    candidates.add(const NotifCandidate(NotifDuJourIds.wellInformed, 0.85));
+    // Relevance abaissée 0.85 → 0.6 : le sondage NPS gagne moins souvent le tri
+    // de la file (rareté non biaisée, cf. WellInformedPromptController).
+    candidates.add(const NotifCandidate(NotifDuJourIds.wellInformed, 0.6));
   }
   if (ref.watch(geolocPromptShouldShowProvider).valueOrNull ?? false) {
     candidates.add(const NotifCandidate(NotifDuJourIds.geoloc, 0.7));

--- a/apps/mobile/lib/features/well_informed/providers/well_informed_prompt_provider.dart
+++ b/apps/mobile/lib/features/well_informed/providers/well_informed_prompt_provider.dart
@@ -1,43 +1,66 @@
+import 'dart:math';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../core/nudges/nudge_coordinator.dart';
 import '../../../core/nudges/nudge_ids.dart';
 import '../../../core/nudges/nudge_service.dart';
+import '../../notif_du_jour/providers/notif_du_jour_provider.dart'
+    show notifIdHash;
 import '../data/well_informed_repository.dart';
 
 /// Clé SharedPreferences portant le timestamp de la DERNIÈRE soumission
 /// (distincte de `nudge.well_informed_poll.lastShown` utilisée par le service
-/// nudges pour tout "shown" — y compris skip). Permet d'imposer 14j après
-/// réponse même si le nudge lui-même a un cooldown de 5j (pour le skip).
+/// nudges pour tout "shown" — y compris skip). Permet d'imposer 60j après
+/// réponse même si le nudge lui-même a un cooldown plus court (pour le skip).
 const String kWellInformedLastSubmittedPrefsKey =
     'well_informed_poll_last_submitted_at_ms';
 
-const Duration kWellInformedSubmittedCooldown = Duration(days: 14);
+/// Clé SharedPreferences portant le salt aléatoire par installation, tiré une
+/// seule fois. Désynchronise le jour d'apparition du sondage entre users (pas
+/// de pic le même jour) tout en restant stable dans la journée pour un user
+/// donné. Injectable en test (pré-seed la clé).
+const String kWellInformedSamplingSaltPrefsKey = 'well_informed_sampling_salt';
+
+/// Cooldown long après une vraie soumission. Porté de 14j → 60j pour rarefier
+/// le sondage NPS (irritant "trop fréquent").
+const Duration kWellInformedSubmittedCooldown = Duration(days: 60);
+
+/// % de jours *éligibles* (cooldowns passés) où le sondage a le droit
+/// d'apparaître — ~1 jour sur 7. Tirage aléatoire **stable par jour
+/// calendaire** (cf. `shouldShow`), **non gaté sur l'engagement** : chaque user
+/// est également susceptible d'être échantillonné, quel que soit son streak →
+/// échantillon non biaisé.
+const int kWellInformedDailySamplingPercent = 15;
 
 /// Coordinateur métier du prompt "bien informé".
 ///
-/// - `shouldShow()` : vrai si aucune soumission < 14j ET le nudge (cooldown 5j
-///   configuré dans NudgeRegistry) autorise l'affichage.
+/// - `shouldShow()` : vrai si aucune soumission < 60j, ET le nudge (cooldown
+///   configuré dans NudgeRegistry) autorise l'affichage, ET le tirage
+///   quotidien stable « sort » (≈15% des jours éligibles).
 /// - `recordShown()` : enregistre un shown (sert pour la cooldown skip).
 /// - `submit()` : POST la note + marque la soumission + avance le cooldown
-///   long (14j).
-/// - `skip()` : marque un shown (cooldown court 5j), pas de POST.
+///   long (60j).
+/// - `skip()` : marque un shown (cooldown court du nudge), pas de POST.
 class WellInformedPromptController {
   WellInformedPromptController({
     required NudgeService nudgeService,
     required WellInformedRepository repository,
     DateTime Function()? clock,
     Future<SharedPreferences> Function()? prefs,
+    int samplingPercent = kWellInformedDailySamplingPercent,
   })  : _nudgeService = nudgeService,
         _repository = repository,
         _clock = clock ?? DateTime.now,
-        _prefsFactory = prefs ?? SharedPreferences.getInstance;
+        _prefsFactory = prefs ?? SharedPreferences.getInstance,
+        _samplingPercent = samplingPercent;
 
   final NudgeService _nudgeService;
   final WellInformedRepository _repository;
   final DateTime Function() _clock;
   final Future<SharedPreferences> Function() _prefsFactory;
+  final int _samplingPercent;
 
   Future<bool> shouldShow() async {
     final prefs = await _prefsFactory();
@@ -48,7 +71,17 @@ class WellInformedPromptController {
         return false;
       }
     }
-    return _nudgeService.canShow(NudgeIds.wellInformedPoll);
+    if (!await _nudgeService.canShow(NudgeIds.wellInformedPoll)) {
+      return false;
+    }
+    // Tirage aléatoire quotidien non biaisé : une fois les cooldowns passés, on
+    // n'affiche PAS systématiquement — n'autorise l'affichage que sur ~1 jour
+    // éligible sur 7. Hash FNV-1a de `salt#yyyy-mm-dd` (stable dans la journée,
+    // pas de `Random()` volatile qui flickerait entre rebuilds) mixé à un salt
+    // par installation pour désynchroniser le jour entre users.
+    final salt = await _samplingSalt(prefs);
+    final dayKey = _dayKey(_clock());
+    return notifIdHash('$salt#$dayKey') % 100 < _samplingPercent;
   }
 
   Future<void> recordShown() async {
@@ -67,6 +100,23 @@ class WellInformedPromptController {
 
   Future<void> skip() async {
     await _nudgeService.markShown(NudgeIds.wellInformedPoll);
+  }
+
+  /// Salt par installation, tiré une seule fois puis persisté. Stable ensuite,
+  /// donc le tirage quotidien ne dépend que du jour calendaire.
+  Future<String> _samplingSalt(SharedPreferences prefs) async {
+    final existing = prefs.getString(kWellInformedSamplingSaltPrefsKey);
+    if (existing != null) return existing;
+    final salt = Random().nextInt(1 << 31).toString();
+    await prefs.setString(kWellInformedSamplingSaltPrefsKey, salt);
+    return salt;
+  }
+
+  /// Clé jour calendaire local `yyyy-mm-dd` — constante sur la journée vécue.
+  String _dayKey(DateTime now) {
+    final m = now.month.toString().padLeft(2, '0');
+    final d = now.day.toString().padLeft(2, '0');
+    return '${now.year}-$m-$d';
   }
 }
 

--- a/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
@@ -13,6 +13,7 @@ import 'package:facteur/features/flux_continu/providers/weather_location_provide
 import 'package:facteur/features/flux_continu/providers/weather_provider.dart';
 import 'package:facteur/features/flux_continu/widgets/edition_timeline_sheet.dart';
 import 'package:facteur/features/flux_continu/widgets/essentiel_hi_fi_card.dart';
+import 'package:facteur/features/flux_continu/widgets/long_press_grow.dart';
 import 'package:facteur/features/settings/models/display_mode_spec.dart';
 import 'package:facteur/features/settings/providers/display_mode_provider.dart';
 import 'package:facteur/widgets/design/facteur_thumbnail.dart';
@@ -33,6 +34,20 @@ Widget _wrap(Widget child, {List<Override> overrides = const []}) {
       home: Scaffold(body: SingleChildScrollView(child: child)),
     ),
   );
+}
+
+/// True si au moins un `LongPressGrowNudge` est en train d'agrandir sa carte
+/// (scale > 1.0). Scopé aux descendants du nudge pour ignorer d'autres
+/// `ScaleTransition` de l'écran (ex. le pulse météo).
+bool _growScaleIsAbove1(WidgetTester tester) {
+  return tester
+      .widgetList<ScaleTransition>(
+        find.descendant(
+          of: find.byType(LongPressGrowNudge),
+          matching: find.byType(ScaleTransition),
+        ),
+      )
+      .any((s) => s.scale.value > 1.0);
 }
 
 class _FakeWeatherNotifier extends WeatherNotifier {
@@ -149,7 +164,7 @@ void main() {
     });
 
     testWidgets(
-        'long-press on the lead opens the article preview overlay',
+        'long-press on the lead grows the card, no floating preview overlay',
         (tester) async {
       await tester.pumpWidget(_wrap(
         EssentielHiFiCard(
@@ -158,24 +173,26 @@ void main() {
         ),
       ));
 
-      // La carte elle-même est text-only (aucune FacteurThumbnail) ; l'aperçu
-      // overlay en rend une → signal propre de présence de l'aperçu.
+      // La carte est text-only : l'ancien overlay rendait une FacteurThumbnail.
+      // Après retrait, aucune ne doit apparaître au long-press.
       expect(find.byType(FacteurThumbnail), findsNothing);
 
       final gesture =
           await tester.startGesture(tester.getCenter(find.text('Titre 1')));
       // Dépasse la deadline long-press (500 ms par défaut du GestureDetector).
       await tester.pump(const Duration(milliseconds: 600));
-      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 80)); // mi-animation grow
 
-      expect(find.byType(FacteurThumbnail), findsOneWidget,
-          reason: 'Long-press should reveal the preview overlay.');
+      expect(find.byType(FacteurThumbnail), findsNothing,
+          reason: 'The floating preview overlay must no longer appear.');
+      expect(_growScaleIsAbove1(tester), isTrue,
+          reason: 'Long-press should scale the card up (nudge grow).');
 
       await gesture.up();
       await tester.pumpAndSettle();
     });
 
-    testWidgets('long-press on a medium tile opens the preview overlay',
+    testWidgets('long-press on a medium tile grows it, no preview overlay',
         (tester) async {
       await tester.pumpWidget(_wrap(
         EssentielHiFiCard(
@@ -187,9 +204,10 @@ void main() {
       final gesture =
           await tester.startGesture(tester.getCenter(find.text('Titre 2')));
       await tester.pump(const Duration(milliseconds: 600));
-      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 80));
 
-      expect(find.byType(FacteurThumbnail), findsOneWidget);
+      expect(find.byType(FacteurThumbnail), findsNothing);
+      expect(_growScaleIsAbove1(tester), isTrue);
 
       await gesture.up();
       await tester.pumpAndSettle();

--- a/apps/mobile/test/features/flux_continu/widgets/long_press_grow_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/long_press_grow_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/flux_continu/widgets/long_press_grow.dart';
+
+void main() {
+  // Enfant hittable (couleur opaque) — un SizedBox nu n'absorbe pas le pointeur,
+  // le long-press ne serait jamais reconnu.
+  Widget wrap(Widget nudge) =>
+      MaterialApp(home: Scaffold(body: Center(child: nudge)));
+
+  Widget child() => Container(width: 100, height: 100, color: Colors.blue);
+
+  /// `ScaleTransition` porté par le nudge (scopé pour ignorer ceux de MaterialApp).
+  ScaleTransition scaleOf(WidgetTester tester) => tester.widget<ScaleTransition>(
+        find.descendant(
+          of: find.byType(LongPressGrowNudge),
+          matching: find.byType(ScaleTransition),
+        ),
+      );
+
+  testWidgets('long-press grows the child then settles back to 1.0',
+      (tester) async {
+    await tester.pumpWidget(wrap(LongPressGrowNudge(child: child())));
+
+    // Au repos, échelle neutre.
+    expect(scaleOf(tester).scale.value, 1.0);
+
+    final gesture =
+        await tester.startGesture(tester.getCenter(find.byType(Container)));
+    await tester.pump(const Duration(milliseconds: 600)); // deadline long-press
+    await tester.pump(const Duration(milliseconds: 80)); // mi-grow
+
+    expect(scaleOf(tester).scale.value, greaterThan(1.0));
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+    // Retour à 1.0 après l'animation.
+    expect(scaleOf(tester).scale.value, closeTo(1.0, 0.001));
+  });
+
+  testWidgets('long-press fires onLongPress (analytics hook) exactly once',
+      (tester) async {
+    var count = 0;
+    await tester.pumpWidget(wrap(
+      LongPressGrowNudge(onLongPress: () => count++, child: child()),
+    ));
+
+    final gesture =
+        await tester.startGesture(tester.getCenter(find.byType(Container)));
+    await tester.pump(const Duration(milliseconds: 600));
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(count, 1);
+  });
+
+  testWidgets(
+      'a plain tap (below the long-press deadline) does not grow or fire',
+      (tester) async {
+    var count = 0;
+    await tester.pumpWidget(wrap(
+      LongPressGrowNudge(onLongPress: () => count++, child: child()),
+    ));
+
+    await tester.tap(find.byType(Container));
+    await tester.pump(const Duration(milliseconds: 80));
+
+    expect(count, 0);
+    expect(scaleOf(tester).scale.value, 1.0);
+  });
+}

--- a/apps/mobile/test/features/well_informed/well_informed_prompt_controller_test.dart
+++ b/apps/mobile/test/features/well_informed/well_informed_prompt_controller_test.dart
@@ -4,6 +4,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:facteur/core/nudges/nudge_ids.dart';
 import 'package:facteur/core/nudges/nudge_service.dart';
 import 'package:facteur/core/nudges/nudge_storage.dart';
+import 'package:facteur/features/notif_du_jour/providers/notif_du_jour_provider.dart'
+    show notifIdHash;
 import 'package:facteur/features/well_informed/data/well_informed_repository.dart';
 import 'package:facteur/features/well_informed/providers/well_informed_prompt_provider.dart';
 
@@ -20,6 +22,17 @@ class _FakeRepository implements WellInformedRepository {
   }
 }
 
+/// Réplique la clé jour du provider (`yyyy-mm-dd`) pour localiser un jour qui
+/// « sort » ou non sous un salt donné.
+String _dayKey(DateTime d) {
+  final m = d.month.toString().padLeft(2, '0');
+  final day = d.day.toString().padLeft(2, '0');
+  return '${d.year}-$m-$day';
+}
+
+bool _sorts(String salt, DateTime day, int percent) =>
+    notifIdHash('$salt#${_dayKey(day)}') % 100 < percent;
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -32,8 +45,9 @@ void main() {
     now = DateTime(2026, 4, 24, 10, 0, 0);
   });
 
+  /// Contrôleur avec le tirage quotidien forcé à 100 % (toujours « sort ») pour
+  /// isoler la logique de cooldown des tests ci-dessous.
   WellInformedPromptController build() {
-    final prefs = SharedPreferences.getInstance;
     return WellInformedPromptController(
       nudgeService: NudgeService(
         storage: NudgeStorage(),
@@ -41,32 +55,33 @@ void main() {
       ),
       repository: repo,
       clock: () => now,
-      prefs: prefs,
+      prefs: SharedPreferences.getInstance,
+      samplingPercent: 100,
     );
   }
 
-  test('shouldShow true on fresh install', () async {
+  test('shouldShow true on fresh install (draw forced on)', () async {
     final c = build();
     expect(await c.shouldShow(), isTrue);
   });
 
-  test('after submit, blocked for 14 days', () async {
+  test('after submit, blocked for 60 days', () async {
     final c = build();
     await c.submit(7);
 
-    now = now.add(const Duration(days: 13, hours: 23));
+    now = now.add(const Duration(days: 59, hours: 23));
     expect(await c.shouldShow(), isFalse);
 
     now = now.add(const Duration(hours: 2));
-    // 14j + 1h écoulés depuis submit → shouldShow true à nouveau.
+    // 60j + 1h écoulés depuis submit → shouldShow true à nouveau.
     expect(await c.shouldShow(), isTrue);
   });
 
-  test('after skip, blocked for 5 days only', () async {
+  test('after skip, blocked for 21 days only', () async {
     final c = build();
     await c.skip();
 
-    now = now.add(const Duration(days: 4, hours: 23));
+    now = now.add(const Duration(days: 20, hours: 23));
     expect(await c.shouldShow(), isFalse);
 
     now = now.add(const Duration(hours: 2));
@@ -97,20 +112,90 @@ void main() {
     expect(repo.calls, isEmpty);
   });
 
-  test('submit uses the long (14j) cooldown even after a prior skip', () async {
+  test('submit uses the long (60j) cooldown even after a prior skip', () async {
     final c = build();
 
     await c.skip();
-    now = now.add(const Duration(days: 6));
+    now = now.add(const Duration(days: 22));
     expect(await c.shouldShow(), isTrue);
 
     await c.submit(5);
-    now = now.add(const Duration(days: 6));
-    // Après submit, le cooldown long 14j domine le cooldown court du nudge.
+    now = now.add(const Duration(days: 22));
+    // Après submit, le cooldown long 60j domine le cooldown court du nudge.
     expect(await c.shouldShow(), isFalse);
   });
 
   test('uses nudge id well_informed_poll', () {
     expect(NudgeIds.wellInformedPoll, 'well_informed_poll');
+  });
+
+  group('tirage quotidien non biaisé (~15%)', () {
+    const salt = 'seed-42';
+
+    WellInformedPromptController drawBuild() {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        kWellInformedSamplingSaltPrefsKey: salt,
+      });
+      return WellInformedPromptController(
+        nudgeService: NudgeService(
+          storage: NudgeStorage(),
+          clock: () => now,
+        ),
+        repository: repo,
+        clock: () => now,
+        prefs: SharedPreferences.getInstance,
+        // samplingPercent par défaut = kWellInformedDailySamplingPercent (15).
+      );
+    }
+
+    test('un jour qui « sort » affiche le sondage', () async {
+      final c = drawBuild();
+      final day = List.generate(60, (i) => DateTime(2026, 1, 1).add(Duration(days: i)))
+          .firstWhere((d) => _sorts(salt, d, kWellInformedDailySamplingPercent));
+      now = day;
+      expect(await c.shouldShow(), isTrue);
+    });
+
+    test('un jour qui ne « sort » pas masque le sondage', () async {
+      final c = drawBuild();
+      final day = List.generate(60, (i) => DateTime(2026, 1, 1).add(Duration(days: i)))
+          .firstWhere((d) => !_sorts(salt, d, kWellInformedDailySamplingPercent));
+      now = day;
+      expect(await c.shouldShow(), isFalse);
+    });
+
+    test('stable dans la journée (pas de flicker entre rebuilds)', () async {
+      final c = drawBuild();
+      now = DateTime(2026, 4, 24, 8, 0);
+      final a = await c.shouldShow();
+      now = DateTime(2026, 4, 24, 22, 0); // même jour calendaire
+      final b = await c.shouldShow();
+      expect(a, equals(b));
+    });
+
+    test('échantillonne ~15% des jours éligibles', () async {
+      final c = drawBuild();
+      var count = 0;
+      for (var i = 0; i < 700; i++) {
+        now = DateTime(2026, 1, 1).add(Duration(days: i));
+        if (await c.shouldShow()) count++;
+      }
+      expect(count / 700, closeTo(0.15, 0.06));
+    });
+
+    test('un salt différent décale les jours qui sortent', () {
+      // Désync inter-installs : sur une fenêtre, deux salts n'allument pas les
+      // mêmes jours.
+      final days = List.generate(90, (i) => DateTime(2026, 1, 1).add(Duration(days: i)));
+      final setA = days
+          .where((d) => _sorts('salt-A', d, kWellInformedDailySamplingPercent))
+          .map(_dayKey)
+          .toSet();
+      final setB = days
+          .where((d) => _sorts('salt-B', d, kWellInformedDailySamplingPercent))
+          .map(_dayKey)
+          .toSet();
+      expect(setA, isNot(equals(setB)));
+    });
   });
 }


### PR DESCRIPTION
## Quoi
Trois finitions de l'écran Essentiel / Flux Continu, remontées par le PO :
- **Haptique de section** — une seule vibration à l'arrivée sur une section (fini le double buzz du drag-puis-snapback), et carte un peu plus « collante » (marge 120→160 px).
- **Long-press** — l'aperçu flottant plein écran (`ArticlePreviewOverlay`) est remplacé par un « grow nudge » discret (1.0→1.06→1.0) via le nouveau widget partagé `LongPressGrowNudge`.
- **Sondage « bien informé » (NPS)** — nettement rarefié : cooldown submit 14j→60j, skip 5j→21j, tirage quotidien stable **non biaisé** (~1 jour éligible sur 7, salt par install × jour calendaire), relevance file 0.85→0.6.

## Pourquoi
Le buzz doublait sur un aller-retour de scroll ; l'aperçu plein écran au long-press était jugé trop intrusif ; le sondage NPS revenait trop souvent (irritant « trop fréquent »).

## Comment ça a été vérifié
- [x] `flutter test test/features/flux_continu/ test/features/well_informed/` — vert (dont `long_press_grow_test`, `well_informed_prompt_controller_test`, `essentiel_hi_fi_card_test`)
- [x] `flutter analyze` sur les dossiers touchés — 0 nouvelle issue (2 `withOpacity` infos pré-existants, fichiers non touchés)
- [x] `/simplify` passé — code jugé propre (3 angles /4 sans finding)
- [x] `changelog.json` — JSON valide, entrée « Essentiel » ajoutée

## Zones à risque
- `flux_continu_screen.dart` : cycle de vie des `ScrollNotification` (snapshot section au ScrollStart, buzz au ScrollEnd).
- `well_informed_prompt_provider.dart` : nouveau tirage quotidien + salt SharedPreferences.
- Le tirage/haptique se valident vraiment sur device (non couverts par test widget plein-écran).

## Suivi (hors scope)
- `notifIdHash` + un formateur `yyyy-mm-dd` sont dupliqués entre features → extraire un helper `core/utils` partagé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)