### PR TITLE
fix(bonnes-nouvelles): exclusion dure du sport en serein (defense-in-depth)

### DIFF
--- a/docs/bugs/bug-bonnes-nouvelles-qualite-regression.md
+++ b/docs/bugs/bug-bonnes-nouvelles-qualite-regression.md
@@ -89,3 +89,53 @@ worker à toucher : uniquement les 4 constantes de settings + le commentaire.
 
 - `packages/api/app/config.py` (4 constantes + commentaire)
 - `docs/bugs/bug-bonnes-nouvelles-qualite-regression.md` (ce doc)
+
+---
+
+## Addendum — P3 HARDENING : exclusion dure du sport en serein (worker mort 30/06)
+
+Contexte réévalué (preuves DB prod juillet 2026) : le batching #914 n'était que
+le déclencheur superficiel. La **vraie** cause du sport (NBA/Basket USA) qui
+remonte dans « Bonnes nouvelles » est double :
+
+1. **Worker de classif mort le 30/06** → tout le frais a
+   `is_good_news / is_serene / theme = NULL` (34,5k articles).
+2. En prod, le fallback d'urgence retombe sur du contenu quelconque non-anxiogène
+   et n'applique **aucune** exclusion sport (le `-80` du sélecteur n'est qu'une
+   pénalité de score, pas un filtre).
+
+P1 (ranimer le worker, ops Railway) et P2 (release hebdo #948/#957) restent des
+actions PO. Ce P3 est le volet code — **defense-in-depth** : empêcher le sport
+d'entrer dans « Bonnes nouvelles » **même si** le classifieur good-news produit un
+faux positif (une altercation/transaction NBA n'est pas « sport-shaped » pour le
+LLM et peut passer `is_good_news=True`).
+
+### Changements
+
+1. **`is_sport_content`** (`services/recommendation/filter_presets.py`) : fallback
+   sur `content.source.theme` quand `content.theme` est NULL (article non
+   classifié). Accès non-déclenchant (`__dict__.get("source")`, relation lue
+   seulement si déjà eager-loaded) → pas de lazy-load async involontaire.
+2. **Sélecteur serein** (`services/digest_selector.py::_score_candidates`) : en
+   mode `serein`, un article sport est **écarté du pool** (`continue`) au lieu
+   d'être seulement pénalisé (-80). En `pour_vous`, la pénalité reste inchangée.
+3. **Fallback d'urgence serein** (`services/digest_service.py::_get_emergency_candidates`) :
+   skip dur des articles sport quand `is_serene` (defense-in-depth sur le dernier
+   recours, source eager-loaded).
+
+### Tests
+
+- `tests/test_low_priority_cap.py` — 3 cas fallback `source.theme` d'`is_sport_content`
+  (NULL→source sport flag ; content.theme prime ; source tech ne flag pas).
+- `tests/test_emergency_candidates_serein.py` — sport exclu du fallback serein
+  par mot-clé (NBA, source mal-thémée `tech`) **et** par `source.theme="sport"`
+  (titre neutre + theme article NULL).
+- `tests/test_digest_selector.py` — l'ancien `test_sport_penalty_applies_in_serein_mode`
+  devient `test_sport_hard_excluded_in_serein_mode` (le sport n'est plus scoré en serein).
+
+### Note qualité modèle
+
+`GOOD_NEWS_MODEL = "mistral-large-latest"` est **inchangé depuis #594** (déjà le
+modèle le plus cher). Repasser à un modèle plus coûteux est inutile : le levier,
+si le tri reste laxiste une fois le worker sain, est la strictness du prompt
+pass-2 ou la porte `serene`, pas un swap de modèle.

--- a/packages/api/app/services/digest_selector.py
+++ b/packages/api/app/services/digest_selector.py
@@ -1428,8 +1428,16 @@ class DigestSelector:
                 # --- Ajustements digest-spécifiques (post-pilier) ---
                 # Pas d'équivalent pilier : appliqués après la combinaison.
 
-                # Pénalité Sport (les deux modes).
+                # Sport : pénalité en « pour_vous », EXCLUSION DURE en serein.
+                # « Bonnes nouvelles » ne doit jamais contenir de sport, même si
+                # le classifieur good-news a produit un faux positif (une
+                # altercation/transaction NBA n'est pas « sport-shaped » pour le
+                # LLM et peut passer is_good_news=True). Une simple pénalité (-80)
+                # laisse le sport remonter quand le pool serein est maigre → on
+                # l'écarte du pool au lieu de le pénaliser.
                 if is_sport_content(content):
+                    if mode == "serein":
+                        continue
                     final_score += ScoringWeights.DIGEST_SPORT_PENALTY
                     breakdown.append(
                         DigestScoreBreakdown(

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -1096,7 +1096,10 @@ class DigestService:
 
         from app.models.content import Content
         from app.models.source import Source
-        from app.services.recommendation.filter_presets import apply_good_news_filter
+        from app.services.recommendation.filter_presets import (
+            apply_good_news_filter,
+            is_sport_content,
+        )
 
         # Mode serein = "Bonnes nouvelles du jour" : la promesse (is_good_news=True)
         # prime sur la quantité. On applique le MÊME hard-filter que le reste du
@@ -1217,6 +1220,13 @@ class DigestService:
         for content in all_contents:
             if len(selected) >= limit:
                 break
+
+            # Exclusion dure sport en serein (defense-in-depth). Même si un
+            # article arrive avec is_good_news=True par erreur, le sport n'entre
+            # jamais dans « Bonnes nouvelles ». `content.source` est eager-loaded
+            # (selectinload ci-dessus) → is_sport_content peut lire source.theme.
+            if is_serene and is_sport_content(content):
+                continue
 
             source_id = content.source_id
             if source_counts[source_id] >= MAX_PER_SOURCE:

--- a/packages/api/app/services/recommendation/filter_presets.py
+++ b/packages/api/app/services/recommendation/filter_presets.py
@@ -582,9 +582,22 @@ def is_sport_cluster(cluster: TopicCluster) -> bool:
 
 
 def is_sport_content(content: Content) -> bool:
-    """Article individuel de type Sport (theme, topics ou keywords titre/desc)."""
+    """Article individuel de type Sport (theme, topics ou keywords titre/desc).
+
+    Quand `content.theme` est NULL (article non encore classifié — ex. worker de
+    classif à l'arrêt, tout le frais a `theme=NULL`), on retombe sur le thème de
+    la **source** (`source.theme`) s'il est déjà chargé. Ça rattrape un média
+    100 % sport (`source.theme="sport"`) dont l'article n'a ni thème propre ni
+    mot-clé sport dans le titre. Accès non-déclenchant : on ne lit la relation
+    que si elle est déjà eager-loaded (`selectinload` dans les chemins digest)
+    pour éviter un lazy-load async involontaire.
+    """
     if content.theme and content.theme.lower() in LOW_PRIORITY_SPORT_THEMES:
         return True
+    if not content.theme:
+        source_theme = getattr(content.__dict__.get("source"), "theme", None)
+        if source_theme and source_theme.lower() in LOW_PRIORITY_SPORT_THEMES:
+            return True
     if content.topics and any(
         isinstance(t, str) and t.lower() == "sport" for t in content.topics
     ):

--- a/packages/api/tests/test_digest_selector.py
+++ b/packages/api/tests/test_digest_selector.py
@@ -996,13 +996,17 @@ class TestScoreCandidatesSportPenalty:
         assert sport_entry.pillar == "penalite"
 
     @pytest.mark.asyncio
-    async def test_sport_penalty_applies_in_serein_mode(self, selector, context):
-        """La pénalité Sport s'applique aussi en mode serein."""
-        from app.services.recommendation.scoring_config import ScoringWeights
+    async def test_sport_hard_excluded_in_serein_mode(self, selector, context):
+        """En serein, le sport est EXCLU du pool (pas seulement pénalisé).
 
+        « Bonnes nouvelles » ne doit jamais contenir de sport, même si le
+        classifieur good-news a produit un faux positif. Un article sport est
+        donc retiré des candidats scorés, tandis qu'un article neutre passe."""
         sport_src = make_source(name="Sport Source", theme="sport")
+        tech_src = make_source(name="Tech Source", theme="tech")
         now = datetime.now(UTC)
         sport_content = make_content(source=sport_src, theme="sport", published_at=now)
+        tech_content = make_content(source=tech_src, theme="tech", published_at=now)
 
         selector.rec_service = Mock()
         selector.rec_service.fetch_impression_data = AsyncMock(return_value={})
@@ -1012,15 +1016,12 @@ class TestScoreCandidatesSportPenalty:
         )
 
         scored = await selector._score_candidates(
-            [sport_content], context, mode="serein"
+            [sport_content, tech_content], context, mode="serein"
         )
 
-        _, _, breakdown, _ = scored[0]
-        sport_entry = next(
-            (b for b in breakdown if b.label == "Sport (priorité réduite)"), None
-        )
-        assert sport_entry is not None
-        assert sport_entry.points == ScoringWeights.DIGEST_SPORT_PENALTY
+        scored_ids = {c.id for c, _, _, _ in scored}
+        assert sport_content.id not in scored_ids
+        assert tech_content.id in scored_ids
 
     @pytest.mark.asyncio
     async def test_sport_detected_via_topics(self, selector, context):

--- a/packages/api/tests/test_emergency_candidates_serein.py
+++ b/packages/api/tests/test_emergency_candidates_serein.py
@@ -125,3 +125,61 @@ async def test_non_serein_emergency_unaffected(db_session):
     )
 
     assert len(items) == 1
+
+
+@pytest.mark.asyncio
+async def test_serein_emergency_excludes_sport_by_keyword(db_session):
+    """Sport exclu du fallback serein même avec is_good_news=True (faux positif).
+
+    Cas réel : source Basket USA mal thémée (`tech`), altercation NBA classée
+    is_good_news=True par erreur → doit être écartée par exclusion dure sport
+    (mot-clé « NBA » dans le titre)."""
+    source = await _make_source(db_session, theme="tech")
+
+    good = await _make_content(
+        db_session,
+        source,
+        "Une avancée concrète pour l'accès à l'eau",
+        is_good_news=True,
+    )
+    # Altercation NBA marquée is_good_news=True par erreur.
+    await _make_content(
+        db_session,
+        source,
+        "Tyler Herro et Bam Adebayo en viennent aux mains (NBA)",
+        is_good_news=True,
+    )
+
+    service = DigestService(db_session)
+    items = await service._get_emergency_candidates(
+        user_id=uuid4(), limit=5, is_serene=True
+    )
+
+    returned_ids = {item.content.id for item in items}
+    assert returned_ids == {good.id}
+
+
+@pytest.mark.asyncio
+async def test_serein_emergency_excludes_sport_by_source_theme(db_session):
+    """Sport exclu via source.theme quand l'article n'a ni thème ni mot-clé.
+
+    Article non classifié (theme NULL) au titre neutre, mais issu d'une source
+    `theme="sport"` — rattrapé par le fallback source.theme d'is_sport_content
+    même si forcé is_good_news=True."""
+    sport_source = await _make_source(db_session, theme="sport")
+
+    # is_good_news=True mais titre neutre + theme article NULL → seul source.theme
+    # le trahit.
+    await _make_content(
+        db_session,
+        sport_source,
+        "Le résumé de la soirée",
+        is_good_news=True,
+    )
+
+    service = DigestService(db_session)
+    items = await service._get_emergency_candidates(
+        user_id=uuid4(), limit=5, is_serene=True
+    )
+
+    assert items == []

--- a/packages/api/tests/test_low_priority_cap.py
+++ b/packages/api/tests/test_low_priority_cap.py
@@ -26,11 +26,17 @@ from app.services.recommendation.filter_presets import (
 
 
 @dataclass
+class _FakeSource:
+    theme: str | None = None
+
+
+@dataclass
 class _FakeContent:
     title: str | None = None
     description: str | None = None
     theme: str | None = None
     topics: list[str] | None = None
+    source: object | None = None
 
 
 @dataclass
@@ -119,6 +125,34 @@ class TestIsSportContent:
         c = _FakeContent(theme=None, topics=None, title=None, description=None)
         assert not is_sport_content(c)
 
+    def test_source_theme_fallback_when_content_theme_null(self):
+        # Article non classifié (theme NULL, titre sans mot-clé sport) mais issu
+        # d'une source 100 % sport → rattrapé par le fallback source.theme.
+        c = _FakeContent(
+            theme=None,
+            title="Le point sur la soirée",
+            source=_FakeSource(theme="sport"),
+        )
+        assert is_sport_content(c)
+
+    def test_source_theme_ignored_when_content_theme_present(self):
+        # Si l'article a déjà un thème propre non-sport, on ne « surclasse » pas
+        # via la source : content.theme prime (le fallback ne joue qu'en NULL).
+        c = _FakeContent(
+            theme="economy",
+            title="Rapport trimestriel",
+            source=_FakeSource(theme="sport"),
+        )
+        assert not is_sport_content(c)
+
+    def test_non_sport_source_theme_does_not_flag(self):
+        c = _FakeContent(
+            theme=None,
+            title="Actu tech neutre",
+            source=_FakeSource(theme="tech"),
+        )
+        assert not is_sport_content(c)
+
 
 class TestIsFaitsDiversCluster:
     def test_majority_faits_divers(self):
@@ -155,9 +189,7 @@ class TestCapLowPriorityClusters:
         assert economy.cluster_id in ids
 
     def test_multiple_faits_divers_capped_to_one(self):
-        fd_a = _make(
-            titles=["Accident mortel", "Incendie", "Braquage"], source_count=5
-        )
+        fd_a = _make(titles=["Accident mortel", "Incendie", "Braquage"], source_count=5)
         fd_b = _make(titles=["Accident", "Incendie", "Collision"], source_count=4)
         politics = _make(theme="politics", titles=["Réforme"], source_count=3)
 
@@ -189,7 +221,11 @@ class TestCapLowPriorityClusters:
         b = _make(theme="sport", titles=["b"])
         c = _make(theme="economy", titles=["c"])
         kept = cap_low_priority_clusters([a, b, c])
-        assert [k.cluster_id for k in kept] == [a.cluster_id, b.cluster_id, c.cluster_id]
+        assert [k.cluster_id for k in kept] == [
+            a.cluster_id,
+            b.cluster_id,
+            c.cluster_id,
+        ]
 
     def test_custom_caps(self):
         sport_a = _make(theme="sport", titles=["a"])
@@ -323,18 +359,14 @@ class TestIsNewsBulletinTitle:
     def test_l_emission_du_president(self):
         """Régression : la forme « L'émission du <x> » reste matchée par le
         pattern historique `^l['émission`."""
-        assert is_news_bulletin_title(
-            "L'émission du président qu'il faut écouter"
-        )
+        assert is_news_bulletin_title("L'émission du président qu'il faut écouter")
 
     # --- bug-actus-du-jour-ranking.md (Partie B) : séries éditoriales nommées ---
 
     def test_serie_jaenada_art_de_la_contre_enquete(self):
         """« Philippe Jaenada, l'art de la contre-enquête » — série France
         Culture qui peuplait l'Essentiel malgré le fix anti-doublon."""
-        assert is_news_bulletin_title(
-            "Philippe Jaenada, l'art de la contre-enquête"
-        )
+        assert is_news_bulletin_title("Philippe Jaenada, l'art de la contre-enquête")
 
     def test_serie_art_de_typographic_apostrophe(self):
         assert is_news_bulletin_title("Marguerite Duras, l’art du roman")


### PR DESCRIPTION
## Quoi

Le sport (NBA / Basket USA) remontait dans « Bonnes nouvelles ». Ce P3 durcit le **volet code** : le sport n'entre plus jamais en mode serein, **même si** le classifieur good-news produit un faux positif.

- **`is_sport_content`** : fallback sur `content.source.theme` quand `content.theme` est `NULL` (article non classifié — cas du worker mort). Accès non-déclenchant (`content.__dict__.get("source")`) → pas de lazy-load async involontaire.
- **Sélecteur serein** (`_score_candidates`) : le sport est **écarté du pool** (`continue`) au lieu d'être seulement pénalisé (-80). En `pour_vous`, la pénalité reste inchangée.
- **Fallback d'urgence serein** (`_get_emergency_candidates`) : skip dur du sport (source eager-loaded).

## Pourquoi

Racine double (preuves DB prod juillet 2026) : (1) worker de classif mort le 30/06 → tout le frais a `theme/is_good_news/is_serene = NULL` ; (2) le fallback d'urgence retombait sur du contenu quelconque non-anxiogène sans exclusion sport (le `-80` n'est qu'une pénalité de score, pas un filtre). P1 (ranimer le worker) et P2 (release hebdo) restent des actions PO ; ce P3 est la defense-in-depth côté code.

`GOOD_NEWS_MODEL = "mistral-large-latest"` reste **inchangé** — le levier n'est pas un swap de modèle.

## Comment ça a été vérifié

- [x] `pytest` suite complète — **2253 passed, 18 skipped, 2 xfailed** (`--import-mode=importlib`)
- [x] Tests ciblés : 3 cas `source.theme` fallback (`test_low_priority_cap`) + 2 cas fallback serein mot-clé/theme (`test_emergency_candidates_serein`) + rename `test_sport_hard_excluded_in_serein_mode` (`test_digest_selector`)
- [x] `ruff check` + `ruff format --check` OK sur les fichiers touchés
- [x] `/simplify` passé (allègement du fallback `is_sport_content`)
- Pas de changement mobile, **aucune migration Alembic**

## Zones à risque

- `digest_selector.py` / `digest_service.py` (chemins digest serein + fallback d'urgence)
- `filter_presets.py::is_sport_content` (prédicat partagé) — le fallback `source.theme` dépend d'un `source` eager-loaded ; les deux call-sites digest le garantissent (`selectinload`).