### PR TITLE
fix(tournée): placement Essentiel/Flâner durable en DB (sources/thèmes conservés à la réinstallation)

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Ma Tournée",
+      "summary": "Tes sources et thèmes rangés dans l'Essentiel y restent : leur place est désormais sauvegardée et retrouvée sur chaque appareil, même après réinstallation."
+    },
+    {
       "tag": "Rattrapage",
       "summary": "« Cette semaine » : accès Tout lire par section et bonnes nouvelles de toute la semaine."
     },

--- a/apps/mobile/lib/features/flux_continu/providers/essentiel_placement_sync.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/essentiel_placement_sync.dart
@@ -1,0 +1,179 @@
+/// Réconciliation du placement Essentiel/Flâner entre la DB (source de vérité
+/// durable) et les prefs locales (cache de rendu).
+///
+/// **Le bug corrigé.** Jusqu'ici le *mode de placement* d'un favori (« Chaque
+/// jour dans l'Essentiel » vs « Flâner ») ne vivait que dans les
+/// SharedPreferences du device (`tournee_order_v1` / `pinned_tabs_order_v1`) —
+/// le favori lui-même étant persisté en DB. À la réinstallation / nouveau
+/// device / purge du stockage, le favori survivait mais son placement Essentiel
+/// disparaissait silencieusement → la source « tombait » de l'Essentiel.
+///
+/// Ce module fait de la colonne DB `essentiel_mode` la source de vérité durable :
+///
+///  1. **Backfill local → DB** (one-shot, gardé par [_kReconciledKey]) : pour
+///     chaque favori dont le backend ignore encore le placement
+///     (`essentiel_mode == null`), on pousse le placement *local actuel* du
+///     device. Capture l'état device **avant** qu'il ne puisse être perdu.
+///  2. **Hydratation DB → local** (à chaque cold boot, idempotente) : pour
+///     chaque favori dont le backend connaît le placement
+///     (`essentiel_mode != null`), on aligne les prefs locales dessus. C'est ce
+///     qui **restaure l'appartenance après réinstallation / nouveau device**.
+///
+/// La règle de rendu (`TourneeOrderState.sourceIsEssentiel`, et pour les thèmes
+/// la présence dans `pinned_tabs_order_v1`) reste inchangée : elle lit les prefs,
+/// désormais rendues durables par l'hydratation.
+///
+/// ⚠️ Asymétrie source/thème (conventions inverses, préservée telle quelle) :
+///  - **Source** : Essentiel ⟺ clé `source:<id>` présente dans `tournee_order_v1`
+///    (défaut = Flâner).
+///  - **Thème** : Flâner ⟺ clé `theme:<slug>` présente dans `pinned_tabs_order_v1`
+///    (défaut = Essentiel).
+library;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../my_interests/models/user_interests_state.dart'
+    show InterestState, ThemeFavoriteRef;
+import '../../my_interests/providers/user_interests_provider.dart';
+import '../../my_interests/providers/user_sources_state_provider.dart';
+import '../../feed/providers/tab_order_prefs_provider.dart'
+    show tabOrderPrefsProvider, tabOrderSourceKey, tabOrderThemeKey;
+import 'tournee_order_prefs_provider.dart'
+    show tourneeOrderPrefsProvider, tourneeSourceKey, tourneeThemeKey;
+
+/// Flag prefs : le backfill local → DB a été effectué une fois sur ce device.
+const String _kReconciledKey = 'essentiel_placement_reconciled_v1';
+
+/// Réconcilie le placement Essentiel/Flâner. À appeler une fois par cold boot,
+/// depuis le bootstrap de la Tournée. Best-effort : toute erreur est avalée
+/// (log debug) — la réconciliation ne doit jamais casser le chargement du feed.
+Future<void> reconcileEssentielPlacement(Ref ref) async {
+  try {
+    // 1. État backend (source de vérité). On force la résolution des deux
+    //    providers (lazy pendant le bootstrap) en parallèle : ils sont
+    //    indépendants, on chevauche donc leurs fetchs plutôt que de les enchaîner.
+    final (sourcesState, interestsState) = await (
+      ref.read(userSourcesStateProvider.future),
+      ref.read(userInterestsProvider.future),
+    ).wait;
+
+    final favSources = sourcesState.sources
+        .where((s) => s.state == InterestState.favorite)
+        .toList();
+    final favThemes = interestsState.themes
+        .where((t) => t.state == InterestState.favorite)
+        .toList();
+    if (favSources.isEmpty && favThemes.isEmpty) return;
+
+    // 2. État local du device (prefs déjà chargées au bootstrap).
+    final tourneeState = ref.read(tourneeOrderPrefsProvider);
+    final tournee = List<String>.of(tourneeState.order);
+    final tab = List<String>.of(ref.read(tabOrderPrefsProvider));
+
+    final prefs = await SharedPreferences.getInstance();
+    final alreadyReconciled = prefs.getBool(_kReconciledKey) ?? false;
+
+    // ── Backfill local → DB (one-shot) ──────────────────────────────────────
+    var backfillFullySucceeded = true;
+    if (!alreadyReconciled) {
+      for (final s in favSources) {
+        if (s.essentielMode != null) continue; // placement déjà connu en DB.
+        // Règle d'appartenance canonique (partagée par le provider Tournée, les
+        // onglets Flâner et la sheet de gestion) — évite une 4ᵉ définition locale.
+        final localEssentiel = tourneeState.sourceIsEssentiel(s.sourceId);
+        try {
+          await ref.read(userSourcesStateProvider.notifier).setSourceState(
+                s.sourceId,
+                InterestState.favorite,
+                essentielMode: localEssentiel,
+              );
+        } catch (e) {
+          backfillFullySucceeded = false;
+          debugPrint('[essentiel-sync] backfill source ${s.sourceId} failed: $e');
+        }
+      }
+      for (final t in favThemes) {
+        if (t.essentielMode != null) continue;
+        // Thème : Flâner ⟺ présent dans pinned_tabs ; sinon Essentiel (défaut).
+        final localEssentiel = !tab.contains(tabOrderThemeKey(t.interestSlug));
+        try {
+          await ref.read(userInterestsProvider.notifier).setInterestState(
+                ThemeFavoriteRef(slug: t.interestSlug),
+                InterestState.favorite,
+                essentielMode: localEssentiel,
+              );
+        } catch (e) {
+          backfillFullySucceeded = false;
+          debugPrint(
+              '[essentiel-sync] backfill theme ${t.interestSlug} failed: $e');
+        }
+      }
+      // On ne pose le flag que si le backfill a intégralement réussi : sinon on
+      // retentera au prochain cold boot (les favoris déjà poussés seront alors
+      // non-null → sautés, donc l'opération reste idempotente).
+      if (backfillFullySucceeded) {
+        try {
+          await prefs.setBool(_kReconciledKey, true);
+        } catch (_) {
+          // best-effort.
+        }
+      }
+    }
+
+    // ── Hydratation DB → local (idempotente, chaque cold boot) ───────────────
+    // On repart des listes backend fraîches : un favori tout juste backfillé a
+    // désormais un essentielMode local == backend, donc l'alignement est un
+    // no-op pour lui. Pour les favoris déjà connus en DB (essentielMode != null,
+    // ex. resync après réinstallation) c'est ici qu'on restaure le placement.
+    // Copies mutables : les originaux `tournee`/`tab` restent la référence pour
+    // le check de drift plus bas. Les clés sont uniques (modèle exclusif + ajouts
+    // gardés par `contains`), donc `remove` (1er match) suffit.
+    final nextTournee = List<String>.of(tournee);
+    final nextTab = List<String>.of(tab);
+
+    for (final s in favSources) {
+      final mode = s.essentielMode;
+      if (mode == null) continue;
+      final tKey = tourneeSourceKey(s.sourceId);
+      final bKey = tabOrderSourceKey(s.sourceId);
+      if (mode) {
+        // Essentiel : présent dans tournee, absent de Flâner (modèle exclusif).
+        if (!nextTournee.contains(tKey)) nextTournee.add(tKey);
+        nextTab.remove(bKey);
+      } else {
+        // Flâner : retiré de l'Essentiel, présent dans les onglets.
+        nextTournee.remove(tKey);
+        if (!nextTab.contains(bKey)) nextTab.add(bKey);
+      }
+    }
+
+    for (final t in favThemes) {
+      final mode = t.essentielMode;
+      if (mode == null) continue;
+      final tKey = tourneeThemeKey(t.interestSlug);
+      final bKey = tabOrderThemeKey(t.interestSlug);
+      if (mode) {
+        // Essentiel = défaut du thème : il suffit de le retirer de Flâner.
+        nextTab.remove(bKey);
+      } else {
+        // Flâner : présent dans les onglets, retiré de l'Essentiel explicite.
+        nextTournee.remove(tKey);
+        if (!nextTab.contains(bKey)) nextTab.add(bKey);
+      }
+    }
+
+    // Écritures groupées (une seule notif par provider) uniquement si drift réel.
+    if (!listEquals(nextTournee, tournee)) {
+      await ref
+          .read(tourneeOrderPrefsProvider.notifier)
+          .setOrder(nextTournee);
+    }
+    if (!listEquals(nextTab, tab)) {
+      await ref.read(tabOrderPrefsProvider.notifier).setOrder(nextTab);
+    }
+  } catch (e, st) {
+    debugPrint('[essentiel-sync] reconcile skipped on error: $e\n$st');
+  }
+}

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -35,6 +35,7 @@ import '../repositories/essentiel_repository.dart';
 import '../repositories/flux_continu_repository.dart';
 import '../services/flux_continu_cache_service.dart';
 import '../services/tournee_progress_service.dart';
+import 'essentiel_placement_sync.dart' show reconcileEssentielPlacement;
 import '../utils/notif_teasers.dart';
 import '../utils/section_fit.dart';
 import '../utils/theme_color_mapping.dart';
@@ -367,6 +368,15 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     // avec un JWT frais. Le squelette/cache est déjà peint, donc cette attente
     // gate la DATA, pas les pixels.
     await _awaitInitialRefresh();
+
+    // Réconciliation du placement Essentiel/Flâner (source de vérité DB) —
+    // non-bloquante : elle ne doit pas retarder la DATA. Lancée pendant que
+    // `_bootstrapping` est encore vrai (les listeners prefs sont donc muets) ;
+    // si elle écrit un placement restauré après la fin du bootstrap, les
+    // listeners `tournee_order`/`pinned_tabs` rejoueront le refetch/recompose
+    // qui fait (ré)apparaître la section dans la Tournée. Cf.
+    // [reconcileEssentielPlacement].
+    unawaited(reconcileEssentielPlacement(ref));
 
     try {
       return await _fetchAll();
@@ -2120,14 +2130,18 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     await ref.read(tourneeOrderPrefsProvider.notifier).markCustomized();
     try {
       if (section.kind == SectionKind.source && section.sourceId != null) {
-        await ref
-            .read(userSourcesStateProvider.notifier)
-            .setSourceState(section.sourceId!, InterestState.favorite);
+        await ref.read(userSourcesStateProvider.notifier).setSourceState(
+              section.sourceId!,
+              InterestState.favorite,
+              // Promotion = placement Essentiel : persiste le mode en DB.
+              essentielMode: true,
+            );
         await _appendTourneeOrder(tourneeSourceKey(section.sourceId!));
       } else if (section.themeSlug != null) {
         await ref.read(userInterestsProvider.notifier).setInterestState(
               ThemeFavoriteRef(slug: section.themeSlug!),
               InterestState.favorite,
+              essentielMode: true,
             );
         await _appendTourneeOrder(tourneeThemeKey(section.themeSlug!));
       }

--- a/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
@@ -194,6 +194,8 @@ class _ManageFavoritesContentState
           .setInterestState(
             ThemeFavoriteRef(slug: slug),
             InterestState.favorite,
+            // Ajout depuis « Gérer » = placement Essentiel, persisté en DB.
+            essentielMode: true,
           );
       await _appendTournee(tourneeThemeKey(slug));
     } catch (e) {
@@ -211,7 +213,12 @@ class _ManageFavoritesContentState
     try {
       await ref
           .read(userSourcesStateProvider.notifier)
-          .setSourceState(sourceId, InterestState.favorite);
+          .setSourceState(
+            sourceId,
+            InterestState.favorite,
+            // Persiste le mode de la porte d'entrée (Essentiel vs Flâner) en DB.
+            essentielMode: toEssentiel,
+          );
       if (toEssentiel) {
         await _appendTournee(tourneeSourceKey(sourceId));
       } else {
@@ -242,6 +249,9 @@ class _ManageFavoritesContentState
     await ref.read(tourneeOrderPrefsProvider.notifier).markCustomized();
     await _removeTournee(tourneeSourceKey(sourceId));
     await _appendTab(tabOrderSourceKey(sourceId));
+    // Persiste le placement Flâner en DB (la source reste favorite, seul le mode
+    // change) — durable au-delà des prefs locales, resync sur chaque device.
+    await _persistSourceMode(sourceId, essentiel: false);
     NotificationService.showSuccess('Déplacé vers Flâner');
   }
 
@@ -249,7 +259,22 @@ class _ManageFavoritesContentState
     await ref.read(tourneeOrderPrefsProvider.notifier).markCustomized();
     await _removeTab(tabOrderSourceKey(sourceId));
     await _appendTournee(tourneeSourceKey(sourceId));
+    await _persistSourceMode(sourceId, essentiel: true);
     NotificationService.showSuccess('Déplacé vers l\'Essentiel');
+  }
+
+  /// Écrit le mode Essentiel/Flâner d'une source favorite en DB (best-effort :
+  /// l'échec réseau ne doit pas casser le déplacement local déjà appliqué).
+  Future<void> _persistSourceMode(String sourceId,
+      {required bool essentiel}) async {
+    try {
+      await ref
+          .read(userSourcesStateProvider.notifier)
+          .setSourceState(sourceId, InterestState.favorite,
+              essentielMode: essentiel);
+    } catch (e) {
+      NotificationService.showError('Erreur : $e');
+    }
   }
 
   // Thèmes : même modèle exclusif que les sources. La clé `theme:<slug>` est
@@ -260,6 +285,9 @@ class _ManageFavoritesContentState
     await ref.read(tourneeOrderPrefsProvider.notifier).markCustomized();
     await _removeTournee(tourneeThemeKey(slug));
     await _appendTab(tabOrderThemeKey(slug));
+    // Persiste le placement Flâner en DB (le thème reste favorite, seul le mode
+    // change) — durable au-delà des prefs locales, resync sur chaque device.
+    await _persistThemeMode(slug, essentiel: false);
     NotificationService.showSuccess('Déplacé vers Flâner');
   }
 
@@ -267,7 +295,20 @@ class _ManageFavoritesContentState
     await ref.read(tourneeOrderPrefsProvider.notifier).markCustomized();
     await _removeTab(tabOrderThemeKey(slug));
     await _appendTournee(tourneeThemeKey(slug));
+    await _persistThemeMode(slug, essentiel: true);
     NotificationService.showSuccess('Déplacé vers l\'Essentiel');
+  }
+
+  /// Écrit le mode Essentiel/Flâner d'un thème favori en DB (best-effort).
+  Future<void> _persistThemeMode(String slug, {required bool essentiel}) async {
+    try {
+      await ref
+          .read(userInterestsProvider.notifier)
+          .setInterestState(ThemeFavoriteRef(slug: slug), InterestState.favorite,
+              essentielMode: essentiel);
+    } catch (e) {
+      NotificationService.showError('Erreur : $e');
+    }
   }
 
   // ── Retraits ────────────────────────────────────────────────────────────

--- a/apps/mobile/lib/features/my_interests/models/user_interests_state.dart
+++ b/apps/mobile/lib/features/my_interests/models/user_interests_state.dart
@@ -156,10 +156,15 @@ class ThemeInterest {
   final double weight;
   final InterestState state;
 
+  /// Placement Essentiel/Flâner persisté en DB (source de vérité durable).
+  /// true = Essentiel, false = Flâner, null = jamais placé / legacy.
+  final bool? essentielMode;
+
   const ThemeInterest({
     required this.interestSlug,
     required this.weight,
     required this.state,
+    this.essentielMode,
   });
 
   factory ThemeInterest.fromJson(Map<String, dynamic> json) {
@@ -167,17 +172,20 @@ class ThemeInterest {
       interestSlug: json['interest_slug'] as String,
       weight: (json['weight'] as num).toDouble(),
       state: InterestState.fromJson(json['state'] as String),
+      essentielMode: json['essentiel_mode'] as bool?,
     );
   }
 
   ThemeInterest copyWith({
     double? weight,
     InterestState? state,
+    bool? essentielMode,
   }) =>
       ThemeInterest(
         interestSlug: interestSlug,
         weight: weight ?? this.weight,
         state: state ?? this.state,
+        essentielMode: essentielMode ?? this.essentielMode,
       );
 }
 

--- a/apps/mobile/lib/features/my_interests/models/user_sources_state.dart
+++ b/apps/mobile/lib/features/my_interests/models/user_sources_state.dart
@@ -11,10 +11,15 @@ class SourceInterest {
   final InterestState state;
   final double priorityMultiplier;
 
+  /// Placement Essentiel/Flâner persisté en DB (source de vérité durable).
+  /// true = Essentiel, false = Flâner, null = jamais placé / legacy.
+  final bool? essentielMode;
+
   const SourceInterest({
     required this.sourceId,
     required this.state,
     required this.priorityMultiplier,
+    this.essentielMode,
   });
 
   factory SourceInterest.fromJson(Map<String, dynamic> json) {
@@ -22,17 +27,20 @@ class SourceInterest {
       sourceId: json['source_id'] as String,
       state: InterestState.fromJson(json['state'] as String),
       priorityMultiplier: (json['priority_multiplier'] as num).toDouble(),
+      essentielMode: json['essentiel_mode'] as bool?,
     );
   }
 
   SourceInterest copyWith({
     InterestState? state,
     double? priorityMultiplier,
+    bool? essentielMode,
   }) =>
       SourceInterest(
         sourceId: sourceId,
         state: state ?? this.state,
         priorityMultiplier: priorityMultiplier ?? this.priorityMultiplier,
+        essentielMode: essentielMode ?? this.essentielMode,
       );
 }
 

--- a/apps/mobile/lib/features/my_interests/providers/user_interests_provider.dart
+++ b/apps/mobile/lib/features/my_interests/providers/user_interests_provider.dart
@@ -21,21 +21,24 @@ class UserInterestsNotifier extends AsyncNotifier<UserInterestsState> {
   /// un snackbar « tu as déjà 5 favoris ».
   Future<void> setInterestState(
     FavoriteRef refTarget,
-    InterestState newState,
-  ) async {
+    InterestState newState, {
+    bool? essentielMode,
+  }) async {
     final current = state.value;
     if (current == null) return;
 
     final repo = ref.read(userInterestsRepositoryProvider);
     final previousState = state;
 
-    final optimistic = _applyLocal(current, refTarget, newState);
+    final optimistic =
+        _applyLocal(current, refTarget, newState, essentielMode: essentielMode);
     state = AsyncValue.data(optimistic);
 
     try {
       final updated = await repo.setInterestState(
         ref: refTarget,
         state: newState,
+        essentielMode: essentielMode,
       );
       state = AsyncValue.data(updated);
     } on FavoriteCapReachedException {
@@ -74,8 +77,9 @@ class UserInterestsNotifier extends AsyncNotifier<UserInterestsState> {
   UserInterestsState _applyLocal(
     UserInterestsState current,
     FavoriteRef refTarget,
-    InterestState newState,
-  ) {
+    InterestState newState, {
+    bool? essentielMode,
+  }) {
     final themes = [...current.themes];
     final customTopics = [...current.customTopics];
 
@@ -83,13 +87,15 @@ class UserInterestsNotifier extends AsyncNotifier<UserInterestsState> {
       case ThemeFavoriteRef(:final slug):
         final idx = themes.indexWhere((t) => t.interestSlug == slug);
         if (idx >= 0) {
-          themes[idx] = themes[idx].copyWith(state: newState);
+          themes[idx] =
+              themes[idx].copyWith(state: newState, essentielMode: essentielMode);
         } else {
           themes.add(
             ThemeInterest(
               interestSlug: slug,
               weight: 1.0,
               state: newState,
+              essentielMode: essentielMode,
             ),
           );
         }

--- a/apps/mobile/lib/features/my_interests/providers/user_sources_state_provider.dart
+++ b/apps/mobile/lib/features/my_interests/providers/user_sources_state_provider.dart
@@ -18,7 +18,13 @@ class UserSourcesStateNotifier extends AsyncNotifier<UserSourcesState> {
     return repo.fetchSourcesState();
   }
 
-  Future<void> setSourceState(String sourceId, InterestState newState) async {
+  /// `essentielMode` : placement Essentiel/Flâner à persister en DB. `null` =
+  /// préserver l'existant côté backend (bascule d'état sans déplacement).
+  Future<void> setSourceState(
+    String sourceId,
+    InterestState newState, {
+    bool? essentielMode,
+  }) async {
     final current = state.value;
     if (current == null) return;
 
@@ -28,12 +34,14 @@ class UserSourcesStateNotifier extends AsyncNotifier<UserSourcesState> {
     final sources = [...current.sources];
     final idx = sources.indexWhere((s) => s.sourceId == sourceId);
     if (idx >= 0) {
-      sources[idx] = sources[idx].copyWith(state: newState);
+      sources[idx] =
+          sources[idx].copyWith(state: newState, essentielMode: essentielMode);
     } else {
       sources.add(SourceInterest(
         sourceId: sourceId,
         state: newState,
         priorityMultiplier: 1.0,
+        essentielMode: essentielMode,
       ));
     }
 
@@ -55,8 +63,11 @@ class UserSourcesStateNotifier extends AsyncNotifier<UserSourcesState> {
     ));
 
     try {
-      final updated =
-          await repo.setSourceState(sourceId: sourceId, state: newState);
+      final updated = await repo.setSourceState(
+        sourceId: sourceId,
+        state: newState,
+        essentielMode: essentielMode,
+      );
       state = AsyncValue.data(updated);
     } on FavoriteCapReachedException {
       state = previousState;

--- a/apps/mobile/lib/features/my_interests/repositories/user_interests_repository.dart
+++ b/apps/mobile/lib/features/my_interests/repositories/user_interests_repository.dart
@@ -35,6 +35,7 @@ class UserInterestsRepository {
     required FavoriteRef ref,
     required InterestState state,
     int? position,
+    bool? essentielMode,
   }) async {
     try {
       final data = await _client.dio.patch<dynamic>(
@@ -44,6 +45,9 @@ class UserInterestsRepository {
           'target_id': ref.targetId,
           'state': state.toJson(),
           if (position != null) 'position': position,
+          // Placement Essentiel/Flâner persisté en DB. Omis quand null pour ne
+          // jamais écraser un placement existant côté backend.
+          if (essentielMode != null) 'essentiel_mode': essentielMode,
         },
       );
       return UserInterestsState.fromJson(data.data as Map<String, dynamic>);
@@ -76,6 +80,7 @@ class UserInterestsRepository {
     required String sourceId,
     required InterestState state,
     int? position,
+    bool? essentielMode,
   }) async {
     try {
       final data = await _client.dio.patch<dynamic>(
@@ -84,6 +89,9 @@ class UserInterestsRepository {
           'source_id': sourceId,
           'state': state.toJson(),
           if (position != null) 'position': position,
+          // Placement Essentiel/Flâner persisté en DB. Omis quand null pour ne
+          // jamais écraser un placement existant côté backend.
+          if (essentielMode != null) 'essentiel_mode': essentielMode,
         },
       );
       return UserSourcesState.fromJson(data.data as Map<String, dynamic>);

--- a/apps/mobile/test/features/feed/widgets/pin_subjects_sheet_test.dart
+++ b/apps/mobile/test/features/feed/widgets/pin_subjects_sheet_test.dart
@@ -31,7 +31,11 @@ class _FakeUserInterestsNotifier extends UserInterestsNotifier {
   Future<UserInterestsState> build() async => _initial;
 
   @override
-  Future<void> setInterestState(FavoriteRef ref, InterestState s) async {}
+  Future<void> setInterestState(
+    FavoriteRef ref,
+    InterestState s, {
+    bool? essentielMode,
+  }) async {}
 }
 
 class _StubSources extends UserSourcesStateNotifier {

--- a/apps/mobile/test/features/flux_continu/providers/essentiel_placement_sync_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/essentiel_placement_sync_test.dart
@@ -1,0 +1,285 @@
+/// Tests du réconciliateur de placement Essentiel/Flâner
+/// ([reconcileEssentielPlacement]).
+///
+/// Couvre les deux moitiés du fix :
+///  - **Backfill local → DB** : un favori dont le backend ignore le placement
+///    (`essentiel_mode == null`) fait remonter le placement *local* du device
+///    en un PATCH (une fois, gardé par le flag prefs).
+///  - **Hydratation DB → local** : un favori dont le backend connaît le
+///    placement restaure les prefs locales — c'est ce qui répare la perte à la
+///    réinstallation.
+library;
+
+import 'package:facteur/features/feed/providers/tab_order_prefs_provider.dart';
+import 'package:facteur/features/flux_continu/providers/essentiel_placement_sync.dart';
+import 'package:facteur/features/flux_continu/providers/tournee_order_prefs_provider.dart';
+import 'package:facteur/features/my_interests/models/user_interests_state.dart';
+import 'package:facteur/features/my_interests/models/user_sources_state.dart';
+import 'package:facteur/features/my_interests/repositories/user_interests_repository.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Repo fake : sert des états contrôlés et enregistre les PATCH émis.
+class _FakeRepo implements UserInterestsRepository {
+  UserSourcesState sources;
+  UserInterestsState interests;
+
+  final List<({String sourceId, bool? mode})> sourcePatches = [];
+  final List<({String slug, bool? mode})> themePatches = [];
+
+  _FakeRepo({required this.sources, required this.interests});
+
+  @override
+  Future<UserSourcesState> fetchSourcesState() async => sources;
+
+  @override
+  Future<UserInterestsState> fetchInterests() async => interests;
+
+  @override
+  Future<UserSourcesState> setSourceState({
+    required String sourceId,
+    required InterestState state,
+    int? position,
+    bool? essentielMode,
+  }) async {
+    sourcePatches.add((sourceId: sourceId, mode: essentielMode));
+    return sources;
+  }
+
+  @override
+  Future<UserInterestsState> setInterestState({
+    required FavoriteRef ref,
+    required InterestState state,
+    int? position,
+    bool? essentielMode,
+  }) async {
+    if (ref is ThemeFavoriteRef) {
+      themePatches.add((slug: ref.slug, mode: essentielMode));
+    }
+    return interests;
+  }
+
+  @override
+  Future<UserSourcesState> reorderSourceFavorites(
+          List<SourceFavoriteRef> ordered) async =>
+      sources;
+
+  @override
+  Future<UserInterestsState> reorderFavorites(
+          List<FavoriteRef> ordered) async =>
+      interests;
+}
+
+/// Probe : expose [reconcileEssentielPlacement] comme un provider awaitable
+/// (la fonction prend un `Ref`, indisponible directement depuis un container).
+final _reconcileProbe =
+    FutureProvider<void>((ref) => reconcileEssentielPlacement(ref));
+
+UserSourcesState _sourcesWith(List<SourceInterest> items) => UserSourcesState(
+      sources: items,
+      favorites: [
+        for (var i = 0; i < items.length; i++)
+          if (items[i].state == InterestState.favorite)
+            SourceFavoriteRef(sourceId: items[i].sourceId, position: i),
+      ],
+      favoriteCount: items.where((s) => s.state == InterestState.favorite).length,
+      favoriteCap: 5,
+    );
+
+UserInterestsState _interestsWith(List<ThemeInterest> themes) =>
+    UserInterestsState(
+      themes: themes,
+      customTopics: const [],
+      favorites: [
+        for (final t in themes)
+          if (t.state == InterestState.favorite)
+            ThemeFavoriteRef(slug: t.interestSlug),
+      ],
+      favoriteCount: themes.where((t) => t.state == InterestState.favorite).length,
+      favoriteCap: 5,
+    );
+
+Future<ProviderContainer> _boot(
+  _FakeRepo repo,
+  Map<String, Object> prefs,
+) async {
+  SharedPreferences.setMockInitialValues(prefs);
+  final container = ProviderContainer(overrides: [
+    userInterestsRepositoryProvider.overrideWithValue(repo),
+  ]);
+  // Réchauffe les StateNotifier prefs (chargement async depuis SharedPreferences)
+  // avant la réconciliation qui lit leur état en synchrone.
+  container.read(tourneeOrderPrefsProvider);
+  container.read(tabOrderPrefsProvider);
+  await Future<void>.delayed(const Duration(milliseconds: 20));
+  return container;
+}
+
+void main() {
+  const s1 = 'S1';
+
+  test('backfill: source Essentiel locale + backend null → PATCH essentiel=true',
+      () async {
+    final repo = _FakeRepo(
+      sources: _sourcesWith(const [
+        SourceInterest(
+          sourceId: s1,
+          state: InterestState.favorite,
+          priorityMultiplier: 1.0,
+          // essentielMode == null → candidat backfill.
+        ),
+      ]),
+      interests: _interestsWith(const []),
+    );
+    // Le device place S1 dans l'Essentiel (clé dans tournee_order_v1).
+    final container = await _boot(repo, {
+      'tournee_order_v1': <String>['source:$s1'],
+    });
+    addTearDown(container.dispose);
+
+    await container.read(_reconcileProbe.future);
+
+    expect(repo.sourcePatches, hasLength(1));
+    expect(repo.sourcePatches.single.sourceId, s1);
+    expect(repo.sourcePatches.single.mode, isTrue);
+    // Flag one-shot posé après un backfill réussi.
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getBool('essentiel_placement_reconciled_v1'), isTrue);
+  });
+
+  test(
+      'backfill: source Flâner locale + backend null → PATCH essentiel=false',
+      () async {
+    final repo = _FakeRepo(
+      sources: _sourcesWith(const [
+        SourceInterest(
+          sourceId: s1,
+          state: InterestState.favorite,
+          priorityMultiplier: 1.0,
+        ),
+      ]),
+      interests: _interestsWith(const []),
+    );
+    // S1 en Flâner (clé dans pinned_tabs_order_v1, absente de tournee_order_v1).
+    final container = await _boot(repo, {
+      'pinned_tabs_order_v1': <String>['source:$s1'],
+    });
+    addTearDown(container.dispose);
+
+    await container.read(_reconcileProbe.future);
+
+    expect(repo.sourcePatches.single.mode, isFalse);
+  });
+
+  test('backfill ne se rejoue pas si le flag est déjà posé', () async {
+    final repo = _FakeRepo(
+      sources: _sourcesWith(const [
+        SourceInterest(
+          sourceId: s1,
+          state: InterestState.favorite,
+          priorityMultiplier: 1.0,
+        ),
+      ]),
+      interests: _interestsWith(const []),
+    );
+    final container = await _boot(repo, {
+      'tournee_order_v1': <String>['source:$s1'],
+      'essentiel_placement_reconciled_v1': true,
+    });
+    addTearDown(container.dispose);
+
+    await container.read(_reconcileProbe.future);
+
+    expect(repo.sourcePatches, isEmpty);
+  });
+
+  test(
+      'hydrate: source backend essentiel=true + prefs vides → clé ré-ajoutée '
+      'à tournee_order (répro du bug réinstallation)', () async {
+    final repo = _FakeRepo(
+      sources: _sourcesWith(const [
+        SourceInterest(
+          sourceId: s1,
+          state: InterestState.favorite,
+          priorityMultiplier: 1.0,
+          essentielMode: true, // placement connu en DB.
+        ),
+      ]),
+      interests: _interestsWith(const []),
+    );
+    // Device fraîchement réinstallé : aucune pref locale.
+    final container = await _boot(repo, <String, Object>{});
+    addTearDown(container.dispose);
+
+    await container.read(_reconcileProbe.future);
+
+    // L'Essentiel est restauré localement.
+    expect(
+      container.read(tourneeOrderPrefsProvider).order,
+      contains('source:$s1'),
+    );
+    // Rien à backfiller (placement déjà connu) → aucun PATCH source.
+    expect(repo.sourcePatches, isEmpty);
+  });
+
+  test(
+      'hydrate: source backend essentiel=false → clé retirée de tournee, '
+      'ajoutée à pinned_tabs', () async {
+    final repo = _FakeRepo(
+      sources: _sourcesWith(const [
+        SourceInterest(
+          sourceId: s1,
+          state: InterestState.favorite,
+          priorityMultiplier: 1.0,
+          essentielMode: false,
+        ),
+      ]),
+      interests: _interestsWith(const []),
+    );
+    // Localement (à tort) placé dans l'Essentiel : l'hydratation doit corriger.
+    final container = await _boot(repo, {
+      'tournee_order_v1': <String>['source:$s1'],
+    });
+    addTearDown(container.dispose);
+
+    await container.read(_reconcileProbe.future);
+
+    expect(
+      container.read(tourneeOrderPrefsProvider).order,
+      isNot(contains('source:$s1')),
+    );
+    expect(
+      container.read(tabOrderPrefsProvider),
+      contains('source:$s1'),
+    );
+  });
+
+  test('hydrate: thème backend essentiel=true → clé retirée de pinned_tabs',
+      () async {
+    final repo = _FakeRepo(
+      sources: _sourcesWith(const []),
+      interests: _interestsWith(const [
+        ThemeInterest(
+          interestSlug: 'tech',
+          weight: 1.0,
+          state: InterestState.favorite,
+          essentielMode: true,
+        ),
+      ]),
+    );
+    // Le thème était (à tort) en Flâner localement.
+    final container = await _boot(repo, {
+      'pinned_tabs_order_v1': <String>['theme:tech'],
+    });
+    addTearDown(container.dispose);
+
+    await container.read(_reconcileProbe.future);
+
+    // Essentiel = défaut du thème : il suffit qu'il quitte Flâner.
+    expect(
+      container.read(tabOrderPrefsProvider),
+      isNot(contains('theme:tech')),
+    );
+  });
+}

--- a/apps/mobile/test/features/flux_continu/widgets/etoffer_theme_footer_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/etoffer_theme_footer_test.dart
@@ -62,7 +62,11 @@ class _FakeUserSourcesStateNotifier extends UserSourcesStateNotifier {
       );
 
   @override
-  Future<void> setSourceState(String sourceId, InterestState newState) async {
+  Future<void> setSourceState(
+    String sourceId,
+    InterestState newState, {
+    bool? essentielMode,
+  }) async {
     calls.add((id: sourceId, state: newState));
   }
 }

--- a/apps/mobile/test/features/flux_continu/widgets/manage_favorites_sheet_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/manage_favorites_sheet_test.dart
@@ -29,13 +29,19 @@ class _SpyInterestsNotifier extends UserInterestsNotifier {
   _SpyInterestsNotifier(this._initial);
   final UserInterestsState _initial;
   final List<(FavoriteRef, InterestState)> stateCalls = [];
+  final List<bool?> modeCalls = [];
 
   @override
   Future<UserInterestsState> build() async => _initial;
 
   @override
-  Future<void> setInterestState(FavoriteRef ref, InterestState s) async {
+  Future<void> setInterestState(
+    FavoriteRef ref,
+    InterestState s, {
+    bool? essentielMode,
+  }) async {
     stateCalls.add((ref, s));
+    modeCalls.add(essentielMode);
   }
 
   @override
@@ -46,13 +52,19 @@ class _SpySourcesNotifier extends UserSourcesStateNotifier {
   _SpySourcesNotifier(this._initial);
   final UserSourcesState _initial;
   final List<(String, InterestState)> stateCalls = [];
+  final List<bool?> modeCalls = [];
 
   @override
   Future<UserSourcesState> build() async => _initial;
 
   @override
-  Future<void> setSourceState(String sourceId, InterestState s) async {
+  Future<void> setSourceState(
+    String sourceId,
+    InterestState s, {
+    bool? essentielMode,
+  }) async {
     stateCalls.add((sourceId, s));
+    modeCalls.add(essentielMode);
   }
 
   @override

--- a/apps/mobile/test/features/my_interests/providers/user_interests_provider_test.dart
+++ b/apps/mobile/test/features/my_interests/providers/user_interests_provider_test.dart
@@ -27,6 +27,7 @@ class _FakeRepo implements UserInterestsRepository {
     required FavoriteRef ref,
     required InterestState state,
     int? position,
+    bool? essentielMode,
   }) async {
     setCalls++;
     if (throwCap) throw const FavoriteCapReachedException(5);
@@ -55,6 +56,7 @@ class _FakeRepo implements UserInterestsRepository {
     required String sourceId,
     required InterestState state,
     int? position,
+    bool? essentielMode,
   }) async =>
       throw UnimplementedError();
 

--- a/apps/mobile/test/features/my_interests/services/interests_sync_service_test.dart
+++ b/apps/mobile/test/features/my_interests/services/interests_sync_service_test.dart
@@ -23,6 +23,7 @@ class _RecorderRepo implements UserInterestsRepository {
     required FavoriteRef ref,
     required InterestState state,
     int? position,
+    bool? essentielMode,
   }) async {
     calls.add((ref, state));
     if (throwOnSet != null) throw throwOnSet!;
@@ -49,6 +50,7 @@ class _RecorderRepo implements UserInterestsRepository {
     required String sourceId,
     required InterestState state,
     int? position,
+    bool? essentielMode,
   }) async =>
       throw UnimplementedError();
 

--- a/apps/mobile/test/features/sources/widgets/pepites_carousel_test.dart
+++ b/apps/mobile/test/features/sources/widgets/pepites_carousel_test.dart
@@ -35,7 +35,11 @@ class _FakeUserSourcesStateNotifier extends UserSourcesStateNotifier {
   Future<UserSourcesState> build() async => _initial;
 
   @override
-  Future<void> setSourceState(String sourceId, InterestState newState) async {
+  Future<void> setSourceState(
+    String sourceId,
+    InterestState newState, {
+    bool? essentielMode,
+  }) async {
     setStateCalls++;
     lastSourceId = sourceId;
     lastState = newState;

--- a/docs/bugs/bug-essentiel-placement-persistence.md
+++ b/docs/bugs/bug-essentiel-placement-persistence.md
@@ -1,0 +1,74 @@
+# Bug — L'appartenance à l'Essentiel (sources + thèmes) se perd
+
+## Symptôme (PO)
+
+> « L'enregistrement des sources dans l'Essentiel de la Tournée du jour se perd
+> très régulièrement. Info trop importante pour être perdue. »
+
+## Cause racine — persistance en *split-brain*
+
+- Le **favori** d'une source / d'un thème *est* persisté en DB
+  (`user_sources.state`, `user_interests.state`). ✓
+- Mais **le mode de placement** — « Chaque jour dans l'Essentiel » vs « Flâner » —
+  ne vivait **que dans `SharedPreferences`** :
+  - source Essentiel ⟺ clé `source:<id>` dans `tournee_order_v1` ;
+  - thème Flâner ⟺ clé `theme:<slug>` dans `pinned_tabs_order_v1` (défaut = Essentiel).
+  Rien côté backend ne distinguait Essentiel de Flâner. ✗
+
+⇒ à la **réinstallation / nouveau device / purge du stockage**, le favori survit
+en DB mais son placement Essentiel disparaît silencieusement → la source « tombe »
+de l'Essentiel. De plus les écritures de prefs sont *best-effort* (erreurs
+avalées), d'où la dérive « régulière ».
+
+## Correctif — la DB devient la source de vérité durable
+
+Colonne **`essentiel_mode BOOLEAN NULL`** ajoutée à `user_sources` et
+`user_interests` (`true`=Essentiel, `false`=Flâner, `NULL`=jamais placé / legacy).
+Migration additive pure `es01_essentiel_placement` (expand-contract, sûre sur la
+DB partagée staging/prod). Les prefs locales restent le cache de rendu.
+
+### Backend
+- Modèles `UserSource` / `UserInterest` : `essentiel_mode: bool | None`.
+- Schémas : champ optionnel sur `SetSourceStateRequest` / `SetInterestStateRequest`
+  (écriture) et exposé sur `SourceStateResponse` / `ThemeInterestResponse` (lecture).
+- Services `set_state` : écrivent `essentiel_mode` **quand fourni**, le
+  **préservent** quand `None` (jamais de `NULL` écrasant un placement connu ;
+  injecté dans les deux branches de l'upsert thème).
+- Routers : passent `body.essentiel_mode` au service.
+
+### Mobile
+- Repo / notifiers / modèles : param + champ `essentielMode` propagés jusqu'au
+  `PATCH` (omis quand `null`).
+- Écriture immédiate à chaque **ajout / déplacement** de mode
+  (`manage_favorites_sheet`, `promoteSuggestion`).
+- **Réconciliation au cold-boot** (`essentiel_placement_sync.dart`, hookée dans le
+  bootstrap de la Tournée) :
+  1. **Backfill local → DB** (one-shot, flag `essentiel_placement_reconciled_v1`) :
+     capture le placement device actuel des favoris encore `NULL` en DB.
+  2. **Hydratation DB → local** (chaque cold-boot, idempotente) : restaure les
+     prefs à partir du placement DB connu → **répare la perte à la réinstallation**.
+  La règle de rendu (`sourceIsEssentiel`) est inchangée : elle lit les prefs,
+  désormais rendues durables par l'hydratation.
+
+### Asymétrie source/thème (préservée)
+- **Source** : Essentiel ⟺ clé dans `tournee_order_v1` (défaut = Flâner).
+- **Thème** : Flâner ⟺ clé dans `pinned_tabs_order_v1` (défaut = Essentiel).
+La réconciliation encode `essentiel_mode` sémantiquement et traduit par type.
+
+## Vérification
+- Alembic : 1 head ; upgrade/downgrade/re-upgrade round-trip OK sur DB vierge.
+- Backend : `pytest` routers sources + interests (persiste quand fourni, préserve
+  quand `None`, `false` distinct de `NULL`).
+- Mobile : test du réconciliateur (backfill Essentiel/Flâner, one-shot gardé,
+  hydratation source/thème — dont la répro « clé ré-ajoutée à `tournee_order` »).
+- `flutter analyze` : 0 erreur ; suites `my_interests` + `flux_continu` vertes.
+
+## Fichiers
+- Migration : `packages/api/alembic/versions/es01_essentiel_placement.py`
+- Backend : `models/source.py`, `models/user.py`, `schemas/user_interests.py`,
+  `services/user_interests_service.py`, `routers/user_sources_state.py`,
+  `routers/user_interests.py`
+- Mobile : `user_interests_repository.dart`, `user_sources_state_provider.dart`,
+  `user_interests_provider.dart`, `user_sources_state.dart`,
+  `user_interests_state.dart`, `manage_favorites_sheet.dart`,
+  `flux_continu_provider.dart`, **nouveau** `essentiel_placement_sync.dart`

--- a/packages/api/alembic/versions/es01_essentiel_placement.py
+++ b/packages/api/alembic/versions/es01_essentiel_placement.py
@@ -1,0 +1,51 @@
+"""essentiel_placement — persister l'appartenance Essentiel/Flâner en DB.
+
+Ajoute une colonne nullable `essentiel_mode BOOLEAN` sur `user_sources` et
+`user_interests`. Jusqu'ici le *mode de placement* d'un favori (« Chaque jour
+dans l'Essentiel » vs « Flâner ») ne vivait que dans les `SharedPreferences` du
+device (clés `tournee_order_v1` / `pinned_tabs_order_v1`) : à la réinstallation
+le favori survivait en DB mais son placement était silencieusement perdu. Cette
+colonne fait de la DB la source de vérité durable.
+
+Sémantique : `true` = Essentiel, `false` = Flâner, `NULL` = jamais placé
+explicitement / legacy (backfillé depuis le device au premier cold-boot).
+
+Purement additive (ADD COLUMN nullable, sans server_default fonctionnel) → sûre
+en expand-contract sur la DB partagée staging/prod : le backend prod (ancien
+code) ignore la colonne jusqu'au passage hebdo, aucune 2ᵉ étape de contract
+requise. Migration idempotente (no-op si la colonne existe déjà).
+
+Head précédent : ``me01_media_eval_tables``. Après : 1 seul head (es01).
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "es01_essentiel_placement"
+down_revision: str | None = "me01_media_eval_tables"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+_COLUMN = "essentiel_mode"
+_TABLES = ("user_sources", "user_interests")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    for table in _TABLES:
+        cols = {c["name"] for c in inspector.get_columns(table)}
+        if _COLUMN in cols:
+            continue
+        op.add_column(table, sa.Column(_COLUMN, sa.Boolean(), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    for table in _TABLES:
+        cols = {c["name"] for c in inspector.get_columns(table)}
+        if _COLUMN not in cols:
+            continue
+        op.drop_column(table, _COLUMN)

--- a/packages/api/app/models/source.py
+++ b/packages/api/app/models/source.py
@@ -221,6 +221,9 @@ class UserSource(Base):
         default=InterestState.FOLLOWED,
         server_default=InterestState.FOLLOWED.value,
     )
+    # Placement Essentiel/Flâner durable (source de vérité DB, resync par device).
+    # true = Essentiel, false = Flâner, NULL = jamais placé / legacy (backfill device).
+    essentiel_mode: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
 
     # Relations
     source: Mapped["Source"] = relationship(back_populates="user_sources")

--- a/packages/api/app/models/user.py
+++ b/packages/api/app/models/user.py
@@ -117,6 +117,9 @@ class UserInterest(Base):
         default=InterestState.FOLLOWED,
         server_default=InterestState.FOLLOWED.value,
     )
+    # Placement Essentiel/Flâner durable (source de vérité DB, resync par device).
+    # true = Essentiel, false = Flâner, NULL = jamais placé / legacy (backfill device).
+    essentiel_mode: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=datetime.utcnow
     )

--- a/packages/api/app/routers/user_interests.py
+++ b/packages/api/app/routers/user_interests.py
@@ -69,6 +69,7 @@ async def set_interest_state(
             target_id=body.target_id,
             state=body.state,
             position=body.position,
+            essentiel_mode=body.essentiel_mode,
         )
     except FavoriteCapReached as e:
         get_posthog_client().capture(

--- a/packages/api/app/routers/user_sources_state.py
+++ b/packages/api/app/routers/user_sources_state.py
@@ -63,6 +63,7 @@ async def set_source_state(
             source_id=body.source_id,
             state=body.state,
             position=body.position,
+            essentiel_mode=body.essentiel_mode,
         )
     except FavoriteCapReached as e:
         get_posthog_client().capture(

--- a/packages/api/app/schemas/user_interests.py
+++ b/packages/api/app/schemas/user_interests.py
@@ -33,6 +33,8 @@ class ThemeInterestResponse(BaseModel):
     interest_slug: str
     weight: float
     state: InterestState
+    # Placement durable : true=Essentiel, false=Flâner, None=jamais placé/legacy.
+    essentiel_mode: bool | None = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -74,6 +76,9 @@ class SetInterestStateRequest(BaseModel):
     target_id: str
     state: InterestState
     position: int | None = Field(None, ge=0)
+    # Placement Essentiel/Flâner à persister. None = préserver l'existant en DB
+    # (ne jamais écraser un placement connu par un PATCH qui ne le fournit pas).
+    essentiel_mode: bool | None = None
 
 
 class ReorderFavoritesRequest(BaseModel):
@@ -100,6 +105,8 @@ class SourceStateResponse(BaseModel):
     source_id: UUID
     state: InterestState
     priority_multiplier: float
+    # Placement durable : true=Essentiel, false=Flâner, None=jamais placé/legacy.
+    essentiel_mode: bool | None = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -126,6 +133,9 @@ class SetSourceStateRequest(BaseModel):
     source_id: UUID
     state: InterestState
     position: int | None = Field(None, ge=0)
+    # Placement Essentiel/Flâner à persister. None = préserver l'existant en DB
+    # (ne jamais écraser un placement connu par un PATCH qui ne le fournit pas).
+    essentiel_mode: bool | None = None
 
 
 class ReorderSourceFavoritesRequest(BaseModel):

--- a/packages/api/app/services/user_interests_service.py
+++ b/packages/api/app/services/user_interests_service.py
@@ -140,9 +140,13 @@ class UserInterestsService:
         target_id: str,
         state: InterestState,
         position: int | None = None,
+        essentiel_mode: bool | None = None,
     ) -> InterestState | None:
         """Mute le state d'un Thème ou Sujet. Returns the previous state, or None
-        if the target was created on the fly (theme without prior row)."""
+        if the target was created on the fly (theme without prior row).
+
+        `essentiel_mode` (Thèmes uniquement) : placement Essentiel/Flâner durable.
+        `None` = préserver l'existant (ne jamais écraser un placement connu)."""
         prev_state: InterestState | None = None
 
         if kind == "theme":
@@ -161,18 +165,31 @@ class UserInterestsService:
                 # Upsert atomique : un double-tap concurrent ne lève plus
                 # d'IntegrityError sur user_interests_user_slug_uniq.
                 # prev_state reste None (sémantique "créé à la volée").
+                values: dict = {
+                    "user_id": user_id,
+                    "interest_slug": interest_slug,
+                    "state": state,
+                }
+                conflict_set: dict = {"state": state}
+                # Le placement n'est écrit (insert ET conflit) que s'il est fourni :
+                # un PATCH sans mode ne doit jamais NULL-er un placement existant.
+                if essentiel_mode is not None:
+                    values["essentiel_mode"] = essentiel_mode
+                    conflict_set["essentiel_mode"] = essentiel_mode
                 stmt = (
                     insert(UserInterest)
-                    .values(user_id=user_id, interest_slug=interest_slug, state=state)
+                    .values(**values)
                     .on_conflict_do_update(
                         constraint="user_interests_user_slug_uniq",
-                        set_={"state": state},
+                        set_=conflict_set,
                     )
                 )
                 await self.db.execute(stmt)
             else:
                 prev_state = row.state
                 row.state = state
+                if essentiel_mode is not None:
+                    row.essentiel_mode = essentiel_mode
         elif kind == "custom_topic":
             try:
                 topic_uuid = UUID(target_id)
@@ -431,7 +448,10 @@ class UserSourcesStateService:
         source_id: UUID,
         state: InterestState,
         position: int | None = None,
+        essentiel_mode: bool | None = None,
     ) -> InterestState | None:
+        """`essentiel_mode` : placement Essentiel/Flâner durable. `None` = préserver
+        l'existant (ne jamais écraser un placement connu par un PATCH sans mode)."""
         row = (
             await self.db.execute(
                 select(UserSource).where(
@@ -443,10 +463,12 @@ class UserSourcesStateService:
             # Upsert : un utilisateur peut basculer une source en
             # followed/favorite directement depuis le reader sans avoir de row
             # préexistante. On crée alors l'association avec le state demandé.
+            # essentiel_mode=None ⇒ colonne laissée à NULL (jamais placé).
             row = UserSource(
                 user_id=user_id,
                 source_id=source_id,
                 state=state,
+                essentiel_mode=essentiel_mode,
             )
             self.db.add(row)
             await self.db.flush()  # mirror UserInterest upsert (line ~163)
@@ -454,6 +476,8 @@ class UserSourcesStateService:
         else:
             prev_state = row.state
             row.state = state
+            if essentiel_mode is not None:
+                row.essentiel_mode = essentiel_mode
 
         await self._sync_favorite_source(
             user_id=user_id, source_id=source_id, state=state, position=position

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -40,3 +40,4 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+addopts = "--import-mode=importlib"

--- a/packages/api/tests/routers/test_user_interests.py
+++ b/packages/api/tests/routers/test_user_interests.py
@@ -441,3 +441,108 @@ async def test_reorder_rejects_non_favorite_target(auth_user_with_themes, db_ses
                 },
             )
     assert resp.status_code == 422
+
+
+def _theme_row(body: dict, slug: str) -> dict:
+    return next(t for t in body["themes"] if t["interest_slug"] == slug)
+
+
+@pytest.mark.asyncio
+async def test_patch_theme_persists_essentiel_mode(auth_user, db_session):
+    """Le placement Essentiel/Flâner d'un Thème est persisté en DB et ré-exposé."""
+    transport = ASGITransport(app=app)
+    with patch(
+        "app.routers.user_interests.get_posthog_client", return_value=MagicMock()
+    ):
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.patch(
+                "/api/user/interests",
+                json={
+                    "kind": "theme",
+                    "target_id": "tech",
+                    "state": "favorite",
+                    "essentiel_mode": True,
+                },
+            )
+            get = await ac.get("/api/user/interests")
+    assert resp.status_code == 200, resp.text
+    assert _theme_row(resp.json(), "tech")["essentiel_mode"] is True
+    assert _theme_row(get.json(), "tech")["essentiel_mode"] is True
+
+
+@pytest.mark.asyncio
+async def test_patch_theme_essentiel_mode_false_is_persisted(auth_user, db_session):
+    transport = ASGITransport(app=app)
+    with patch(
+        "app.routers.user_interests.get_posthog_client", return_value=MagicMock()
+    ):
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.patch(
+                "/api/user/interests",
+                json={
+                    "kind": "theme",
+                    "target_id": "tech",
+                    "state": "favorite",
+                    "essentiel_mode": False,
+                },
+            )
+    assert resp.status_code == 200, resp.text
+    assert _theme_row(resp.json(), "tech")["essentiel_mode"] is False
+
+
+@pytest.mark.asyncio
+async def test_patch_theme_omitting_essentiel_mode_preserves_existing(
+    auth_user, db_session
+):
+    """Un PATCH d'état sans placement ne doit pas écraser le mode existant
+    (branche row-exists : ne jamais NULL-er un placement connu)."""
+    transport = ASGITransport(app=app)
+    with patch(
+        "app.routers.user_interests.get_posthog_client", return_value=MagicMock()
+    ):
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            await ac.patch(
+                "/api/user/interests",
+                json={
+                    "kind": "theme",
+                    "target_id": "tech",
+                    "state": "favorite",
+                    "essentiel_mode": True,
+                },
+            )
+            resp = await ac.patch(
+                "/api/user/interests",
+                json={"kind": "theme", "target_id": "tech", "state": "followed"},
+            )
+    assert resp.status_code == 200, resp.text
+    assert _theme_row(resp.json(), "tech")["essentiel_mode"] is True
+
+
+@pytest.mark.asyncio
+async def test_patch_theme_can_flip_essentiel_mode(auth_user, db_session):
+    """Un déplacement Essentiel -> Flâner met bien à jour le placement existant."""
+    transport = ASGITransport(app=app)
+    with patch(
+        "app.routers.user_interests.get_posthog_client", return_value=MagicMock()
+    ):
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            await ac.patch(
+                "/api/user/interests",
+                json={
+                    "kind": "theme",
+                    "target_id": "tech",
+                    "state": "favorite",
+                    "essentiel_mode": True,
+                },
+            )
+            resp = await ac.patch(
+                "/api/user/interests",
+                json={
+                    "kind": "theme",
+                    "target_id": "tech",
+                    "state": "favorite",
+                    "essentiel_mode": False,
+                },
+            )
+    assert resp.status_code == 200, resp.text
+    assert _theme_row(resp.json(), "tech")["essentiel_mode"] is False

--- a/packages/api/tests/routers/test_user_sources_state.py
+++ b/packages/api/tests/routers/test_user_sources_state.py
@@ -168,3 +168,108 @@ async def test_source_accepts_more_than_cap_favorites(auth_user_with_sources):
     assert body["favorite_count"] == 6
     positions = sorted(f["position"] for f in body["favorites"])
     assert positions == [0, 1, 2, 3, 4, 5]
+
+
+def _source_row(body: dict, source_id: str) -> dict:
+    return next(s for s in body["sources"] if s["source_id"] == source_id)
+
+
+@pytest.mark.asyncio
+async def test_patch_persists_essentiel_mode(auth_user_with_sources):
+    """Le placement Essentiel/Flâner envoyé au PATCH est persisté et ré-exposé
+    par le GET (source de vérité DB, resync device — anti perte à la réinstall)."""
+    _, sources = auth_user_with_sources
+    sid = str(sources[0].id)
+    transport = ASGITransport(app=app)
+    with patch(
+        "app.routers.user_sources_state.get_posthog_client",
+        return_value=MagicMock(),
+    ):
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.patch(
+                "/api/user/sources",
+                json={
+                    "source_id": sid,
+                    "state": "favorite",
+                    "essentiel_mode": True,
+                },
+            )
+            get = await ac.get("/api/user/sources")
+    assert resp.status_code == 200, resp.text
+    assert _source_row(resp.json(), sid)["essentiel_mode"] is True
+    assert _source_row(get.json(), sid)["essentiel_mode"] is True
+
+
+@pytest.mark.asyncio
+async def test_patch_essentiel_mode_false_is_persisted(auth_user_with_sources):
+    """`false` (= Flâner) est une valeur distincte de NULL et doit être persistée."""
+    _, sources = auth_user_with_sources
+    sid = str(sources[0].id)
+    transport = ASGITransport(app=app)
+    with patch(
+        "app.routers.user_sources_state.get_posthog_client",
+        return_value=MagicMock(),
+    ):
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.patch(
+                "/api/user/sources",
+                json={
+                    "source_id": sid,
+                    "state": "favorite",
+                    "essentiel_mode": False,
+                },
+            )
+    assert resp.status_code == 200, resp.text
+    assert _source_row(resp.json(), sid)["essentiel_mode"] is False
+
+
+@pytest.mark.asyncio
+async def test_patch_omitting_essentiel_mode_preserves_existing(
+    auth_user_with_sources,
+):
+    """Un PATCH sans `essentiel_mode` (ex: bascule d'état depuis le reader) ne doit
+    JAMAIS NULL-er un placement déjà connu."""
+    _, sources = auth_user_with_sources
+    sid = str(sources[0].id)
+    transport = ASGITransport(app=app)
+    with patch(
+        "app.routers.user_sources_state.get_posthog_client",
+        return_value=MagicMock(),
+    ):
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            await ac.patch(
+                "/api/user/sources",
+                json={
+                    "source_id": sid,
+                    "state": "favorite",
+                    "essentiel_mode": True,
+                },
+            )
+            # Second PATCH sans essentiel_mode : le placement doit survivre.
+            resp = await ac.patch(
+                "/api/user/sources",
+                json={"source_id": sid, "state": "followed"},
+            )
+    assert resp.status_code == 200, resp.text
+    assert _source_row(resp.json(), sid)["essentiel_mode"] is True
+
+
+@pytest.mark.asyncio
+async def test_patch_defaults_essentiel_mode_null_when_never_provided(
+    auth_user_with_sources,
+):
+    """Sans placement fourni, la colonne reste NULL (legacy / jamais placé)."""
+    _, sources = auth_user_with_sources
+    sid = str(sources[0].id)
+    transport = ASGITransport(app=app)
+    with patch(
+        "app.routers.user_sources_state.get_posthog_client",
+        return_value=MagicMock(),
+    ):
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.patch(
+                "/api/user/sources",
+                json={"source_id": sid, "state": "favorite"},
+            )
+    assert resp.status_code == 200, resp.text
+    assert _source_row(resp.json(), sid)["essentiel_mode"] is None


### PR DESCRIPTION
## Quoi

L'appartenance à l'Essentiel (sources **et** thèmes) se perdait « très régulièrement » — surtout à la réinstallation / nouveau device. Ce PR fait de la DB la source de vérité durable du **mode de placement** (« Chaque jour dans l'Essentiel » vs « Flâner »).

## Pourquoi

Le favori était persisté en DB, mais son **placement** ne vivait que dans les `SharedPreferences` (`tournee_order_v1` / `pinned_tabs_order_v1`). À la purge du stockage, le favori survivait mais son placement Essentiel disparaissait silencieusement → la source « tombait » de l'Essentiel. Les écritures de prefs étant best-effort, d'où la dérive « régulière ».

## Comment

- **Migration** additive `es01_essentiel_placement` : colonne `essentiel_mode BOOLEAN NULL` sur `user_sources` + `user_interests` (expand-contract, sûre sur la DB partagée staging/prod ; idempotente).
- **Backend** : champ optionnel en écriture (`Set*StateRequest`) et exposé en lecture (`*StateResponse`). Le service écrit `essentiel_mode` **quand fourni**, le **préserve** quand `None` — jamais de `NULL` écrasant un placement connu (insert ET update, thèmes ET sources).
- **Mobile** : `essentielMode` propagé jusqu'au PATCH (omis quand `null`) ; écriture immédiate à chaque ajout/déplacement ; **réconciliation au cold-boot** (`essentiel_placement_sync.dart`) — backfill local→DB one-shot puis hydratation DB→local qui **répare la perte à la réinstallation**.

## Comment ça a été vérifié

- [x] `pytest` — suite backend **2249 passed** ; 24 tests routers touchés verts (persiste quand fourni, préserve quand `None`, `false` distinct de `NULL`). (1 erreur de collection pré-existante `test_health_readiness_migrations` = shadow du dossier `alembic/` sur `python -m pytest`, non liée.)
- [x] Alembic — 1 head ; upgrade/downgrade/re-upgrade + no-op idempotent OK sur DB vierge.
- [x] `flutter test` sur les fichiers touchés (**49 verts**, dont le réconciliateur : backfill Essentiel/Flâner, one-shot gardé, répro « clé ré-ajoutée à tournee_order ») + `flutter analyze` 0 erreur.
- [x] `/simplify` passé (fetch providers parallélisés, getter `sourceIsEssentiel` réutilisé, `remove` en place).

## Zones à risque

- **DB partagée staging/prod** : migration strictement additive nullable, aucune 2ᵉ étape de contract requise (le backend prod ignore la colonne jusqu'au passage hebdo).
- Asymétrie source/thème (conventions inverses tournee_order / pinned_tabs) encodée sémantiquement dans la réconciliation.
