### PR TITLE
perf(reader): ouverture article + carrousel plus fluides + analyses débloquées

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,14 @@
 {
   "unreleased": [
     {
+      "tag": "Lecture",
+      "summary": "Ouverture des articles plus rapide et défilement de la couverture médiatique plus fluide."
+    },
+    {
+      "tag": "Analyses",
+      "summary": "L'analyse des perspectives se charge toujours quand tu en as besoin ; après la première du jour, on t'explique simplement notre modèle sans pub."
+    },
+    {
       "tag": "Essentiel",
       "summary": "Défilement affiné : une seule vibration à l'arrivée sur une section, un maintien appui qui fait respirer la carte, et un sondage bien plus rare."
     },

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -56,7 +56,6 @@ import '../../lettres/providers/pending_save_nudge_provider.dart';
 import '../../saved/widgets/collection_picker_sheet.dart';
 import '../../saved/providers/collections_provider.dart';
 import '../../soutien/providers/analyse_quota_provider.dart';
-import '../../soutien/widgets/paywall_sheet.dart';
 import '../../../widgets/design/facteur_thumbnail.dart';
 
 @visibleForTesting
@@ -249,6 +248,12 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   Timer? _linkCopiedHeaderTimer;
   late DateTime _startTime;
   WebViewController? _webViewController;
+  // Le chargement de l'URL externe (site complet : pubs/JS/trackers) est
+  // **déféré** hors du montage — c'est le plus gros coût d'ouverture d'article.
+  // Le contrôleur est construit tôt (bon marché) ; `loadRequest` n'est déclenché
+  // qu'au 1er signal d'intention (scroll, fallback idle, ou tap CTA), via
+  // `_maybeStartWebViewLoad()`. Ce flag rend les déclencheurs suivants no-op.
+  bool _webViewLoadStarted = false;
   // Chemin premium (source payante connectée) : WebView sur flutter_inappwebview
   // pour réutiliser la session du média (cookies). Distinct du WebView
   // webview_flutter du scroll-to-site des sources gratuites.
@@ -601,17 +606,27 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   /// le câblage des callbacks WebView.
   int _nowMs() => DateTime.now().millisecondsSinceEpoch;
 
-  void _initScrollToSiteWebView() {
-    final content = _content;
-    if (content == null || kIsWeb) return;
-    if (content.contentType != ContentType.article) return;
-    if (!content.hasInAppContent) return;
-
+  /// Vrai si le scroll-to-site s'applique à [content] (article in-app, non-web,
+  /// source gratuite). Facteur commun aux gardes de construction et de
+  /// chargement du WebView.
+  bool _eligibleForScrollToSiteWebView(Content? content) {
+    if (content == null || kIsWeb) return false;
+    if (content.contentType != ContentType.article) return false;
+    if (!content.hasInAppContent) return false;
     // Source premium connectée : la couche révélée au scroll rend un
     // `PremiumWebView` (cookies) — inutile (et contre-productif : paywall)
     // de charger le contrôleur gratuit sur l'URL payante. `_buildWebViewLayer`
     // court-circuite avant de toucher `_webViewController` sur ce chemin.
-    if (_isConnectedPremiumSource(content)) return;
+    if (_isConnectedPremiumSource(content)) return false;
+    return true;
+  }
+
+  /// Construit le contrôleur WebView (delegate + channel `ScrollBridge`) sans
+  /// **charger** l'URL externe : le `loadRequest` coûteux est déféré à
+  /// [_maybeStartWebViewLoad], déclenché au 1er signal d'intention.
+  void _initScrollToSiteWebView() {
+    final content = _content;
+    if (!_eligibleForScrollToSiteWebView(content)) return;
 
     _historyTracker.reset(_nowMs());
     _webViewController = WebViewController()
@@ -629,8 +644,23 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       ..addJavaScriptChannel(
         'ScrollBridge',
         onMessageReceived: _onScrollBridgeMessage,
-      )
-      ..loadRequest(Uri.parse(content.url));
+      );
+  }
+
+  /// Déclenche (une seule fois) le chargement de l'URL externe dans le WebView
+  /// du scroll-to-site. Idempotent : le 1er appelant (scroll, fallback idle ou
+  /// tap CTA) préchauffe, les suivants sont no-op. Construit le contrôleur au
+  /// besoin si le montage l'avait court-circuité.
+  void _maybeStartWebViewLoad() {
+    if (_webViewLoadStarted) return;
+    final content = _content;
+    if (!_eligibleForScrollToSiteWebView(content)) return;
+    if (_webViewController == null) {
+      _initScrollToSiteWebView();
+      if (_webViewController == null) return;
+    }
+    _webViewLoadStarted = true;
+    _webViewController!.loadRequest(Uri.parse(content!.url));
   }
 
   /// Inject JS to drive the reader chrome from finger gestures + track
@@ -1192,6 +1222,12 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           if (_webViewController == null) {
             _initScrollToSiteWebView();
           }
+          // Fallback idle : couvre « ne scrolle jamais puis tape le CTA ». Le
+          // chargement reste déféré ~1 s après résolution du contenu ; le 1er
+          // scroll ou le tap CTA gagne la course s'il arrive avant. Idempotent.
+          Future.delayed(const Duration(seconds: 1), () {
+            if (mounted) _maybeStartWebViewLoad();
+          });
           // Auto-fetch perspectives if not yet loaded
           if (_perspectivesResponse == null &&
               !_perspectivesLoading &&
@@ -1886,12 +1922,12 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   void _openPerspectivesAnalysis() {
     HapticFeedback.mediumImpact();
     if (_analysisSheetData.value.state == PerspectivesAnalysisState.idle) {
-      // Lancement frais (pas d'analyse cachée) → quota free 1/jour. La
-      // réouverture d'une analyse déjà chargée (state != idle) reste libre.
-      if (!ref.read(analyseQuotaProvider.notifier).tryConsume()) {
-        PaywallSheet.show(context, PaywallWallVariant.analyses);
-        return;
-      }
+      // Lancement frais (pas d'analyse cachée). L'analyse se charge TOUJOURS
+      // (plus de blocage paywall) ; on marque juste l'usage du jour de façon
+      // non-bloquante (no-op premium) pour piloter le nudge doux « Notre
+      // histoire » dans la surface quota du carrousel. La réouverture d'une
+      // analyse déjà chargée (state != idle) reste libre et ne marque rien.
+      ref.read(analyseQuotaProvider.notifier).recordUse();
       _requestPerspectivesAnalysis();
     }
     showAnalysisBottomSheet(
@@ -1987,6 +2023,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
               NotificationListener<ScrollNotification>(
                 onNotification: (notification) {
                   if (notification is ScrollUpdateNotification) {
+                    // 1er scroll = signal d'intention primaire : préchauffe le
+                    // WebView externe (déféré au montage). Idempotent.
+                    _maybeStartWebViewLoad();
                     final delta = notification.scrollDelta ?? 0.0;
                     final metrics = notification.metrics;
                     if (metrics.pixels <= 0 &&
@@ -2120,6 +2159,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       _openOriginalUrl();
       return;
     }
+    // Garantie : le tap CTA lance la révélation (animateTo 500 ms). On préchauffe
+    // le WebView dès maintenant pour lui donner une longueur d'avance. Idempotent.
+    _maybeStartWebViewLoad();
     final content = _content;
     if (content == null) return;
     final articleText = content.htmlContent ?? content.description;

--- a/apps/mobile/lib/features/detail/widgets/article_reader_widget.dart
+++ b/apps/mobile/lib/features/detail/widgets/article_reader_widget.dart
@@ -6,7 +6,7 @@ import '../../../../config/theme.dart';
 import '../../../../core/utils/html_utils.dart';
 
 /// Widget for rendering HTML article content in-app (Story 5.2)
-class ArticleReaderWidget extends StatelessWidget {
+class ArticleReaderWidget extends StatefulWidget {
   final String? htmlContent;
   final String? description;
   final String title;
@@ -33,109 +33,145 @@ class ArticleReaderWidget extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
-    final colors = context.facteurColors;
+  State<ArticleReaderWidget> createState() => _ArticleReaderWidgetState();
+}
 
+class _ArticleReaderWidgetState extends State<ArticleReaderWidget> {
+  /// HTML sanitisé, mémoïsé : `sanitizeArticleHtml` (regex lourdes) ne se relance
+  /// qu'au changement de `htmlContent`/`description`, pas à chaque `setState` de
+  /// l'écran parent (nombreux à l'ouverture).
+  late String _sanitized;
+
+  @override
+  void initState() {
+    super.initState();
+    _sanitized = _computeSanitized();
+  }
+
+  @override
+  void didUpdateWidget(ArticleReaderWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.htmlContent != widget.htmlContent ||
+        oldWidget.description != widget.description) {
+      _sanitized = _computeSanitized();
+    }
+  }
+
+  String _computeSanitized() {
     // Sanitize htmlContent, fallback to description if result is empty
     String content = '';
-    if (htmlContent != null && htmlContent!.isNotEmpty) {
-      content = sanitizeArticleHtml(htmlContent!);
+    if (widget.htmlContent != null && widget.htmlContent!.isNotEmpty) {
+      content = sanitizeArticleHtml(widget.htmlContent!);
     }
-    if (content.isEmpty && description != null && description!.isNotEmpty) {
-      content = sanitizeArticleHtml(description!);
+    if (content.isEmpty &&
+        widget.description != null &&
+        widget.description!.isNotEmpty) {
+      content = sanitizeArticleHtml(widget.description!);
     }
+    return content;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final content = _sanitized;
 
     final column = Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        if (header != null) header!,
-        if (bodyPlaceholder != null)
-          bodyPlaceholder!
+        if (widget.header != null) widget.header!,
+        if (widget.bodyPlaceholder != null)
+          widget.bodyPlaceholder!
         else
-          Html(
-            data: content,
-            style: {
-              'body': Style(
-                fontSize: FontSize(17),
-                lineHeight: const LineHeight(1.7),
-                color: colors.textPrimary,
-                fontFamily: 'DMSans',
-                margin: Margins.zero,
-                padding: HtmlPaddings.zero,
-              ),
-              'p': Style(margin: Margins.only(bottom: 16)),
-              'h1': Style(
-                fontSize: FontSize(24),
-                fontWeight: FontWeight.w600,
-                margin: Margins.only(bottom: 16, top: 24),
-                color: colors.textPrimary,
-              ),
-              'h2': Style(
-                fontSize: FontSize(20),
-                fontWeight: FontWeight.w600,
-                margin: Margins.only(bottom: 16, top: 24),
-                color: colors.textPrimary,
-              ),
-              'h3': Style(
-                fontSize: FontSize(18),
-                fontWeight: FontWeight.w500,
-                margin: Margins.only(bottom: 16, top: 16),
-                color: colors.textPrimary,
-              ),
-              'a': Style(
-                color: colors.textSecondary,
-                textDecoration: TextDecoration.none,
-              ),
-              'img': Style(margin: Margins.symmetric(vertical: 16)),
-              'blockquote': Style(
-                border: Border(
-                  left: BorderSide(
-                    color: colors.primary.withValues(alpha: 0.5),
-                    width: 3,
-                  ),
+          RepaintBoundary(
+            child: Html(
+              data: content,
+              style: {
+                'body': Style(
+                  fontSize: FontSize(17),
+                  lineHeight: const LineHeight(1.7),
+                  color: colors.textPrimary,
+                  fontFamily: 'DMSans',
+                  margin: Margins.zero,
+                  padding: HtmlPaddings.zero,
                 ),
-                padding: HtmlPaddings.only(left: 16),
-                margin: Margins.symmetric(vertical: 16),
-                fontStyle: FontStyle.italic,
-                color: colors.textSecondary,
-              ),
-              'ul': Style(margin: Margins.only(bottom: 16)),
-              'ol': Style(margin: Margins.only(bottom: 16)),
-              'li': Style(margin: Margins.only(bottom: 8)),
-              'figure': Style(margin: Margins.symmetric(vertical: 16)),
-              'figcaption': Style(
-                fontSize: FontSize(14),
-                color: colors.textTertiary,
-                textAlign: TextAlign.center,
-                margin: Margins.only(top: 8),
-              ),
-              // Defensive: prevent leftover divs/iframes/asides from creating gaps
-              'div': Style(margin: Margins.zero, padding: HtmlPaddings.zero),
-              'iframe': Style(display: Display.none),
-              'aside': Style(display: Display.none),
-            },
-            onLinkTap: (url, _, __) async {
-              if (url != null) {
-                if (onLinkTap != null) {
-                  onLinkTap!(url);
-                } else {
-                  final uri = Uri.tryParse(url);
-                  if (uri != null && await canLaunchUrl(uri)) {
-                    await launchUrl(uri, mode: LaunchMode.externalApplication);
+                'p': Style(margin: Margins.only(bottom: 16)),
+                'h1': Style(
+                  fontSize: FontSize(24),
+                  fontWeight: FontWeight.w600,
+                  margin: Margins.only(bottom: 16, top: 24),
+                  color: colors.textPrimary,
+                ),
+                'h2': Style(
+                  fontSize: FontSize(20),
+                  fontWeight: FontWeight.w600,
+                  margin: Margins.only(bottom: 16, top: 24),
+                  color: colors.textPrimary,
+                ),
+                'h3': Style(
+                  fontSize: FontSize(18),
+                  fontWeight: FontWeight.w500,
+                  margin: Margins.only(bottom: 16, top: 16),
+                  color: colors.textPrimary,
+                ),
+                'a': Style(
+                  color: colors.textSecondary,
+                  textDecoration: TextDecoration.none,
+                ),
+                'img': Style(margin: Margins.symmetric(vertical: 16)),
+                'blockquote': Style(
+                  border: Border(
+                    left: BorderSide(
+                      color: colors.primary.withValues(alpha: 0.5),
+                      width: 3,
+                    ),
+                  ),
+                  padding: HtmlPaddings.only(left: 16),
+                  margin: Margins.symmetric(vertical: 16),
+                  fontStyle: FontStyle.italic,
+                  color: colors.textSecondary,
+                ),
+                'ul': Style(margin: Margins.only(bottom: 16)),
+                'ol': Style(margin: Margins.only(bottom: 16)),
+                'li': Style(margin: Margins.only(bottom: 8)),
+                'figure': Style(margin: Margins.symmetric(vertical: 16)),
+                'figcaption': Style(
+                  fontSize: FontSize(14),
+                  color: colors.textTertiary,
+                  textAlign: TextAlign.center,
+                  margin: Margins.only(top: 8),
+                ),
+                // Defensive: prevent leftover divs/iframes/asides from creating gaps
+                'div': Style(margin: Margins.zero, padding: HtmlPaddings.zero),
+                'iframe': Style(display: Display.none),
+                'aside': Style(display: Display.none),
+              },
+              onLinkTap: (url, _, __) async {
+                if (url != null) {
+                  if (widget.onLinkTap != null) {
+                    widget.onLinkTap!(url);
+                  } else {
+                    final uri = Uri.tryParse(url);
+                    if (uri != null && await canLaunchUrl(uri)) {
+                      await launchUrl(
+                        uri,
+                        mode: LaunchMode.externalApplication,
+                      );
+                    }
                   }
                 }
-              }
-            },
+              },
+            ),
           ),
-        if (footer != null) ...[
-          if (footerSpacing > 0) SizedBox(height: footerSpacing),
-          footer!,
+        if (widget.footer != null) ...[
+          if (widget.footerSpacing > 0) SizedBox(height: widget.footerSpacing),
+          widget.footer!,
         ],
       ],
     );
 
-    if (shrinkWrap) {
+    if (widget.shrinkWrap) {
       return Padding(
         padding: const EdgeInsets.symmetric(horizontal: FacteurSpacing.space4),
         child: column,

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:ui' show ImageFilter;
 
 import 'package:flutter/foundation.dart' show ValueListenable;
 import 'package:flutter/material.dart';
@@ -12,7 +11,6 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 import '../../../config/routes.dart';
 import '../../../config/theme.dart';
 import '../../../core/providers/analytics_provider.dart';
-import '../../../core/web/web_perf.dart';
 import '../../../widgets/design/facteur_card.dart';
 import '../../../widgets/design/facteur_image.dart';
 import '../../digest/widgets/divergence_inline_badge.dart';
@@ -23,7 +21,6 @@ import '../../sources/providers/sources_providers.dart';
 import '../../sources/widgets/source_detail_modal.dart';
 import '../../soutien/providers/analyse_quota_provider.dart';
 import '../../soutien/soutien_copy.dart';
-import '../../soutien/widgets/paywall_sheet.dart';
 import '../../premium/premium_provider.dart';
 import '../models/content_model.dart';
 import '../providers/feed_provider.dart';
@@ -388,12 +385,12 @@ class _PerspectivesBottomSheetState
   }
 
   Future<void> _requestAnalysis() async {
-    // Lancement frais uniquement (le retry après erreur ne re-consomme pas
-    // le quota) : gating free 1 analyse/jour.
-    if (_analysisState == PerspectivesAnalysisState.idle &&
-        !ref.read(analyseQuotaProvider.notifier).tryConsume()) {
-      PaywallSheet.show(context, PaywallWallVariant.analyses);
-      return;
+    // L'analyse se charge TOUJOURS (plus de blocage paywall). Sur un lancement
+    // frais (state idle, pas un retry après erreur), on marque l'usage du jour
+    // de façon non-bloquante (no-op premium) : signal de présentation pour le
+    // nudge doux « Notre histoire » de la surface quota.
+    if (_analysisState == PerspectivesAnalysisState.idle) {
+      unawaited(ref.read(analyseQuotaProvider.notifier).recordUse());
     }
     setState(() => _analysisState = PerspectivesAnalysisState.loading);
 
@@ -430,11 +427,35 @@ class _PerspectivesBottomSheetState
     }
     final quotaUsed = ref.watch(analyseQuotaProvider).valueOrNull ?? false;
     if (quotaUsed && _analysisState == PerspectivesAnalysisState.idle) {
+      // Nudge doux, non-bloquant : l'analyse reste libre. Après le 1er usage du
+      // jour, on explique le coût réel et on renvoie vers « Notre histoire »
+      // (écran Soutien), du même geste que le paywall (`context.pushNamed`).
       return Center(
-        child: Text(
-          SoutienCopy.analysesQuotaBanner,
-          textAlign: TextAlign.center,
-          style: textTheme.bodySmall?.copyWith(color: colors.textSecondary),
+        child: InkWell(
+          onTap: () => context.pushNamed(RouteNames.soutien),
+          borderRadius: BorderRadius.circular(8),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  SoutienCopy.analysesQuotaBanner,
+                  textAlign: TextAlign.center,
+                  style: textTheme.bodySmall
+                      ?.copyWith(color: colors.textSecondary),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  SoutienCopy.missionLinkLabel,
+                  style: textTheme.bodySmall?.copyWith(
+                    color: colors.primary,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
         ),
       );
     }
@@ -1832,40 +1853,32 @@ class _PerspectivesInlineSectionState
     required bool isReady,
     required Widget child,
   }) {
-    // Teinte quasi-invisible : à peine ~2 % sous le parchemin de la page. La
-    // zone ne se lit plus comme un panneau ; c'est la hairline qui délimite.
-    // Clair : crème translucide très léger. Sombre : backgroundPrimary discret.
+    // Teinte statique : plus de `BackdropFilter` (re-rasterisé chaque frame, le
+    // pattern retiré du chrome reader par #970). Zéro coût par frame ⇒ scroll du
+    // carrousel fluide. L'alpha est légèrement remonté pour compenser la perte
+    // d'assombrissement du blur (parité visuelle : le rendu web `fallbackColor`
+    // prouvait déjà que la bande tient en statique).
+    // Clair : crème translucide. Sombre : backgroundPrimary discret.
     final tint = isDark
-        ? colors.backgroundPrimary.withValues(alpha: 0.6)
-        : const Color.fromRGBO(232, 222, 203, 0.55);
-    // Web n'a pas de blur (no-op opaque) → teinte composée plus proche du fond.
-    final fallbackColor = isDark
-        ? colors.backgroundPrimary
-        : const Color.fromRGBO(237, 228, 211, 1);
+        ? colors.backgroundPrimary.withValues(alpha: 0.75)
+        : const Color.fromRGBO(232, 222, 203, 0.72);
     // Hairline chaude nette mais fine : c'est la VRAIE séparation (élégante,
     // marquée). Top + bottom, gardée sur isReady.
     final hairlineColor = isDark
         ? Colors.white.withValues(alpha: isReady ? 0.09 : 0)
         : colors.border.withValues(alpha: isReady ? 0.7 : 0);
 
-    return ClipRect(
-      // ClipRect (bords droits) borne le BackdropFilter → vrai effet verre.
-      child: webBlurFallback(
-        filter: ImageFilter.blur(sigmaX: 14, sigmaY: 14),
-        fallbackColor: fallbackColor,
-        child: DecoratedBox(
-          decoration: BoxDecoration(
-            color: tint,
-            border: Border(
-              top: BorderSide(color: hairlineColor, width: 1),
-              bottom: BorderSide(color: hairlineColor, width: 1),
-            ),
-          ),
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(0, 16, 0, 6),
-            child: child,
-          ),
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: tint,
+        border: Border(
+          top: BorderSide(color: hairlineColor, width: 1),
+          bottom: BorderSide(color: hairlineColor, width: 1),
         ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(0, 16, 0, 6),
+        child: child,
       ),
     );
   }

--- a/apps/mobile/lib/features/soutien/providers/analyse_quota_provider.dart
+++ b/apps/mobile/lib/features/soutien/providers/analyse_quota_provider.dart
@@ -41,22 +41,14 @@ class AnalyseQuotaNotifier extends AsyncNotifier<bool> {
     return !(state.valueOrNull ?? false);
   }
 
-  /// À appeler uniquement sur un lancement frais (state `idle`), jamais sur
-  /// la réouverture d'une analyse déjà cachée. No-op pour les premium.
+  /// À appeler sur un lancement frais (state `idle`), jamais sur la réouverture
+  /// d'une analyse déjà cachée. No-op pour les premium. Ne bloque plus rien :
+  /// l'analyse se charge toujours (cf. déblocage #965) ; ce marqueur ne sert
+  /// qu'à piloter le nudge doux « Notre histoire » après le 1er usage du jour.
   Future<void> recordUse() async {
     if (ref.read(isPremiumProvider)) return;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_todayKey, true);
     state = const AsyncData(true);
-  }
-
-  /// Gate d'un lancement frais (state `idle`) : consomme le quota du jour et
-  /// renvoie `true` si autorisé, `false` si le quota free est déjà épuisé.
-  /// Premium → toujours `true` (sans consommer). Centralise l'invariant
-  /// [canLaunch] + [recordUse] partagé par les points d'entrée d'analyse.
-  bool tryConsume() {
-    if (!canLaunch) return false;
-    recordUse();
-    return true;
   }
 }

--- a/apps/mobile/lib/features/soutien/soutien_copy.dart
+++ b/apps/mobile/lib/features/soutien/soutien_copy.dart
@@ -113,8 +113,9 @@ class SoutienCopy {
   static const sourcesPillFree = 'médias suivis'; // « N / 30 médias suivis »
   static const sourcesPillPremium = 'Sources illimitées · Fact·eur·isse';
   static const analysesQuotaBanner =
-      'Ton analyse offerte du jour a été utilisée. Reviens demain, ou passe '
-      'en illimité.';
+      'Chaque analyse Facteur a un coût réel de génération. On te la laisse '
+      'quand tu en as besoin. Si tu veux nous aider à financer une info sans '
+      'pub ni actionnaire, on te raconte tout.';
   static const analysesPillPremium = 'Analyses illimitées · Fact·eur·isse';
 
   // ─── Confirmation « lien envoyé » ───


### PR DESCRIPTION
## Quoi

Fluidité du lecteur et du carrousel « couverture médiatique », plus déblocage des analyses. Mobile-only, aucun changement backend.

**Fluidité (3 leviers) :**
- **WebView externe déféré** : le chargement de l'URL complète (site avec pubs/JS/trackers), le plus gros coût d'ouverture d'article, ne se déclenche plus au montage. Le contrôleur est construit tôt (bon marché) ; le `loadRequest` attend le 1er signal d'intention (scroll, fallback idle ~1 s, ou tap CTA) via `_maybeStartWebViewLoad()` idempotent.
- **HTML mémoïsé** : `ArticleReaderWidget` passe Stateless → Stateful ; `sanitizeArticleHtml` (regex lourdes) ne se relance qu'au changement de contenu, plus à chaque `setState` parent. `Html` isolé dans un `RepaintBoundary`.
- **Bande carrousel statique** : `BackdropFilter` (re-rasterisé chaque frame) remplacé par une teinte statique (alpha remonté pour parité visuelle). Zéro coût par frame.

**Analyses débloquées :** l'analyse des perspectives se charge toujours (`tryConsume` retiré). On marque juste l'usage du jour (`recordUse`, no-op premium) pour piloter un nudge doux « Notre histoire » vers l'écran Soutien après la 1re analyse du jour. Copie de la bannière réécrite (coût réel, sans pub ni actionnaire).

## Pourquoi

Le carrouset/reader accusait des lenteurs à l'ouverture (chargement WebView synchrone au montage) et un scroll saccadé (blur re-rasterisé). Côté produit, on ne veut plus bloquer une analyse derrière un paywall : on la laisse et on explique le modèle en douceur.

## Comment ça a été vérifié

- [x] `flutter test` sur les fichiers touchés OK (article_reader, perspectives_bottom_sheet, perspective_opens_in_app_reader, analyse_quota_provider). Le seul échec, `perspectives_bottom_sheet_intro_test`, est **pré-existant** (reproduit sur `origin/main`, non lié à ce diff).
- [x] `flutter analyze` : aucun nouveau lint (7 `info` vs 8 sur la base ; ce diff en retire un). Aucun `warning`/`error`.
- [x] `/simplify` passé (4 agents) — architecture jugée au bon niveau ; findings restants = hors-diff (tests) ou changements de comportement/visuel, écartés.
- [ ] Playwright non exécuté : refonte perf + logique couverte par les widget tests ; pas de dépendance API nouvelle.

## Zones à risque

- `content_detail_screen.dart` (Auth/Reader) : câblage WebView + déclencheurs. Chemin premium (source payante) court-circuité inchangé.
- Suppression du gating paywall sur les analyses : vérifier qu'aucun autre point d'entrée n'attendait ce blocage (grep : les 2 seuls call-sites sont mis à jour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)