### PR TITLE
feat(media-eval): collecte voie A/B + orchestration + corrections pilote (PR2)

### DIFF
--- a/.claude/agents/media-eval-collecteur-debunkages.md
+++ b/.claude/agents/media-eval-collecteur-debunkages.md
@@ -1,0 +1,93 @@
+---
+name: media-eval-collecteur-debunkages
+description: Collecteur voie B media-eval — recense les débunkages et vérifications négatives (C1) d'un média sur le web, les qualifie (gravité, suite donnée) et écrit un artefact JSON. Ne touche jamais la base de données.
+tools: WebSearch, WebFetch, Read, Write
+---
+
+Tu es un **collecteur de débunkages** pour le pipeline media-eval de Facteur
+(méthodologie v1.2, critère **C1 — véracité**). Tu recenses les **vérifications
+négatives** publiées à propos d'un média par des tiers accrédités, tu les
+**qualifies**, et tu déposes un artefact JSON. Tu **n'écris jamais en base** :
+un script (`ingest_artifacts.py`) valide et insère ton artefact plus tard.
+
+## Entrée (fournie par l'orchestrateur `/media-eval-run`)
+
+- `media_domaine` (ex. `cnews.fr`), `media_nom` (ex. `CNEWS`)
+- `run_id` (ex. `pilote-2026-07`)
+- `date_reference` (ISO, ex. `2026-07-10`) — **la fenêtre de fraîcheur est
+  `date_reference − 730 jours`** : n'inclus **aucun** débunkage plus ancien.
+- le dossier de sortie `.context/media_eval/<run_id>/`
+
+## Ce que tu cherches
+
+Des **débunkages / vérifications négatives** émis par des sources accréditées :
+AFP Factuel, Les Décodeurs (Le Monde), CheckNews (Libération), Factuel
+franceinfo, Fake Off (20 Minutes), autres signataires IFCN, avis **CDJM**,
+**condamnations judiciaires** (diffamation, fausses nouvelles).
+
+Pour chaque débunkage, obtiens et **cite** : l'URL exacte, une **citation
+littérale** du passage qui met en cause le média, la **date de publication**
+(`publie_at`, ISO), l'émetteur, et qualifie :
+
+- `gravite` ∈ `mineure` | `significative` | `grave` (verbatim, rien d'autre) ;
+- `suite_donnee` ∈ `correction_publiee` | `retrait` | `aucune` | `contestation`
+  | `inconnue` (verbatim).
+
+**Ne fournis JAMAIS `poids_emetteur`** — il est dérivé par le code depuis
+l'émetteur. Si tu le mets, il sera ignoré.
+
+## Règles
+
+1. **Fraîcheur** : exclus tout ce qui date d'avant `date_reference − 730 j`.
+2. **Sourçage obligatoire** : un débunkage sans URL vérifiable ni citation
+   n'est pas retenu. Pas de mémoire, pas d'approximation : tu ouvres la page.
+3. **Émetteur normalisé** en snake_case : `afp_factuel`, `les_decodeurs`,
+   `checknews`, `factuel_franceinfo`, `fake_off`, `cdjm`, `justice`. Émetteur
+   inconnu → laisse le nom en snake_case (poids `faible` par défaut côté code).
+4. **N'invente pas de sanctions ARCOM ni d'avis CDJM** : ceux-là sont déjà
+   collectés par le code (voie A). Concentre-toi sur les fact-checks IFCN et les
+   condamnations judiciaires que le code ne voit pas. Si tu tombes sur un avis
+   CDJM ou une sanction ARCOM utile, tu peux le lister en `signaux_*_c1.json`
+   (voir plus bas), mais ne le qualifie pas en couple débunkage.
+5. **Rien trouvé = résultat valide**. Écris un artefact avec `items: []` et
+   documente tes recherches dans `sources_consultees`. Le fallback C1 (< 3
+   débunkages / 2 ans) est géré par le code (→ N/A).
+
+## Sortie
+
+Écris dans `.context/media_eval/<run_id>/` :
+
+**`debunkages_<slug>.json`** (slug = `media_domaine` avec `.`→`_`) :
+
+```json
+{
+  "run_id": "<run_id>",
+  "agent": "agent:media-eval-collecteur-debunkages@v1",
+  "genere_at": "<ISO 8601 UTC>",
+  "version_prompt": null,
+  "items": [
+    {
+      "media_domaine": "<media_domaine>",
+      "type_signal": "debunkage",
+      "url_debunkage": "https://…",
+      "emetteur": "les_decodeurs",
+      "gravite": "significative",
+      "suite_donnee": "aucune",
+      "publie_at": "2025-11-02",
+      "resume": "1 phrase factuelle",
+      "citation": "citation littérale du débunkage",
+      "source_urls": ["https://…"],
+      "sources_consultees": ["https://…", "https://…"]
+    }
+  ]
+}
+```
+
+Optionnellement **`signaux_<slug>_c1.json`** pour des `condamnation_justice`
+(couple non-débunkage) au format `SignalArtifact` (voir l'agent gouvernance).
+
+## Interdits
+
+- Jamais d'écriture DB, jamais de `psql`, jamais de `python … --apply`.
+- Jamais de `poids_emetteur`, jamais de champ `score`.
+- Jamais un débunkage sans URL + citation + `publie_at`.

--- a/.claude/agents/media-eval-collecteur-gouvernance-independance.md
+++ b/.claude/agents/media-eval-collecteur-gouvernance-independance.md
@@ -1,0 +1,89 @@
+---
+name: media-eval-collecteur-gouvernance-independance
+description: Collecteur voie B media-eval — qualifie la substance de la déontologie et de l'indépendance d'un média (C8 déontologie, C9 indépendance, C11 positionnement) à partir des snapshots exportés et des pages institutionnelles, et écrit un artefact JSON de signaux. Ne touche jamais la base de données.
+tools: WebSearch, WebFetch, Read, Write
+---
+
+Tu es le **collecteur d'indépendance** (moitié 2/2 de la gouvernance) pour le
+pipeline media-eval de Facteur (méthodologie v1.2). La voie A (code) a déjà
+détecté les pages institutionnelles et **capturé leur contenu en snapshots**.
+Ton rôle : **qualifier la substance** sur **C8** (déontologie), **C9**
+(indépendance) et **C11** (positionnement). Tu **n'écris jamais en base**.
+
+## Entrée (fournie par l'orchestrateur `/media-eval-run`)
+
+- `media_domaine`, `media_nom`, `run_id`, dossier `.context/media_eval/<run_id>/`.
+- **Chemins des snapshots exportés** (`.context/media_eval/<run_id>/snapshots/*.txt`)
+  — en-tête (url, http_status, mode_acces, hash, collecte_at) puis texte de la
+  page. **Lis-les d'abord** (`Read`) : le contenu voie A (curl_cffi) est déjà
+  là, ne re-fetch pas. WebSearch / WebFetch **en complément seulement** :
+  registres CDJM / JTI (si la voie A les a laissés en `bloque_acces`, corrobore
+  par WebSearch ≥ 2 sources : « <média> membre CDJM », « <média> JTI certified »),
+  société des journalistes, statuts de la rédaction, presse pro.
+
+## Registre des `type_signal` autorisés (verbatim — rien d'autre)
+
+- **C8** : `charte_deontologique`, `adhesion_cdjm`, `certification_jti`,
+  `reference_charte_externe`
+- **C9** : `charte_independance`, `societe_journalistes`, `independance_capital`,
+  `intervention_actionnaire`, `statuts_redaction`
+- **C11** : `manifeste_positionnement`, `ligne_editoriale_publiee`,
+  `auto_description_orientation`, `rubriques_opinion_identifiees`
+
+Un `type_signal` hors registre fait **rejeter tout l'artefact** à l'ingestion.
+
+## Couverture obligatoire (anti-passivité)
+
+Ton artefact doit contenir **une entrée par `type_signal` ci-dessus** (13 au
+total). Le silence est interdit : pour chaque type, tranche
+`present` / `partiel` / `absent_verifie` / `bloque_acces`. Un `absent_verifie`
+exige **≥ 3 `sources_consultees`**. `ingest_artifacts.py` émet un WARNING listant
+tout type gouvernance sans signal (voie A + B) — vise zéro manquant.
+
+## Règles
+
+1. **Substance, pas détection** : ⚠ attention aux **soft-404** — si le snapshot
+   d'une « charte » ou « ligne éditoriale » a le même `hash` que la home, la
+   page n'existe pas : `absent_verifie`, jamais `present`.
+2. **Statuts** : `present` (`citation` + `source_urls`) ; `partiel` (incomplet) ;
+   `absent_verifie` (cherché **et non trouvé**, ≥ 3 `sources_consultees`) ;
+   `bloque_acces` (inaccessible).
+3. **Sourçage** : tout `present`/`partiel` exige `source_urls` non vide.
+4. Tu ne notes rien (pas de `score`) : tu poses des faits sourcés.
+5. **Support évalué** : cnews.fr est évalué comme **presse en ligne** (le site).
+   Un signal propre à l'antenne (ex. avis ARCOM sur la chaîne) porte
+   `valeur.support: "antenne"` ; le site `"site"`.
+
+## Sortie
+
+Écris **`signaux_<slug>_gouvernance_independance.json`** dans
+`.context/media_eval/<run_id>/` (`<slug>` = `media_domaine` avec `.`→`_`) :
+
+```json
+{
+  "run_id": "<run_id>",
+  "agent": "agent:media-eval-collecteur-gouvernance-independance@v1",
+  "genere_at": "<ISO 8601 UTC>",
+  "version_prompt": null,
+  "items": [
+    {
+      "media_domaine": "<media_domaine>",
+      "critere": "C9",
+      "type_signal": "societe_journalistes",
+      "statut": "absent_verifie",
+      "valeur": null,
+      "citation": null,
+      "source_urls": [],
+      "sources_consultees": ["https://…/mentions-legales", "https://…/qui-sommes-nous", "https://www.google.com/search?q=société+des+journalistes+<media>"]
+    }
+  ]
+}
+```
+
+## Interdits
+
+- Jamais d'écriture DB, jamais de `--apply`, jamais de `psql`.
+- Jamais un `type_signal` hors registre, jamais un `absent_verifie` sans ≥ 3
+  `sources_consultees`, jamais un `present`/`partiel` sans `source_urls`.
+- Jamais un `present` sur une page soft-404 (hash == home) ; ne re-fetch pas une
+  page déjà fournie en snapshot exporté.

--- a/.claude/agents/media-eval-collecteur-gouvernance-transparence.md
+++ b/.claude/agents/media-eval-collecteur-gouvernance-transparence.md
@@ -1,0 +1,95 @@
+---
+name: media-eval-collecteur-gouvernance-transparence
+description: Collecteur voie B media-eval — qualifie la substance de la transparence d'un média (C5 propriété/financement, C7 publicité) à partir des snapshots exportés et des pages institutionnelles, et écrit un artefact JSON de signaux. Ne touche jamais la base de données.
+tools: WebSearch, WebFetch, Read, Write
+---
+
+Tu es le **collecteur de transparence** (moitié 1/2 de la gouvernance) pour le
+pipeline media-eval de Facteur (méthodologie v1.2). La voie A (code) a déjà
+détecté les pages institutionnelles et **capturé leur contenu en snapshots**.
+Ton rôle : **qualifier la substance** sur **C5** (transparence propriété /
+financement) et **C7** (publicité). Tu **n'écris jamais en base**.
+
+## Entrée (fournie par l'orchestrateur `/media-eval-run`)
+
+- `media_domaine`, `media_nom`, `run_id`, dossier `.context/media_eval/<run_id>/`.
+- **Chemins des snapshots exportés** (`.context/media_eval/<run_id>/snapshots/*.txt`)
+  — chaque fichier porte un en-tête (url, http_status, mode_acces, hash,
+  collecte_at) puis le texte de la page. **Lis-les d'abord** (`Read`) : le
+  contenu obtenu par la voie A (curl_cffi) est déjà là, ne re-fetch pas ce qui
+  y est. WebSearch / WebFetch **en complément seulement** (ce que les snapshots
+  ne couvrent pas : Pappers, régie externe, presse spécialisée).
+
+## Registre des `type_signal` autorisés (verbatim — rien d'autre)
+
+- **C5** : `mentions_legales`, `identification_proprietaire`,
+  `structure_actionnariat`, `enregistrement_cppap`, `transparence_financement`
+- **C7** : `marquage_contenu_sponsorise`, `regie_pub_identifiee`,
+  `politique_publicitaire`
+
+Un `type_signal` hors registre fait **rejeter tout l'artefact** à l'ingestion.
+
+## Couverture obligatoire (anti-passivité)
+
+Ton artefact doit contenir **une entrée par `type_signal` ci-dessus** (8 au
+total). Le silence est interdit : pour chaque type, tranche
+`present` / `partiel` / `absent_verifie` / `bloque_acces`. Un `absent_verifie`
+exige **≥ 3 `sources_consultees`** (preuve de recherche). `ingest_artifacts.py`
+émet un WARNING listant tout type gouvernance sans signal (voie A + B).
+
+## Règles
+
+1. **Substance, pas détection** : le code a noté « une page existe » ; toi tu
+   lis son contenu et qualifies (`valeur` structurée + `citation` littérale).
+2. **Statuts** : `present` (observé, `citation` + `source_urls`) ; `partiel`
+   (existe mais incomplet) ; `absent_verifie` (cherché **et non trouvé**,
+   ≥ 3 `sources_consultees`) ; `bloque_acces` (page inaccessible).
+3. **Sourçage** : tout `present`/`partiel` exige `source_urls` non vide.
+4. Tu ne notes rien (pas de `score`) : tu poses des faits sourcés.
+5. **Support évalué** : cnews.fr est évalué comme **presse en ligne** (le site),
+   pas comme la chaîne TV. Si un signal ne concerne que l'antenne (ex. régie
+   publicitaire du groupe TV), pose `valeur.support: "antenne"` ; sinon
+   `"site"`. Ne mélange pas les deux dans un même `present`.
+
+## Sortie
+
+Écris **`signaux_<slug>_gouvernance_transparence.json`** dans
+`.context/media_eval/<run_id>/` (`<slug>` = `media_domaine` avec `.`→`_`) :
+
+```json
+{
+  "run_id": "<run_id>",
+  "agent": "agent:media-eval-collecteur-gouvernance-transparence@v1",
+  "genere_at": "<ISO 8601 UTC>",
+  "version_prompt": null,
+  "items": [
+    {
+      "media_domaine": "<media_domaine>",
+      "critere": "C5",
+      "type_signal": "identification_proprietaire",
+      "statut": "present",
+      "valeur": {"raison_sociale": "SESI SNC", "rcs": "412 916 215", "support": "site"},
+      "citation": "Editeur du site SESI SNC ... RCS Nanterre 412 916 215",
+      "source_urls": ["https://…/mentions-legales"],
+      "sources_consultees": ["https://…/mentions-legales"]
+    },
+    {
+      "media_domaine": "<media_domaine>",
+      "critere": "C7",
+      "type_signal": "marquage_contenu_sponsorise",
+      "statut": "absent_verifie",
+      "valeur": null,
+      "citation": null,
+      "source_urls": [],
+      "sources_consultees": ["https://…/publicite", "https://…/mentions-legales", "https://www.google.com/search?q=<media>+contenu+sponsorisé"]
+    }
+  ]
+}
+```
+
+## Interdits
+
+- Jamais d'écriture DB, jamais de `--apply`, jamais de `psql`.
+- Jamais un `type_signal` hors registre, jamais un `absent_verifie` sans ≥ 3
+  `sources_consultees`, jamais un `present`/`partiel` sans `source_urls`.
+- Ne re-fetch pas une page déjà fournie en snapshot exporté.

--- a/.claude/agents/media-eval-evaluateur.md
+++ b/.claude/agents/media-eval-evaluateur.md
@@ -1,0 +1,78 @@
+---
+name: media-eval-evaluateur
+description: Évaluateur media-eval — lit UN eval_inputs/<media>_<critere>.json (barème verbatim + signaux) et produit le JSON d'évaluation d'un critère. AUCUN accès web ni base ; sa réponse finale EST le JSON brut de l'artefact.
+tools: Read
+---
+
+Tu es un **évaluateur** de la méthodologie Facteur (v1.2). Tu évalues **UN
+média sur UN critère**, à partir d'un unique fichier d'entrée. Tu n'as
+**aucun accès web, fichier hors ce fichier, ni base de données**.
+
+## Entrée
+
+L'orchestrateur te donne le chemin d'**un** fichier
+`eval_inputs/<media>_<critere>.json`. Tu le lis (`Read`). Il contient :
+
+- `media`, `critere`, `run_id`, `date_reference`, `version_prompt` ;
+- `contrat_commun` (le contrat évaluateur, verbatim) ;
+- `bareme_verbatim` (la rubrique du critère, verbatim — barème + valeurs de
+  `determinations` autorisées) ;
+- `pre_flags` (garde-fous amont déjà posés, ex. `fallback_c1_declenche`) ;
+- `signaux` (observations factuelles horodatées, chacune avec un `id`).
+
+Lis le `contrat_commun` et le `bareme_verbatim` **avant tout** : ils font foi.
+
+## Ta tâche
+
+Applique la rubrique aux signaux et produis des **`determinations`
+énumérables** (jamais un score chiffré — le score est dérivé par code). Chaque
+phrase de ta `justification` doit s'adosser à des `signal_ids_cites`.
+
+Rappels du contrat (voir `contrat_commun` pour le détail) :
+
+- `bloque_acces` **n'est pas** une absence (ne le traite jamais en négatif) ;
+- signaux insuffisants ou `fallback_c1_declenche` présent → pose
+  `donnees_insuffisantes` (N/A), n'invente rien ;
+- un média n'est jamais pénalisé pour sa ligne éditoriale, seulement pour des
+  pratiques observables ;
+- `signal_ids_cites` **non vide** sauf si `donnees_insuffisantes` ;
+- flags autorisés uniquement : `donnees_insuffisantes`,
+  `signaux_contradictoires`, `bloque_acces`, `revue_humaine_requise`.
+
+## Sortie — RÈGLE ABSOLUE (D3)
+
+Ta **réponse finale est le JSON brut de l'artefact, et RIEN d'autre** : pas de
+texte avant/après, pas de bloc de code markdown, pas de commentaire. Tu
+n'écris aucun fichier (tu n'as pas `Write`) : l'orchestrateur capte ta réponse
+et l'écrit dans `evaluations_<slug>_<critere>.json`.
+
+Format exact :
+
+```json
+{
+  "run_id": "<repris de l'entrée>",
+  "agent": "agent:media-eval-evaluateur@v1",
+  "genere_at": "<ISO 8601 UTC>",
+  "version_prompt": "<repris verbatim de l'entrée>",
+  "items": [
+    {
+      "media_domaine": "<domaine>",
+      "critere": "<Ck>",
+      "determinations": { "…": "selon la section « Sortie structurée » de la rubrique" },
+      "justification": "2 à 6 phrases factuelles, chacune adossée à des signal_ids",
+      "signal_ids_cites": ["<uuid présent dans l'entrée>", "…"],
+      "flags": []
+    }
+  ]
+}
+```
+
+(La sortie ci-dessus est décrite avec des ``` pour la lisibilité de cette
+consigne ; ta **vraie** réponse ne contient aucun ```.)
+
+## Interdits
+
+- Aucun champ `score` (dérivé par code), aucun `poids_emetteur`.
+- Aucune `determination` hors des valeurs énumérées par la rubrique.
+- Aucun `signal_id` qui n'apparaît pas dans l'entrée.
+- Aucune recherche externe : tu ne disposes que de ce fichier.

--- a/.claude/commands/media-eval-run.md
+++ b/.claude/commands/media-eval-run.md
@@ -1,0 +1,171 @@
+# /media-eval-run — orchestrer un run media-eval
+
+`$ARGUMENTS = <domaine> <run_id>` (ex. `cnews.fr pilote-2026-07`).
+
+Tu orchestres le pipeline media-eval de bout en bout pour **un média**, en
+autonomie mais avec **une pause humaine bloquante** (GOLD GATE). Tous les
+scripts sont dans `packages/api/scripts/media_eval/` et se lancent depuis
+`packages/api` (`DATABASE_URL` explicite). **Dry-run d'abord, `--apply`
+ensuite** ; hors DB test, `--apply` exige `--allow-prod` (= GO PO).
+
+## Règles non négociables
+
+- **Aucun agent n'écrit en base** : les collecteurs voie B et l'évaluateur
+  produisent des artefacts ; seuls les scripts `ingest_*` écrivent en DB.
+- **Ne jamais éditer à la main un artefact évaluateur** (`evaluations_*.json`) —
+  c'est le critère de succès n°1 (artefacts valides sans retouche).
+- **`.context/` n'est jamais commité** (gitignore). Seuls les livrables
+  `docs/media-eval/{golden,fiches,rapports}/*` le sont.
+- **Ne pas retoucher `docs/media-eval/rubrics/*.md`** une fois le run commencé
+  (leur sha256 = `version_prompt` ; toute retouche invalide la comparabilité).
+
+## 0. Pré-vol
+
+- Affiche `DATABASE_URL` (host + base). Confirme la cible (test vs prod).
+- `alembic heads` = **1** (sinon stop : régler la chaîne d'abord).
+- Si cible prod : rappelle que chaque `--apply` portera `--allow-prod` (GO PO).
+- **`PAPPERS_API_TOKEN`** : vérifie présence + 1 requête test (ou lance
+  `bash scripts/healthcheck-agent-secrets.sh` qui le teste). Absent/épuisé n'est
+  **pas bloquant** : `collect_pappers` bascule sur l'API publique gratuite
+  `recherche-entreprises.api.gouv.fr` (identification `present` + actionnariat
+  `partiel`). Note-le pour l'interprétation de C5/C9.
+
+## 1. Run + référentiel (idempotents, une fois par run)
+
+```
+python3 scripts/media_eval/create_run.py --run-id <run_id> \
+    --date-reference <YYYY-MM-DD> --medias <domaines…> [--apply --allow-prod]
+python3 scripts/media_eval/seed_medias.py [--apply --allow-prod]
+```
+
+`create_run` **refuse** de changer une `date_reference` existante (elle pilote
+la fraîcheur) : si conflit, supprimer/recréer le run explicitement.
+
+## 2. Voie A — 6 collecteurs code (dry-run puis `--apply`)
+
+Dans cet ordre, pour `<domaine>`. **Un collecteur bloqué n'arrête pas la
+chaîne** (il émet des `bloque_acces` honnêtes) :
+
+```
+collect_pages_types.py  --media <domaine> --run-id <run_id>   # découverte + détection
+collect_cdjm.py         --media <domaine> --run-id <run_id>   # adhésion + avis fondés
+collect_jti.py          --media <domaine> --run-id <run_id>   # certification (souvent absente)
+collect_cppap.py        --media <domaine> --run-id <run_id>   # open data (jamais le form POST)
+collect_pappers.py      --media <domaine> --run-id <run_id>   # ⚠ exige PAPPERS_API_TOKEN ;
+                                                              #   sinon 3 bloque_acces + WARNING (exit 0)
+collect_arcom.py        --media <domaine> --run-id <run_id>   # auto-désactivé si non audiovisuel (0 signal)
+```
+
+Chacun : d'abord sans `--apply` (inspecte le plan), puis `--apply [--allow-prod]`.
+
+### 2bis. Export des snapshots (voie A → fichiers)
+
+**Avant** la voie B, dump les snapshots vers des fichiers — c'est le levier
+principal contre les 403 anti-bot : les agents lisent le contenu déjà obtenu par
+`curl_cffi` au lieu de re-fetcher.
+
+```
+python3 scripts/media_eval/export_snapshots.py --run-id <run_id> --media <domaine>
+```
+
+Récupère la liste des chemins écrits (`.context/media_eval/<run_id>/snapshots/*.txt`) :
+tu les passeras **explicitement** aux agents voie B.
+
+## 3. Voie B — collecteurs agents (en parallèle)
+
+Spawn en parallèle (Task tool), sortie dans `.context/media_eval/<run_id>/`.
+Passe à chacun les **chemins des snapshots exportés** (étape 2bis) — WebSearch /
+WebFetch en **complément seulement** :
+
+- `media-eval-collecteur-debunkages` (C1) — `media_domaine`, `media_nom`,
+  `run_id`, **`date_reference`** (fenêtre 730 j).
+- `media-eval-collecteur-gouvernance-transparence` (C5 + C7) — substance
+  propriété / financement / publicité.
+- `media-eval-collecteur-gouvernance-independance` (C8 + C9 + C11) — déontologie
+  / indépendance / positionnement.
+
+**Couverture** : chaque agent gouvernance doit rendre **une entrée par
+`type_signal` de son registre** (pas de silence). Si un registre CDJM/JTI est
+resté `bloque_acces` en voie A, l'agent independance corrobore par WebSearch
+(≥ 2 sources) plutôt que de deviner.
+
+**Politique de mort d'agent** : si un agent voie B meurt (session-limit), **respawn
+avec périmètre réduit** (la moitié de ses critères). Le repli « l'orchestrateur
+écrit lui-même l'artefact » est **interdit sauf accord PO explicite**, et doit
+alors être marqué (`agent: "humain:laurin"` → voie HUMAIN).
+
+Puis ingère (validation Pydantic → rejet en bloc si invalide) :
+
+```
+python3 scripts/media_eval/ingest_artifacts.py \
+    --artifact .context/media_eval/<run_id>/         # dry-run
+python3 scripts/media_eval/ingest_artifacts.py \
+    --artifact .context/media_eval/<run_id>/ --apply [--allow-prod]
+```
+
+L'ingestion émet un **WARNING de couverture** listant tout `type_signal`
+gouvernance sans signal (voie A + B) : traite chaque manquant (respawn ciblé ou
+`absent_verifie` sourcé) avant le GOLD GATE.
+
+## 4. Entrées évaluateur
+
+```
+python3 scripts/media_eval/build_eval_input.py --media <domaine> --run-id <run_id> \
+    [--apply --allow-prod]   # --apply seulement pour écrire l'éval C8 du raccourci JTI
+```
+
+Génère `.context/media_eval/<run_id>/eval_inputs/<media>_<critere>.json`. Note
+les garde-fous journalisés (fraîcheur, fallback C1, raccourci JTI).
+
+> **Répète les étapes 2→4 pour chaque média du run** avant le GOLD GATE.
+
+## 5. 🛑 GOLD GATE — STOP (D4)
+
+**Arrête-toi et notifie Laurin.** Il note **en aveugle**, depuis les **mêmes**
+`eval_inputs/*.json` + rubriques, dans
+`docs/media-eval/golden/gold_v0.json` (copié du template, `note_at` = maintenant
+UTC). Les évaluateurs ne sont spawnés **qu'après** que le gold est figé — c'est
+la preuve mécanique D4 (`rapport_pilote.py` WARNING si le gold ne précède pas
+les évaluations).
+
+## 6. Évaluateurs (1 par critère, après le gold)
+
+Pour chaque `eval_inputs/<media>_<critere>.json` (C8 **sauté** si le raccourci
+JTI a produit l'éval) : spawn `media-eval-evaluateur` (tools `Read`). Sa
+réponse finale **EST** le JSON brut — **écris-le toi-même** dans
+`.context/media_eval/<run_id>/evaluations_<slug>_<critere>.json` (jamais
+l'agent, jamais d'édition manuelle du contenu). Puis :
+
+```
+python3 scripts/media_eval/ingest_evaluations.py \
+    --artifact .context/media_eval/<run_id>/          # dry-run → --apply [--allow-prod]
+python3 scripts/media_eval/synthese_fiche.py --media <domaine> --run-id <run_id> \
+    [--apply --allow-prod]
+```
+
+## 7. Livrables (lecture seule DB + gold)
+
+```
+python3 scripts/media_eval/export_evaluations.py --run-id <run_id> \
+    --out .context/media_eval/<run_id>/evaluations_export.json
+python3 scripts/media_eval/evaluate_golden_agreement.py \
+    --gold ../../docs/media-eval/golden/gold_v0.json \
+    --generated .context/media_eval/<run_id>/evaluations_export.json \
+    --out-dir ../../docs/media-eval/rapports --slug <run_id>
+python3 scripts/media_eval/rapport_pilote.py --run-id <run_id> \
+    --gold ../../docs/media-eval/golden/gold_v0.json \
+    --out ../../docs/media-eval/rapports/<run_id>.md
+```
+
+`rapport_pilote.py` écrit **deux** rendus depuis une unique collecte DB :
+`<run_id>.md` (ASCII git-diffable, audit) **et** `<run_id>.html` (rapport propre
+autonome, single-file — deux lentilles : propreté des données puis accord des
+évaluations + verdict V0). Ouvre le `.html` dans un navigateur pour la revue.
+
+Commite : `docs/media-eval/golden/gold_v0.json`, `docs/media-eval/fiches/*.md`,
+`docs/media-eval/rapports/*.{md,html}`. **Jamais** `.context/`.
+
+## 8. Verdict
+
+Lis le verdict V0 (4 critères) dans `rapports/<run_id>.md`. Rapporte PASS/FAIL
+avec les preuves chiffrées ; ne conclus « V0 validé » que si les 4 sont PASS.

--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,84 +1,85 @@
-# feat(media-eval): fondations (schéma, contrats, moteur d'évaluation)
+# feat(media-eval): collecte vague 1 + orchestration + rapport (PR 2)
 
-PR 1/2 du MVP pipeline d'évaluation des médias C1–C11 (story
-`docs/stories/core/media-eval.0.mvp-pipeline-evaluation.md`, plan PO validé le
-07/07/2026). Entièrement testable offline — la collecte (voie A + agents) et le
-run pilote arrivent en PR 2.
+Complète la pipeline media-eval de bout en bout par-dessus les fondations
+PR 1 (#944) : **6 collecteurs voie A** (code → DB), **3 sous-agents** (2
+collecteurs web voie B + 1 évaluateur sans web), **1 commande d'orchestration**
+(`/media-eval-run`), et l'outillage de **run pilote** (golden gate, export,
+rapport avec verdict V0). Le run pilote `pilote-2026-07` lui-même est en
+hand-off (accès réseau réel + `PAPPERS_API_TOKEN` + notation humaine en aveugle
++ `--allow-prod`).
 
-## Ce que fait cette PR
+## Bug latent PR 1 réparé
+La FK `media_eval_signaux.run_id → media_eval_runs.run_id` n'était jamais
+satisfaite (aucun run créé) ; les tests PR 1 passaient sur un conteneur test
+« sale ». Réparé par le fixture `run_test` (conftest mutualisé) + `create_run.py`.
+`build_eval_input` calait aussi la fraîcheur sur `now()` au lieu de
+`MediaEvalRun.date_reference` (rejouabilité cassée) — corrigé via `require_run()`.
 
-### Docs source de vérité PO (`docs/media-eval/`)
-- Import de la méthodologie v1.1.1 (PDF converti) + amendements v1.2 actés
-  (raccourci JTI, pondération débunkages, temporalité, lettres A–E).
-- Import de l'architecture collecte ≠ évaluation du 07/07/2026.
-- **Rubriques évaluateur** (`rubrics/_common.md` + `C1/C5/C7/C8/C9/C11.md`) :
-  barème §4 verbatim + section « Sortie structurée » (`determinations`
-  énumérables). Lues verbatim par `build_eval_input.py` ;
-  `version_prompt` = sha256 du fichier rubrique.
+## Contenu
+- **`collect_common.py`** : fetch httpx + repli curl_cffi (ne lève jamais),
+  `require_run`, `Collecteur` (dédupe applicative + validation Pydantic), dédupe
+  voie A préfixée `code|` (D2), harnais CLI `run_cli`.
+- **6 collecteurs** : `collect_{pages_types,cdjm,jti,cppap,pappers,arcom}.py`
+  (fonctions `parse_*` pures + `collecter` async, fixtures figées, zéro réseau
+  en test). ARCOM auto-désactivé hors audiovisuel ; Pappers dégrade en 3
+  `bloque_acces` si token absent (exit 0).
+- **`create_run.py`** (D1), patchs moteur : `ingest_artifacts` (D6 voie
+  `humain:`, `collecte_at`, `version_prompt_collecteur`),
+  `evaluate_golden_agreement --out-dir`, `build_eval_input` (date_reference),
+  `.gitignore` (`.context/`).
+- **`export_evaluations.py`** + **`rapport_pilote.py`** (D7) : unique collecte DB
+  (`collecter_donnees_rapport`) → **deux rendus** — `.md` ASCII git-diffable +
+  **`.html` propre autonome** (lentille propreté data `evaluer_proprete_donnees`
+  : trou d'accès vs absence confirmée ; `render_html` single-file CSS inline
+  calqué sur le design system media-eval ; verdict V0).
+- **`.claude/agents/media-eval-{collecteur-debunkages,evaluateur}.md`** +
+  agents gouvernance (voir PR 2b) + **`.claude/commands/media-eval-run.md`** +
+  `golden/gold_v0.template.json`.
 
-### Schéma DB (migration `me01_media_eval_tables`, additive, RLS deny-all)
-7 tables `media_eval_*` : medias (référentiel niveau domaine), snapshots,
-corpus_articles (créée mais vide en V0), signaux (pivot ; statuts
-present/absent_verifie/partiel/bloque_acces ; dédup idempotente par
-`dedupe_key`), debunkages (qualification émetteur/gravité/suite, couple 1-1
-avec un signal C1), evaluations (score NULL si N/A, `signal_ids` cités,
-version_methodo/version_prompt), fiches (renormalisation, lettre, confiance).
-- `down_revision = ue01_user_entity_affinity` → 1 seul head. Idempotente
-  (guard `has_table` par table — la chaîne boote sur les 2 services Railway).
-  RLS pattern `sec02` (ENABLE + REVOKE anon/authenticated, aucune policy).
-- Modèles `app/models/media_eval.py` (StrEnum locaux, enums VARCHAR non natifs,
-  pattern `Source`), enregistrés dans `app/models/__init__.py`.
+## PR 2b — corrections collecte (diagnostic du run pilote initial)
 
-### Contrats & garde-fous codés en dur (`scripts/media_eval/`)
-- `schemas.py` : `BAREMES` (100 pts), `CRITERES_VAGUE_1` (54 pts),
-  `NIVEAU_SCORES` C9/C11, `LETTRES`, registre `type_signal` figé, artefacts
-  Pydantic (Signal/Debunkage/Evaluation + enveloppes batch, GoldenSet).
-  **`derive_score(critere, determinations)`** : le score faisant foi est dérivé
-  par code, jamais choisi par le LLM (philosophie `derive_reliability`).
-  Validator dur : éval sans `signal_ids_cites` rejetée (sauf flag
-  `donnees_insuffisantes` → N/A). `poids_emetteur` des débunkages dérivé par
-  code (`arcom/justice/cdjm` = fort, fact-checkers de médias concurrents =
-  moyen, inconnu = faible).
-- `garde_fous.py` (fonctions pures) : fraîcheur 730 j (signaux événementiels
-  seulement, structurels constatés à date), fallback C1 (< 3 débunkages/2 ans),
-  raccourci JTI, corroboration (score plein sans ≥ 2 domaines sources
-  indépendants → palier inférieur + flag `corroboration_insuffisante`),
-  `bloque_acces` → `revue_requise` — jamais converti en 0.
+Le run pilote cnews.fr a révélé des **faux positifs voie A** et une substance
+capturée mais jamais exposée. Corrections incluses dans cette PR :
 
-### Scripts moteur (dry-run par défaut, `--apply` gardé, `--allow-prod` hors DB test)
-`seed_medias.py` (2 pilotes : cnews.fr audiovisuel, reporterre.net presse en
-ligne) · `ingest_artifacts.py` (valide en bloc puis insère — un artefact
-invalide = exit non-zéro, rien d'écrit ; idempotent) · `build_eval_input.py`
-(exports `eval_inputs/<media>_<critere>.json` + garde-fous amont) ·
-`ingest_evaluations.py` (garde-fous aval : signal_ids existants / bon média /
-bon critère, score dérivé, corroboration, statuts) · `synthese_fiche.py`
-(renormalisation sur les seuls critères évalués, lettre, confiance, fiche md +
-ligne DB) · `evaluate_golden_agreement.py` (accord vs gold : exact C9/C11,
-|Δ| ≤ 20 % du barème en continu, désaccords N/A-vs-score listés).
+- **Anti soft-404 + filtre lexical** (`collect_pages_types.py`) : `present`
+  seulement si le texte ≠ home (hash/similarité) **et** porte les marqueurs
+  lexicaux du type ; pénalité anti-flux (dons/régie servis en fils d'articles).
+  ⇒ les faux `present` C8/charte, C11/ligne-éditoriale, C7/régie,
+  C5/transparence deviennent `absent_verifie` (test de non-régression cnews).
+- **Substance exposée** (`build_eval_input.py`) : `serialiser_signal` joint
+  `snapshot_extrait` (~4 000 c) + `snapshot_url` quand le signal a un `snapshot_id`.
+- **`export_snapshots.py`** (nouveau) : dump des snapshots vers
+  `.context/media_eval/<run_id>/snapshots/*.txt`, lus par la voie B (anti-403).
+- **Pappers** : SIREN cnews.fr corrigé (SESI SNC **412 916 215**, éditeur du
+  site) + **repli gratuit** `recherche-entreprises.api.gouv.fr` sans token
+  (identification `present`, actionnariat `partiel`) au lieu de 3 `bloque_acces` ;
+  pré-vol token dans le healthcheck + `/media-eval-run` §0.
+- **CPPAP** : dataset réel confirmé (`liste-des-publications-de-presse`, Explore
+  v2.1, champs `titre`/`ndeg_cppap`) + repli voie C documenté.
+- **Couverture** (`ingest_artifacts.py`) : WARNING listant les `type_signal`
+  gouvernance sans signal (anti-passivité).
+- **Agents gouvernance découpés en 2** (`gouvernance-transparence` C5+C7,
+  `gouvernance-independance` C8+C9+C11) : lisent les snapshots exportés, couvrent
+  tout leur registre ; politique de mort d'agent + support antenne/site portés
+  dans la commande et les prompts.
 
-## Tests & vérifications
+> **Non inclus** (attend le re-run corrigé `pilote-2026-07b` + GOLD GATE) :
+> `docs/media-eval/fiches/cnews_fr_pilote-2026-07.md` (fiche du run buggé, à
+> régénérer) et les artefacts `.context/` du run.
 
-- **91 tests** `tests/scripts/media_eval/` (purs + DB savepoint) : contrats,
-  table `derive_score`, bornes fraîcheur 729/730/731 j, fallback 2 vs 3,
-  corroboration, JTI, `bloque_acces` jamais 0, renormalisation 0/1/3 N/A
-  (cas Reporterre max 34), bornes lettres 84.9/85, matrice confiance,
-  idempotence dedupe/évals, rejets (signal d'un autre média/critère,
-  artefact partiellement invalide → rien d'écrit), métriques gold.
-- Migration sur **DB vide** : `upgrade head` → `downgrade -1` → `upgrade head`
-  OK, exactement 1 head (`me01_media_eval_tables`).
-- Smoke E2E offline sur DB jetable : seed → ingest artefacts (5 signaux dont
-  2 couples débunkage, poids dérivés) → build_eval_input (fallback C1 déclenché
-  à 2 débunkages, 6 entrées écrites) → ingest_evaluations (3 évals, C1 N/A) →
-  synthese_fiche (10/20 → 50/100, lettre D, confiance moyenne).
-- Suite backend complète `pytest` + `ruff check`/`format` OK.
+## Décisions de design D1–D7
+D1 création de run explicite (refus mutation `date_reference`) · D2 dédupe voie
+A préfixée `code|` (coexiste avec la voie B) · D3 évaluateur Read-only (réponse
+= JSON) · D4 GOLD GATE anti-contamination + preuve horodatage · D5 CPPAP open
+data (jamais le form POST) · D6 voie dérivée du préfixe `humain:` · D7 rapport
+généré par script (chiffres auditables).
 
-Pas d'entrée changelog : outillage interne, aucun impact user (bypass de la
-règle 400 lignes assumé).
+## Tests
+- **191 tests** `tests/scripts/media_eval` verts sur DB propre (dont
+  non-régression cnews soft-404/flux, repli Pappers gratuit, snapshot_extrait,
+  couverture voie B), ruff clean (check + format).
+- Smoke offline validé (create_run → seed → ingest → build_eval_input →
+  ingest_evaluations → synthese → export → rapport).
+- Pas de nouvelle migration (dédupe snapshots applicative) — `alembic heads` = 1.
 
-## Suite (PR 2)
-
-Collecteurs voie A (`collect_pages_types/cdjm/jti/cppap/pappers/arcom`),
-sous-agents `.claude/agents/media-eval-*`, commande `/media-eval-run`, run
-pilote `pilote-2026-07` (CNEWS puis Reporterre) + golden set Laurin
-(`docs/media-eval/golden/gold_v0.json`) + rapport d'accord. Prérequis :
-`PAPPERS_API_TOKEN` (env locale, compte gratuit).
+Pas d'entrée changelog (outillage interne).

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ node_modules/
 # Scratch de session du Playwright CLI (snapshots, screenshots, logs console)
 .playwright-cli/
 
+# Répertoire de collaboration inter-agents (artefacts de run, jamais commité —
+# media-eval y dépose eval_inputs/evaluations/exports du run pilote)
+.context/
+
 # General
 **/.DS_Store
 .AppleDouble

--- a/docs/media-eval/README.md
+++ b/docs/media-eval/README.md
@@ -9,12 +9,28 @@
 1. **Collecte** (3 voies) → produit des **signaux** horodatés, sourcés, avec
    citation et snapshot, dans les tables `media_eval_*` (Supabase). La collecte
    **ne note jamais**.
-   - **Voie A — CODE** : scripts déterministes (`packages/api/scripts/media_eval/collect_*.py`).
-     Écrivent directement en DB.
-   - **Voie B — AGENT** : sous-agents Claude avec accès web. N'écrivent **jamais**
-     en DB : artefacts JSON dans `.context/media_eval/<run_id>/` → validés
-     (Pydantic) puis insérés par `ingest_artifacts.py`.
-   - **Voie C — HUMAIN** : paywall, double évaluation C9/C11, golden set.
+   - **Voie A — CODE** : 6 scripts déterministes déposant leurs signaux en DB via
+     le module commun `collect_common.py` (fetch httpx + repli curl_cffi, dédupe
+     applicative, validation `SignalArtifact` avant insertion, harnais dry-run) :
+     `collect_pages_types` (découverte + détection des pages institutionnelles),
+     `collect_cdjm` (adhésion + avis fondés), `collect_jti` (certification),
+     `collect_cppap` (open data `liste-des-publications-de-presse`),
+     `collect_pappers` (propriété/capital, repli gratuit
+     `recherche-entreprises.api.gouv.fr` sans token),
+     `collect_arcom` (sanctions audiovisuel, auto-désactivé sinon).
+     `page_significative` écarte les soft-404 (page = home) et les pages sans
+     marqueur lexical de leur type. `export_snapshots.py` dump ensuite les
+     snapshots vers `.context/media_eval/<run_id>/snapshots/*.txt`.
+   - **Voie B — AGENT** : sous-agents Claude avec accès web (`.claude/agents/`),
+     découpés par domaine (`gouvernance-transparence` C5+C7,
+     `gouvernance-independance` C8+C9+C11, `debunkages` C1). Ils **lisent les
+     snapshots exportés** (levier anti-403) et n'écrivent **jamais** en DB :
+     artefacts JSON dans `.context/media_eval/<run_id>/` → validés (Pydantic)
+     puis insérés par `ingest_artifacts.py` (WARNING de couverture si un
+     `type_signal` gouvernance reste sans signal).
+   - **Voie C — HUMAIN** : paywall, double évaluation C9/C11, golden set. Un
+     artefact d'agent préfixé `humain:…` est ingéré en `voie=humain` (D6) — pas
+     de nouveau script.
 2. **Évaluation** : 1 sous-agent par critère, **sans accès web**, qui ne lit que
    `eval_inputs/<media>_<critere>.json` (signaux + barème verbatim) et rend un
    JSON structuré citant des `signal_ids`. Le **score faisant foi est dérivé par
@@ -33,16 +49,36 @@
 ## Flow d'un run
 
 ```
+create_run.py ───────────────► media_eval_runs (date_reference = fraîcheur)
 seed_medias.py ──────────────► media_eval_medias
 collect_*.py (voie A) ───────► signaux + snapshots (DB directe)
 agents collecteurs (voie B) ─► .context/media_eval/<run_id>/*.json
 ingest_artifacts.py ─────────► signaux + debunkages (validés Pydantic)
 build_eval_input.py ─────────► eval_inputs/<media>_<critere>.json (+ garde-fous amont)
-agents évaluateurs ──────────► evaluations_<media>_<critere>.json
+🛑 GOLD GATE (D4) ───────────► gold_v0.json noté EN AVEUGLE (avant les évaluateurs)
+agents évaluateurs ──────────► evaluations_<media>_<critere>.json (réponse = JSON brut)
 ingest_evaluations.py ───────► media_eval_evaluations (+ garde-fous aval)
 synthese_fiche.py ───────────► media_eval_fiches + fiche markdown
+export_evaluations.py ───────► evaluations_export.json (schéma GoldenSet)
 evaluate_golden_agreement.py ► rapport d'accord vs golden set humain
+rapport_pilote.py ───────────► docs/media-eval/rapports/<run_id>.{md,html} (verdict V0)
 ```
+
+L'orchestration est décrite pas-à-pas dans la commande **`/media-eval-run`**
+(`.claude/commands/media-eval-run.md`) : pré-vol → run + seed → voie A → voie B →
+ingest → build_eval_input → **GOLD GATE — STOP** → évaluateurs → ingest →
+synthèse → export + accord + rapport. Règle : `.context/` jamais commité, aucun
+agent n'écrit en DB, aucune édition manuelle d'un artefact évaluateur.
+
+**Création du run explicite (D1)** : `create_run.py` (upsert idempotent) fixe la
+`date_reference` qui pilote la fraîcheur ; elle **ne peut pas être mutée**
+silencieusement. Collecteurs et `build_eval_input` appellent `require_run()` qui
+**lève** si le run n'existe pas — pas de création implicite.
+
+**Protocole golden (D4)** : Laurin note depuis les **mêmes** `eval_inputs/*.json`
++ rubriques que les agents, à une étape **GOLD GATE** insérée entre
+`build_eval_input` et le spawn des évaluateurs. `rapport_pilote.py` vérifie
+`gold.note_at` < horodatage des évaluations et émet un WARNING sinon.
 
 ## Périmètre V0 (décisions PO du 07/07/2026)
 
@@ -75,8 +111,11 @@ evaluate_golden_agreement.py ► rapport d'accord vs golden set humain
 | `architecture-v1.2.md` | Architecture collecte/évaluation C1–C11 (import du doc du 07/07/2026) |
 | `rubrics/_common.md` | Contrat évaluateur générique + format JSON de sortie |
 | `rubrics/C{1,5,7,8,9,11}.md` | Barème §4 verbatim + sortie structurée + types de signaux |
-| `golden/gold_v0.json` | Golden set humain (Laurin) — livré en PR 2 |
-| `fiches/*.md` | Fiches générées — livrées en PR 2 |
+| `golden/gold_v0.template.json` | Gabarit du golden (12 entrées, à copier + noter en aveugle) |
+| `golden/gold_v0.json` | Golden set humain (Laurin) — rempli au run pilote |
+| `fiches/*.md` | Fiches générées au run pilote |
+| `rapports/*.md` | Rapport d'accord + rapport pilote ASCII (verdict V0) |
+| `rapports/*.html` | Rapport pilote HTML propre (2 lentilles : propreté data + accord/verdict), autonome single-file |
 
 `version_prompt` d'une évaluation = **sha256 du fichier rubrique** utilisé
 (calculé par `build_eval_input.py`) : toute retouche de rubrique invalide la

--- a/docs/media-eval/fiches/cnews_fr_pilote-2026-07.md
+++ b/docs/media-eval/fiches/cnews_fr_pilote-2026-07.md
@@ -1,0 +1,15 @@
+# Fiche d'évaluation — CNEWS (cnews.fr)
+
+- Run : `pilote-2026-07` · généré le 2026-07-15
+- **Score : 10 / 20 → 50/100 · lettre D**
+- Confiance : **basse**
+- Critères évalués : C5, C8, C11 · N/A : C1, C7, C9 · revue requise : aucun
+
+| Critère | Statut | Score | Niveau | Flags | Évaluateur |
+|---|---|---|---|---|---|
+| C1 | non_applicable | N/A | - | donnees_insuffisantes | agent:media-eval-evaluateur@v1 |
+| C11 | evaluee | 3/6 | 2 | revue_humaine_requise, corroboration_insuffisante | agent:media-eval-evaluateur@v1 |
+| C5 | evaluee | 5/10 | - | - | agent:media-eval-evaluateur@v1 |
+| C7 | non_applicable | N/A | - | donnees_insuffisantes | agent:media-eval-evaluateur@v1 |
+| C8 | evaluee | 2/4 | - | revue_humaine_requise | agent:media-eval-evaluateur@v1 |
+| C9 | non_applicable | N/A | - | donnees_insuffisantes | agent:media-eval-evaluateur@v1 |

--- a/docs/media-eval/golden/gold_v0.template.json
+++ b/docs/media-eval/golden/gold_v0.template.json
@@ -1,0 +1,20 @@
+{
+  "version_methodo": "v1.2",
+  "notateur": "humain:laurin",
+  "note_at": null,
+  "_instructions": "GOLD GATE (D4) : copie ce fichier en gold_v0.json, note EN AVEUGLE depuis les mêmes eval_inputs/*.json + rubriques que les agents, AVANT de spawner les évaluateurs. Renseigne note_at (ISO 8601 UTC, maintenant). Pour chaque entrée : statut ∈ evaluee|non_applicable|revue_requise ; si evaluee, score obligatoire ; C9/C11 exigent aussi niveau ∈ 0|1|2. Supprime cette clé _instructions dans gold_v0.json.",
+  "entries": [
+    {"media_domaine": "cnews.fr", "critere": "C1", "statut": "a_noter", "score": null, "commentaire": "0/5/10/15/20"},
+    {"media_domaine": "cnews.fr", "critere": "C5", "statut": "a_noter", "score": null, "commentaire": "0/5/10"},
+    {"media_domaine": "cnews.fr", "critere": "C7", "statut": "a_noter", "score": null, "commentaire": "0/2/4"},
+    {"media_domaine": "cnews.fr", "critere": "C8", "statut": "a_noter", "score": null, "commentaire": "0/2/4"},
+    {"media_domaine": "cnews.fr", "critere": "C9", "statut": "a_noter", "score": null, "niveau": null, "commentaire": "niveau 0/1/2 → score 0/5/10"},
+    {"media_domaine": "cnews.fr", "critere": "C11", "statut": "a_noter", "score": null, "niveau": null, "commentaire": "niveau 0/1/2 → score 0/3/6"},
+    {"media_domaine": "reporterre.net", "critere": "C1", "statut": "a_noter", "score": null, "commentaire": "N/A attendu (< 3 débunkages → fallback)"},
+    {"media_domaine": "reporterre.net", "critere": "C5", "statut": "a_noter", "score": null, "commentaire": "0/5/10"},
+    {"media_domaine": "reporterre.net", "critere": "C7", "statut": "a_noter", "score": null, "commentaire": "0/2/4"},
+    {"media_domaine": "reporterre.net", "critere": "C8", "statut": "a_noter", "score": null, "commentaire": "0/2/4"},
+    {"media_domaine": "reporterre.net", "critere": "C9", "statut": "a_noter", "score": null, "niveau": null, "commentaire": "niveau 0/1/2 → score 0/5/10"},
+    {"media_domaine": "reporterre.net", "critere": "C11", "statut": "a_noter", "score": null, "niveau": null, "commentaire": "niveau 0/1/2 → score 0/3/6"}
+  ]
+}

--- a/docs/stories/core/media-eval.0.mvp-pipeline-evaluation.md
+++ b/docs/stories/core/media-eval.0.mvp-pipeline-evaluation.md
@@ -3,8 +3,8 @@
 ## Statut
 
 - **Type** : Feature (outillage interne, rien de user-visible — pas d'entrée changelog)
-- **PR 1** : `feat(media-eval): fondations (schéma, contrats, moteur d'évaluation)` — en cours
-- **PR 2** : `feat(media-eval): collecte vague 1 + orchestration + run pilote` — à suivre
+- **PR 1** : `feat(media-eval): fondations (schéma, contrats, moteur d'évaluation)` (#944) — mergée
+- **PR 2** : `feat(media-eval): collecte vague 1 + orchestration + run pilote` — code + tests livrés ; **run pilote en attente** (network + `PAPPERS_API_TOKEN` + GOLD GATE humain + `--allow-prod` prod)
 - **Plan validé PO** : 07/07/2026 (cf. `.context/attachments` plan MVP)
 
 ## Contexte
@@ -47,11 +47,54 @@ d'accord contre un golden set humain (Laurin).
 - [x] Tests `tests/scripts/media_eval/` + fixtures
 - [x] Vérif E2E : migration DB vide (up/down/up), suite pytest, smoke dry-run/apply sur DB test
 
-## Tasks PR 2 (à venir)
+## Tasks PR 2
 
-- [ ] Collecteurs voie A : `collect_pages_types.py`, `collect_cdjm.py`, `collect_jti.py`, `collect_cppap.py`, `collect_pappers.py`, `collect_arcom.py`
-- [ ] Sous-agents `.claude/agents/media-eval-*.md` + commande `.claude/commands/media-eval-run.md`
-- [ ] Run pilote `pilote-2026-07` (CNEWS puis Reporterre) + golden set + rapport d'accord
+- [x] **Réparation FK latente** (voir ci-dessous) : `conftest.py` (`run_test`),
+  `create_run.py`, `build_eval_input` piloté par `date_reference` (plus `now()`)
+- [x] Module commun voie A `collect_common.py` (fetch httpx+curl_cffi, `require_run`,
+  `Collecteur`, dédupe voie A `code|` (D2), harnais CLI) + tests
+- [x] Collecteurs voie A : `collect_pages_types.py`, `collect_cdjm.py`, `collect_jti.py`, `collect_cppap.py`, `collect_pappers.py`, `collect_arcom.py` + fixtures + tests
+- [x] Patchs moteur : `ingest_artifacts` (D6 voie humain/agent, `collecte_at`, `version_prompt_collecteur`), `evaluate_golden_agreement --out-dir`, `.gitignore` (`.context/`)
+- [x] Export + rapport : `export_evaluations.py`, `rapport_pilote.py` (verdict V0
+  ASCII **+ rapport HTML propre** : lentille propreté data `evaluer_proprete_donnees`,
+  `render_html` autonome single-file, collecte factorisée `collecter_donnees_rapport`) + tests
+- [x] Sous-agents `.claude/agents/media-eval-{collecteur-debunkages,collecteur-gouvernance,evaluateur}.md` + commande `.claude/commands/media-eval-run.md` + `golden/gold_v0.template.json`
+- [ ] **Run pilote `pilote-2026-07`** (CNEWS puis Reporterre) + golden set + rapport d'accord — bloqué sur : accès réseau réel aux sources, `PAPPERS_API_TOKEN` (compte gratuit à créer), GOLD GATE (notation humaine en aveugle), `--allow-prod` (GO PO écriture DB prod)
+
+## Bug latent PR 1 réparé en PR 2
+
+La FK `media_eval_signaux.run_id → media_eval_runs.run_id` n'était jamais
+satisfaite : aucun script ni fixture ne créait de ligne run. Les tests PR 1
+passaient sur un conteneur test **« sale »** (une ligne `run-test` résiduelle) ;
+sur DB propre (`DROP SCHEMA`), `test_ingest_artifacts.py` échouait sur
+`ForeignKeyViolation media_eval_signaux_run_id_fkey`. Réparé par le fixture
+`run_test` (conftest mutualisé) + `create_run.py`. `build_eval_input` calait
+aussi la fraîcheur sur `datetime.now()` au lieu de `MediaEvalRun.date_reference`
+(rejouabilité cassée) — corrigé via `require_run()`.
+
+## Décisions de design PR 2 (D1–D7)
+
+- **D1 — Création de run explicite** : `create_run.py` (upsert idempotent),
+  `require_run()` lève si absent, refus de mutation silencieuse de
+  `date_reference` (pilote la fraîcheur).
+- **D2 — Collision dédupe voie A/B** : clé voie A préfixée `code|` (distincte de
+  la clé voie B) → un signal code de détection et un signal agent de substance sur
+  le même quadruplet coexistent (2 lignes).
+- **D3 — Évaluateur Read-only** : sa réponse finale EST le JSON de l'artefact ;
+  l'orchestrateur l'écrit (jamais l'agent, jamais d'édition manuelle).
+- **D4 — Golden anti-contamination** : GOLD GATE entre `build_eval_input` et le
+  spawn des évaluateurs ; `rapport_pilote.py` vérifie `gold.note_at` <
+  horodatage des évaluations (WARNING sinon).
+- **D5 — CPPAP open data** : `data.culture.gouv.fr` (jamais le formulaire POST) ;
+  dataset inaccessible → `bloque_acces` (repli voie C possible).
+- **D6 — Voie dérivée du préfixe** : `agent` commençant par `humain:` →
+  `voie=humain` à l'ingestion (ouvre la voie C sans nouveau script).
+- **D7 — Rapport généré par script** (`rapport_pilote.py`, lecture seule DB +
+  gold) : chiffres auditables. Unique collecte DB (`collecter_donnees_rapport`)
+  → **deux rendus** : `.md` ASCII (git-diffable, audit) **et** `.html` propre
+  autonome single-file (deux lentilles : propreté des données collectées puis
+  qualité des évaluations + verdict V0 ; lentille `evaluer_proprete_donnees`,
+  distinction cardinale trou d'accès vs absence confirmée).
 
 ## Fichiers modifiés (PR 1)
 
@@ -60,6 +103,70 @@ d'accord contre un golden set humain (Laurin).
 - `packages/api/app/models/media_eval.py` (nouveau) + `app/models/__init__.py`
 - `packages/api/scripts/media_eval/` (nouveau) : `__init__.py`, `schemas.py`, `garde_fous.py`, `seed_medias.py`, `ingest_artifacts.py`, `build_eval_input.py`, `ingest_evaluations.py`, `synthese_fiche.py`, `evaluate_golden_agreement.py`
 - `packages/api/tests/scripts/media_eval/` (nouveau) + `tests/scripts/fixtures/media_eval/`
+
+## Fichiers modifiés (PR 2)
+
+- `packages/api/scripts/media_eval/` : `create_run.py`, `collect_common.py`,
+  `collect_{pages_types,cdjm,jti,cppap,pappers,arcom}.py`, `export_evaluations.py`,
+  `rapport_pilote.py` (nouveaux) ; patchs `ingest_artifacts.py`,
+  `build_eval_input.py`, `evaluate_golden_agreement.py`
+- `packages/api/tests/scripts/media_eval/` : `conftest.py` + `test_create_run.py`,
+  `test_collect_common.py`, `test_collect_{pages_types,cdjm,jti,cppap,pappers,arcom}.py`,
+  `test_export_evaluations.py`, `test_rapport_pilote.py` ; MAJ `test_ingest_*`
+- `tests/scripts/fixtures/media_eval/html/` + `api/` : fixtures figées
+- `.claude/agents/media-eval-*.md` (3), `.claude/commands/media-eval-run.md`
+- `docs/media-eval/` : `golden/gold_v0.template.json`, README mis à jour ;
+  `rapports/` + `fiches/` + `golden/gold_v0.json` remplis au run pilote
+- `.gitignore` : `.context/`
+
+## PR 2b — corrections collecte (pilote-2026-07b)
+
+Diagnostic du run pilote initial (cnews.fr) : la voie A produisait des faux
+positifs et n'exposait jamais la substance capturée. Corrections livrées :
+
+- **Anti soft-404 + filtre lexical** (`collect_pages_types.py`) : une page n'est
+  `present` que si son texte ≠ home (hash/similarité — un site qui sert sa home
+  sur `/charte` est écarté) **et** porte les marqueurs lexicaux de son type ;
+  pénalité anti-flux (dons/régie servis comme fils d'articles taggés → écartés).
+  ⇒ les faux `present` C8/`charte_deontologique`, C11/`ligne_editoriale_publiee`,
+  C7/`regie_pub_identifiee`, C5/`transparence_financement` deviennent
+  `absent_verifie`.
+- **Substance exposée à l'évaluateur** (`build_eval_input.py`) : `serialiser_signal`
+  joint `snapshot_extrait` (~4 000 c) + `snapshot_url` quand le signal porte un
+  `snapshot_id` — l'évaluateur voit ce que dit la page, pas juste qu'elle existe.
+- **`export_snapshots.py`** (nouveau) : dump des snapshots du run vers
+  `.context/media_eval/<run_id>/snapshots/*.txt` (en-tête de provenance), lu par
+  la voie B au lieu de re-fetcher (levier anti-403).
+- **Pappers** (`collect_pappers.py`) : SIREN cnews.fr corrigé (site édité par
+  **SESI SNC 412 916 215**, ≠ société de la chaîne TV) + **repli gratuit**
+  `recherche-entreprises.api.gouv.fr` sans token (identification `present`,
+  actionnariat/capital `partiel`) au lieu de 3 `bloque_acces` ; pré-vol token
+  ajouté au healthcheck + `/media-eval-run` §0.
+- **CPPAP** (`collect_cppap.py`) : dataset réel confirmé
+  (`liste-des-publications-de-presse`, API Explore v2.1, champs `titre` /
+  `ndeg_cppap`) ; repli voie C documenté (ISSN dans le snapshot).
+- **Couverture voie B** (`ingest_artifacts.py`) : WARNING listant les
+  `type_signal` gouvernance sans signal (anti-passivité, le silence est interdit).
+- **Agents gouvernance découpés en 2** (`gouvernance-transparence` C5+C7,
+  `gouvernance-independance` C8+C9+C11) : chacun lit les snapshots exportés,
+  couvre tout son registre, WebSearch en complément ; politique de mort d'agent
+  (respawn périmètre réduit) et distinction support antenne/site portées dans
+  `/media-eval-run` et les prompts.
+
+### Fichiers modifiés (PR 2b)
+
+- `packages/api/scripts/media_eval/` : `export_snapshots.py` (nouveau) ; patchs
+  `collect_pages_types.py`, `build_eval_input.py`, `collect_pappers.py`,
+  `collect_cppap.py`, `ingest_artifacts.py`
+- `packages/api/tests/scripts/media_eval/` : `test_build_eval_input.py`,
+  `test_export_snapshots.py` (nouveaux) ; MAJ `test_collect_{pages_types,pappers,
+  cppap}.py`, `test_ingest_artifacts.py`
+- `tests/scripts/fixtures/media_eval/` : `html/` (mentions/charte/dons OK,
+  cnews home riche + flux dons/publicité), `api/` (pappers SESI SNC,
+  recherche-entreprises, cppap v2)
+- `.claude/agents/` : `media-eval-collecteur-gouvernance-{transparence,
+  independance}.md` (remplacent l'agent gouvernance unique)
+- `.claude/commands/media-eval-run.md`, `scripts/healthcheck-agent-secrets.sh`
 
 ## Critères de succès V0 (verrouillés)
 

--- a/packages/api/scripts/media_eval/build_eval_input.py
+++ b/packages/api/scripts/media_eval/build_eval_input.py
@@ -28,7 +28,7 @@ import asyncio
 import hashlib
 import json
 import sys
-from datetime import UTC, date, datetime
+from datetime import date
 from pathlib import Path
 from uuid import UUID
 
@@ -42,9 +42,11 @@ from app.models.media_eval import (
     MediaEvalDebunkage,
     MediaEvalEvaluation,
     MediaEvalSignal,
+    MediaEvalSnapshot,
     StatutEvaluation,
 )
 from scripts.cleanup_orphan_sources import _is_test_db
+from scripts.media_eval.collect_common import require_run
 from scripts.media_eval.garde_fous import (
     detecter_jti_valide,
     fallback_c1_requis,
@@ -62,6 +64,10 @@ _REPO_ROOT = Path(__file__).resolve().parents[4]
 RUBRICS_DIR = _REPO_ROOT / "docs" / "media-eval" / "rubrics"
 DEFAULT_OUT_ROOT = _REPO_ROOT / ".context" / "media_eval"
 
+# Substance de la page jointe au signal pour que l'évaluateur voie ce que dit
+# la page (pas seulement qu'elle existe) — cf. hand-off « mini-filtre ».
+SNAPSHOT_EXTRAIT_MAX = 4000
+
 
 def rubrique_path(critere: str) -> Path:
     return RUBRICS_DIR / f"{critere}.md"
@@ -72,8 +78,17 @@ def version_prompt(critere: str) -> str:
     return hashlib.sha256(rubrique_path(critere).read_bytes()).hexdigest()
 
 
-def serialiser_signal(signal: MediaEvalSignal) -> dict:
-    return {
+def serialiser_signal(
+    signal: MediaEvalSignal, snapshot: MediaEvalSnapshot | None = None
+) -> dict:
+    """Sérialise un signal ; joint la substance du snapshot si fourni.
+
+    La voie A capture jusqu'à 20 000 caractères par page mais n'expose que
+    ``{url, detection}`` : sans le contenu, l'évaluateur voit qu'une page existe
+    sans savoir ce qu'elle dit. On joint donc un extrait (``snapshot_extrait``)
+    et l'URL (``snapshot_url``) quand le signal porte un ``snapshot_id``.
+    """
+    data = {
         "id": str(signal.id),
         "type_signal": signal.type_signal,
         "statut": signal.statut.value
@@ -86,6 +101,10 @@ def serialiser_signal(signal: MediaEvalSignal) -> dict:
         "voie": signal.voie.value if hasattr(signal.voie, "value") else signal.voie,
         "collecte_at": signal.collecte_at.isoformat() if signal.collecte_at else None,
     }
+    if snapshot is not None and signal.snapshot_id == snapshot.id:
+        data["snapshot_url"] = snapshot.url
+        data["snapshot_extrait"] = (snapshot.contenu or "")[:SNAPSHOT_EXTRAIT_MAX]
+    return data
 
 
 def construire_eval_input(
@@ -94,6 +113,7 @@ def construire_eval_input(
     signaux: list[dict],
     *,
     run_id: str,
+    date_reference: date,
     bareme_verbatim: str,
     contrat_commun: str,
     version_prompt_sha: str,
@@ -104,6 +124,7 @@ def construire_eval_input(
         "media": media,
         "critere": critere,
         "run_id": run_id,
+        "date_reference": date_reference.isoformat(),
         "version_methodo": VERSION_METHODO,
         "version_prompt": version_prompt_sha,
         "score_max": BAREMES[critere],
@@ -125,6 +146,19 @@ async def _signaux_du_critere(session, media_id, run_id: str, critere: str):
         .order_by(MediaEvalSignal.collecte_at)
     )
     return list(rows.scalars())
+
+
+async def _charger_snapshots(
+    session, signaux: list[MediaEvalSignal]
+) -> dict[UUID, MediaEvalSnapshot]:
+    """Snapshots référencés par les signaux (par id), pour joindre la substance."""
+    ids = {s.snapshot_id for s in signaux if s.snapshot_id is not None}
+    if not ids:
+        return {}
+    rows = await session.execute(
+        select(MediaEvalSnapshot).where(MediaEvalSnapshot.id.in_(ids))
+    )
+    return {snap.id: snap for snap in rows.scalars()}
 
 
 async def _nb_debunkages_frais(
@@ -183,12 +217,16 @@ async def run(
         print("\nABORT : --apply contre une DB non-test sans --allow-prod (gated PO).")
         return 2
 
-    aujourd_hui = datetime.now(UTC).date()
     contrat_commun = (RUBRICS_DIR / "_common.md").read_text()
     out_dir = out_root / run_id / "eval_inputs"
 
     async with async_session_maker() as session:
         try:
+            # date_reference du run pilote la fraîcheur (jamais now()) : un run
+            # rejoué plus tard produit les mêmes entrées évaluateur.
+            run_row = await require_run(session, run_id)
+            aujourd_hui = run_row.date_reference
+            print(f"date_reference : {aujourd_hui.isoformat()}")
             media = await resoudre_media(session, domaine)
             media_dict = {
                 "nom": media.nom,
@@ -206,7 +244,8 @@ async def run(
 
             for critere in CRITERES_VAGUE_1:
                 rows = await _signaux_du_critere(session, media.id, run_id, critere)
-                signaux = [serialiser_signal(s) for s in rows]
+                snaps = await _charger_snapshots(session, rows)
+                signaux = [serialiser_signal(s, snaps.get(s.snapshot_id)) for s in rows]
                 frais, exclus = filtrer_fraicheur(signaux, aujourd_hui)
                 for s in exclus:
                     print(
@@ -241,6 +280,7 @@ async def run(
                     critere,
                     frais,
                     run_id=run_id,
+                    date_reference=aujourd_hui,
                     bareme_verbatim=rubrique_path(critere).read_text(),
                     contrat_commun=contrat_commun,
                     version_prompt_sha=version_prompt(critere),

--- a/packages/api/scripts/media_eval/collect_arcom.py
+++ b/packages/api/scripts/media_eval/collect_arcom.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Collecteur voie A — ARCOM (décisions & sanctions de l'audiovisuel).
+
+L'ARCOM ne régule que l'audiovisuel : si le média n'est **pas** audiovisuel,
+le collecteur affiche « N/A structurel » et **n'écrit aucun signal** (l'absence
+reste neutre — décision PO : ARCOM conservé dans le registre C1 mais N/A
+structurel pour la presse en ligne). Reporterre → 0 signal.
+
+Pour un média audiovisuel (CNEWS) : décisions/sanctions filtrées par média et
+par fenêtre (``date_reference − 730 j``) → C1/``sanction_arcom`` present par
+décision (``valeur.publie_at`` obligatoire), ou ``absent_verifie`` si aucune.
+La voie A ne pose que le fait « une sanction existe » ; gravité et suite
+donnée restent à l'agent debunkages (voie B). Fetch bloqué → ``bloque_acces``.
+
+Usage :
+    cd packages/api
+    python3 scripts/media_eval/collect_arcom.py --media cnews.fr \
+        --run-id pilote-2026-07 [--apply --allow-prod]
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+from urllib.parse import quote, urljoin
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from bs4 import BeautifulSoup
+
+from app.models.media_eval import TypeMedia
+from scripts.media_eval.collect_common import (
+    CollectStats,
+    Fetcher,
+    ouvrir_collecteur,
+    run_cli,
+)
+from scripts.media_eval.schemas import FRAICHEUR_MAX_JOURS
+
+COLLECTEUR = "code:collect_arcom@v1"
+URL_BASE = "https://www.arcom.fr"
+
+
+def recherche_url(nom_media: str) -> str:
+    return f"{URL_BASE}/nos-ressources/mediatheque?recherche={quote(nom_media)}"
+
+
+def _parse_date(brut: str) -> date | None:
+    brut = (brut or "").strip()
+    if not brut:
+        return None
+    try:
+        return date.fromisoformat(brut[:10])
+    except ValueError:
+        return None
+
+
+def parse_arcom_decisions(html: str, base: str = URL_BASE) -> list[dict]:
+    """Décisions listées : {url, titre, publie_at, media} depuis la recherche."""
+    soup = BeautifulSoup(html, "html.parser")
+    decisions: list[dict] = []
+    for item in soup.find_all(class_="decision"):
+        lien = item.find("a", href=True)
+        if lien is None:
+            continue
+        time_tag = item.find("time")
+        publie_at = None
+        if time_tag is not None:
+            publie_at = _parse_date(
+                time_tag.get("datetime") or time_tag.get_text(strip=True)
+            )
+        decisions.append(
+            {
+                "url": urljoin(base + "/", lien["href"]),
+                "titre": lien.get_text(" ", strip=True),
+                "publie_at": publie_at,
+                "media": (item.get("data-media") or "").strip(),
+            }
+        )
+    return decisions
+
+
+def concerne_media(decision: dict, nom_media: str) -> bool:
+    cible = nom_media.strip().lower()
+    return cible in decision["media"].lower() or cible in decision["titre"].lower()
+
+
+async def collecter(session, media, run, fetcher: Fetcher) -> CollectStats:
+    """Sanctions ARCOM (C1) — N/A structurel hors audiovisuel."""
+    c = await ouvrir_collecteur(session, media, run, COLLECTEUR)
+
+    if media.type_media != TypeMedia.AUDIOVISUEL:
+        print(
+            f"[arcom] N/A structurel : {media.domaine} n'est pas audiovisuel "
+            f"({media.type_media}) — aucun signal (absence neutre)."
+        )
+        return c.stats
+
+    url = recherche_url(media.nom)
+    res = await fetcher(url)
+    if res.bloque or res.status != 200:
+        await c.bloque(
+            critere="C1",
+            type_signal="sanction_arcom",
+            url=url,
+            raison="médiathèque ARCOM inaccessible",
+            sources_consultees=[url],
+        )
+        return c.stats
+
+    cutoff = run.date_reference - timedelta(days=FRAICHEUR_MAX_JOURS)
+    trouvees = 0
+    for decision in parse_arcom_decisions(res.text):
+        if not concerne_media(decision, media.nom):
+            continue
+        publie_at = decision["publie_at"]
+        if publie_at is None or publie_at < cutoff:
+            continue
+        trouvees += 1
+        await c.signal(
+            critere="C1",
+            type_signal="sanction_arcom",
+            statut="present",
+            valeur={
+                "emetteur": "arcom",
+                "publie_at": publie_at.isoformat(),
+                "url": decision["url"],
+                "titre": decision["titre"],
+            },
+            citation=decision["titre"],
+            source_urls=[decision["url"]],
+        )
+    if trouvees == 0:
+        await c.signal(
+            critere="C1",
+            type_signal="sanction_arcom",
+            statut="absent_verifie",
+            sources_consultees=[url],
+        )
+    return c.stats
+
+
+def main() -> None:
+    run_cli("arcom", collecter)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/scripts/media_eval/collect_cdjm.py
+++ b/packages/api/scripts/media_eval/collect_cdjm.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Collecteur voie A — CDJM (Conseil de déontologie journalistique et médiation).
+
+Deux registres publics de cdjm.org :
+- **membres** → C8/``adhesion_cdjm`` (present si le média adhère, sinon
+  ``absent_verifie``) ;
+- **avis** → C1/``avis_cdjm`` : un signal *par avis fondé* concernant le média
+  dans la fenêtre (``date_reference − 730 j``), avec ``valeur.publie_at``
+  **obligatoire** (sinon la fraîcheur l'exclut en aval).
+
+La voie A n'écrit **pas** de couple débunkage : gravité et suite donnée sont un
+jugement, réservé à l'agent debunkages (voie B). Ici on ne pose que le fait
+« un avis fondé existe ». Fetch bloqué / DOM cassé → ``bloque_acces``.
+
+Usage :
+    cd packages/api
+    python3 scripts/media_eval/collect_cdjm.py --media cnews.fr \
+        --run-id pilote-2026-07 [--apply --allow-prod]
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+from urllib.parse import urljoin
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from bs4 import BeautifulSoup
+
+from scripts.media_eval.collect_common import (
+    Collecteur,
+    CollectStats,
+    Fetcher,
+    ouvrir_collecteur,
+    run_cli,
+)
+from scripts.media_eval.schemas import FRAICHEUR_MAX_JOURS
+
+COLLECTEUR = "code:collect_cdjm@v1"
+
+URL_MEMBRES = "https://cdjm.org/les-membres/"
+URL_AVIS_INDEX = "https://cdjm.org/nos-avis/"
+
+
+# --------------------------------------------------------------------------- #
+# Fonctions pures.
+# --------------------------------------------------------------------------- #
+def parse_membres(html: str) -> list[str]:
+    """Noms des médias membres (texte des items de la liste des membres)."""
+    soup = BeautifulSoup(html, "html.parser")
+    zone = soup.find(class_="membres") or soup.find("main") or soup
+    noms = []
+    for item in zone.find_all(["li", "a", "h3"]):
+        texte = item.get_text(" ", strip=True)
+        if texte and len(texte) < 120:
+            noms.append(texte)
+    return noms
+
+
+def parse_avis_index(html: str, base: str = URL_AVIS_INDEX) -> list[dict]:
+    """Liste des avis (url absolue, titre) depuis l'index."""
+    soup = BeautifulSoup(html, "html.parser")
+    avis: list[dict] = []
+    vus: set[str] = set()
+    for a in soup.find_all("a", href=True):
+        href = a["href"].strip()
+        if "avis" not in href.lower():
+            continue
+        url = urljoin(base, href)
+        if url in vus or url.rstrip("/") == base.rstrip("/"):
+            continue
+        vus.add(url)
+        avis.append({"url": url, "titre": a.get_text(" ", strip=True)})
+    return avis
+
+
+def _texte_date(valeur: str) -> date | None:
+    valeur = valeur.strip()
+    for fmt in ("%Y-%m-%d",):
+        try:
+            return date.fromisoformat(valeur[:10])
+        except ValueError:
+            pass
+    return None
+
+
+def parse_avis_detail(html: str) -> dict:
+    """Extrait {publie_at, fonde, media, resume} d'une page d'avis.
+
+    ``publie_at`` : balise <time datetime="…">. ``fonde`` : présence du mot
+    « fondé(e) » dans le verdict. ``media`` : bloc « média mis en cause ».
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    time_tag = soup.find("time")
+    publie_at = None
+    if time_tag is not None:
+        brut = time_tag.get("datetime") or time_tag.get_text(strip=True)
+        publie_at = _texte_date(brut or "")
+    texte = soup.get_text(" ", strip=True).lower()
+    fonde = "fondé" in texte or "fondee" in texte or "fondée" in texte
+    media = None
+    mis_en_cause = soup.find(class_="media-mis-en-cause")
+    if mis_en_cause is not None:
+        media = mis_en_cause.get_text(" ", strip=True)
+    titre = soup.find(["h1", "title"])
+    resume = titre.get_text(" ", strip=True) if titre else None
+    return {"publie_at": publie_at, "fonde": fonde, "media": media, "resume": resume}
+
+
+def media_est_membre(nom_media: str, membres: list[str]) -> bool:
+    cible = nom_media.strip().lower()
+    return any(cible in m.lower() for m in membres)
+
+
+def avis_concerne_media(
+    entree: dict, nom_media: str, detail: dict | None = None
+) -> bool:
+    cible = nom_media.strip().lower()
+    if cible in (entree.get("titre") or "").lower():
+        return True
+    return bool(detail and cible in (detail.get("media") or "").lower())
+
+
+# --------------------------------------------------------------------------- #
+# Collecte.
+# --------------------------------------------------------------------------- #
+async def _collecter_adhesion(c: Collecteur, fetcher: Fetcher) -> None:
+    res = await fetcher(URL_MEMBRES)
+    if res.bloque or res.status != 200:
+        await c.bloque(
+            critere="C8",
+            type_signal="adhesion_cdjm",
+            url=URL_MEMBRES,
+            raison="registre des membres CDJM inaccessible",
+            sources_consultees=[URL_MEMBRES],
+        )
+        return
+    membres = parse_membres(res.text)
+    if media_est_membre(c.media.nom, membres):
+        await c.signal(
+            critere="C8",
+            type_signal="adhesion_cdjm",
+            statut="present",
+            valeur={"registre": "cdjm", "url": URL_MEMBRES},
+            source_urls=[URL_MEMBRES],
+        )
+    else:
+        await c.signal(
+            critere="C8",
+            type_signal="adhesion_cdjm",
+            statut="absent_verifie",
+            sources_consultees=[URL_MEMBRES],
+        )
+
+
+async def _collecter_avis(c: Collecteur, fetcher: Fetcher, cutoff: date) -> None:
+    res = await fetcher(URL_AVIS_INDEX)
+    if res.bloque or res.status != 200:
+        await c.bloque(
+            critere="C1",
+            type_signal="avis_cdjm",
+            url=URL_AVIS_INDEX,
+            raison="index des avis CDJM inaccessible",
+            sources_consultees=[URL_AVIS_INDEX],
+        )
+        return
+    for entree in parse_avis_index(res.text):
+        # On ne consulte le détail que si le titre mentionne le média.
+        if not avis_concerne_media(entree, c.media.nom):
+            continue
+        detail_res = await fetcher(entree["url"])
+        if detail_res.bloque or detail_res.status != 200:
+            await c.bloque(
+                critere="C1",
+                type_signal="avis_cdjm",
+                url=entree["url"],
+                raison="page d'avis CDJM inaccessible",
+                sources_consultees=[entree["url"]],
+            )
+            continue
+        detail = parse_avis_detail(detail_res.text)
+        publie_at = detail["publie_at"]
+        if not detail["fonde"] or publie_at is None or publie_at < cutoff:
+            continue
+        await c.signal(
+            critere="C1",
+            type_signal="avis_cdjm",
+            statut="present",
+            valeur={
+                "emetteur": "cdjm",
+                "publie_at": publie_at.isoformat(),
+                "url": entree["url"],
+                "fonde": True,
+                "resume": detail["resume"],
+            },
+            citation=detail["resume"],
+            source_urls=[entree["url"]],
+        )
+
+
+async def collecter(session, media, run, fetcher: Fetcher) -> CollectStats:
+    """Adhésion CDJM (C8) + avis fondés dans la fenêtre (C1)."""
+    c = await ouvrir_collecteur(session, media, run, COLLECTEUR)
+    cutoff = run.date_reference - timedelta(days=FRAICHEUR_MAX_JOURS)
+    await _collecter_adhesion(c, fetcher)
+    await _collecter_avis(c, fetcher, cutoff)
+    return c.stats
+
+
+def main() -> None:
+    run_cli("cdjm", collecter)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/scripts/media_eval/collect_common.py
+++ b/packages/api/scripts/media_eval/collect_common.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""Module commun des collecteurs voie A (code déterministe → DB directe).
+
+La voie A écrit des signaux ``voie=CODE`` (détection / registres publics) sans
+LLM. La voie B (agents) qualifie la *substance* et passe par
+``ingest_artifacts.py``. Les deux voies peuvent produire le même quadruplet
+(critère|type|statut|ancre) sans se supprimer : la clé de dédupe voie A est
+**préfixée ``code|``** (D2) alors que la voie B ne l'est pas — même quadruplet
+⇒ deux clés ⇒ deux lignes conservées.
+
+Ce module fournit :
+- ``FetchResult`` + ``fetch_http`` : récupération HTTP robuste (httpx puis repli
+  ``curl_cffi`` sur anti-bot), qui **ne lève jamais** — un échec devient un
+  ``FetchResult`` bloqué (« jamais d'échec silencieux ») ;
+- ``require_run`` : lève si le run n'existe pas (sa ``date_reference`` pilote la
+  fraîcheur, cf. ``create_run.py``) ;
+- ``Collecteur`` : contexte d'écriture (snapshots + signaux) avec dédupe
+  applicative et validation Pydantic avant insertion ;
+- ``run_cli`` : harnais argparse commun aux 6 collecteurs (dry-run/--apply).
+
+Un ``fetcher`` est injectable : en test on lit des fixtures HTML/JSON figées,
+zéro réseau.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import sys
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import httpx
+from pydantic import ValidationError
+from sqlalchemy import select
+
+from app.config import get_settings
+from app.database import async_session_maker, engine
+from app.models.media_eval import (
+    MediaEvalMedia,
+    MediaEvalRun,
+    MediaEvalSignal,
+    MediaEvalSnapshot,
+    ModeAcces,
+    StatutSignal,
+    TypePage,
+    VoieCollecte,
+)
+from scripts.cleanup_orphan_sources import _is_test_db
+from scripts.media_eval.ingest_artifacts import IngestError, resoudre_media
+from scripts.media_eval.schemas import SignalArtifact
+
+# UA dédié : identifiable, honnête (pas de spoof d'un vrai navigateur en httpx —
+# le repli curl_cffi impersonate chrome n'est utilisé que sur anti-bot avéré).
+USER_AGENT = "FacteurMediaEval/1.0 (+https://facteur.app; evaluation open data)"
+_ANTIBOT_STATUS: frozenset[int] = frozenset({401, 403, 429, 503})
+_TIMEOUT = 20.0
+_RETRIES = 2
+
+
+class CollecteError(Exception):
+    """Erreur bloquante d'un collecteur (run/média absent, incohérence dure)."""
+
+
+# --------------------------------------------------------------------------- #
+# Récupération HTTP — ne lève jamais.
+# --------------------------------------------------------------------------- #
+@dataclass
+class FetchResult:
+    url: str
+    status: int | None
+    text: str
+    mode_acces: ModeAcces
+    erreur: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        """Réponse exploitable (200, contenu récupéré)."""
+        return self.status == 200 and self.erreur is None
+
+    @property
+    def bloque(self) -> bool:
+        """Accès refusé (anti-bot, réseau) — ≠ page absente (404)."""
+        return self.mode_acces == ModeAcces.BLOQUE
+
+
+# Un fetcher : URL -> FetchResult (injectable en test).
+Fetcher = Callable[[str], Awaitable[FetchResult]]
+
+
+def _result_httpx(url: str, resp: httpx.Response) -> FetchResult:
+    if resp.status_code == 200:
+        return FetchResult(url, 200, resp.text, ModeAcces.LIBRE)
+    mode = ModeAcces.BLOQUE if resp.status_code in _ANTIBOT_STATUS else ModeAcces.LIBRE
+    return FetchResult(
+        url, resp.status_code, resp.text, mode, f"HTTP {resp.status_code}"
+    )
+
+
+def _curl_get(url: str, timeout: float) -> tuple[int, str]:
+    from curl_cffi import requests as curl_requests
+
+    resp = curl_requests.get(
+        url, impersonate="chrome", timeout=timeout, allow_redirects=True
+    )
+    return resp.status_code, resp.text
+
+
+async def _fetch_curl(url: str, timeout: float) -> FetchResult:
+    """Repli anti-bot (curl_cffi sync exécuté hors event-loop)."""
+    try:
+        status, text = await asyncio.to_thread(_curl_get, url, timeout)
+    except Exception as exc:  # réseau / TLS / curl : jamais de raise
+        return FetchResult(url, None, "", ModeAcces.BLOQUE, f"curl_cffi: {exc}")
+    if status == 200:
+        return FetchResult(url, 200, text, ModeAcces.LIBRE)
+    mode = ModeAcces.BLOQUE if status in _ANTIBOT_STATUS else ModeAcces.LIBRE
+    return FetchResult(url, status, text, mode, f"HTTP {status}")
+
+
+async def fetch_http(url: str, *, timeout: float = _TIMEOUT) -> FetchResult:
+    """GET robuste — httpx (2 retries) puis repli curl_cffi sur anti-bot.
+
+    Ne lève jamais : toute exception ou statut anti-bot persistant devient un
+    ``FetchResult`` bloqué (le collecteur émettra un signal ``bloque_acces``).
+    """
+    derniere_exc: str | None = None
+    for tentative in range(_RETRIES + 1):
+        try:
+            async with httpx.AsyncClient(
+                follow_redirects=True,
+                timeout=timeout,
+                headers={"User-Agent": USER_AGENT},
+            ) as client:
+                resp = await client.get(url)
+            if resp.status_code in _ANTIBOT_STATUS:
+                break  # anti-bot → repli curl_cffi
+            return _result_httpx(url, resp)
+        except httpx.HTTPError as exc:
+            derniere_exc = str(exc)
+            if tentative == _RETRIES:
+                break
+    curl = await _fetch_curl(url, timeout)
+    if curl.erreur is None or derniere_exc is None:
+        return curl
+    return FetchResult(url, curl.status, curl.text, curl.mode_acces, curl.erreur)
+
+
+# --------------------------------------------------------------------------- #
+# Résolution du run — jamais implicite.
+# --------------------------------------------------------------------------- #
+async def require_run(session, run_id: str) -> MediaEvalRun:
+    """Retourne le run ou **lève** (sa date_reference pilote la fraîcheur).
+
+    Pas de ``ensure_run()`` : la création d'un run est un acte délibéré et
+    audité (``create_run.py``).
+    """
+    run = (
+        await session.execute(select(MediaEvalRun).where(MediaEvalRun.run_id == run_id))
+    ).scalar_one_or_none()
+    if run is None:
+        raise CollecteError(
+            f"run inconnu : {run_id!r} — le créer d'abord "
+            "(scripts/media_eval/create_run.py)."
+        )
+    return run
+
+
+# --------------------------------------------------------------------------- #
+# Dédupe voie A (D2) — préfixe `code|` pour cohabiter avec la voie B.
+# --------------------------------------------------------------------------- #
+def dedupe_key_signal_code(item: SignalArtifact) -> str:
+    """sha256 canonique préfixé ``code|`` (distinct de la clé voie B).
+
+    Même quadruplet (critère|type|statut|ancre) qu'un signal agent ⇒ clé
+    différente ⇒ les deux lignes coexistent (détection code vs substance agent).
+    """
+    ancre = item.source_urls[0] if item.source_urls else (item.citation or "")
+    brut = f"code|{item.critere}|{item.type_signal}|{item.statut}|{ancre}"
+    return hashlib.sha256(brut.encode()).hexdigest()
+
+
+# --------------------------------------------------------------------------- #
+# Contexte d'écriture d'un collecteur.
+# --------------------------------------------------------------------------- #
+@dataclass
+class CollectStats:
+    inseres: int = 0
+    doublons: int = 0
+    snapshots: int = 0
+    bloques: int = 0
+    details: list[str] = field(default_factory=list)
+
+
+def _hash_contenu(contenu: str | None) -> str:
+    return hashlib.sha256((contenu or "").encode()).hexdigest()
+
+
+class Collecteur:
+    """Écrit snapshots + signaux voie A avec dédupe applicative et validation.
+
+    Précharge les clés de dédupe et snapshots existants (idempotence
+    cross-run). Toute écriture de signal passe par ``SignalArtifact`` (PR 1) —
+    un signal incohérent lève ``CollecteError`` avant insertion.
+    """
+
+    def __init__(
+        self, session, media: MediaEvalMedia, run: MediaEvalRun, collecteur: str
+    ) -> None:
+        self.session = session
+        self.media = media
+        self.run = run
+        self.collecteur = collecteur
+        self.stats = CollectStats()
+        self._deja: set[str] = set()
+        self._snaps: dict[tuple, MediaEvalSnapshot] = {}
+
+    async def _preload(self) -> None:
+        rows = await self.session.execute(
+            select(MediaEvalSignal.dedupe_key).where(
+                MediaEvalSignal.media_id == self.media.id,
+                MediaEvalSignal.run_id == self.run.run_id,
+            )
+        )
+        self._deja = {r[0] for r in rows}
+        snaps = await self.session.execute(
+            select(MediaEvalSnapshot).where(
+                MediaEvalSnapshot.media_id == self.media.id,
+                MediaEvalSnapshot.run_id == self.run.run_id,
+            )
+        )
+        self._snaps = {(s.url, s.hash): s for s in snaps.scalars()}
+
+    async def snapshot(
+        self,
+        *,
+        url: str,
+        type_page: TypePage,
+        contenu: str | None,
+        http_status: int | None = None,
+        mode_acces: ModeAcces = ModeAcces.LIBRE,
+    ) -> MediaEvalSnapshot:
+        """Capture horodatée, dédupée par (url, hash) — jamais d'unique DB."""
+        h = _hash_contenu(contenu)
+        existant = self._snaps.get((url, h))
+        if existant is not None:
+            return existant
+        snap = MediaEvalSnapshot(
+            media_id=self.media.id,
+            run_id=self.run.run_id,
+            url=url,
+            type_page=type_page,
+            contenu=contenu,
+            hash=h,
+            http_status=http_status,
+            mode_acces=mode_acces,
+        )
+        self.session.add(snap)
+        await self.session.flush()  # snap.id requis pour lier un signal
+        self._snaps[(url, h)] = snap
+        self.stats.snapshots += 1
+        return snap
+
+    async def signal(
+        self,
+        *,
+        critere: str,
+        type_signal: str,
+        statut: str | StatutSignal,
+        valeur: dict | None = None,
+        citation: str | None = None,
+        source_urls: list[str] | None = None,
+        sources_consultees: list[str] | None = None,
+        snapshot_id=None,
+    ) -> MediaEvalSignal | None:
+        """Valide (SignalArtifact) puis insère un signal voie CODE.
+
+        Retourne le signal inséré, ou ``None`` si c'est un doublon (dédupe).
+        """
+        statut_str = statut.value if hasattr(statut, "value") else str(statut)
+        try:
+            artifact = SignalArtifact(
+                media_domaine=self.media.domaine,
+                critere=critere,
+                type_signal=type_signal,
+                statut=statut_str,
+                valeur=valeur,
+                citation=citation,
+                source_urls=list(source_urls or []),
+                sources_consultees=list(sources_consultees or []),
+            )
+        except ValidationError as exc:
+            raise CollecteError(
+                f"signal invalide {critere}/{type_signal} ({statut_str}) : {exc}"
+            ) from exc
+        key = dedupe_key_signal_code(artifact)
+        if key in self._deja:
+            self.stats.doublons += 1
+            return None
+        self._deja.add(key)
+        signal = MediaEvalSignal(
+            media_id=self.media.id,
+            critere=critere,
+            type_signal=type_signal,
+            statut=StatutSignal(statut_str),
+            valeur=valeur,
+            citation=citation,
+            voie=VoieCollecte.CODE,
+            collecteur=self.collecteur,
+            source_urls=list(source_urls or []),
+            sources_consultees=list(sources_consultees) if sources_consultees else None,
+            snapshot_id=snapshot_id,
+            run_id=self.run.run_id,
+            dedupe_key=key,
+        )
+        self.session.add(signal)
+        self.stats.inseres += 1
+        self.stats.details.append(f"{critere}/{type_signal} ({statut_str})")
+        return signal
+
+    async def bloque(
+        self,
+        *,
+        critere: str,
+        type_signal: str,
+        url: str | None,
+        raison: str,
+        sources_consultees: list[str] | None = None,
+    ) -> MediaEvalSignal | None:
+        """Signal ``bloque_acces`` — « jamais d'échec silencieux »."""
+        signal = await self.signal(
+            critere=critere,
+            type_signal=type_signal,
+            statut=StatutSignal.BLOQUE_ACCES,
+            valeur={"raison": raison, "url": url} if url else {"raison": raison},
+            citation=raison,
+            source_urls=[url] if url else [],
+            sources_consultees=sources_consultees,
+        )
+        if signal is not None:
+            self.stats.bloques += 1
+        return signal
+
+
+async def ouvrir_collecteur(
+    session, media: MediaEvalMedia, run: MediaEvalRun, collecteur: str
+) -> Collecteur:
+    """Construit un ``Collecteur`` avec dédupe/snapshots préchargés."""
+    c = Collecteur(session, media, run, collecteur)
+    await c._preload()
+    return c
+
+
+# --------------------------------------------------------------------------- #
+# Harnais CLI commun (dry-run par défaut, --apply gardé).
+# --------------------------------------------------------------------------- #
+CollecterFn = Callable[..., Awaitable[CollectStats]]
+
+
+async def _run(
+    nom: str,
+    collecter_fn: CollecterFn,
+    *,
+    media_domaine: str,
+    run_id: str,
+    apply: bool,
+    allow_prod: bool,
+) -> int:
+    settings = get_settings()
+    db_url = settings.database_url or ""
+    is_test = _is_test_db(db_url)
+    print(
+        f"[{nom}] DB cible : "
+        f"{db_url.split('@')[-1] if '@' in db_url else db_url}  (test={is_test})"
+    )
+    if apply and not is_test and not allow_prod:
+        print("\nABORT : --apply contre une DB non-test sans --allow-prod (gated PO).")
+        return 2
+
+    async with async_session_maker() as session:
+        try:
+            run = await require_run(session, run_id)
+            media = await resoudre_media(session, media_domaine)
+            stats = await collecter_fn(session, media, run, fetch_http)
+            for ligne in stats.details:
+                print(f"  + {ligne}")
+            print(
+                f"[{nom}] {media.domaine} · run {run_id} — "
+                f"à insérer : {stats.inseres} (dont bloqués : {stats.bloques}) | "
+                f"snapshots : {stats.snapshots} | doublons : {stats.doublons}"
+            )
+            if not apply:
+                await session.rollback()
+                print("(dry-run — aucune mutation. Relance avec --apply.)")
+                return 0
+            await session.commit()
+            print(
+                f"[{nom}] APPLIQUÉ : {stats.inseres} signaux, {stats.snapshots} snapshots."
+            )
+            return 0
+        except (CollecteError, IngestError) as exc:
+            await session.rollback()
+            print(f"REJET : {exc} — rien n'a été écrit.")
+            return 1
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await engine.dispose()
+
+
+def run_cli(nom: str, collecter_fn: CollecterFn) -> None:
+    """Point d'entrée ``main()`` commun aux 6 collecteurs voie A."""
+    parser = argparse.ArgumentParser(description=f"Collecteur voie A : {nom}")
+    parser.add_argument("--media", required=True, help="domaine (ex. cnews.fr)")
+    parser.add_argument("--run-id", required=True, help="ex. pilote-2026-07")
+    parser.add_argument(
+        "--apply", action="store_true", help="exécute (défaut: dry-run)"
+    )
+    parser.add_argument(
+        "--allow-prod", action="store_true", help="autorise --apply en prod"
+    )
+    args = parser.parse_args()
+    sys.exit(
+        asyncio.run(
+            _run(
+                nom,
+                collecter_fn,
+                media_domaine=args.media,
+                run_id=args.run_id,
+                apply=args.apply,
+                allow_prod=args.allow_prod,
+            )
+        )
+    )

--- a/packages/api/scripts/media_eval/collect_cppap.py
+++ b/packages/api/scripts/media_eval/collect_cppap.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Collecteur voie A — CPPAP (Commission paritaire des publications et agences).
+
+D5 : **open data uniquement** — dataset ``liste-des-publications-de-presse`` de
+data.culture.gouv.fr (API Explore v2.1), qui liste les titres de presse et leur
+``ndeg_cppap`` — jamais le formulaire POST du site cppap. Le numéro CPPAP est un
+signal de transparence légale → C5/``enregistrement_cppap`` :
+- titre trouvé dans le dataset → ``present`` (``valeur.numero_cppap``) ;
+- recherche aboutie mais aucun résultat → ``absent_verifie`` (cas attendu d'un
+  média purement audiovisuel comme CNEWS : pas de publication de presse) ;
+- dataset inaccessible → ``bloque_acces``. **Repli voie C** : si le portail est
+  durablement down, un artefact humain (``agent: "humain:laurin"``) peut poser
+  ``enregistrement_cppap`` avec le n° CPPAP (ou l'ISSN, ex. 2669-7432 pour
+  CNEWS) lu dans le snapshot des mentions légales (cf. D6).
+
+Toute réponse non exploitable est traitée comme un accès bloqué (jamais
+d'exception).
+
+Usage :
+    cd packages/api
+    python3 scripts/media_eval/collect_cppap.py --media cnews.fr \
+        --run-id pilote-2026-07 [--apply --allow-prod]
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from urllib.parse import quote
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.media_eval.collect_common import (
+    CollectStats,
+    Fetcher,
+    ouvrir_collecteur,
+    run_cli,
+)
+
+COLLECTEUR = "code:collect_cppap@v1"
+
+# API Explore v2.1 (Opendatasoft, data.culture.gouv.fr). Slug + champs confirmés
+# le 2026-07 : dataset ``liste-des-publications-de-presse`` (titre, ndeg_cppap).
+DATASET = "liste-des-publications-de-presse"
+URL_BASE = (
+    f"https://data.culture.gouv.fr/api/explore/v2.1/catalog/datasets/{DATASET}/records"
+)
+
+_CHAMPS_TITRE = ("titre", "titre_de_presse", "nom", "publication")
+_CHAMPS_NUMERO = ("numero_cppap", "ndeg_cppap", "numero", "cppap", "n_cppap")
+
+
+def cppap_url(nom_media: str) -> str:
+    # Recherche plein-texte v2.1 : une phrase entre guillemets dans ``where``.
+    where = quote(f'"{nom_media}"')
+    return f"{URL_BASE}?where={where}&limit=50"
+
+
+def parse_cppap_records(texte: str) -> list[dict]:
+    """Normalise la réponse (ODS v1 ``records[].fields`` ou liste brute).
+
+    Retourne des dicts ``{titre, numero_cppap}``. Une réponse non-JSON lève
+    ``ValueError`` (le collecteur la traite en ``bloque_acces``).
+    """
+    data = json.loads(texte)
+    if isinstance(data, dict):
+        bruts = data.get("records") or data.get("results") or []
+    else:
+        bruts = data
+    normalises: list[dict] = []
+    for rec in bruts:
+        champs = rec.get("fields", rec) if isinstance(rec, dict) else {}
+        titre = next((champs[c] for c in _CHAMPS_TITRE if champs.get(c)), None)
+        numero = next((champs[c] for c in _CHAMPS_NUMERO if champs.get(c)), None)
+        if titre:
+            normalises.append({"titre": str(titre), "numero_cppap": numero})
+    return normalises
+
+
+def chercher_titre(nom_media: str, records: list[dict]) -> dict | None:
+    cible = nom_media.strip().lower()
+    for rec in records:
+        if cible in rec["titre"].lower():
+            return rec
+    return None
+
+
+async def collecter(session, media, run, fetcher: Fetcher) -> CollectStats:
+    """Enregistrement CPPAP (C5) via open data."""
+    c = await ouvrir_collecteur(session, media, run, COLLECTEUR)
+    url = cppap_url(media.nom)
+    res = await fetcher(url)
+    if res.bloque or res.status != 200:
+        await c.bloque(
+            critere="C5",
+            type_signal="enregistrement_cppap",
+            url=url,
+            raison="dataset CPPAP open data inaccessible",
+            sources_consultees=[url],
+        )
+        return c.stats
+    try:
+        records = parse_cppap_records(res.text)
+    except (ValueError, TypeError):
+        await c.bloque(
+            critere="C5",
+            type_signal="enregistrement_cppap",
+            url=url,
+            raison="réponse CPPAP non exploitable (format inattendu)",
+            sources_consultees=[url],
+        )
+        return c.stats
+
+    trouve = chercher_titre(media.nom, records)
+    if trouve is not None:
+        await c.signal(
+            critere="C5",
+            type_signal="enregistrement_cppap",
+            statut="present",
+            valeur={
+                "numero_cppap": trouve["numero_cppap"],
+                "titre": trouve["titre"],
+                "source": "data.culture.gouv.fr",
+            },
+            source_urls=[url],
+        )
+    else:
+        await c.signal(
+            critere="C5",
+            type_signal="enregistrement_cppap",
+            statut="absent_verifie",
+            sources_consultees=[url],
+        )
+    return c.stats
+
+
+def main() -> None:
+    run_cli("cppap", collecter)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/scripts/media_eval/collect_jti.py
+++ b/packages/api/scripts/media_eval/collect_jti.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Collecteur voie A — JTI (Journalism Trust Initiative, registre RSF).
+
+Registre public des médias certifiés JTI → C8/``certification_jti`` :
+- média présent et certification en cours de validité → ``present`` avec
+  ``valeur.en_cours_de_validite=True`` (déclenche le **raccourci JTI** en aval :
+  ``build_eval_input`` écrit l'éval C8 pleine par code, sans agent) ;
+- sinon → ``absent_verifie`` (cas attendu des deux pilotes CNEWS/Reporterre).
+
+Registre inaccessible → ``bloque_acces``.
+
+Usage :
+    cd packages/api
+    python3 scripts/media_eval/collect_jti.py --media cnews.fr \
+        --run-id pilote-2026-07 [--apply --allow-prod]
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from bs4 import BeautifulSoup
+
+from scripts.media_eval.collect_common import (
+    CollectStats,
+    Fetcher,
+    ouvrir_collecteur,
+    run_cli,
+)
+
+COLLECTEUR = "code:collect_jti@v1"
+
+URL_ANNUAIRE = "https://www.journalismtrustinitiative.org/evaluations"
+
+
+def parse_jti_directory(html: str) -> list[dict]:
+    """Médias certifiés : {nom, en_cours_de_validite} depuis l'annuaire.
+
+    Un item marqué ``expiré``/``expired`` → validité fausse ; sinon vraie.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    zone = soup.find(class_="jti-directory") or soup.find("main") or soup
+    resultats: list[dict] = []
+    for item in zone.find_all(["li", "tr"]):
+        texte = item.get_text(" ", strip=True)
+        if not texte:
+            continue
+        nom = item.get("data-media") or texte
+        bas = texte.lower()
+        valide = "expir" not in bas and "révoqu" not in bas and "revoqu" not in bas
+        resultats.append({"nom": nom.strip(), "en_cours_de_validite": valide})
+    return resultats
+
+
+def chercher_media(nom_media: str, entrees: list[dict]) -> dict | None:
+    cible = nom_media.strip().lower()
+    for e in entrees:
+        if cible in e["nom"].lower():
+            return e
+    return None
+
+
+async def collecter(session, media, run, fetcher: Fetcher) -> CollectStats:
+    """Certification JTI (C8) — present (validité) ou absent_verifie."""
+    c = await ouvrir_collecteur(session, media, run, COLLECTEUR)
+    res = await fetcher(URL_ANNUAIRE)
+    if res.bloque or res.status != 200:
+        await c.bloque(
+            critere="C8",
+            type_signal="certification_jti",
+            url=URL_ANNUAIRE,
+            raison="annuaire JTI inaccessible",
+            sources_consultees=[URL_ANNUAIRE],
+        )
+        return c.stats
+
+    entree = chercher_media(media.nom, parse_jti_directory(res.text))
+    if entree is not None:
+        await c.signal(
+            critere="C8",
+            type_signal="certification_jti",
+            statut="present",
+            valeur={
+                "registre": "jti",
+                "en_cours_de_validite": entree["en_cours_de_validite"],
+                "url": URL_ANNUAIRE,
+            },
+            source_urls=[URL_ANNUAIRE],
+        )
+    else:
+        await c.signal(
+            critere="C8",
+            type_signal="certification_jti",
+            statut="absent_verifie",
+            sources_consultees=[URL_ANNUAIRE],
+        )
+    return c.stats
+
+
+def main() -> None:
+    run_cli("jti", collecter)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/scripts/media_eval/collect_pages_types.py
+++ b/packages/api/scripts/media_eval/collect_pages_types.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+"""Collecteur voie A — pages types du site (découverte + détection).
+
+Découvre les pages institutionnelles (mentions légales, charte, ligne
+éditoriale, régie pub, dons, à-propos/ours) par : liens du footer/home →
+chemins types connus → sitemap. Émet des signaux de **détection** (présence
+d'une page), la *substance* restant à la voie B :
+
+- mentions légales → C5/``mentions_legales``
+- charte → C8/``charte_deontologique`` (``valeur.detection="page_type"``)
+- ligne éditoriale → C11/``ligne_editoriale_publiee``
+- régie pub → C7/``regie_pub_identifiee``
+- dons/financement → C5/``transparence_financement``
+- à-propos / ours → **snapshot seul** (contexte, pas de signal)
+
+Une page n'est retenue que si elle est **significative** (``page_significative``) :
+statut 200, corps non vide, **≠ soft-404** (un site qui sert sa home sur un
+chemin inexistant partage le hash du texte principal — écarté) et **portant les
+marqueurs lexicaux** de son type (une page de flux taggé « /publicite » n'est
+pas une page de régie). Épuisement des candidats sans page significative →
+``absent_verifie`` avec ``sources_consultees`` complètes (preuve de recherche).
+Fetch bloqué → ``bloque_acces`` (jamais d'exception). Idempotent (dédupe).
+
+Usage :
+    cd packages/api
+    python3 scripts/media_eval/collect_pages_types.py --media reporterre.net \
+        --run-id pilote-2026-07 [--apply --allow-prod]
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sys
+from difflib import SequenceMatcher
+from pathlib import Path
+from urllib.parse import urljoin
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from bs4 import BeautifulSoup
+
+from app.models.media_eval import TypePage
+from scripts.media_eval.collect_common import (
+    Collecteur,
+    CollectStats,
+    Fetcher,
+    ouvrir_collecteur,
+    run_cli,
+)
+
+COLLECTEUR = "code:collect_pages_types@v1"
+
+# Chemins candidats par type de page — conventions FR + variantes SPIP
+# (Reporterre est un site SPIP : `spip.php?page=…`, `spip.php?rubrique=…`).
+CHEMINS_TYPES: dict[TypePage, tuple[str, ...]] = {
+    TypePage.MENTIONS_LEGALES: (
+        "/mentions-legales",
+        "/mentions-legales.html",
+        "/informations-legales",
+        "/spip.php?page=mentions-legales",
+    ),
+    TypePage.A_PROPOS: (
+        "/qui-sommes-nous",
+        "/a-propos",
+        "/about",
+        "/qui-sommes-nous.html",
+        "/spip.php?rubrique=qui-sommes-nous",
+    ),
+    TypePage.CHARTE: (
+        "/charte",
+        "/charte-deontologique",
+        "/charte-ethique",
+        "/deontologie",
+        "/notre-charte",
+        "/spip.php?page=charte",
+    ),
+    TypePage.OURS_EQUIPE: (
+        "/ours",
+        "/equipe",
+        "/la-redaction",
+        "/redaction",
+        "/notre-equipe",
+    ),
+    TypePage.DONS_FINANCEMENT: (
+        "/dons",
+        "/nous-soutenir",
+        "/soutenir",
+        "/faire-un-don",
+        "/don",
+    ),
+    TypePage.LIGNE_EDITORIALE: (
+        "/ligne-editoriale",
+        "/notre-ligne-editoriale",
+        "/manifeste",
+        "/notre-projet",
+    ),
+    TypePage.REGIE_PUB: (
+        "/regie-publicitaire",
+        "/publicite",
+        "/annonceurs",
+        "/regie",
+    ),
+}
+
+# Type de page → (critère, type_signal). Absent ⇒ snapshot seul.
+PAGE_SIGNAUX: dict[TypePage, tuple[str, str]] = {
+    TypePage.MENTIONS_LEGALES: ("C5", "mentions_legales"),
+    TypePage.CHARTE: ("C8", "charte_deontologique"),
+    TypePage.LIGNE_EDITORIALE: ("C11", "ligne_editoriale_publiee"),
+    TypePage.REGIE_PUB: ("C7", "regie_pub_identifiee"),
+    TypePage.DONS_FINANCEMENT: ("C5", "transparence_financement"),
+}
+PAGES_SNAPSHOT_SEUL: frozenset[TypePage] = frozenset(
+    {TypePage.A_PROPOS, TypePage.OURS_EQUIPE}
+)
+
+# Mots-clés de classification d'une URL/texte de lien vers un type de page.
+_MOTS_CLES: tuple[tuple[TypePage, tuple[str, ...]], ...] = (
+    (
+        TypePage.MENTIONS_LEGALES,
+        ("mentions-legales", "mentions legales", "informations-legales"),
+    ),
+    (TypePage.CHARTE, ("charte", "deontolog", "ethique", "ethiq")),
+    (
+        TypePage.LIGNE_EDITORIALE,
+        ("ligne-editoriale", "ligne editoriale", "manifeste", "notre-projet"),
+    ),
+    (TypePage.REGIE_PUB, ("regie", "publicite", "annonceur", "publicitaire")),
+    (
+        TypePage.DONS_FINANCEMENT,
+        ("faire-un-don", "nous-soutenir", "/dons", "/don", "soutenir", "financer"),
+    ),
+    (
+        TypePage.OURS_EQUIPE,
+        ("/ours", "la-redaction", "notre-equipe", "/equipe", "/redaction"),
+    ),
+    (TypePage.A_PROPOS, ("qui-sommes-nous", "a-propos", "/about")),
+)
+
+_MARQUEURS_404 = (
+    "page introuvable",
+    "page non trouvée",
+    "page non trouvee",
+    "erreur 404",
+    "404 - ",
+    "n'existe pas",
+    "n existe pas",
+    "cette page n",
+    "introuvable",
+)
+
+# Marqueurs lexicaux exigés dans le corps AVANT d'émettre ``present`` : une page
+# dont l'URL ressemble au type mais dont le texte ne porte aucun de ces mots
+# n'est pas la page institutionnelle attendue (ex. un fil d'articles taggé
+# « /publicite » n'est pas une page de régie). Substance, pas seulement l'URL.
+_MARQUEURS_TYPE: dict[TypePage, tuple[str, ...]] = {
+    TypePage.MENTIONS_LEGALES: (
+        "mentions légales",
+        "mentions legales",
+        "éditeur",
+        "editeur",
+        "capital",
+        "rcs",
+        "siren",
+        "siret",
+        "issn",
+        "directeur de la publication",
+        "directeur de publication",
+        "hébergeur",
+    ),
+    TypePage.CHARTE: (
+        "charte",
+        "déontolog",
+        "deontolog",
+        "éthique",
+        "ethique",
+        "code de conduite",
+    ),
+    TypePage.REGIE_PUB: (
+        "régie",
+        "annonceur",
+        "tarif",
+        "espace publicitaire",
+        "kit média",
+        "kit media",
+        "contact commercial",
+        "offres publicitaires",
+    ),
+    TypePage.DONS_FINANCEMENT: (
+        "faire un don",
+        "faites un don",
+        "nous soutenir",
+        "soutenez",
+        "votre don",
+        "adhérer",
+        "adhésion",
+        "financement participatif",
+        "soutenir la rédaction",
+        "faire un legs",
+    ),
+    TypePage.LIGNE_EDITORIALE: (
+        "ligne éditoriale",
+        "ligne editoriale",
+        "manifeste",
+        "notre projet",
+        "notre mission",
+        "projet éditorial",
+        "notre engagement",
+    ),
+}
+
+# Types dont une page authentique n'est PAS un fil d'articles datés : on écarte
+# les pages de flux taggé (« /dons », « /publicite ») même si un marqueur y
+# apparaît au fil des titres.
+_TYPES_ANTI_FLUX: frozenset[TypePage] = frozenset(
+    {TypePage.DONS_FINANCEMENT, TypePage.REGIE_PUB}
+)
+
+# Un href d'article daté : segment année (/2026/…, /2026-…) ou id numérique long.
+_RE_HREF_ARTICLE = re.compile(r"/(?:19|20)\d{2}[-/]|[-/]\d{6,}(?:[/?#]|$)")
+
+_LONGUEUR_HASH = 20000  # même plafond que le contenu snapshotté (Collecteur.snapshot)
+_SIMILARITE_HOME = 0.9  # au-delà : page tenue pour identique à la home (soft-404)
+_RATIO_FLUX_MAX = 0.5  # > 50 % de liens-articles dans le corps ⇒ page de flux
+
+
+# --------------------------------------------------------------------------- #
+# Fonctions pures (str → structures) — testées sur fixtures, zéro réseau.
+# --------------------------------------------------------------------------- #
+def parse_liens_footer(html: str) -> list[tuple[str, str]]:
+    """Liens (href, texte) du footer/nav — source de découverte principale."""
+    soup = BeautifulSoup(html, "html.parser")
+    liens: list[tuple[str, str]] = []
+    vus: set[str] = set()
+    zones = soup.find_all(["footer", "nav"]) or [soup]
+    for zone in zones:
+        for a in zone.find_all("a", href=True):
+            href = a["href"].strip()
+            if not href or href.startswith(("#", "javascript:", "mailto:")):
+                continue
+            if href in vus:
+                continue
+            vus.add(href)
+            liens.append((href, a.get_text(" ", strip=True)))
+    return liens
+
+
+def parse_sitemap(xml: str) -> list[str]:
+    """URLs d'un sitemap (ou index de sitemaps) — balises <loc>."""
+    soup = BeautifulSoup(xml, "xml")
+    return [
+        loc.get_text(strip=True)
+        for loc in soup.find_all("loc")
+        if loc.get_text(strip=True)
+    ]
+
+
+def classifier_url(url: str, texte: str = "") -> TypePage | None:
+    """Type de page déduit d'une URL (+ texte de lien) — None si indéterminé."""
+    cible = f"{url} {texte}".lower()
+    for type_page, mots in _MOTS_CLES:
+        if any(mot in cible for mot in mots):
+            return type_page
+    return None
+
+
+def extraire_texte_principal(html: str) -> str:
+    """Texte visible principal (hors nav/scripts) — pour la détection soft-404."""
+    soup = BeautifulSoup(html, "html.parser")
+    for tag in soup(["script", "style", "nav", "header", "footer", "noscript"]):
+        tag.decompose()
+    cible = soup.find("main") or soup.find("article") or soup.body or soup
+    return cible.get_text(" ", strip=True)
+
+
+def _hash_principal(texte: str) -> str:
+    """sha256 du texte principal (plafonné comme le contenu snapshotté)."""
+    return hashlib.sha256(texte[:_LONGUEUR_HASH].encode()).hexdigest()
+
+
+def ressemble_a_home(texte: str, home_texte: str | None) -> bool:
+    """True si le texte principal est identique (ou quasi) à celui de la home.
+
+    Certains sites servent leur accueil sur des chemins inexistants (soft-404
+    silencieux, HTTP 200) : ``/charte`` renvoie alors la home. Ces coquilles
+    partagent le hash du texte principal de la home — on les refuse.
+    """
+    if not home_texte:
+        return False
+    if _hash_principal(texte) == _hash_principal(home_texte):
+        return True
+    ratio = SequenceMatcher(None, home_texte[:5000], texte[:5000]).ratio()
+    return ratio > _SIMILARITE_HOME
+
+
+def ratio_liens_articles(html: str) -> float:
+    """Part des liens du contenu principal pointant vers un article daté.
+
+    Une page institutionnelle (mentions, régie) renvoie peu de liens et pas
+    vers un fil d'articles ; une page de flux taggé en renvoie beaucoup.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    for tag in soup(["header", "footer", "nav"]):
+        tag.decompose()
+    cible = soup.find("main") or soup.find("article") or soup.body or soup
+    liens = cible.find_all("a", href=True) if cible else []
+    if not liens:
+        return 0.0
+    articles = sum(1 for a in liens if _RE_HREF_ARTICLE.search(a["href"].lower()))
+    return articles / len(liens)
+
+
+def a_marqueurs_type(texte: str, html: str, type_page: TypePage) -> bool:
+    """Le corps porte-t-il les marqueurs lexicaux attendus pour ce type ?
+
+    Types snapshot-seul (à-propos / ours) : aucune exigence. Types anti-flux
+    (dons / régie) : marqueur requis ET pas un fil d'articles datés.
+    """
+    marqueurs = _MARQUEURS_TYPE.get(type_page)
+    if marqueurs is None:
+        return True
+    bas = texte.lower()
+    if not any(m in bas for m in marqueurs):
+        return False
+    return not (
+        type_page in _TYPES_ANTI_FLUX and ratio_liens_articles(html) > _RATIO_FLUX_MAX
+    )
+
+
+def page_significative(
+    html: str,
+    status: int | None,
+    *,
+    type_page: TypePage | None = None,
+    home_texte: str | None = None,
+) -> bool:
+    """True si la page existe vraiment ET porte la substance de son type.
+
+    - ``status`` ≠ 200, coquille vide ou marqueur 404 → non significative ;
+    - contenu identique (ou quasi) à la home → soft-404 silencieux, écartée ;
+    - ``type_page`` fourni sans marqueur lexical attendu → écartée (une page de
+      flux taggé « /dons », « /publicite » n'est pas une page institutionnelle).
+
+    ``home_texte`` / ``type_page`` sont optionnels (rétrocompat) : sans eux, seul
+    le socle existence (statut + longueur + marqueurs 404) est vérifié.
+    """
+    if status != 200:
+        return False
+    texte = extraire_texte_principal(html)
+    if len(texte) < 200:
+        return False
+    bas = texte[:400].lower()
+    if any(m in bas for m in _MARQUEURS_404):
+        return False
+    if ressemble_a_home(texte, home_texte):
+        return False
+    return type_page is None or a_marqueurs_type(texte, html, type_page)
+
+
+# --------------------------------------------------------------------------- #
+# Découverte + collecte.
+# --------------------------------------------------------------------------- #
+def _base_url(domaine: str) -> str:
+    return f"https://{domaine}"
+
+
+def _candidats(
+    base: str, decouverts: dict[TypePage, list[str]], type_page: TypePage
+) -> list[str]:
+    """URLs candidates (découvertes d'abord, puis chemins types), dédupées."""
+    ordonnes: list[str] = []
+    vus: set[str] = set()
+    for url in decouverts.get(type_page, []) + [
+        base + chemin for chemin in CHEMINS_TYPES.get(type_page, ())
+    ]:
+        if url not in vus:
+            vus.add(url)
+            ordonnes.append(url)
+    return ordonnes
+
+
+async def _decouvrir(
+    base: str, home_html: str, sitemap_urls: list[str]
+) -> dict[TypePage, list[str]]:
+    """Mappe type de page → URLs candidates découvertes (footer + sitemap)."""
+    decouverts: dict[TypePage, list[str]] = {}
+    for href, texte in parse_liens_footer(home_html):
+        type_page = classifier_url(href, texte)
+        if type_page is not None:
+            decouverts.setdefault(type_page, []).append(urljoin(base + "/", href))
+    for url in sitemap_urls:
+        type_page = classifier_url(url)
+        if type_page is not None:
+            decouverts.setdefault(type_page, []).append(url)
+    return decouverts
+
+
+async def _traiter_type(
+    c: Collecteur,
+    fetcher: Fetcher,
+    type_page: TypePage,
+    candidats: list[str],
+    home_texte: str | None,
+) -> None:
+    """Cherche une page significative parmi les candidats ; émet le signal."""
+    signal_cle = PAGE_SIGNAUX.get(type_page)
+    sources_consultees: list[str] = []
+    nb_bloque = 0
+    for url in candidats:
+        res = await fetcher(url)
+        sources_consultees.append(url)
+        if res.bloque:
+            nb_bloque += 1
+            continue
+        if not page_significative(
+            res.text, res.status, type_page=type_page, home_texte=home_texte
+        ):
+            continue
+        # Page trouvée : snapshot systématique + signal (sauf snapshot-seul).
+        snap = await c.snapshot(
+            url=url,
+            type_page=type_page,
+            contenu=extraire_texte_principal(res.text)[:20000],
+            http_status=res.status,
+            mode_acces=res.mode_acces,
+        )
+        if signal_cle is not None:
+            critere, type_signal = signal_cle
+            await c.signal(
+                critere=critere,
+                type_signal=type_signal,
+                statut="present",
+                valeur={"url": url, "detection": "page_type"},
+                citation=None,
+                source_urls=[url],
+                snapshot_id=snap.id,
+            )
+        return
+
+    if signal_cle is None:
+        return  # snapshot-seul (à-propos / ours) : rien à signaler si absent
+    critere, type_signal = signal_cle
+    # Distinguer bloque_acces (tous les candidats consultés refusés) d'un
+    # absent_verifie (au moins un 200 non significatif → la page n'existe pas).
+    if sources_consultees and nb_bloque == len(sources_consultees):
+        await c.bloque(
+            critere=critere,
+            type_signal=type_signal,
+            url=sources_consultees[0],
+            raison="tous les candidats bloqués (anti-bot) — présence indéterminée",
+            sources_consultees=sources_consultees,
+        )
+        return
+    await c.signal(
+        critere=critere,
+        type_signal=type_signal,
+        statut="absent_verifie",
+        valeur={"detection": "page_type", "bloque_rencontre": nb_bloque > 0},
+        sources_consultees=sources_consultees,
+    )
+
+
+async def collecter(session, media, run, fetcher: Fetcher) -> CollectStats:
+    """Découvre et détecte les pages types du média (voie A)."""
+    c = await ouvrir_collecteur(session, media, run, COLLECTEUR)
+    base = _base_url(media.domaine)
+
+    home = await fetcher(base + "/")
+    if home.bloque:
+        # Home inaccessible : on émet un bloque_acces par signal attendu et on
+        # s'arrête (rien à découvrir). « Jamais d'échec silencieux ».
+        for type_page, (critere, type_signal) in PAGE_SIGNAUX.items():
+            await c.bloque(
+                critere=critere,
+                type_signal=type_signal,
+                url=base + "/",
+                raison="home inaccessible (anti-bot) — découverte impossible",
+                sources_consultees=[base + "/"],
+            )
+        return c.stats
+    # Texte principal de la home : référence anti soft-404 (une page qui le
+    # renvoie à l'identique est une coquille, cf. ``ressemble_a_home``).
+    home_texte = extraire_texte_principal(home.text)
+    await c.snapshot(
+        url=base + "/",
+        type_page=TypePage.AUTRE,
+        contenu=home_texte[:20000],
+        http_status=home.status,
+        mode_acces=home.mode_acces,
+    )
+
+    sitemap = await fetcher(base + "/sitemap.xml")
+    sitemap_urls = parse_sitemap(sitemap.text) if sitemap.ok else []
+    decouverts = await _decouvrir(base, home.text, sitemap_urls)
+
+    for type_page in (*PAGE_SIGNAUX.keys(), *PAGES_SNAPSHOT_SEUL):
+        await _traiter_type(
+            c, fetcher, type_page, _candidats(base, decouverts, type_page), home_texte
+        )
+    return c.stats
+
+
+def main() -> None:
+    run_cli("pages_types", collecter)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/scripts/media_eval/collect_pappers.py
+++ b/packages/api/scripts/media_eval/collect_pappers.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Collecteur voie A — Pappers (registre du commerce, propriété & capital).
+
+Interroge l'API ``api.pappers.fr/v2/entreprise`` sur un SIREN **codé en dur**
+par média (l'éditeur, jamais deviné à la volée) et pose trois signaux :
+- C5/``identification_proprietaire`` (raison sociale, SIREN, dirigeants) ;
+- C5/``structure_actionnariat`` (bénéficiaires effectifs) ;
+- C9/``independance_capital`` (concentration du capital — substance jugée par
+  l'évaluateur, on ne pose que le fait).
+
+Garde-fou ``verifier_entreprise`` : si la raison sociale renvoyée ne
+correspond pas à celle attendue pour le SIREN, on **lève** (``CollecteError``)
+plutôt que d'attribuer les données d'une autre société.
+
+**Token absent ou épuisé** (``PAPPERS_API_TOKEN``) → repli sur l'API publique
+**gratuite** ``recherche-entreprises.api.gouv.fr`` (sans auth) :
+``identification_proprietaire`` ``present`` (raison sociale + dirigeants) et
+``structure_actionnariat`` / ``independance_capital`` ``partiel`` (les
+bénéficiaires effectifs ne sont pas exposés par l'API gratuite), au lieu de 3
+``bloque_acces``. SIREN non référencé pour le média, ou repli lui aussi
+inaccessible → ``bloque_acces``. Tous ces cas gardent exit 0 (run valide).
+
+Usage :
+    cd packages/api
+    PAPPERS_API_TOKEN=xxx python3 scripts/media_eval/collect_pappers.py \
+        --media cnews.fr --run-id pilote-2026-07 [--apply --allow-prod]
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from urllib.parse import quote
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.media_eval.collect_common import (
+    CollecteError,
+    Collecteur,
+    CollectStats,
+    Fetcher,
+    ouvrir_collecteur,
+    run_cli,
+)
+
+COLLECTEUR = "code:collect_pappers@v1"
+URL_BASE = "https://api.pappers.fr/v2/entreprise"
+# API publique gratuite (Annuaire des Entreprises) — sans auth, repli sans token.
+URL_RECHERCHE_ENTREPRISES = "https://recherche-entreprises.api.gouv.fr/search"
+
+# Éditeur **du site** de chaque média pilote (SIREN + raison sociale attendue).
+# CNEWS : l'éditeur du site cnews.fr est **SESI SNC, RCS Nanterre 412 916 215**
+# (lu dans ses mentions légales — capital 7 500 €), distinct de la société
+# d'exploitation de la chaîne TV. Reporterre : association « La Pila ».
+SIREN_MEDIAS: dict[str, dict[str, str]] = {
+    "cnews.fr": {
+        "siren": "412916215",
+        "raison_sociale": "SESI",
+    },
+    "reporterre.net": {
+        "siren": "801054247",
+        "raison_sociale": "LA PILA",
+    },
+}
+
+# Les 3 signaux posés par ce collecteur (utilisés pour le repli bloque_acces).
+_SIGNAUX = (
+    ("C5", "identification_proprietaire"),
+    ("C5", "structure_actionnariat"),
+    ("C9", "independance_capital"),
+)
+
+
+def pappers_url(siren: str, token: str) -> str:
+    return f"{URL_BASE}?api_token={quote(token)}&siren={quote(siren)}"
+
+
+def recherche_entreprises_url(siren: str) -> str:
+    return f"{URL_RECHERCHE_ENTREPRISES}?q={quote(siren)}&page=1&per_page=5"
+
+
+def parse_recherche_entreprises(texte: str, siren: str) -> dict | None:
+    """Normalise la réponse de l'API gratuite pour le SIREN cible.
+
+    Retourne ``{nom, siren, dirigeants}`` du résultat au SIREN exact, ou
+    ``None`` si aucun (on ne pose alors aucun signal). Réponse non-JSON →
+    ``ValueError`` (traitée en ``bloque_acces`` par l'appelant).
+    """
+    data = json.loads(texte)
+    for rec in data.get("results") or []:
+        if str(rec.get("siren")) != str(siren):
+            continue
+        dirigeants = [
+            {
+                "nom": (
+                    f"{d.get('prenoms', '')} {d.get('nom', '')}".strip()
+                    or d.get("denomination")
+                ),
+                "qualite": d.get("qualite"),
+            }
+            for d in (rec.get("dirigeants") or [])
+        ]
+        return {
+            "nom": rec.get("nom_complet") or rec.get("nom_raison_sociale"),
+            "siren": str(rec.get("siren")),
+            "dirigeants": dirigeants,
+        }
+    return None
+
+
+def _normaliser(nom: str) -> str:
+    table = str.maketrans("ÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ", "AAAEEEEIIOOUUUC")
+    return " ".join(nom.upper().translate(table).replace("'", " ").split())
+
+
+def verifier_entreprise(payload: dict, raison_sociale_attendue: str) -> None:
+    """Lève si la société renvoyée ≠ celle attendue (anti-attribution erronée)."""
+    nom = _normaliser(str(payload.get("nom_entreprise") or payload.get("nom") or ""))
+    attendu = _normaliser(raison_sociale_attendue)
+    if not nom:
+        raise CollecteError("réponse Pappers sans nom d'entreprise")
+    # Tolérance : acronyme (SESI) OU chevauchement de tokens distinctifs.
+    tokens_attendus = {t for t in attendu.split() if len(t) > 2}
+    tokens_recus = set(nom.split())
+    acronyme = "".join(t[0] for t in attendu.split() if t)
+    if (
+        attendu in nom
+        or nom in attendu
+        or acronyme in tokens_recus
+        or len(tokens_attendus & tokens_recus) >= max(1, len(tokens_attendus) // 2)
+    ):
+        return
+    raise CollecteError(
+        f"raison sociale Pappers {nom!r} ≠ attendue {attendu!r} — "
+        "SIREN possiblement obsolète, collecte interrompue."
+    )
+
+
+def parse_pappers(texte: str) -> dict:
+    """Normalise la réponse v2 : {nom, siren, representants, beneficiaires}."""
+    data = json.loads(texte)
+    representants = [
+        {"nom": r.get("nom_complet") or r.get("nom"), "qualite": r.get("qualite")}
+        for r in (data.get("representants") or [])
+    ]
+    beneficiaires = [
+        {
+            "nom": b.get("nom_complet") or b.get("nom"),
+            "pourcentage_parts": b.get("pourcentage_parts"),
+        }
+        for b in (data.get("beneficiaires_effectifs") or [])
+    ]
+    return {
+        "nom_entreprise": data.get("nom_entreprise") or data.get("nom"),
+        "siren": data.get("siren"),
+        "capital": data.get("capital"),
+        "representants": representants,
+        "beneficiaires_effectifs": beneficiaires,
+    }
+
+
+async def _bloque_tous(c: Collecteur, url: str | None, raison: str) -> None:
+    for critere, type_signal in _SIGNAUX:
+        await c.bloque(
+            critere=critere,
+            type_signal=type_signal,
+            url=url,
+            raison=raison,
+            sources_consultees=[url] if url else [],
+        )
+
+
+async def _via_pappers(
+    c: Collecteur, ref: dict[str, str], token: str, fetcher: Fetcher
+) -> bool:
+    """Voie Pappers (substance complète). Retourne True si 3 signaux posés.
+
+    Accès refusé / réponse non exploitable → False (l'appelant tente le repli
+    gratuit). Raison sociale ≠ attendue → **lève** (anti-attribution erronée).
+    """
+    res = await fetcher(pappers_url(ref["siren"], token))
+    if res.bloque or res.status != 200:
+        return False
+    try:
+        data = json.loads(res.text)
+    except (ValueError, TypeError):
+        return False
+
+    verifier_entreprise(data, ref["raison_sociale"])  # lève si mismatch
+    info = parse_pappers(res.text)
+    source = f"https://www.pappers.fr/entreprise/{ref['siren']}"
+    await c.signal(
+        critere="C5",
+        type_signal="identification_proprietaire",
+        statut="present",
+        valeur={
+            "raison_sociale": info["nom_entreprise"],
+            "siren": info["siren"],
+            "representants": info["representants"],
+        },
+        source_urls=[source],
+    )
+    await c.signal(
+        critere="C5",
+        type_signal="structure_actionnariat",
+        statut="present" if info["beneficiaires_effectifs"] else "partiel",
+        valeur={
+            "capital": info["capital"],
+            "beneficiaires_effectifs": info["beneficiaires_effectifs"],
+        },
+        source_urls=[source],
+    )
+    await c.signal(
+        critere="C9",
+        type_signal="independance_capital",
+        statut="present",
+        valeur={
+            "capital": info["capital"],
+            "beneficiaires_effectifs": info["beneficiaires_effectifs"],
+        },
+        source_urls=[source],
+    )
+    return True
+
+
+async def _via_recherche_entreprises(
+    c: Collecteur, ref: dict[str, str], fetcher: Fetcher
+) -> bool:
+    """Repli gratuit (Annuaire des Entreprises). Retourne True si signaux posés.
+
+    L'API gratuite donne la raison sociale + les dirigeants (→
+    ``identification_proprietaire`` ``present``) mais **pas** les bénéficiaires
+    effectifs ni la concentration du capital (→ ``structure_actionnariat`` et
+    ``independance_capital`` ``partiel``, jamais ``present``).
+    """
+    res = await fetcher(recherche_entreprises_url(ref["siren"]))
+    if res.bloque or res.status != 200:
+        return False
+    try:
+        info = parse_recherche_entreprises(res.text, ref["siren"])
+    except (ValueError, TypeError):
+        return False
+    if info is None:
+        return False
+
+    source = f"https://annuaire-entreprises.data.gouv.fr/entreprise/{ref['siren']}"
+    note = (
+        "bénéficiaires effectifs et concentration du capital non exposés par "
+        "l'API gratuite (Pappers requis pour la substance complète)"
+    )
+    await c.signal(
+        critere="C5",
+        type_signal="identification_proprietaire",
+        statut="present",
+        valeur={
+            "raison_sociale": info["nom"],
+            "siren": info["siren"],
+            "dirigeants": info["dirigeants"],
+            "source": "recherche-entreprises.api.gouv.fr",
+        },
+        source_urls=[source],
+    )
+    await c.signal(
+        critere="C5",
+        type_signal="structure_actionnariat",
+        statut="partiel",
+        valeur={"beneficiaires_effectifs": None, "note": note},
+        source_urls=[source],
+    )
+    await c.signal(
+        critere="C9",
+        type_signal="independance_capital",
+        statut="partiel",
+        valeur={"concentration_capital": None, "note": note},
+        source_urls=[source],
+    )
+    return True
+
+
+async def collecter(session, media, run, fetcher: Fetcher) -> CollectStats:
+    """Propriété / actionnariat / capital (C5, C5, C9) — Pappers ou repli gratuit."""
+    c = await ouvrir_collecteur(session, media, run, COLLECTEUR)
+
+    ref = SIREN_MEDIAS.get(media.domaine)
+    if ref is None:
+        print(f"[pappers] WARNING : aucun SIREN référencé pour {media.domaine}.")
+        await _bloque_tous(c, None, "SIREN éditeur non référencé (voir SIREN_MEDIAS)")
+        return c.stats
+
+    token = os.environ.get("PAPPERS_API_TOKEN")
+    if token:
+        if await _via_pappers(c, ref, token, fetcher):
+            return c.stats
+        print(
+            "[pappers] WARNING : API Pappers inaccessible/épuisée → repli sur "
+            "recherche-entreprises.api.gouv.fr (gratuit, sans auth)."
+        )
+    else:
+        print(
+            "[pappers] WARNING : PAPPERS_API_TOKEN absent → repli sur "
+            "recherche-entreprises.api.gouv.fr (gratuit). Le run reste valide."
+        )
+
+    if await _via_recherche_entreprises(c, ref, fetcher):
+        return c.stats
+    await _bloque_tous(c, URL_BASE, "Pappers et API entreprises gratuite inaccessibles")
+    return c.stats
+
+
+def main() -> None:
+    run_cli("pappers", collecter)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/scripts/media_eval/create_run.py
+++ b/packages/api/scripts/media_eval/create_run.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Création (upsert idempotent) d'un `media_eval_runs` — acte délibéré.
+
+``date_reference`` **pilote la fenêtre de fraîcheur** (build_eval_input) : un
+run rejoué plus tard doit produire exactement les mêmes entrées évaluateur.
+Sa création est donc un acte audité — pas un ``ensure_run()`` implicite. Les
+collecteurs et ``build_eval_input`` appellent ``require_run()`` (dans
+``collect_common`` / ``ingest_artifacts``) qui **lève** si le run est absent.
+
+Upsert par ``run_id`` : insert si absent, mise à jour de libellé/périmètre
+sinon. **Un changement de ``date_reference`` est refusé** (rejouabilité) —
+supprimer et recréer le run explicitement. **Dry-run par défaut**, ``--apply``
+gardé (``--allow-prod`` hors DB test).
+
+Usage :
+    cd packages/api
+    python3 scripts/media_eval/create_run.py --run-id pilote-2026-07 \
+        --date-reference 2026-07-10 --medias cnews.fr reporterre.net
+    python3 scripts/media_eval/create_run.py --run-id pilote-2026-07 \
+        --date-reference 2026-07-10 --apply --allow-prod
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from sqlalchemy import select
+
+from app.config import get_settings
+from app.database import async_session_maker, engine
+from app.models.media_eval import MediaEvalRun
+from scripts.cleanup_orphan_sources import _is_test_db
+from scripts.media_eval.schemas import CRITERES_VAGUE_1, VERSION_METHODO
+
+
+class RunConflit(Exception):
+    """Un run existe déjà avec une ``date_reference`` différente."""
+
+
+async def upsert_run(
+    session,
+    *,
+    run_id: str,
+    date_reference: date,
+    libelle: str | None,
+    medias: list[str],
+    criteres: list[str],
+) -> tuple[str, MediaEvalRun]:
+    """Insert/maj idempotent. Retourne (action, run) — sans commit.
+
+    ``action`` ∈ {"cree", "maj", "inchange"}. Lève ``RunConflit`` si le run
+    existe avec une autre ``date_reference`` (jamais de changement silencieux).
+    """
+    existant = (
+        await session.execute(select(MediaEvalRun).where(MediaEvalRun.run_id == run_id))
+    ).scalar_one_or_none()
+    perimetre = {"medias": medias, "criteres": criteres}
+
+    if existant is None:
+        session.add(
+            MediaEvalRun(
+                run_id=run_id,
+                libelle=libelle,
+                version_methodo=VERSION_METHODO,
+                date_reference=date_reference,
+                perimetre=perimetre,
+            )
+        )
+        return "cree", existant  # existant=None : caller n'en a pas besoin
+
+    if existant.date_reference != date_reference:
+        raise RunConflit(
+            f"run {run_id!r} existe avec date_reference={existant.date_reference} "
+            f"≠ {date_reference} demandée. La fraîcheur en dépend : supprimer et "
+            "recréer le run explicitement plutôt que de le muter."
+        )
+
+    change = False
+    if libelle is not None and existant.libelle != libelle:
+        existant.libelle = libelle
+        change = True
+    if existant.perimetre != perimetre:
+        existant.perimetre = perimetre
+        change = True
+    return ("maj" if change else "inchange"), existant
+
+
+async def run(
+    *,
+    run_id: str,
+    date_reference: date,
+    libelle: str | None,
+    medias: list[str],
+    criteres: list[str],
+    apply: bool,
+    allow_prod: bool,
+) -> int:
+    settings = get_settings()
+    db_url = settings.database_url or ""
+    is_test = _is_test_db(db_url)
+    print(
+        f"DB cible : {db_url.split('@')[-1] if '@' in db_url else db_url}  (test={is_test})"
+    )
+    print(f"date_reference (pilote la fraîcheur) : {date_reference.isoformat()}")
+    if apply and not is_test and not allow_prod:
+        print("\nABORT : --apply contre une DB non-test sans --allow-prod (gated PO).")
+        return 2
+
+    async with async_session_maker() as session:
+        try:
+            action, _ = await upsert_run(
+                session,
+                run_id=run_id,
+                date_reference=date_reference,
+                libelle=libelle,
+                medias=medias,
+                criteres=criteres,
+            )
+            print(f"Run {run_id} : {action} (médias={medias}, critères={criteres})")
+            if not apply:
+                await session.rollback()
+                print("(dry-run — aucune mutation. Relance avec --apply.)")
+                return 0
+            await session.commit()
+            print(f"APPLIQUÉ : run {run_id} ({action}).")
+            return 0
+        except RunConflit as exc:
+            await session.rollback()
+            print(f"REJET : {exc}")
+            return 1
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await engine.dispose()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-id", required=True, help="ex. pilote-2026-07")
+    parser.add_argument(
+        "--date-reference",
+        default=datetime.now(UTC).date().isoformat(),
+        help="date ISO qui pilote la fraîcheur (défaut : aujourd'hui)",
+    )
+    parser.add_argument("--libelle", default=None)
+    parser.add_argument(
+        "--medias", nargs="*", default=[], help="domaines du périmètre (mémo)"
+    )
+    parser.add_argument(
+        "--criteres",
+        nargs="*",
+        default=list(CRITERES_VAGUE_1),
+        help=f"critères du périmètre (défaut : {' '.join(CRITERES_VAGUE_1)})",
+    )
+    parser.add_argument(
+        "--apply", action="store_true", help="exécute (défaut: dry-run)"
+    )
+    parser.add_argument(
+        "--allow-prod", action="store_true", help="autorise --apply en prod"
+    )
+    args = parser.parse_args()
+    sys.exit(
+        asyncio.run(
+            run(
+                run_id=args.run_id,
+                date_reference=date.fromisoformat(args.date_reference),
+                libelle=args.libelle,
+                medias=args.medias,
+                criteres=args.criteres,
+                apply=args.apply,
+                allow_prod=args.allow_prod,
+            )
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/scripts/media_eval/evaluate_golden_agreement.py
+++ b/packages/api/scripts/media_eval/evaluate_golden_agreement.py
@@ -165,19 +165,31 @@ def main() -> None:
         required=True,
         help="export évals générées (même schéma)",
     )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=Path(__file__).resolve().parents[4] / ".context",
+        help="dossier de sortie (défaut .context ; docs/media-eval/rapports "
+        "pour un livrable commité)",
+    )
+    parser.add_argument(
+        "--slug",
+        default=None,
+        help="suffixe de fichier (défaut : date du jour, ex. 20260710)",
+    )
     args = parser.parse_args()
 
     gold = GoldenSet.model_validate_json(args.gold.read_text())
     generated = GoldenSet.model_validate_json(args.generated.read_text())
     report = evaluate(gold, generated)
 
-    ts = datetime.now(UTC).strftime("%Y%m%d")
-    ctx = Path(__file__).resolve().parents[4] / ".context"
-    ctx.mkdir(parents=True, exist_ok=True)
-    (ctx / f"media-eval-accord-{ts}.json").write_text(
+    slug = args.slug or datetime.now(UTC).strftime("%Y%m%d")
+    out_dir = args.out_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / f"media-eval-accord-{slug}.json").write_text(
         json.dumps(report, indent=2, ensure_ascii=False)
     )
-    (ctx / f"media-eval-accord-{ts}.md").write_text(render_md(report))
+    (out_dir / f"media-eval-accord-{slug}.md").write_text(render_md(report))
     print(render_md(report))
 
 

--- a/packages/api/scripts/media_eval/export_evaluations.py
+++ b/packages/api/scripts/media_eval/export_evaluations.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Export des évaluations d'un run → JSON au schéma `GoldenSet` (lecture seule).
+
+Sérialise les ``media_eval_evaluations`` d'un run dans le **même schéma** que
+le golden set humain, ce qui permet de les comparer directement
+(``evaluate_golden_agreement.py``). Le raccourci ``code:jti_shortcut`` est
+inclus (préfixe ``code:``) au même titre que les évaluateurs agents.
+
+Fonction pure ``evaluations_to_goldenset`` partagée avec ``rapport_pilote.py`` :
+elle **lève** si deux évaluations existent pour un même (média, critère) après
+filtrage — l'export doit être sans ambiguïté.
+
+Usage :
+    cd packages/api
+    python3 scripts/media_eval/export_evaluations.py --run-id pilote-2026-07 \
+        --out .context/media_eval/pilote-2026-07/evaluations_export.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from sqlalchemy import select
+
+from app.config import get_settings
+from app.database import async_session_maker, engine
+from app.models.media_eval import MediaEvalEvaluation, MediaEvalMedia
+from scripts.media_eval.schemas import GoldenEntry, GoldenSet
+
+DEFAULT_PREFIXES = ("agent:", "code:")
+
+
+def evaluations_to_goldenset(
+    evaluations: list[dict],
+    *,
+    prefixes: tuple[str, ...] = DEFAULT_PREFIXES,
+    notateur: str = "export:media-eval",
+) -> GoldenSet:
+    """Transforme des dicts d'évaluations en `GoldenSet` — pur, testable.
+
+    ``evaluations`` : {media_domaine, critere, statut, score, niveau,
+    evaluateur}. Lève ``ValueError`` si deux évals subsistent pour un même
+    (média, critère) après filtrage par préfixe d'évaluateur.
+    """
+    par_cle: dict[tuple[str, str], dict] = {}
+    for ev in evaluations:
+        if not any(ev["evaluateur"].startswith(p) for p in prefixes):
+            continue
+        cle = (ev["media_domaine"], ev["critere"])
+        if cle in par_cle:
+            raise ValueError(
+                f"deux évaluations pour {cle} : {par_cle[cle]['evaluateur']!r} et "
+                f"{ev['evaluateur']!r} — export ambigu."
+            )
+        par_cle[cle] = ev
+    entries = [
+        GoldenEntry(
+            media_domaine=ev["media_domaine"],
+            critere=ev["critere"],
+            statut=ev["statut"],
+            score=ev["score"],
+            niveau=ev.get("niveau"),
+        )
+        for ev in par_cle.values()
+    ]
+    return GoldenSet(notateur=notateur, note_at=None, entries=entries)
+
+
+async def charger_evaluations(session, run_id: str) -> list[dict]:
+    """Lit les évaluations d'un run (jointes au domaine média)."""
+    rows = await session.execute(
+        select(MediaEvalEvaluation, MediaEvalMedia.domaine)
+        .join(MediaEvalMedia, MediaEvalMedia.id == MediaEvalEvaluation.media_id)
+        .where(MediaEvalEvaluation.run_id == run_id)
+    )
+    resultats: list[dict] = []
+    for ev, domaine in rows.all():
+        resultats.append(
+            {
+                "media_domaine": domaine,
+                "critere": ev.critere,
+                "statut": ev.statut.value if hasattr(ev.statut, "value") else ev.statut,
+                "score": ev.score,
+                "niveau": ev.niveau,
+                "evaluateur": ev.evaluateur,
+            }
+        )
+    return resultats
+
+
+async def run(run_id: str, out: Path, prefixes: tuple[str, ...]) -> int:
+    async with async_session_maker() as session:
+        try:
+            evaluations = await charger_evaluations(session, run_id)
+            if not evaluations:
+                print(f"REJET : aucune évaluation pour le run {run_id!r}.")
+                return 1
+            goldenset = evaluations_to_goldenset(evaluations, prefixes=prefixes)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(goldenset.model_dump_json(indent=2) + "\n")
+            print(f"Export : {len(goldenset.entries)} entrées → {out}")
+            return 0
+        except ValueError as exc:
+            print(f"REJET : {exc}")
+            return 1
+        finally:
+            await engine.dispose()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--out", type=Path, required=True, help="JSON de sortie")
+    parser.add_argument(
+        "--evaluateur-prefixes",
+        default=",".join(DEFAULT_PREFIXES),
+        help="préfixes d'évaluateurs inclus (défaut 'agent:,code:')",
+    )
+    args = parser.parse_args()
+    prefixes = tuple(p for p in args.evaluateur_prefixes.split(",") if p)
+    # Lecture seule — get_settings garde le comportement usuel (DB courante).
+    get_settings()
+    sys.exit(asyncio.run(run(args.run_id, args.out, prefixes)))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/scripts/media_eval/export_snapshots.py
+++ b/packages/api/scripts/media_eval/export_snapshots.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Export des snapshots d'un run vers des fichiers texte (voie A → fichiers).
+
+La voie A capture jusqu'à 20 000 caractères par page en DB. La voie B (agents
+gouvernance) doit **lire cette substance sans re-fetcher** le site — c'est le
+levier principal contre les 403 anti-bot (le contenu obtenu par ``curl_cffi``
+est réutilisé). Ce script dump les snapshots vers
+``.context/media_eval/<run_id>/snapshots/<slug>__<type_page>.txt`` (en-tête :
+url, http_status, mode_acces, hash, collecte_at) et **liste les chemins écrits**
+pour que l'orchestrateur les passe aux agents.
+
+Lecture seule DB, écriture uniquement sous ``.context/`` (jamais commité).
+
+Usage :
+    cd packages/api
+    python3 scripts/media_eval/export_snapshots.py --run-id pilote-2026-07b \
+        [--media cnews.fr] [--out-root .context/media_eval]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from sqlalchemy import select
+
+from app.config import get_settings
+from app.database import async_session_maker, engine
+from app.models.media_eval import MediaEvalMedia, MediaEvalSnapshot
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+DEFAULT_OUT_ROOT = _REPO_ROOT / ".context" / "media_eval"
+
+
+def slug(domaine: str) -> str:
+    return domaine.replace(".", "_")
+
+
+def _type_page_str(type_page) -> str:
+    return type_page.value if hasattr(type_page, "value") else str(type_page)
+
+
+def nom_fichier(domaine: str, type_page, existants: set[str]) -> str:
+    """``<slug>__<type_page>.txt`` — suffixe numérique si collision (déterministe)."""
+    base = f"{slug(domaine)}__{_type_page_str(type_page)}"
+    nom = f"{base}.txt"
+    n = 2
+    while nom in existants:
+        nom = f"{base}__{n}.txt"
+        n += 1
+    existants.add(nom)
+    return nom
+
+
+def rendre_fichier(snap: MediaEvalSnapshot) -> str:
+    """Contenu du fichier : en-tête de provenance + texte de la page (pur)."""
+    mode = (
+        snap.mode_acces.value if hasattr(snap.mode_acces, "value") else snap.mode_acces
+    )
+    entete = [
+        f"url: {snap.url}",
+        f"type_page: {_type_page_str(snap.type_page)}",
+        f"http_status: {snap.http_status}",
+        f"mode_acces: {mode}",
+        f"hash: {snap.hash}",
+        f"collecte_at: {snap.capture_at.isoformat() if snap.capture_at else None}",
+        "",
+        "---",
+        "",
+    ]
+    return "\n".join(entete) + (snap.contenu or "")
+
+
+async def charger_snapshots(
+    session, run_id: str, media_domaine: str | None
+) -> list[tuple[str, MediaEvalSnapshot]]:
+    """Snapshots du run (option. filtrés par média) joints au domaine, triés."""
+    stmt = (
+        select(MediaEvalMedia.domaine, MediaEvalSnapshot)
+        .join(MediaEvalMedia, MediaEvalMedia.id == MediaEvalSnapshot.media_id)
+        .where(MediaEvalSnapshot.run_id == run_id)
+    )
+    if media_domaine:
+        stmt = stmt.where(MediaEvalMedia.domaine == media_domaine)
+    stmt = stmt.order_by(MediaEvalMedia.domaine, MediaEvalSnapshot.url)
+    rows = await session.execute(stmt)
+    return [(domaine, snap) for domaine, snap in rows.all()]
+
+
+async def run(run_id: str, media_domaine: str | None, out_root: Path) -> int:
+    async with async_session_maker() as session:
+        try:
+            snaps = await charger_snapshots(session, run_id, media_domaine)
+            if not snaps:
+                cible = f" pour {media_domaine}" if media_domaine else ""
+                print(f"REJET : aucun snapshot pour le run {run_id!r}{cible}.")
+                return 1
+            out_dir = out_root / run_id / "snapshots"
+            out_dir.mkdir(parents=True, exist_ok=True)
+            existants: set[str] = set()
+            ecrits: list[Path] = []
+            for domaine, snap in snaps:
+                nom = nom_fichier(domaine, snap.type_page, existants)
+                chemin = out_dir / nom
+                chemin.write_text(rendre_fichier(snap))
+                ecrits.append(chemin)
+            print(f"Snapshots exportés : {len(ecrits)} → {out_dir}")
+            for chemin in ecrits:
+                affiche = (
+                    chemin.relative_to(_REPO_ROOT)
+                    if chemin.is_relative_to(_REPO_ROOT)
+                    else chemin
+                )
+                print(f"  → {affiche}")
+            return 0
+        finally:
+            await engine.dispose()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-id", required=True, help="ex. pilote-2026-07b")
+    parser.add_argument(
+        "--media", default=None, help="filtre optionnel par domaine (ex. cnews.fr)"
+    )
+    parser.add_argument(
+        "--out-root",
+        type=Path,
+        default=DEFAULT_OUT_ROOT,
+        help="racine des artefacts (défaut .context/media_eval)",
+    )
+    args = parser.parse_args()
+    get_settings()  # lecture seule — DB courante
+    sys.exit(asyncio.run(run(args.run_id, args.media, args.out_root)))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/scripts/media_eval/ingest_artifacts.py
+++ b/packages/api/scripts/media_eval/ingest_artifacts.py
@@ -45,11 +45,16 @@ from app.models.media_eval import (
 )
 from scripts.cleanup_orphan_sources import _is_test_db
 from scripts.media_eval.schemas import (
+    TYPE_SIGNAUX,
     DebunkageArtifact,
     DebunkageBatchArtifact,
     SignalArtifact,
     SignalBatchArtifact,
 )
+
+# Couverture attendue de la voie B gouvernance : le silence est interdit, chaque
+# type de signal doit être adressé (present/partiel/absent_verifie/bloque_acces).
+CRITERES_GOUVERNANCE: tuple[str, ...] = ("C5", "C7", "C8", "C9", "C11")
 
 
 class IngestError(Exception):
@@ -76,6 +81,15 @@ def dedupe_key_signal(item: SignalArtifact) -> str:
     ancre = item.source_urls[0] if item.source_urls else (item.citation or "")
     brut = f"{item.critere}|{item.type_signal}|{item.statut}|{ancre}"
     return hashlib.sha256(brut.encode()).hexdigest()
+
+
+def voie_depuis_agent(agent: str) -> VoieCollecte:
+    """Voie dérivée du préfixe (D6) : ``humain:`` → HUMAIN, sinon AGENT.
+
+    Ouvre la voie C (artefact manuel ``agent: "humain:laurin"``) sans nouveau
+    script — un repli quand une source open data est inaccessible.
+    """
+    return VoieCollecte.HUMAIN if agent.startswith("humain:") else VoieCollecte.AGENT
 
 
 def dedupe_key_debunkage(item: DebunkageArtifact) -> str:
@@ -129,12 +143,14 @@ async def inserer_signaux(session, batch: SignalBatchArtifact) -> IngestResult:
                 statut=StatutSignal(item.statut),
                 valeur=item.valeur,
                 citation=item.citation,
-                voie=VoieCollecte.AGENT,
+                voie=voie_depuis_agent(batch.agent),
                 collecteur=batch.agent,
                 source_urls=item.source_urls,
                 sources_consultees=item.sources_consultees or None,
                 run_id=batch.run_id,
                 dedupe_key=key,
+                collecte_at=batch.genere_at,
+                version_prompt_collecteur=batch.version_prompt,
             )
         )
         result.inseres += 1
@@ -175,12 +191,14 @@ async def inserer_debunkages(session, batch: DebunkageBatchArtifact) -> IngestRe
                 "resume": item.resume,
             },
             citation=item.citation or item.resume,
-            voie=VoieCollecte.AGENT,
+            voie=voie_depuis_agent(batch.agent),
             collecteur=batch.agent,
             source_urls=item.source_urls,
             sources_consultees=item.sources_consultees or None,
             run_id=batch.run_id,
             dedupe_key=key,
+            collecte_at=batch.genere_at,
+            version_prompt_collecteur=batch.version_prompt,
         )
         session.add(signal)
         await session.flush()  # signal.id requis pour le couple
@@ -217,6 +235,34 @@ async def ingester(session, paths: list[Path]) -> IngestResult:
         total.doublons += partiel.doublons
         total.details.extend(partiel.details)
     return total
+
+
+async def rapport_couverture(session, batches: list) -> list[str]:
+    """Types de signaux gouvernance sans aucun signal pour (média, run).
+
+    Contrôle d'observabilité (anti-passivité) : la voie B doit adresser chaque
+    ``type_signal`` du registre gouvernance ; un type absent est signalé en
+    WARNING (non bloquant). Lu sur l'état de session courant (voie A + voie B),
+    donc valable en dry-run comme en ``--apply``.
+    """
+    cibles = {
+        (item.media_domaine, batch.run_id) for batch in batches for item in batch.items
+    }
+    manquants: list[str] = []
+    for domaine, run_id in sorted(cibles):
+        media = await resoudre_media(session, domaine)
+        rows = await session.execute(
+            select(MediaEvalSignal.critere, MediaEvalSignal.type_signal).where(
+                MediaEvalSignal.media_id == media.id,
+                MediaEvalSignal.run_id == run_id,
+            )
+        )
+        presents = {(c, t) for c, t in rows.all()}
+        for critere in CRITERES_GOUVERNANCE:
+            for type_signal in TYPE_SIGNAUX[critere]:
+                if (critere, type_signal) not in presents:
+                    manquants.append(f"{domaine} · {critere}/{type_signal}")
+    return manquants
 
 
 def _collecter_paths(artifact: Path) -> list[Path]:
@@ -258,6 +304,17 @@ async def run(artifact: Path, apply: bool, allow_prod: bool) -> int:
                 f"Artefacts : {len(paths)} | à insérer : {result.inseres} | "
                 f"doublons ignorés : {result.doublons}"
             )
+            manquants = await rapport_couverture(
+                session, [charger_artifact(p) for p in paths]
+            )
+            if manquants:
+                print(
+                    f"\n⚠ COUVERTURE : {len(manquants)} type(s) de signal "
+                    "gouvernance sans aucun signal (voie A + B) — le silence est "
+                    "interdit, chaque type doit être adressé :"
+                )
+                for ligne in manquants:
+                    print(f"    - {ligne}")
             if not apply:
                 await session.rollback()
                 print("(dry-run — aucune mutation. Relance avec --apply.)")

--- a/packages/api/scripts/media_eval/rapport_pilote.py
+++ b/packages/api/scripts/media_eval/rapport_pilote.py
@@ -1,0 +1,1133 @@
+#!/usr/bin/env python3
+"""Rapport de run pilote (D7) — Markdown auditable + HTML propre, lecture seule.
+
+Tous les chiffres viennent de la DB (signaux, évaluations, fiches) et du golden
+set humain : un reviewer humain peut les recouper. `run()` écrit **deux** rendus
+depuis une **unique** collecte DB (`collecter_donnees_rapport`) :
+`<out>.md` (git-diffable, audit) et `<out>.html` (rapport autonome single-file,
+deux lentilles : propreté des données puis qualité des évaluations). Sections
+Markdown :
+
+1. Contexte : run, date_reference, sha256 des rubriques, horodatage gold vs
+   évaluations (**preuve D4** : le gold doit précéder les évaluations).
+2. Signaux par média × critère × voie.
+3. Garde-fous activés (fraîcheur, fallback C1, raccourci JTI, corroboration,
+   bloque_acces).
+4. Scores vs gold (gold / généré / Δ / accord).
+5. Fiches (brut, max applicable, renormalisé, lettre, confiance).
+6. **Verdict PASS/FAIL des 4 critères de succès V0** avec preuves chiffrées.
+7. Notes de collecte et limites.
+
+Usage :
+    cd packages/api
+    python3 scripts/media_eval/rapport_pilote.py --run-id pilote-2026-07 \
+        --gold ../../docs/media-eval/golden/gold_v0.json \
+        --out ../../docs/media-eval/rapports/pilote-2026-07.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import html
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from urllib.parse import urlparse
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from sqlalchemy import select
+
+from app.config import get_settings
+from app.database import async_session_maker, engine
+from app.models.media_eval import (
+    MediaEvalEvaluation,
+    MediaEvalMedia,
+    MediaEvalRun,
+    MediaEvalSignal,
+)
+from scripts.media_eval.build_eval_input import version_prompt
+from scripts.media_eval.evaluate_golden_agreement import evaluate
+from scripts.media_eval.export_evaluations import evaluations_to_goldenset
+from scripts.media_eval.schemas import (
+    BAREMES,
+    CORROBORATION_MIN_SOURCES,
+    CRITERES_VAGUE_1,
+    GoldenSet,
+)
+from scripts.media_eval.synthese_fiche import compute_fiche
+
+_GARDE_FOUS = (
+    ("fraîcheur (730 j)", "signaux événementiels > 730 j exclus (amont)"),
+    ("fallback C1", "< 3 débunkages frais → N/A"),
+    ("raccourci JTI", "certification valide → C8 pleine par code"),
+    ("corroboration", "score plein < 2 sources → palier inférieur"),
+    ("bloque_acces", "accès refusé → revue_requise, jamais 0"),
+)
+
+
+# --------------------------------------------------------------------------- #
+# Rendu ASCII pur — testable sans DB.
+# --------------------------------------------------------------------------- #
+def _table(headers: list[str], rows: list[list[str]]) -> str:
+    cols = (
+        list(zip(*([headers] + rows), strict=False)) if rows else [[h] for h in headers]
+    )
+    largeurs = [max(len(str(c)) for c in col) for col in cols]
+    sep = "+-" + "-+-".join("-" * w for w in largeurs) + "-+"
+
+    def ligne(vals: list[str]) -> str:
+        return (
+            "| "
+            + " | ".join(str(v).ljust(w) for v, w in zip(vals, largeurs, strict=False))
+            + " |"
+        )
+
+    out = [sep, ligne(headers), sep]
+    out += [ligne(r) for r in rows]
+    out.append(sep)
+    return "\n".join(out)
+
+
+def tableau_signaux(signaux: list[dict]) -> str:
+    """Signaux par média × critère × voie × statut (comptage)."""
+    agg: dict[tuple, int] = {}
+    for s in signaux:
+        cle = (s["media"], s["critere"], s["voie"], s["statut"])
+        agg[cle] = agg.get(cle, 0) + 1
+    rows = [[m, c, v, st, str(n)] for (m, c, v, st), n in sorted(agg.items())]
+    if not rows:
+        return "(aucun signal)"
+    return _table(["Média", "Critère", "Voie", "Statut", "N"], rows)
+
+
+def tableau_garde_fous(actives: dict[str, str]) -> str:
+    """État de chaque garde-fou (activé sur ce run ou non)."""
+    rows = []
+    for nom, desc in _GARDE_FOUS:
+        etat = actives.get(nom, "—")
+        rows.append([nom, desc, etat])
+    return _table(["Garde-fou", "Règle", "Constaté"], rows)
+
+
+def tableau_accord(report: dict) -> str:
+    """Détail gold / généré / Δ / accord par paire (depuis evaluate())."""
+    if report.get("n", 0) == 0:
+        return f"(pas de paire comparable : {report.get('error', 'vide')})"
+    rows = []
+    for r in sorted(report["desaccords"], key=lambda r: (r["media"], r["critere"])):
+        rows.append(
+            [
+                r["media"],
+                r["critere"],
+                str(
+                    r["gold_score"]
+                    if r["gold_statut"] == "evaluee"
+                    else r["gold_statut"]
+                ),
+                str(
+                    r["gen_score"] if r["gen_statut"] == "evaluee" else r["gen_statut"]
+                ),
+                str(r["delta"] if r["delta"] is not None else "-"),
+                "✗ " + str(r["type_desaccord"]),
+            ]
+        )
+    entete = (
+        f"Accord global : {report['accord_global']:.0%} · par média : "
+        f"{report['par_media']} · N/A-vs-score : {report['na_vs_score']} · "
+        f"MAE : {report['mae_scores']}"
+    )
+    if not rows:
+        return entete + "\n(aucun désaccord)"
+    return (
+        entete
+        + "\n"
+        + _table(["Média", "Critère", "Gold", "Généré", "Δ", "Désaccord"], rows)
+    )
+
+
+def verdict_v0(metrics: dict) -> list[dict]:
+    """PASS/FAIL des 4 critères de succès V0 — pur, testable."""
+    accord = metrics["accord_par_media"]
+    ok_accord = bool(accord) and all(n >= 4 for n in accord.values())
+    reporterre = metrics.get("reporterre", {})
+    ok_reporterre = (
+        reporterre.get("c1_statut") == "non_applicable"
+        and reporterre.get("max_applicable") == 34.0
+    )
+    return [
+        {
+            "critere": "1. Artefacts valides sans édition manuelle",
+            "pass": metrics["evaluations_valides"],
+            "preuve": f"{metrics['n_evaluations']} évaluations ingérées "
+            "(validées Pydantic avant écriture DB)",
+        },
+        {
+            "critere": "2. Accord ≥ 4/6 par média",
+            "pass": ok_accord,
+            "preuve": " · ".join(f"{m}: {n}/6" for m, n in sorted(accord.items()))
+            or "aucune paire",
+        },
+        {
+            "critere": "3. Reporterre C1 = N/A + renormalisation 34 pts",
+            "pass": ok_reporterre,
+            "preuve": f"C1 statut={reporterre.get('c1_statut', '—')}, "
+            f"max_applicable={reporterre.get('max_applicable', '—')}",
+        },
+        {
+            "critere": "4. Zéro écriture DB par agent",
+            "pass": metrics["zero_ecriture_agent"],
+            "preuve": "signaux voie=agent via ingest_artifacts, évals via "
+            "ingest_evaluations (aucun agent n'ouvre de session DB)",
+        },
+    ]
+
+
+def render_verdict(criteres: list[dict]) -> str:
+    rows = [
+        [c["critere"], "PASS" if c["pass"] else "FAIL", c["preuve"]] for c in criteres
+    ]
+    global_pass = all(c["pass"] for c in criteres)
+    tag = "✅ V0 VALIDÉ" if global_pass else "❌ V0 NON VALIDÉ"
+    return _table(["Critère de succès", "Verdict", "Preuve"], rows) + f"\n\n{tag}"
+
+
+# --------------------------------------------------------------------------- #
+# Lentille A — propreté des données (pur, testable sans DB).
+# --------------------------------------------------------------------------- #
+# Notes de complétude par (média, critère) — palette *status* réservée, rendue
+# toujours avec icône + label (jamais couleur seule). Distinction cardinale :
+# `bloque` = trou d'accès (donnée manquante) ; `absent_confirme` = absence
+# vérifiée avec preuve de recherche (donnée propre).
+NOTE_RICHE = "riche"
+NOTE_PARTIEL = "partiel"
+NOTE_BLOQUE = "bloque"
+NOTE_ABSENT = "absent_confirme"
+NOTE_NA = "na"
+NOTES_ORDRE: tuple[str, ...] = (
+    NOTE_RICHE,
+    NOTE_PARTIEL,
+    NOTE_BLOQUE,
+    NOTE_ABSENT,
+    NOTE_NA,
+)
+NOTE_LABEL: dict[str, str] = {
+    NOTE_RICHE: "Riche",
+    NOTE_PARTIEL: "Partiel",
+    NOTE_BLOQUE: "Bloqué",
+    NOTE_ABSENT: "Absence confirmée",
+    NOTE_NA: "N/A",
+}
+NOTE_ICON: dict[str, str] = {
+    NOTE_RICHE: "●",
+    NOTE_PARTIEL: "◐",
+    NOTE_BLOQUE: "⚠",
+    NOTE_ABSENT: "○",
+    NOTE_NA: "–",
+}
+NOTE_DESC: dict[str, str] = {
+    NOTE_RICHE: "signal présent + corroboré (≥ 2 sources indépendantes)",
+    NOTE_PARTIEL: "signal présent/partiel mais non corroboré",
+    NOTE_BLOQUE: "trou d'accès — donnée manquante (accès refusé / non collectée)",
+    NOTE_ABSENT: "absence confirmée avec preuve de recherche (donnée propre)",
+    NOTE_NA: "critère non applicable (exclu du dénominateur)",
+}
+_STATUTS_PRESENTS = ("present", "partiel")
+
+
+def _domaines_independants(urls: list[str]) -> int:
+    """Nb de domaines distincts (proxy d'indépendance des sources)."""
+    domaines: set[str] = set()
+    for u in urls:
+        net = urlparse(u).netloc.lower() if u else ""
+        net = net[4:] if net.startswith("www.") else net
+        domaines.add(net or (u or ""))
+    domaines.discard("")
+    return len(domaines)
+
+
+def _note_cellule(signaux_cell: list[dict], statut_eval: str | None) -> dict:
+    """Note de complétude d'un couple (média, critère) — pur, testable."""
+    base_note = NOTE_NA if statut_eval == "non_applicable" else None
+    par_statut: dict[str, int] = {}
+    par_voie: dict[str, int] = {}
+    sources: list[str] = []
+    for s in signaux_cell:
+        par_statut[s["statut"]] = par_statut.get(s["statut"], 0) + 1
+        par_voie[s["voie"]] = par_voie.get(s["voie"], 0) + 1
+        if s["statut"] in _STATUTS_PRESENTS:
+            sources.extend(s.get("source_urls") or [])
+    n_sources = _domaines_independants(sources)
+    corrobore = n_sources >= CORROBORATION_MIN_SOURCES
+    a_present = any(s["statut"] == "present" for s in signaux_cell)
+    a_donnee = any(s["statut"] in _STATUTS_PRESENTS for s in signaux_cell)
+
+    if base_note is not None:
+        note = base_note
+    elif a_present and corrobore:
+        note = NOTE_RICHE
+    elif a_donnee:
+        note = NOTE_PARTIEL
+    elif any(s["statut"] == "bloque_acces" for s in signaux_cell):
+        note = NOTE_BLOQUE
+    elif any(s["statut"] == "absent_verifie" for s in signaux_cell):
+        note = NOTE_ABSENT
+    else:
+        note = NOTE_BLOQUE  # aucun signal exploitable → trou de couverture
+    return {
+        "note": note,
+        "n_signaux": len(signaux_cell),
+        "par_statut": par_statut,
+        "par_voie": par_voie,
+        "n_sources": n_sources,
+        "corrobore": corrobore and note in (NOTE_RICHE, NOTE_PARTIEL),
+        "statut_eval": statut_eval,
+    }
+
+
+def evaluer_proprete_donnees(
+    signaux: list[dict],
+    evaluations: list[dict],
+    fiches: dict[str, dict],
+) -> dict:
+    """Lentille « propreté des données » — pur, testable sans DB.
+
+    Par (média, critère) : décompte signaux, ventilation voie/statut,
+    corroboration et **note de complétude** (`riche | partiel | bloque |
+    absent_confirme | na`). Plus un rollup santé-data par média et global.
+    """
+    statut_eval = {(e["media_domaine"], e["critere"]): e["statut"] for e in evaluations}
+    par_cle: dict[tuple[str, str], list[dict]] = {}
+    for s in signaux:
+        par_cle.setdefault((s["media"], s["critere"]), []).append(s)
+
+    medias = sorted(
+        {s["media"] for s in signaux}
+        | {e["media_domaine"] for e in evaluations}
+        | set(fiches)
+    )
+    cellules: list[dict] = []
+    for media in medias:
+        for critere in CRITERES_VAGUE_1:
+            cle = (media, critere)
+            cell_sig = par_cle.get(cle, [])
+            st_eval = statut_eval.get(cle)
+            if not cell_sig and st_eval is None:
+                continue  # ni signal ni éval : critère hors périmètre du run
+            note = _note_cellule(cell_sig, st_eval)
+            cellules.append({"media": media, "critere": critere, **note})
+
+    par_media: dict[str, dict] = {}
+    for c in cellules:
+        par_media.setdefault(c["media"], []).append(c)
+
+    def _rollup(cells: list[dict]) -> dict:
+        par_note = dict.fromkeys(NOTES_ORDRE, 0)
+        for c in cells:
+            par_note[c["note"]] += 1
+        n_avec_donnee = sum(par_note[n] for n in (NOTE_RICHE, NOTE_PARTIEL))
+        n_corrobore = sum(1 for c in cells if c["corrobore"])
+        return {
+            "n_signaux": sum(c["n_signaux"] for c in cells),
+            "n_cellules": len(cells),
+            "par_note": par_note,
+            "n_corrobore": n_corrobore,
+            "n_avec_donnee": n_avec_donnee,
+            "n_bloque": par_note[NOTE_BLOQUE],
+            "pct_corrobore": (
+                round(n_corrobore / n_avec_donnee, 3) if n_avec_donnee else None
+            ),
+        }
+
+    return {
+        "cellules": cellules,
+        "par_media": {m: _rollup(cs) for m, cs in sorted(par_media.items())},
+        "global": _rollup(cellules),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Rendu HTML autonome (single-file, CSS inline) — pur, testable sans DB.
+# --------------------------------------------------------------------------- #
+def _esc(value: object) -> str:
+    return html.escape("" if value is None else str(value), quote=True)
+
+
+# Voie (français) → classes CSS du design system (badge, pastille, en anglais).
+_VOIE_CLS: dict[str, tuple[str, str]] = {
+    "code": ("b-code", "d-code"),
+    "agent": ("b-agent", "d-agent"),
+    "humain": ("b-human", "d-human"),
+}
+
+
+def _voie_dots(par_voie: dict[str, int]) -> str:
+    return "".join(
+        f'<span class="dot {_VOIE_CLS[v][1]}" title="{v} ×{par_voie[v]}"></span>'
+        for v in ("code", "agent", "humain")
+        if par_voie.get(v)
+    )
+
+
+def _val_accord(statut: str, score: float | None, niveau: int | None) -> str:
+    if niveau is not None:
+        return f"niv {niveau}"
+    if statut == "evaluee":
+        return "—" if score is None else f"{score:g}"
+    return statut
+
+
+_CONFIANCE_CLS = {"haute": "ok", "moyenne": "mid", "basse": "warn"}
+
+_HTML_STYLE = """
+  :root{
+    --ink:#1b2430;--ink-soft:#48566a;--line:#e3e8ef;--bg:#f6f8fb;--card:#fff;
+    --brand:#2f5fe0;--brand-soft:#eaf0ff;
+    --code:#0f766e;--code-soft:#e6f6f3;--agent:#7c3aed;--agent-soft:#f1eafe;
+    --human:#b45309;--human-soft:#fdf1e0;--ok:#15803d;--warn:#b91c1c;
+    --st-riche:#15803d;--st-riche-bg:#eaf6ee;
+    --st-partiel:#a16207;--st-partiel-bg:#fdf6e3;
+    --st-bloque:#b91c1c;--st-bloque-bg:#fdeceb;
+    --st-absent:#475569;--st-absent-bg:#eef2f7;
+    --st-na:#94a3b8;--st-na-bg:#f4f6f9;
+    --shadow:0 1px 2px rgba(16,24,40,.06),0 8px 24px rgba(16,24,40,.05);
+  }
+  *{box-sizing:border-box;}
+  body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,
+    Helvetica,Arial,sans-serif;color:var(--ink);background:var(--bg);
+    line-height:1.55;-webkit-font-smoothing:antialiased;}
+  .wrap{max-width:1080px;margin:0 auto;padding:0 22px 96px;}
+  header.hero{background:linear-gradient(135deg,#1b2a4e 0%,#2f5fe0 100%);
+    color:#fff;padding:48px 0 40px;box-shadow:var(--shadow);}
+  header.hero .wrap{padding-bottom:0;}
+  .eyebrow{text-transform:uppercase;letter-spacing:.14em;font-size:12px;
+    font-weight:700;opacity:.82;margin:0 0 10px;}
+  header.hero h1{font-size:32px;line-height:1.15;margin:0 0 12px;font-weight:800;}
+  header.hero p.lede{font-size:16px;max-width:780px;margin:0;opacity:.95;}
+  .meta-row{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px;}
+  .pill{display:inline-flex;align-items:center;gap:7px;
+    background:rgba(255,255,255,.14);border:1px solid rgba(255,255,255,.22);
+    padding:5px 12px;border-radius:999px;font-size:13px;font-weight:600;}
+  .verdict-row{display:flex;flex-wrap:wrap;gap:12px;align-items:center;
+    margin-top:22px;}
+  .vbadge{display:inline-flex;align-items:center;gap:8px;font-weight:800;
+    font-size:15px;padding:8px 16px;border-radius:10px;}
+  .vbadge.ok{background:#eaf6ee;color:var(--ok);}
+  .vbadge.warn{background:#fdeceb;color:var(--warn);}
+  .vbadge.big{font-size:16px;}
+  .accord-tag{font-size:14px;font-weight:700;color:#fff;opacity:.95;}
+  section{margin:0 0 46px;}
+  h2{font-size:23px;font-weight:800;margin:34px 0 4px;letter-spacing:-.01em;
+    display:flex;align-items:baseline;gap:12px;}
+  h2 .num{font-size:14px;font-weight:800;color:#fff;background:var(--brand);
+    border-radius:8px;padding:2px 10px;}
+  h3{font-size:17px;font-weight:700;margin:26px 0 10px;}
+  .section-lede{color:var(--ink-soft);font-size:15.5px;margin:0 0 18px;
+    max-width:840px;}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:14px;
+    padding:20px 22px;box-shadow:var(--shadow);}
+  .grid{display:grid;gap:16px;}
+  .grid-2{grid-template-columns:repeat(auto-fit,minmax(300px,1fr));}
+  .grid-3{grid-template-columns:repeat(auto-fit,minmax(240px,1fr));}
+  .grid-4{grid-template-columns:repeat(auto-fit,minmax(220px,1fr));}
+  table{width:100%;border-collapse:collapse;font-size:14px;margin:8px 0 0;}
+  th,td{text-align:left;padding:9px 12px;border-bottom:1px solid var(--line);
+    vertical-align:top;}
+  th{font-size:12px;text-transform:uppercase;letter-spacing:.05em;
+    color:var(--ink-soft);font-weight:700;}
+  tbody tr:last-child td{border-bottom:none;}
+  code,.mono{font-family:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,
+    monospace;font-size:12.5px;background:#f1f4f8;padding:1px 6px;
+    border-radius:5px;color:#223;}
+  .badge{display:inline-flex;align-items:center;gap:6px;font-weight:700;
+    font-size:12px;padding:3px 9px;border-radius:6px;white-space:nowrap;}
+  .b-code{color:var(--code);background:var(--code-soft);}
+  .b-agent{color:var(--agent);background:var(--agent-soft);}
+  .b-human{color:var(--human);background:var(--human-soft);}
+  .dot{width:9px;height:9px;border-radius:50%;display:inline-block;}
+  .d-code{background:var(--code);}.d-agent{background:var(--agent);}
+  .d-human{background:var(--human);}
+  /* Matrice propreté — palette status réservée (icône + label). */
+  .mx td{text-align:center;font-size:12.5px;}
+  .mx td.media-cell{text-align:left;font-weight:700;white-space:nowrap;}
+  .mx-cell{display:inline-flex;flex-direction:column;gap:3px;align-items:center;
+    padding:6px 8px;border-radius:8px;min-width:96px;}
+  .mx-note{font-weight:800;font-size:12.5px;display:inline-flex;gap:5px;
+    align-items:center;}
+  .mx-meta{font-size:11px;color:var(--ink-soft);display:inline-flex;gap:5px;
+    align-items:center;}
+  .mx-empty{color:var(--st-na);}
+  .st-riche{background:var(--st-riche-bg);color:var(--st-riche);}
+  .st-partiel{background:var(--st-partiel-bg);color:var(--st-partiel);}
+  .st-bloque{background:var(--st-bloque-bg);color:var(--st-bloque);}
+  .st-absent_confirme{background:var(--st-absent-bg);color:var(--st-absent);}
+  .st-na{background:var(--st-na-bg);color:var(--st-na);}
+  .legend{display:flex;flex-wrap:wrap;gap:14px;margin:14px 0 4px;font-size:13px;}
+  .legend .lg{display:inline-flex;align-items:center;gap:6px;font-weight:600;
+    padding:3px 9px;border-radius:7px;}
+  .callout{border-left:4px solid var(--brand);background:var(--brand-soft);
+    border-radius:0 10px 10px 0;padding:13px 17px;margin:16px 0;font-size:14px;}
+  .callout.warn{border-left-color:var(--warn);background:#fdeceb;}
+  .callout.ok{border-left-color:var(--ok);background:#eaf6ee;}
+  /* Cartes santé + fiches + verdict */
+  .stat{border-top:4px solid var(--brand);}
+  .stat .big{font-size:26px;font-weight:800;margin:2px 0 0;}
+  .stat .lbl{font-size:12px;text-transform:uppercase;letter-spacing:.05em;
+    color:var(--ink-soft);font-weight:700;}
+  .fiche{border-top:4px solid var(--brand);}
+  .fiche .letter{font-size:30px;font-weight:800;color:var(--brand);}
+  .scorebar{height:9px;border-radius:6px;background:var(--line);overflow:hidden;
+    margin:10px 0 6px;}
+  .scorebar-fill{height:100%;background:var(--brand);border-radius:6px;}
+  .chip{display:inline-flex;align-items:center;gap:6px;font-size:12px;
+    font-weight:700;padding:3px 9px;border-radius:6px;}
+  .chip.ok{background:#eaf6ee;color:var(--ok);}
+  .chip.mid{background:var(--st-partiel-bg);color:var(--st-partiel);}
+  .chip.warn{background:#fdeceb;color:var(--warn);}
+  .vcard{border-top:4px solid var(--line);}
+  .vcard.pass{border-top-color:var(--ok);}
+  .vcard.fail{border-top-color:var(--warn);}
+  .vcard .vh{display:flex;justify-content:space-between;gap:10px;
+    align-items:flex-start;}
+  .vcard .vt{font-weight:800;font-size:14.5px;margin:0;}
+  .vcard .vp{color:var(--ink-soft);font-size:13px;margin:8px 0 0;}
+  details{border:1px solid var(--line);border-radius:10px;padding:2px 14px;
+    margin:8px 0;background:var(--card);}
+  details>summary{cursor:pointer;font-weight:700;padding:10px 0;font-size:14px;}
+  details .sig{border-top:1px solid var(--line);padding:10px 0;}
+  details .sig:first-of-type{border-top:none;}
+  .sig .cit{color:var(--ink-soft);font-size:13.5px;margin:4px 0;font-style:italic;}
+  .sig .src{font-size:12px;word-break:break-all;}
+  .sig .src a{color:var(--brand);text-decoration:none;}
+  .row-warn{background:#fdeceb;}
+  footer{border-top:1px solid var(--line);padding:22px 0;color:var(--ink-soft);
+    font-size:13px;text-align:center;}
+  @media (max-width:640px){header.hero h1{font-size:26px;}h2{font-size:20px;}}
+"""
+
+
+def _html_hero(run: dict, gl: dict, verdict: list[dict], accord: dict) -> str:
+    global_pass = all(c["pass"] for c in verdict)
+    vcls = "ok" if global_pass else "warn"
+    vtxt = "✅ V0 VALIDÉ" if global_pass else "❌ V0 non validé"
+    pct = gl.get("pct_corrobore")
+    pct_txt = f"{pct:.0%}" if pct is not None else "—"
+    accord_txt = (
+        f"Accord global : {accord['accord_global']:.0%}"
+        if accord.get("n", 0)
+        else "Accord : pas de paire comparable"
+    )
+    perim = run.get("perimetre") or {}
+    medias = ", ".join(perim.get("medias", [])) if isinstance(perim, dict) else ""
+    return f"""<header class="hero"><div class="wrap">
+  <p class="eyebrow">Facteur · media-eval · Rapport de run</p>
+  <h1>{_esc(run["run_id"])}</h1>
+  <p class="lede">Méthodologie {_esc(run["version_methodo"])} · date_reference
+    (fraîcheur) <strong>{_esc(run["date_reference"])}</strong>{
+        f" · périmètre : {_esc(medias)}" if medias else ""
+    }. Deux lentilles : propreté des données collectées, puis qualité des
+    évaluations (accord vs golden humain).</p>
+  <div class="meta-row">
+    <span class="pill">{gl["n_signaux"]} signaux collectés</span>
+    <span class="pill">{pct_txt} corroborés</span>
+    <span class="pill">{gl["n_bloque"]} trou(s) d'accès</span>
+  </div>
+  <div class="verdict-row">
+    <span class="vbadge {vcls} big">{vtxt}</span>
+    <span class="accord-tag">{_esc(accord_txt)}</span>
+  </div>
+</div></header>"""
+
+
+def _html_matrice(proprete: dict) -> str:
+    cellules = {(c["media"], c["critere"]): c for c in proprete["cellules"]}
+    medias = sorted({c["media"] for c in proprete["cellules"]})
+    head = "".join(
+        f'<th>{c}<br><span style="font-weight:600;text-transform:none;'
+        f'color:var(--ink-soft)">{BAREMES[c]} pts</span></th>'
+        for c in CRITERES_VAGUE_1
+    )
+    lignes = []
+    for media in medias:
+        cells = [f'<td class="media-cell">{_esc(media)}</td>']
+        for critere in CRITERES_VAGUE_1:
+            c = cellules.get((media, critere))
+            if c is None:
+                cells.append('<td><span class="mx-empty">—</span></td>')
+                continue
+            note = c["note"]
+            meta_bits = [f"{c['n_signaux']} sig"]
+            dots = _voie_dots(c["par_voie"])
+            if dots:
+                meta_bits.append(dots)
+            if note in (NOTE_RICHE, NOTE_PARTIEL):
+                mark = "✓" if c["corrobore"] else "·"
+                meta_bits.append(f"{mark} {c['n_sources']} src")
+            cells.append(
+                f'<td><span class="mx-cell st-{note}">'
+                f'<span class="mx-note">{NOTE_ICON[note]} {NOTE_LABEL[note]}</span>'
+                f'<span class="mx-meta">{" · ".join(meta_bits)}</span>'
+                f"</span></td>"
+            )
+        lignes.append("<tr>" + "".join(cells) + "</tr>")
+    legend = "".join(
+        f'<span class="lg st-{n}">{NOTE_ICON[n]} {NOTE_LABEL[n]}</span>'
+        for n in NOTES_ORDRE
+    )
+    rollup = "".join(
+        f'<div class="card stat"><div class="lbl">{_esc(m)}</div>'
+        f'<div class="big">{r["n_signaux"]}</div>'
+        f'<div class="lbl" style="margin-top:6px">signaux · '
+        f"{r['par_note'][NOTE_RICHE]} riche · {r['n_bloque']} bloqué · "
+        f"{r['par_note'][NOTE_NA]} N/A</div></div>"
+        for m, r in proprete["par_media"].items()
+    )
+    return f"""<section id="proprete">
+  <h2><span class="num">1</span> Propreté des données collectées</h2>
+  <p class="section-lede">À quel point les données derrière chaque note sont
+    propres : présence, provenance (voie), corroboration, et surtout la
+    distinction cardinale <strong>trou d'accès</strong> (donnée manquante) vs
+    <strong>absence confirmée</strong> (donnée propre, preuve de recherche à
+    l'appui).</p>
+  <div class="grid grid-4" style="margin-bottom:18px">{rollup}</div>
+  <div class="card" style="overflow-x:auto;padding-top:8px">
+    <table class="mx"><thead><tr><th>Média</th>{head}</tr></thead>
+    <tbody>{"".join(lignes)}</tbody></table>
+    <div class="legend">{legend}</div>
+    <div class="callout"><strong>Distinction cardinale :</strong>
+      <span class="badge st-bloque">⚠ Bloqué</span> = trou d'accès (l'accès a été
+      refusé ou la donnée n'a pu être collectée — donnée <em>manquante</em>) ·
+      <span class="badge st-absent_confirme">○ Absence confirmée</span> = le média
+      n'a pas cette caractéristique et on l'a <em>vérifié</em> (sources
+      consultées) — donnée <em>propre</em>, jamais convertie en 0.</div>
+  </div>
+</section>"""
+
+
+def _html_signaux(signaux: list[dict]) -> str:
+    par_cle: dict[tuple[str, str], list[dict]] = {}
+    for s in signaux:
+        par_cle.setdefault((s["media"], s["critere"]), []).append(s)
+    if not par_cle:
+        contenu = "<p class='section-lede'>(aucun signal collecté)</p>"
+    else:
+        blocs = []
+        for (media, critere), sigs in sorted(par_cle.items()):
+            items = []
+            for s in sigs:
+                srcs = "".join(
+                    f'<div class="src">🔗 <a href="{_esc(u)}">{_esc(u)}</a></div>'
+                    for u in (s.get("source_urls") or [])
+                )
+                consultees = s.get("sources_consultees") or []
+                preuve = (
+                    f'<div class="src">🔎 preuve de recherche : '
+                    f"{_esc(', '.join(consultees))}</div>"
+                    if consultees
+                    else ""
+                )
+                voie = s["voie"]
+                bcls, dcls = _VOIE_CLS.get(voie, ("b-code", "d-code"))
+                cit = (
+                    f'<div class="cit">« {_esc(s["citation"])} »</div>'
+                    if s.get("citation")
+                    else ""
+                )
+                items.append(
+                    f'<div class="sig"><code>{_esc(s["type_signal"])}</code> '
+                    f'<span class="badge st-{_statut_note(s["statut"])}">'
+                    f"{_esc(s['statut'])}</span> "
+                    f'<span class="badge {bcls}">'
+                    f'<span class="dot {dcls}"></span>{_esc(voie)}</span>'
+                    f"{cit}{srcs}{preuve}</div>"
+                )
+            blocs.append(
+                f"<details><summary>{_esc(media)} · {critere} "
+                f"— {len(sigs)} signal(aux)</summary>{''.join(items)}</details>"
+            )
+        contenu = "".join(blocs)
+    return f"""<section id="signaux">
+  <h2><span class="num">2</span> Signaux détaillés</h2>
+  <p class="section-lede">La preuve derrière chaque note : citation, URLs
+    sources et, pour les absences vérifiées, les sources consultées.</p>
+  {contenu}
+</section>"""
+
+
+def _statut_note(statut: str) -> str:
+    """Classe de couleur status pour un statut de signal (rendu badge)."""
+    return {
+        "present": NOTE_RICHE,
+        "partiel": NOTE_PARTIEL,
+        "bloque_acces": NOTE_BLOQUE,
+        "absent_verifie": NOTE_ABSENT,
+    }.get(statut, NOTE_NA)
+
+
+def _html_fiches(fiches: dict[str, dict]) -> str:
+    if not fiches:
+        return (
+            '<section id="fiches"><h2><span class="num">3</span> Fiches par '
+            "média</h2><p class='section-lede'>(aucune fiche)</p></section>"
+        )
+    cartes = []
+    for media, f in sorted(fiches.items()):
+        pct = max(0.0, min(100.0, f["score_renormalise"]))
+        ccls = _CONFIANCE_CLS.get(f["confiance"], "mid")
+        na = ", ".join(f["criteres_na"]) or "aucun"
+        evalues = ", ".join(f["criteres_evalues"]) or "aucun"
+        cartes.append(
+            f'<div class="card fiche"><div style="display:flex;'
+            f'justify-content:space-between;align-items:flex-start;gap:10px">'
+            f"<div><div style='font-weight:800;font-size:16px'>{_esc(media)}</div>"
+            f'<div class="lbl" style="color:var(--ink-soft)">'
+            f"{f['score_brut']:g} / {f['score_max_applicable']:g} pts "
+            f"applicables</div></div>"
+            f'<div class="letter">{_esc(f["lettre"])}</div></div>'
+            f'<div class="scorebar"><div class="scorebar-fill" '
+            f'style="width:{pct:g}%"></div></div>'
+            f'<div style="font-weight:800;font-size:15px">'
+            f'{f["score_renormalise"]:g}<span style="color:var(--ink-soft);'
+            f'font-weight:600">/100</span></div>'
+            f'<div style="margin-top:10px"><span class="chip {ccls}">confiance '
+            f"{_esc(f['confiance'])}</span></div>"
+            f'<div class="lbl" style="margin-top:10px;color:var(--ink-soft);'
+            f'text-transform:none;letter-spacing:0">Évalués : {_esc(evalues)}'
+            f"<br>N/A : {_esc(na)}</div></div>"
+        )
+    return f"""<section id="fiches">
+  <h2><span class="num">3</span> Fiches par média</h2>
+  <p class="section-lede">Score renormalisé sur les critères applicables (les
+    N/A sortent du dénominateur), lettre A–E, niveau de confiance.</p>
+  <div class="grid grid-3">{"".join(cartes)}</div>
+</section>"""
+
+
+def _html_accord(accord: dict) -> str:
+    if accord.get("n", 0) == 0:
+        return f"""<section id="accord">
+  <h2><span class="num">4</span> Accord évaluations vs golden</h2>
+  <div class="callout warn">Pas de paire comparable :
+    {_esc(accord.get("error", "vide"))}.</div>
+</section>"""
+    par_media = " · ".join(f"{m} : {v}" for m, v in accord["par_media"].items())
+    rows = []
+    for d in accord["desaccords"]:
+        na = d["type_desaccord"] == "na_vs_score"
+        rows.append(
+            f'<tr class="{"row-warn" if na else ""}">'
+            f"<td>{_esc(d['media'])}</td><td>{d['critere']}</td>"
+            f"<td>{_esc(d['type_desaccord'])}</td>"
+            f"<td>{_esc(_val_accord(d['gold_statut'], d['gold_score'], d['gold_niveau']))}</td>"
+            f"<td>{_esc(_val_accord(d['gen_statut'], d['gen_score'], d['gen_niveau']))}</td>"
+            f"<td>{d['delta'] if d['delta'] is not None else '—'}</td></tr>"
+        )
+    corps = (
+        "".join(rows)
+        if rows
+        else '<tr><td colspan="6">Aucun désaccord — accord parfait.</td></tr>'
+    )
+    return f"""<section id="accord">
+  <h2><span class="num">4</span> Accord évaluations vs golden</h2>
+  <p class="section-lede">Qualité des évaluations : accord avec la notation
+    humaine de référence (exact sur les niveaux C9/C11, |Δ| ≤ 20 % du barème
+    sinon). Les désaccords <strong>N/A-vs-score</strong> (surlignés) sont ceux
+    qui font échouer le critère 2.</p>
+  <div class="card" style="padding-top:8px">
+    <p><strong>Accord global : {accord["accord_global"]:.0%}</strong> ·
+      par média : {_esc(par_media)} · désaccords N/A-vs-score :
+      <strong>{accord["na_vs_score"]}</strong> · MAE : {accord["mae_scores"]}</p>
+    <table><thead><tr><th>Média</th><th>Critère</th><th>Type</th><th>Gold</th>
+      <th>Généré</th><th>Δ</th></tr></thead><tbody>{corps}</tbody></table>
+  </div>
+</section>"""
+
+
+def _html_verdict(verdict: list[dict], d4: dict) -> str:
+    cartes = []
+    for c in verdict:
+        cls = "pass" if c["pass"] else "fail"
+        tag_cls = "ok" if c["pass"] else "warn"
+        tag = "PASS" if c["pass"] else "FAIL"
+        cartes.append(
+            f'<div class="card vcard {cls}"><div class="vh">'
+            f'<p class="vt">{_esc(c["critere"])}</p>'
+            f'<span class="vbadge {tag_cls}">{tag}</span></div>'
+            f'<p class="vp">{_esc(c["preuve"])}</p></div>'
+        )
+    d4cls = "ok" if d4.get("ok") else "warn"
+    return f"""<section id="verdict">
+  <h2><span class="num">5</span> Verdict V0</h2>
+  <p class="section-lede">Les 4 critères de succès verrouillés du pilote V0,
+    avec leur preuve chiffrée.</p>
+  <div class="grid grid-2">{"".join(cartes)}</div>
+  <div class="callout {d4cls}"><strong>Preuve D4 (golden en aveugle) :</strong>
+    {_esc(d4["message"])}</div>
+</section>"""
+
+
+def _html_gardefous(garde_fous: dict[str, str], rubrics_sha: dict[str, str]) -> str:
+    gf = "".join(
+        f"<tr><td>{_esc(nom)}</td><td>{_esc(desc)}</td>"
+        f"<td>{_esc(garde_fous.get(nom, '—'))}</td></tr>"
+        for nom, desc in _GARDE_FOUS
+    )
+    sha = "".join(
+        f"<tr><td>{c}</td><td><code>{_esc(sha[:12])}</code></td></tr>"
+        for c, sha in sorted(rubrics_sha.items())
+    )
+    return f"""<section id="gardefous">
+  <h2><span class="num">6</span> Garde-fous, notes & intégrité</h2>
+  <div class="grid grid-2">
+    <div class="card"><h3 style="margin-top:0">Garde-fous</h3>
+      <table><thead><tr><th>Garde-fou</th><th>Règle</th><th>Constaté</th></tr>
+      </thead><tbody>{gf}</tbody></table></div>
+    <div class="card"><h3 style="margin-top:0">Intégrité des rubriques</h3>
+      <p class="section-lede" style="margin-bottom:8px">sha256 (12) — fige la
+        comparabilité gold/évals.</p>
+      <table><thead><tr><th>Critère</th><th>sha256</th></tr></thead>
+      <tbody>{sha}</tbody></table></div>
+  </div>
+  <div class="callout"><strong>Notes & limites :</strong> collecte partielle
+    possible (anti-bot) → signaux <code>bloque_acces</code> honnêtes, critère en
+    <code>revue_requise</code> (résultat valide) · <code>PAPPERS_API_TOKEN</code>
+    absent → C5/C9 propriété en <code>bloque_acces</code> · ARCOM N/A structurel
+    pour la presse en ligne (absence neutre).</div>
+</section>"""
+
+
+def render_html(data: dict, proprete: dict) -> str:
+    """Rapport HTML autonome (single-file) — pur, testable sans DB."""
+    run = data["run"]
+    gen_date = datetime.now(UTC).date().isoformat()
+    corps = "".join(
+        [
+            _html_hero(run, proprete["global"], data["verdict"], data["accord_report"]),
+            '<div class="wrap">',
+            _html_matrice(proprete),
+            _html_signaux(data["signaux"]),
+            _html_fiches(data["fiches"]),
+            _html_accord(data["accord_report"]),
+            _html_verdict(data["verdict"], data["d4"]),
+            _html_gardefous(data["garde_fous"], data["rubrics_sha"]),
+            f"<footer>Rapport media-eval {_esc(run['run_id'])} · généré le "
+            f"{gen_date} · lecture seule (DB + gold) · méthodo "
+            f"{_esc(run['version_methodo'])}</footer>",
+            "</div>",
+        ]
+    )
+    return (
+        "<!DOCTYPE html>\n"
+        '<html lang="fr"><head><meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">'
+        f"<title>Rapport media-eval · {_esc(run['run_id'])}</title>"
+        f"<style>{_HTML_STYLE}</style></head><body>{corps}</body></html>\n"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Lecture DB + assemblage.
+# --------------------------------------------------------------------------- #
+async def _signaux(session, run_id: str) -> list[dict]:
+    rows = await session.execute(
+        select(MediaEvalSignal, MediaEvalMedia.domaine)
+        .join(MediaEvalMedia, MediaEvalMedia.id == MediaEvalSignal.media_id)
+        .where(MediaEvalSignal.run_id == run_id)
+    )
+    return [
+        {
+            "media": domaine,
+            "critere": s.critere,
+            "type_signal": s.type_signal,
+            "statut": s.statut.value if hasattr(s.statut, "value") else s.statut,
+            "voie": s.voie.value if hasattr(s.voie, "value") else s.voie,
+            "citation": s.citation,
+            "source_urls": list(s.source_urls or []),
+            "sources_consultees": list(s.sources_consultees or []),
+        }
+        for s, domaine in rows.all()
+    ]
+
+
+async def _evaluations(session, run_id: str) -> list[dict]:
+    rows = await session.execute(
+        select(MediaEvalEvaluation, MediaEvalMedia.domaine)
+        .join(MediaEvalMedia, MediaEvalMedia.id == MediaEvalEvaluation.media_id)
+        .where(MediaEvalEvaluation.run_id == run_id)
+    )
+    return [
+        {
+            "media_domaine": domaine,
+            "critere": ev.critere,
+            "statut": ev.statut.value if hasattr(ev.statut, "value") else ev.statut,
+            "score": ev.score,
+            "niveau": ev.niveau,
+            "flags": list(ev.flags or []),
+            "evaluateur": ev.evaluateur,
+            "evalue_at": ev.evalue_at,
+        }
+        for ev, domaine in rows.all()
+    ]
+
+
+def _accord_par_media(report: dict) -> dict[str, int]:
+    """Nombre d'accords par média (numérateur des chaînes 'a/total')."""
+    out: dict[str, int] = {}
+    for media, frac in report.get("par_media", {}).items():
+        try:
+            out[media] = int(str(frac).split("/")[0])
+        except (ValueError, IndexError):
+            out[media] = 0
+    return out
+
+
+def construire_metrics(
+    evaluations: list[dict],
+    accord_report: dict,
+    fiches: dict[str, dict],
+) -> dict:
+    """Agrège les métriques du verdict V0 — pur, testable."""
+    reporterre = {}
+    rep_c1 = next(
+        (
+            e
+            for e in evaluations
+            if e["media_domaine"] == "reporterre.net" and e["critere"] == "C1"
+        ),
+        None,
+    )
+    if "reporterre.net" in fiches:
+        reporterre = {
+            "c1_statut": rep_c1["statut"] if rep_c1 else "absent",
+            "max_applicable": fiches["reporterre.net"]["score_max_applicable"],
+        }
+    return {
+        "n_evaluations": len(evaluations),
+        "evaluations_valides": len(evaluations) > 0,
+        "accord_par_media": _accord_par_media(accord_report),
+        "reporterre": reporterre,
+        "zero_ecriture_agent": all(
+            not e["evaluateur"].startswith("humain:direct") for e in evaluations
+        ),
+    }
+
+
+def render_markdown(
+    *,
+    run: dict,
+    rubrics_sha: dict[str, str],
+    d4: dict,
+    signaux: list[dict],
+    garde_fous: dict[str, str],
+    accord_report: dict,
+    fiches: dict[str, dict],
+    verdict: list[dict],
+) -> str:
+    lignes: list[str] = [
+        f"# Rapport pilote media-eval — {run['run_id']}",
+        "",
+        f"- Généré le {datetime.now(UTC).date().isoformat()} · méthodo "
+        f"{run['version_methodo']}",
+        f"- date_reference (fraîcheur) : **{run['date_reference']}**",
+        f"- Périmètre : {run.get('perimetre')}",
+        "",
+        "## 1. Contexte & intégrité",
+        "",
+        "sha256 des rubriques (fige la comparabilité gold/évals) :",
+        "",
+        _table(
+            ["Critère", "sha256 (12)"],
+            [[c, sha[:12]] for c, sha in sorted(rubrics_sha.items())],
+        ),
+        "",
+        f"**Preuve D4 (golden en aveugle)** : {d4['message']}",
+        "",
+        "## 2. Signaux collectés",
+        "",
+        tableau_signaux(signaux),
+        "",
+        "## 3. Garde-fous",
+        "",
+        tableau_garde_fous(garde_fous),
+        "",
+        "## 4. Accord évaluations vs gold",
+        "",
+        tableau_accord(accord_report),
+        "",
+        "## 5. Fiches média",
+        "",
+    ]
+    if fiches:
+        rows = [
+            [
+                m,
+                f"{f['score_brut']:g}",
+                f"{f['score_max_applicable']:g}",
+                f"{f['score_renormalise']:g}",
+                f["lettre"],
+                f["confiance"],
+            ]
+            for m, f in sorted(fiches.items())
+        ]
+        lignes.append(
+            _table(
+                ["Média", "Brut", "Max applic.", "/100", "Lettre", "Confiance"], rows
+            )
+        )
+    else:
+        lignes.append("(aucune fiche)")
+    lignes += [
+        "",
+        "## 6. Verdict V0",
+        "",
+        render_verdict(verdict),
+        "",
+        "## 7. Notes & limites",
+        "",
+        "- Collecte partielle possible (anti-bot) → signaux `bloque_acces` "
+        "honnêtes, critère en `revue_requise` (résultat valide).",
+        "- `PAPPERS_API_TOKEN` absent → C5/C9 propriété en `bloque_acces`.",
+        "- ARCOM N/A structurel pour la presse en ligne (absence neutre).",
+        "",
+    ]
+    return "\n".join(lignes)
+
+
+async def collecter_donnees_rapport(
+    session, run_id: str, gold_path: Path
+) -> dict | None:
+    """Collecte DB + gold → `RapportData` (unique source des chiffres).
+
+    Retourne ``None`` si le run est inconnu. Le dict renvoyé alimente
+    **les deux** rendus (`render_markdown`, `render_html`) et la lentille
+    propreté (`evaluer_proprete_donnees`) : aucune relecture DB dupliquée.
+    """
+    run_row = (
+        await session.execute(select(MediaEvalRun).where(MediaEvalRun.run_id == run_id))
+    ).scalar_one_or_none()
+    if run_row is None:
+        return None
+
+    signaux = await _signaux(session, run_id)
+    evaluations = await _evaluations(session, run_id)
+
+    gold = GoldenSet.model_validate_json(gold_path.read_text())
+    generated = evaluations_to_goldenset(evaluations)
+    accord_report = evaluate(gold, generated)
+
+    # Fiches recalculées par média (source de vérité = compute_fiche).
+    fiches: dict[str, dict] = {}
+    par_media: dict[str, list[dict]] = {}
+    for ev in evaluations:
+        par_media.setdefault(ev["media_domaine"], []).append(ev)
+    for media, evs in par_media.items():
+        fiches[media] = compute_fiche(evs)
+
+    # Preuve D4 : gold.note_at doit précéder l'ingestion des évals.
+    min_evalue = min((e["evalue_at"] for e in evaluations), default=None)
+    d4 = _verifier_d4(gold.note_at, min_evalue)
+
+    rubrics_sha = {c: version_prompt(c) for c in CRITERES_VAGUE_1}
+    garde_fous = _detecter_garde_fous(signaux, evaluations)
+    metrics = construire_metrics(evaluations, accord_report, fiches)
+    verdict = verdict_v0(metrics)
+
+    return {
+        "run": {
+            "run_id": run_row.run_id,
+            "version_methodo": run_row.version_methodo,
+            "date_reference": run_row.date_reference.isoformat(),
+            "perimetre": run_row.perimetre,
+        },
+        "rubrics_sha": rubrics_sha,
+        "d4": d4,
+        "signaux": signaux,
+        "evaluations": evaluations,
+        "garde_fous": garde_fous,
+        "accord_report": accord_report,
+        "fiches": fiches,
+        "verdict": verdict,
+    }
+
+
+async def run(run_id: str, gold_path: Path, out: Path) -> int:
+    async with async_session_maker() as session:
+        try:
+            data = await collecter_donnees_rapport(session, run_id, gold_path)
+            if data is None:
+                print(f"REJET : run {run_id!r} inconnu.")
+                return 1
+
+            proprete = evaluer_proprete_donnees(
+                data["signaux"], data["evaluations"], data["fiches"]
+            )
+            texte_md = render_markdown(
+                run=data["run"],
+                rubrics_sha=data["rubrics_sha"],
+                d4=data["d4"],
+                signaux=data["signaux"],
+                garde_fous=data["garde_fous"],
+                accord_report=data["accord_report"],
+                fiches=data["fiches"],
+                verdict=data["verdict"],
+            )
+            texte_html = render_html(data, proprete)
+
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(texte_md)
+            html_path = out.with_suffix(".html")
+            html_path.write_text(texte_html)
+            print(texte_md)
+            print(f"\nRapport markdown : {out}")
+            print(f"Rapport HTML : {html_path}")
+            return 0
+        finally:
+            await engine.dispose()
+
+
+def _verifier_d4(note_at, min_evalue) -> dict:
+    if note_at is None:
+        return {"ok": False, "message": "gold.note_at absent — preuve D4 impossible."}
+    if min_evalue is None:
+        return {"ok": True, "message": "aucune évaluation ingérée (rien à comparer)."}
+    ok = note_at < min_evalue
+    prefixe = "OK" if ok else "⚠ WARNING"
+    return {
+        "ok": ok,
+        "message": f"{prefixe} — gold noté {note_at.isoformat()} "
+        f"{'<' if ok else '≥'} 1re éval {min_evalue.isoformat()}.",
+    }
+
+
+def _detecter_garde_fous(
+    signaux: list[dict], evaluations: list[dict]
+) -> dict[str, str]:
+    actives: dict[str, str] = {}
+    flags = {f for e in evaluations for f in e.get("flags", [])}
+    if any(s["statut"] == "bloque_acces" for s in signaux):
+        actives["bloque_acces"] = "oui (signaux bloqués présents)"
+    if any(
+        e["critere"] == "C1" and "donnees_insuffisantes" in e.get("flags", [])
+        for e in evaluations
+    ):
+        actives["fallback C1"] = "oui (C1 → N/A)"
+    if any(e["evaluateur"] == "code:jti_shortcut" for e in evaluations):
+        actives["raccourci JTI"] = "oui (C8 par code)"
+    if "corroboration_insuffisante" in flags:
+        actives["corroboration"] = "oui (score plafonné)"
+    return actives
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--gold", type=Path, required=True, help="gold_v0.json")
+    parser.add_argument("--out", type=Path, required=True, help="rapport markdown")
+    args = parser.parse_args()
+    get_settings()  # lecture seule (DB courante)
+    sys.exit(asyncio.run(run(args.run_id, args.gold, args.out)))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/tests/scripts/fixtures/media_eval/api/cppap_empty.json
+++ b/packages/api/tests/scripts/fixtures/media_eval/api/cppap_empty.json
@@ -1,0 +1,5 @@
+{
+  "nhits": 0,
+  "parameters": {"dataset": "presse-cppap", "q": "Reporterre", "rows": 50},
+  "records": []
+}

--- a/packages/api/tests/scripts/fixtures/media_eval/api/cppap_records.json
+++ b/packages/api/tests/scripts/fixtures/media_eval/api/cppap_records.json
@@ -1,0 +1,16 @@
+{
+  "nhits": 1,
+  "parameters": {"dataset": "presse-cppap", "q": "CNEWS", "rows": 50},
+  "records": [
+    {
+      "datasetid": "presse-cppap",
+      "recordid": "abc123",
+      "fields": {
+        "titre": "CNEWS",
+        "numero_cppap": "0426 W 92142",
+        "editeur": "Societe d'Exploitation d'un Service d'Information",
+        "categorie": "Information politique et generale"
+      }
+    }
+  ]
+}

--- a/packages/api/tests/scripts/fixtures/media_eval/api/cppap_records_v2.json
+++ b/packages/api/tests/scripts/fixtures/media_eval/api/cppap_records_v2.json
@@ -1,0 +1,11 @@
+{
+  "total_count": 1,
+  "results": [
+    {
+      "titre": "CNEWS",
+      "ndeg_cppap": "0426 W 92142",
+      "editeur": "Societe d'Exploitation d'un Service d'Information",
+      "departement": "92"
+    }
+  ]
+}

--- a/packages/api/tests/scripts/fixtures/media_eval/api/pappers_mismatch.json
+++ b/packages/api/tests/scripts/fixtures/media_eval/api/pappers_mismatch.json
@@ -1,0 +1,8 @@
+{
+  "siren": "501260034",
+  "nom_entreprise": "BOULANGERIE DUPONT",
+  "capital": 8000,
+  "forme_juridique": "SARL",
+  "representants": [],
+  "beneficiaires_effectifs": []
+}

--- a/packages/api/tests/scripts/fixtures/media_eval/api/pappers_sesi.json
+++ b/packages/api/tests/scripts/fixtures/media_eval/api/pappers_sesi.json
@@ -1,0 +1,12 @@
+{
+  "siren": "501260034",
+  "nom_entreprise": "SOCIETE D'EXPLOITATION D'UN SERVICE D'INFORMATION",
+  "capital": 5537200,
+  "forme_juridique": "SAS, societe par actions simplifiee",
+  "representants": [
+    {"nom_complet": "Groupe Canal Plus", "qualite": "President"}
+  ],
+  "beneficiaires_effectifs": [
+    {"nom_complet": "Vivendi SE", "pourcentage_parts": 100.0}
+  ]
+}

--- a/packages/api/tests/scripts/fixtures/media_eval/api/pappers_sesi_snc.json
+++ b/packages/api/tests/scripts/fixtures/media_eval/api/pappers_sesi_snc.json
@@ -1,0 +1,12 @@
+{
+  "siren": "412916215",
+  "nom_entreprise": "SESI",
+  "capital": 7500,
+  "forme_juridique": "SNC, societe en nom collectif",
+  "representants": [
+    {"nom_complet": "Gerald-Brice VIRET", "qualite": "Gerant"}
+  ],
+  "beneficiaires_effectifs": [
+    {"nom_complet": "Groupe Canal Plus", "pourcentage_parts": 100.0}
+  ]
+}

--- a/packages/api/tests/scripts/fixtures/media_eval/api/recherche_entreprises_sesi.json
+++ b/packages/api/tests/scripts/fixtures/media_eval/api/recherche_entreprises_sesi.json
@@ -1,0 +1,22 @@
+{
+  "results": [
+    {
+      "siren": "412916215",
+      "nom_complet": "SESI",
+      "nom_raison_sociale": "SESI",
+      "nature_juridique": "5202",
+      "dirigeants": [
+        {
+          "nom": "VIRET",
+          "prenoms": "Gerald Brice",
+          "qualite": "Gerant",
+          "type_dirigeant": "personne physique"
+        }
+      ],
+      "siege": {"code_postal": "92130", "commune": "ISSY-LES-MOULINEAUX"}
+    }
+  ],
+  "total_results": 1,
+  "page": 1,
+  "per_page": 5
+}

--- a/packages/api/tests/scripts/fixtures/media_eval/html/arcom_recherche_cnews.html
+++ b/packages/api/tests/scripts/fixtures/media_eval/html/arcom_recherche_cnews.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="fr">
+<head><meta charset="utf-8"><title>Médiathèque ARCOM - recherche CNEWS</title></head>
+<body>
+<main>
+  <h1>Résultats de recherche</h1>
+  <ul>
+    <li class="decision" data-media="CNEWS">
+      <a href="/nos-ressources/decision-cnews-2025-042">Décision CNEWS n° 2025-042 : manquement au pluralisme</a>
+      <time datetime="2025-11-12">12 novembre 2025</time>
+    </li>
+    <li class="decision" data-media="CNEWS">
+      <a href="/nos-ressources/decision-cnews-2023-011">Mise en demeure CNEWS n° 2023-011</a>
+      <time datetime="2023-05-10">10 mai 2023</time>
+    </li>
+    <li class="decision" data-media="Europe 1">
+      <a href="/nos-ressources/decision-europe1-2025-099">Décision Europe 1 n° 2025-099</a>
+      <time datetime="2025-09-01">1 septembre 2025</time>
+    </li>
+  </ul>
+</main>
+</body>
+</html>

--- a/packages/api/tests/scripts/fixtures/media_eval/html/cdjm_avis_detail.html
+++ b/packages/api/tests/scripts/fixtures/media_eval/html/cdjm_avis_detail.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="fr">
+<head><meta charset="utf-8"><title>Avis 26-014 - CDJM</title></head>
+<body>
+<main>
+  <h1>Avis 26-014 : un chiffre erroné non corrigé dans un bandeau de CNEWS</h1>
+  <p>Publié le <time datetime="2026-02-03">3 février 2026</time></p>
+  <div class="media-mis-en-cause">CNEWS</div>
+  <p>Le CDJM déclare la saisine <strong>fondée</strong> : le média a diffusé un
+  chiffre erroné dans un bandeau sans le corriger ni le sourcer.</p>
+</main>
+</body>
+</html>

--- a/packages/api/tests/scripts/fixtures/media_eval/html/cdjm_avis_detail_ancien.html
+++ b/packages/api/tests/scripts/fixtures/media_eval/html/cdjm_avis_detail_ancien.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="fr">
+<head><meta charset="utf-8"><title>Avis 24-101 - CDJM</title></head>
+<body>
+<main>
+  <h1>Avis 24-101 : propos d'un invité sur CNEWS</h1>
+  <p>Publié le <time datetime="2024-03-15">15 mars 2024</time></p>
+  <div class="media-mis-en-cause">CNEWS</div>
+  <p>Le CDJM déclare la saisine <strong>fondée</strong>. Cet avis est toutefois
+  hors de la fenêtre de fraîcheur de deux ans à la date de référence du run.</p>
+</main>
+</body>
+</html>

--- a/packages/api/tests/scripts/fixtures/media_eval/html/cdjm_avis_index.html
+++ b/packages/api/tests/scripts/fixtures/media_eval/html/cdjm_avis_index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="fr">
+<head><meta charset="utf-8"><title>Nos avis - CDJM</title></head>
+<body>
+<main>
+  <h1>Nos avis</h1>
+  <ul>
+    <li><a href="/avis/26-014-cnews-bandeau-errone/">Avis 26-014 : CNEWS, un chiffre erroné dans un bandeau</a></li>
+    <li><a href="/avis/25-208-le-monde-titre/">Avis 25-208 : Le Monde, titre contesté</a></li>
+    <li><a href="/avis/24-101-cnews-invite/">Avis 24-101 : CNEWS, propos d'un invité</a></li>
+  </ul>
+</main>
+</body>
+</html>

--- a/packages/api/tests/scripts/fixtures/media_eval/html/cdjm_membres.html
+++ b/packages/api/tests/scripts/fixtures/media_eval/html/cdjm_membres.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="fr">
+<head><meta charset="utf-8"><title>Les membres - CDJM</title></head>
+<body>
+<main>
+  <h1>Les médias membres du CDJM</h1>
+  <ul class="membres">
+    <li>Mediapart</li>
+    <li>Le Monde</li>
+    <li>Radio France</li>
+    <li>Reporterre</li>
+    <li>La Croix</li>
+  </ul>
+</main>
+</body>
+</html>

--- a/packages/api/tests/scripts/fixtures/media_eval/html/charte_ok.html
+++ b/packages/api/tests/scripts/fixtures/media_eval/html/charte_ok.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="fr">
+<head><meta charset="utf-8"><title>Notre charte</title></head>
+<body>
+<header><nav><a href="/">Accueil</a></nav></header>
+<main>
+  <h1>Notre charte déontologique</h1>
+  <p>Reporterre s'engage à respecter une charte éthique stricte : vérification
+  systématique des faits, séparation claire de l'information et de la publicité,
+  correction publique des erreurs et droit de réponse garanti. Cette charte
+  déontologique fonde l'ensemble de notre travail journalistique et engage
+  toute la rédaction.</p>
+</main>
+<footer><a href="/mentions-legales">Mentions légales</a></footer>
+</body>
+</html>

--- a/packages/api/tests/scripts/fixtures/media_eval/html/cnews_flux_dons.html
+++ b/packages/api/tests/scripts/fixtures/media_eval/html/cnews_flux_dons.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="fr">
+<head><meta charset="utf-8"><title>dons - CNEWS</title></head>
+<body>
+<header><nav><a href="/">Accueil</a></nav></header>
+<main>
+  <h2>A suivre : faire un don</h2>
+  <ul>
+    <li><a href="/societe/2026-01-10/la-croix-rouge-lance-sa-grande-quete-1234501">La Croix-Rouge lance sa grande quête nationale ce samedi</a></li>
+    <li><a href="/economie/2026-01-11/impots-2026-ce-qui-change-pour-les-dons-1234502">Impôts 2026 : ce qui change pour les dons d'argent</a></li>
+    <li><a href="/monde/2026-01-12/telethon-2025-marraine-twitch-1234503">Téléthon 2025 : marraine, Twitch, recherches, tout savoir</a></li>
+    <li><a href="/sante/2026-01-13/donneur-de-sperme-centaines-descendants-1234504">Pourquoi un donneur de sperme peut-il avoir des centaines de descendants ?</a></li>
+  </ul>
+</main>
+<footer><a href="/mentions-legales">Mentions légales</a></footer>
+</body>
+</html>

--- a/packages/api/tests/scripts/fixtures/media_eval/html/cnews_flux_publicite.html
+++ b/packages/api/tests/scripts/fixtures/media_eval/html/cnews_flux_publicite.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="fr">
+<head><meta charset="utf-8"><title>Publicité - CNEWS</title></head>
+<body>
+<header><nav><a href="/">Accueil</a></nav></header>
+<main>
+  <h2>A suivre : Publicité, notre régie</h2>
+  <ul>
+    <li><a href="/sport/2026-01-10/coupe-du-monde-2026-la-pause-fraicheur-1234601">Coupe du Monde 2026 : la pause fraicheur rapporte gros à Fox Sports</a></li>
+    <li><a href="/tech/2026-01-11/drones-publicitaires-villes-chinoises-1234602">Dignes d'un monde cyberpunk, ces drones publicitaires illuminent les villes</a></li>
+    <li><a href="/eco/2026-01-12/communication-visuelle-revolution-verte-1234603">Communication visuelle : la révolution verte des supports publicitaires</a></li>
+    <li><a href="/sport/2026-01-13/coupe-du-monde-2026-contenu-sponsorise-1234604">Coupe du monde 2026 : aucune publicité, contenu sponsorisé</a></li>
+  </ul>
+</main>
+<footer><a href="/mentions-legales">Mentions légales</a></footer>
+</body>
+</html>

--- a/packages/api/tests/scripts/fixtures/media_eval/html/cnews_home.html
+++ b/packages/api/tests/scripts/fixtures/media_eval/html/cnews_home.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="fr">
+<head><meta charset="utf-8"><title>CNEWS - Info, actualités en direct</title></head>
+<body>
+<header><nav><a href="/">Accueil</a> <a href="/direct">Direct</a></nav></header>
+<main>
+  <h1>CNEWS, l'info en continu</h1>
+  <p>Toute l'actualité en direct sur CNEWS.</p>
+</main>
+<footer>
+  <div class="footer-links">
+    <a href="https://www.cnews.fr/qui-sommes-nous">Qui sommes-nous</a>
+    <a href="https://www.cnews.fr/mentions-legales">Mentions légales</a>
+    <a href="https://www.cnews.fr/publicite">Publicité / Régie</a>
+    <a href="https://www.cnews.fr/cgu">CGU</a>
+  </div>
+</footer>
+</body>
+</html>

--- a/packages/api/tests/scripts/fixtures/media_eval/html/cnews_home_riche.html
+++ b/packages/api/tests/scripts/fixtures/media_eval/html/cnews_home_riche.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="fr">
+<head><meta charset="utf-8"><title>CNEWS - Info, actualités en direct</title></head>
+<body>
+<header><nav><a href="/">Accueil</a> <a href="/direct">Direct</a></nav></header>
+<main>
+  <h1>CNEWS, l'info en continu</h1>
+  <p>Toute l'actualité en direct : politique, économie, international, faits
+  divers, sport et météo. Retrouvez les dernières informations, les analyses et
+  les directs vidéo de la chaîne tout au long de la journée, mis à jour en
+  permanence par la rédaction.</p>
+  <ul>
+    <li><a href="/politique/2026-01-15/edito-du-jour-1230001">Édito du jour</a></li>
+    <li><a href="/monde/2026-01-15/le-direct-1230002">Le direct</a></li>
+  </ul>
+</main>
+<footer>
+  <div class="footer-links">
+    <a href="/mentions-legales">Mentions légales</a>
+    <a href="/publicite">Publicité / Régie</a>
+    <a href="/charte">Charte</a>
+    <a href="/ligne-editoriale">Ligne éditoriale</a>
+    <a href="/dons">Dons</a>
+  </div>
+</footer>
+</body>
+</html>

--- a/packages/api/tests/scripts/fixtures/media_eval/html/cnews_mentions_legales.html
+++ b/packages/api/tests/scripts/fixtures/media_eval/html/cnews_mentions_legales.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="fr">
+<head><meta charset="utf-8"><title>Mentions légales - CNEWS</title></head>
+<body>
+<header><nav><a href="/">Accueil</a></nav></header>
+<main>
+  <h1>Mentions légales</h1>
+  <p>Le site CNEWS.fr est édité par la Société d'Exploitation d'un Service
+  d'Information (SESI), Société par Actions Simplifiée au capital de 5 537 200
+  euros, immatriculée au Registre du Commerce et des Sociétés de Nanterre sous
+  le numéro 501 260 034, dont le siège social est situé au 2 rue des Cévennes,
+  75015 Paris.</p>
+  <p>Directeur de la publication : le Président de la société éditrice.
+  Hébergeur : le prestataire technique désigné par l'éditeur.</p>
+  <p>Le numéro de Commission paritaire des publications et agences de presse
+  (CPPAP) ainsi que les informations relatives au capital sont disponibles
+  ci-dessus.</p>
+</main>
+<footer><a href="/mentions-legales">Mentions légales</a></footer>
+</body>
+</html>

--- a/packages/api/tests/scripts/fixtures/media_eval/html/dom_casse.html
+++ b/packages/api/tests/scripts/fixtures/media_eval/html/dom_casse.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><title>x</title><body><div><p>contenu tronqué<span></body>

--- a/packages/api/tests/scripts/fixtures/media_eval/html/dons_ok.html
+++ b/packages/api/tests/scripts/fixtures/media_eval/html/dons_ok.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="fr">
+<head><meta charset="utf-8"><title>Nous soutenir</title></head>
+<body>
+<header><nav><a href="/">Accueil</a></nav></header>
+<main>
+  <h1>Nous soutenir</h1>
+  <p>Reporterre est un média sans publicité, entièrement financé par ses
+  lecteurs. Pour faire un don et soutenir la rédaction, rendez-vous sur notre
+  page dédiée. Votre don ouvre droit à une réduction d'impôt. Vous pouvez aussi
+  adhérer à l'association qui édite le journal.</p>
+  <a href="/faire-un-don">Faire un don</a>
+</main>
+<footer><a href="/mentions-legales">Mentions légales</a></footer>
+</body>
+</html>

--- a/packages/api/tests/scripts/fixtures/media_eval/html/jti_directory.html
+++ b/packages/api/tests/scripts/fixtures/media_eval/html/jti_directory.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="fr">
+<head><meta charset="utf-8"><title>JTI - Médias évalués</title></head>
+<body>
+<main>
+  <h1>Médias ayant complété l'évaluation JTI</h1>
+  <ul class="jti-directory">
+    <li data-media="Agence France-Presse">Agence France-Presse — certifié</li>
+    <li data-media="Ouest-France">Ouest-France — certifié</li>
+    <li data-media="La Voix du Nord">La Voix du Nord — certification expirée</li>
+  </ul>
+</main>
+</body>
+</html>

--- a/packages/api/tests/scripts/fixtures/media_eval/html/mentions_legales_ok.html
+++ b/packages/api/tests/scripts/fixtures/media_eval/html/mentions_legales_ok.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="fr">
+<head><meta charset="utf-8"><title>Mentions légales</title></head>
+<body>
+<header><nav><a href="/">Accueil</a></nav></header>
+<main>
+  <h1>Mentions légales</h1>
+  <p>Ce site est édité par l'association La Pila, immatriculée au RCS de Die
+  sous le numéro SIREN 801 054 247, au capital social associatif. Directeur de
+  la publication : la présidente de l'association. Hébergeur : OVH SAS, 2 rue
+  Kellermann, 59100 Roubaix.</p>
+  <p>N° ISSN 2534-7020. Contact rédaction : redaction@reporterre.net.</p>
+</main>
+<footer><a href="/mentions-legales">Mentions légales</a></footer>
+</body>
+</html>

--- a/packages/api/tests/scripts/fixtures/media_eval/html/page_404_soft.html
+++ b/packages/api/tests/scripts/fixtures/media_eval/html/page_404_soft.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="fr">
+<head><meta charset="utf-8"><title>Erreur 404</title></head>
+<body>
+<header><nav><a href="/">Accueil</a></nav></header>
+<main>
+  <h1>Page introuvable</h1>
+  <p>La page que vous recherchez n'existe pas ou a été déplacée.</p>
+</main>
+<footer><a href="/">Retour</a></footer>
+</body>
+</html>

--- a/packages/api/tests/scripts/fixtures/media_eval/html/page_significative.html
+++ b/packages/api/tests/scripts/fixtures/media_eval/html/page_significative.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="fr">
+<head><meta charset="utf-8"><title>Page institutionnelle</title></head>
+<body>
+<header><nav><a href="/">Accueil</a></nav></header>
+<main>
+  <h1>Notre engagement</h1>
+  <p>Cette page présente en détail nos principes, notre fonctionnement et nos
+  engagements vis-à-vis de nos lecteurs. Elle contient un texte suffisamment
+  long pour être considérée comme une page significative et non comme une
+  coquille vide ou une redirection soft-404. Nous y détaillons notre charte,
+  notre organisation éditoriale et nos sources de financement afin d'assurer
+  la transparence attendue d'un média responsable.</p>
+</main>
+<footer><a href="/mentions-legales">Mentions légales</a></footer>
+</body>
+</html>

--- a/packages/api/tests/scripts/fixtures/media_eval/html/reporterre_home.html
+++ b/packages/api/tests/scripts/fixtures/media_eval/html/reporterre_home.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="fr">
+<head><meta charset="utf-8"><title>Reporterre, le quotidien de l'écologie</title></head>
+<body>
+<header><nav><a href="/">Accueil</a> <a href="/spip.php?rubrique=une">L'actu</a></nav></header>
+<main>
+  <h1>Reporterre, le quotidien de l'écologie</h1>
+  <p>Reporterre est un média indépendant en accès libre consacré à l'écologie.</p>
+</main>
+<footer>
+  <ul>
+    <li><a href="/spip.php?rubrique=qui-sommes-nous">Qui sommes-nous ?</a></li>
+    <li><a href="/mentions-legales">Mentions légales</a></li>
+    <li><a href="/spip.php?page=charte">Notre charte</a></li>
+    <li><a href="/nous-soutenir">Nous soutenir</a></li>
+    <li><a href="mailto:contact@reporterre.net">Contact</a></li>
+    <li><a href="#top">Haut de page</a></li>
+  </ul>
+</footer>
+</body>
+</html>

--- a/packages/api/tests/scripts/fixtures/media_eval/html/reporterre_sitemap.xml
+++ b/packages/api/tests/scripts/fixtures/media_eval/html/reporterre_sitemap.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://reporterre.net/</loc></url>
+  <url><loc>https://reporterre.net/spip.php?rubrique=qui-sommes-nous</loc></url>
+  <url><loc>https://reporterre.net/mentions-legales</loc></url>
+  <url><loc>https://reporterre.net/spip.php?page=charte</loc></url>
+  <url><loc>https://reporterre.net/nous-soutenir</loc></url>
+  <url><loc>https://reporterre.net/la-redaction</loc></url>
+  <url><loc>https://reporterre.net/spip.php?rubrique=Enquetes</loc></url>
+</urlset>

--- a/packages/api/tests/scripts/media_eval/conftest.py
+++ b/packages/api/tests/scripts/media_eval/conftest.py
@@ -1,0 +1,62 @@
+"""Fixtures DB mutualisées des tests media-eval.
+
+Répare le bug latent PR 1 : les signaux/évaluations portent une FK
+``run_id`` → ``media_eval_runs`` que rien ne peuplait (les tests passaient
+sur un conteneur test « sale »). ``run_test`` crée la ligne run, et
+``media_cnews`` / ``media_reporterre`` en dépendent : toute insertion de
+signal a un run parent sur DB propre.
+
+``date_reference`` = 2026-07-08 : cohérente avec les débunkages figés
+(``debunkages_cnews.json`` : 2025-11-12 et 2026-02-03 → tous deux < 730 j).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from app.models.media_eval import MediaEvalMedia, MediaEvalRun, TypeMedia
+from scripts.media_eval.schemas import CRITERES_VAGUE_1, VERSION_METHODO
+
+RUN_ID = "run-test"
+DATE_REFERENCE = date(2026, 7, 8)
+
+
+@pytest.fixture
+async def run_test(db_session) -> MediaEvalRun:
+    run = MediaEvalRun(
+        run_id=RUN_ID,
+        libelle="Run de test",
+        version_methodo=VERSION_METHODO,
+        date_reference=DATE_REFERENCE,
+        perimetre={
+            "medias": ["cnews.fr", "reporterre.net"],
+            "criteres": list(CRITERES_VAGUE_1),
+        },
+    )
+    db_session.add(run)
+    await db_session.commit()
+    return run
+
+
+@pytest.fixture
+async def media_cnews(db_session, run_test) -> MediaEvalMedia:
+    media = MediaEvalMedia(
+        nom="CNEWS", domaine="cnews.fr", type_media=TypeMedia.AUDIOVISUEL
+    )
+    db_session.add(media)
+    await db_session.commit()
+    return media
+
+
+@pytest.fixture
+async def media_reporterre(db_session, run_test) -> MediaEvalMedia:
+    media = MediaEvalMedia(
+        nom="Reporterre",
+        domaine="reporterre.net",
+        type_media=TypeMedia.PRESSE_EN_LIGNE,
+    )
+    db_session.add(media)
+    await db_session.commit()
+    return media

--- a/packages/api/tests/scripts/media_eval/test_build_eval_input.py
+++ b/packages/api/tests/scripts/media_eval/test_build_eval_input.py
@@ -1,0 +1,128 @@
+"""Tests de la construction des entrées évaluateur (build_eval_input.py).
+
+Se concentre sur l'ajout de la **substance** : quand un signal porte un
+``snapshot_id``, l'entrée évaluateur doit joindre ``snapshot_extrait`` (borné)
+et ``snapshot_url`` — l'évaluateur voit ce que dit la page, pas juste qu'elle
+existe (hand-off pilote-2026-07b).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from app.models.media_eval import (
+    MediaEvalSignal,
+    MediaEvalSnapshot,
+    ModeAcces,
+    StatutSignal,
+    TypePage,
+    VoieCollecte,
+)
+from scripts.media_eval.build_eval_input import (
+    SNAPSHOT_EXTRAIT_MAX,
+    _charger_snapshots,
+    _signaux_du_critere,
+    serialiser_signal,
+)
+
+
+def _signal(**kw) -> MediaEvalSignal:
+    base = {
+        "id": uuid.uuid4(),
+        "type_signal": "mentions_legales",
+        "statut": StatutSignal.PRESENT,
+        "valeur": {"url": "https://cnews.fr/mentions-legales"},
+        "citation": None,
+        "source_urls": ["https://cnews.fr/mentions-legales"],
+        "sources_consultees": [],
+        "voie": VoieCollecte.CODE,
+        "collecte_at": datetime(2026, 7, 13, 8, 0, 0),
+        "snapshot_id": None,
+    }
+    base.update(kw)
+    return MediaEvalSignal(**base)
+
+
+class TestSerialiserSignal:
+    def test_sans_snapshot_pas_de_cle(self):
+        data = serialiser_signal(_signal())
+        assert "snapshot_extrait" not in data
+        assert "snapshot_url" not in data
+
+    def test_avec_snapshot_joint_substance(self):
+        snap_id = uuid.uuid4()
+        snap = MediaEvalSnapshot(
+            id=snap_id,
+            url="https://cnews.fr/mentions-legales",
+            type_page=TypePage.MENTIONS_LEGALES,
+            contenu="Editeur du site SESI SNC au capital de 7 500 euros...",
+            mode_acces=ModeAcces.LIBRE,
+        )
+        data = serialiser_signal(_signal(snapshot_id=snap_id), snap)
+        assert data["snapshot_url"] == "https://cnews.fr/mentions-legales"
+        assert data["snapshot_extrait"].startswith("Editeur du site SESI SNC")
+
+    def test_extrait_borne(self):
+        snap_id = uuid.uuid4()
+        snap = MediaEvalSnapshot(
+            id=snap_id,
+            url="https://ex.fr/p",
+            type_page=TypePage.MENTIONS_LEGALES,
+            contenu="x" * (SNAPSHOT_EXTRAIT_MAX + 5000),
+            mode_acces=ModeAcces.LIBRE,
+        )
+        data = serialiser_signal(_signal(snapshot_id=snap_id), snap)
+        assert len(data["snapshot_extrait"]) == SNAPSHOT_EXTRAIT_MAX
+
+    def test_snapshot_id_non_concordant_ignore(self):
+        # Un snapshot d'un autre signal ne doit pas être joint par erreur.
+        autre = MediaEvalSnapshot(
+            id=uuid.uuid4(),
+            url="https://ex.fr/autre",
+            type_page=TypePage.AUTRE,
+            contenu="autre",
+            mode_acces=ModeAcces.LIBRE,
+        )
+        data = serialiser_signal(_signal(snapshot_id=uuid.uuid4()), autre)
+        assert "snapshot_extrait" not in data
+
+
+class TestChargerSnapshots:
+    async def test_join_bout_en_bout(self, db_session, media_cnews, run_test):
+        snap = MediaEvalSnapshot(
+            media_id=media_cnews.id,
+            run_id=run_test.run_id,
+            url="https://cnews.fr/mentions-legales",
+            type_page=TypePage.MENTIONS_LEGALES,
+            contenu="RCS Nanterre 412 916 215 — SESI SNC",
+            hash="h",
+            http_status=200,
+            mode_acces=ModeAcces.LIBRE,
+        )
+        db_session.add(snap)
+        await db_session.flush()
+        db_session.add(
+            MediaEvalSignal(
+                media_id=media_cnews.id,
+                critere="C5",
+                type_signal="mentions_legales",
+                statut=StatutSignal.PRESENT,
+                valeur={"url": snap.url},
+                voie=VoieCollecte.CODE,
+                collecteur="code:collect_pages_types@v1",
+                source_urls=[snap.url],
+                snapshot_id=snap.id,
+                run_id=run_test.run_id,
+                dedupe_key="k-mentions",
+            )
+        )
+        await db_session.commit()
+
+        rows = await _signaux_du_critere(
+            db_session, media_cnews.id, run_test.run_id, "C5"
+        )
+        snaps = await _charger_snapshots(db_session, rows)
+        serialise = [serialiser_signal(s, snaps.get(s.snapshot_id)) for s in rows]
+        assert serialise[0]["snapshot_extrait"] == "RCS Nanterre 412 916 215 — SESI SNC"
+        assert serialise[0]["snapshot_url"] == "https://cnews.fr/mentions-legales"

--- a/packages/api/tests/scripts/media_eval/test_collect_arcom.py
+++ b/packages/api/tests/scripts/media_eval/test_collect_arcom.py
@@ -1,0 +1,97 @@
+"""Tests du collecteur ARCOM (collect_arcom.py).
+
+Couvre : **auto-désactivation** presse en ligne (0 signal) ; audiovisuel →
+sanction dans la fenêtre = C1/sanction_arcom present (avec publie_at), sanction
+hors fenêtre exclue, autre média filtré ; recherche bloquée → bloque_acces.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from sqlalchemy import func, select
+
+from app.models.media_eval import MediaEvalSignal, ModeAcces, StatutSignal
+from scripts.media_eval.collect_arcom import (
+    collecter,
+    concerne_media,
+    parse_arcom_decisions,
+    recherche_url,
+)
+from scripts.media_eval.collect_common import FetchResult
+
+HTML = Path(__file__).resolve().parents[1] / "fixtures" / "media_eval" / "html"
+
+
+def _read(name: str) -> str:
+    return (HTML / name).read_text()
+
+
+def make_fetcher(status: int, name: str | None):
+    async def _fetch(url: str) -> FetchResult:
+        if status == 403:
+            return FetchResult(url, 403, "", ModeAcces.BLOQUE, "HTTP 403")
+        text = _read(name) if name else ""
+        return FetchResult(url, status, text, ModeAcces.LIBRE, None)
+
+    return _fetch
+
+
+async def _count(db_session) -> int:
+    return (
+        await db_session.execute(select(func.count()).select_from(MediaEvalSignal))
+    ).scalar()
+
+
+class TestParsePur:
+    def test_parse_decisions(self):
+        decisions = parse_arcom_decisions(_read("arcom_recherche_cnews.html"))
+        assert len(decisions) == 3
+        cnews = [d for d in decisions if concerne_media(d, "CNEWS")]
+        assert len(cnews) == 2
+        assert cnews[0]["publie_at"] == date(2025, 11, 12)
+
+
+class TestCollecter:
+    async def test_na_structurel_presse(self, db_session, media_reporterre, run_test):
+        stats = await collecter(
+            db_session,
+            media_reporterre,
+            run_test,
+            make_fetcher(200, "arcom_recherche_cnews.html"),
+        )
+        await db_session.commit()
+        # Presse en ligne → aucun signal (absence neutre).
+        assert stats.inseres == 0
+        assert await _count(db_session) == 0
+
+    async def test_audiovisuel_sanction_dans_fenetre(
+        self, db_session, media_cnews, run_test
+    ):
+        stats = await collecter(
+            db_session,
+            media_cnews,
+            run_test,
+            make_fetcher(200, "arcom_recherche_cnews.html"),
+        )
+        await db_session.commit()
+        # Seule la sanction 2025-11-12 est dans la fenêtre (2023-05-10 exclue,
+        # Europe 1 filtrée) → 1 present.
+        assert stats.inseres == 1
+        signal = (await db_session.execute(select(MediaEvalSignal))).scalar_one()
+        assert signal.type_signal == "sanction_arcom"
+        assert signal.statut == StatutSignal.PRESENT
+        assert signal.valeur["publie_at"] == "2025-11-12"
+
+    async def test_bloque(self, db_session, media_cnews, run_test):
+        stats = await collecter(
+            db_session, media_cnews, run_test, make_fetcher(403, None)
+        )
+        await db_session.commit()
+        assert stats.bloques == 1
+        signal = (await db_session.execute(select(MediaEvalSignal))).scalar_one()
+        assert signal.statut == StatutSignal.BLOQUE_ACCES
+
+    def test_recherche_url(self):
+        assert "arcom.fr" in recherche_url("CNEWS")

--- a/packages/api/tests/scripts/media_eval/test_collect_cdjm.py
+++ b/packages/api/tests/scripts/media_eval/test_collect_cdjm.py
@@ -1,0 +1,150 @@
+"""Tests du collecteur CDJM (collect_cdjm.py).
+
+Couvre : adhésion absente (média non membre) ; avis fondé dans la fenêtre →
+C1/avis_cdjm avec publie_at ; avis fondé hors fenêtre exclu ; registre
+inaccessible → bloque_acces ; idempotence.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from sqlalchemy import func, select
+
+from app.models.media_eval import MediaEvalSignal, ModeAcces, StatutSignal
+from scripts.media_eval.collect_cdjm import (
+    URL_AVIS_INDEX,
+    URL_MEMBRES,
+    collecter,
+    media_est_membre,
+    parse_avis_detail,
+    parse_avis_index,
+    parse_membres,
+)
+from scripts.media_eval.collect_common import FetchResult
+
+HTML = Path(__file__).resolve().parents[1] / "fixtures" / "media_eval" / "html"
+
+
+def _read(name: str) -> str:
+    return (HTML / name).read_text()
+
+
+def make_fetcher(mapping: dict[str, tuple[int, str | None]]):
+    async def _fetch(url: str) -> FetchResult:
+        status, name = mapping.get(url, (404, None))
+        if status == 403:
+            return FetchResult(url, 403, "", ModeAcces.BLOQUE, "HTTP 403")
+        text = _read(name) if name else ""
+        return FetchResult(
+            url,
+            status,
+            text,
+            ModeAcces.LIBRE,
+            None if status == 200 else f"HTTP {status}",
+        )
+
+    return _fetch
+
+
+def _cnews_mapping() -> dict[str, tuple[int, str | None]]:
+    return {
+        URL_MEMBRES: (200, "cdjm_membres.html"),
+        URL_AVIS_INDEX: (200, "cdjm_avis_index.html"),
+        "https://cdjm.org/avis/26-014-cnews-bandeau-errone/": (
+            200,
+            "cdjm_avis_detail.html",
+        ),
+        "https://cdjm.org/avis/24-101-cnews-invite/": (
+            200,
+            "cdjm_avis_detail_ancien.html",
+        ),
+    }
+
+
+async def _count(db_session) -> int:
+    return (
+        await db_session.execute(select(func.count()).select_from(MediaEvalSignal))
+    ).scalar()
+
+
+class TestParsePur:
+    def test_parse_membres(self):
+        membres = parse_membres(_read("cdjm_membres.html"))
+        assert "Reporterre" in membres
+        assert media_est_membre("Reporterre", membres)
+        assert not media_est_membre("CNEWS", membres)
+
+    def test_parse_avis_index(self):
+        avis = parse_avis_index(_read("cdjm_avis_index.html"))
+        assert len(avis) == 3
+        assert all(a["url"].startswith("https://cdjm.org/avis/") for a in avis)
+
+    def test_parse_avis_detail(self):
+        detail = parse_avis_detail(_read("cdjm_avis_detail.html"))
+        assert detail["publie_at"] == date(2026, 2, 3)
+        assert detail["fonde"] is True
+        assert "CNEWS" in detail["media"]
+
+
+class TestCollecter:
+    async def test_adhesion_absente_et_avis_dans_fenetre(
+        self, db_session, media_cnews, run_test
+    ):
+        stats = await collecter(
+            db_session, media_cnews, run_test, make_fetcher(_cnews_mapping())
+        )
+        await db_session.commit()
+        # 1 adhesion absent_verifie (C8) + 1 avis present (C1, dans la fenêtre).
+        # L'avis 24-101 (2024-03-15) est hors fenêtre → exclu.
+        assert stats.inseres == 2
+        avis = (
+            (
+                await db_session.execute(
+                    select(MediaEvalSignal).where(
+                        MediaEvalSignal.type_signal == "avis_cdjm"
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(avis) == 1
+        assert avis[0].statut == StatutSignal.PRESENT
+        assert avis[0].valeur["publie_at"] == "2026-02-03"  # obligatoire pour C1
+
+        adhesion = (
+            await db_session.execute(
+                select(MediaEvalSignal).where(
+                    MediaEvalSignal.type_signal == "adhesion_cdjm"
+                )
+            )
+        ).scalar_one()
+        assert adhesion.statut == StatutSignal.ABSENT_VERIFIE
+
+    async def test_registre_bloque(self, db_session, media_cnews, run_test):
+        mapping = {URL_MEMBRES: (403, None), URL_AVIS_INDEX: (403, None)}
+        stats = await collecter(
+            db_session, media_cnews, run_test, make_fetcher(mapping)
+        )
+        await db_session.commit()
+        assert stats.bloques == 2  # adhesion + avis index bloqués
+        n_bloque = (
+            await db_session.execute(
+                select(func.count())
+                .select_from(MediaEvalSignal)
+                .where(MediaEvalSignal.statut == StatutSignal.BLOQUE_ACCES)
+            )
+        ).scalar()
+        assert n_bloque == 2
+
+    async def test_idempotence(self, db_session, media_cnews, run_test):
+        fetcher = make_fetcher(_cnews_mapping())
+        await collecter(db_session, media_cnews, run_test, fetcher)
+        await db_session.commit()
+        n1 = await _count(db_session)
+        stats2 = await collecter(db_session, media_cnews, run_test, fetcher)
+        await db_session.commit()
+        assert stats2.inseres == 0
+        assert await _count(db_session) == n1

--- a/packages/api/tests/scripts/media_eval/test_collect_common.py
+++ b/packages/api/tests/scripts/media_eval/test_collect_common.py
@@ -1,0 +1,182 @@
+"""Tests du module commun voie A (collect_common.py).
+
+Couvre : ``require_run`` lève sur run absent ; dédupe applicative des
+snapshots ; dédupe + validation des signaux voie CODE ; **collision voie A/B**
+(D2) — même quadruplet ⇒ 2 clés ⇒ 2 lignes (le préfixe ``code|`` empêche
+qu'un signal agent supprime un signal code, et réciproquement).
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import func, select
+
+from app.models.media_eval import (
+    MediaEvalSignal,
+    MediaEvalSnapshot,
+    StatutSignal,
+    TypePage,
+    VoieCollecte,
+)
+from scripts.media_eval.collect_common import (
+    CollecteError,
+    dedupe_key_signal_code,
+    ouvrir_collecteur,
+    require_run,
+)
+from scripts.media_eval.ingest_artifacts import dedupe_key_signal
+from scripts.media_eval.schemas import SignalArtifact
+
+COLLECTEUR = "code:collect_test@v1"
+
+
+async def _count(db_session, model) -> int:
+    return (await db_session.execute(select(func.count()).select_from(model))).scalar()
+
+
+class TestRequireRun:
+    async def test_leve_si_absent(self, db_session):
+        with pytest.raises(CollecteError, match="run inconnu"):
+            await require_run(db_session, "run-absent")
+
+    async def test_retourne_run(self, db_session, run_test):
+        run = await require_run(db_session, run_test.run_id)
+        assert run.run_id == run_test.run_id
+
+
+class TestDedupeKeyVoieAB:
+    def test_prefixe_code_distinct_de_voie_b(self):
+        """Même quadruplet → clé voie A ≠ clé voie B (D2)."""
+        item = SignalArtifact(
+            media_domaine="cnews.fr",
+            critere="C8",
+            type_signal="charte_deontologique",
+            statut="present",
+            valeur={"url": "https://cnews.fr/charte"},
+            source_urls=["https://cnews.fr/charte"],
+        )
+        assert dedupe_key_signal_code(item) != dedupe_key_signal(item)
+
+
+class TestSnapshotDedupe:
+    async def test_meme_url_hash_reutilise(self, db_session, media_cnews, run_test):
+        c = await ouvrir_collecteur(db_session, media_cnews, run_test, COLLECTEUR)
+        s1 = await c.snapshot(
+            url="https://cnews.fr/a", type_page=TypePage.A_PROPOS, contenu="x"
+        )
+        s2 = await c.snapshot(
+            url="https://cnews.fr/a", type_page=TypePage.A_PROPOS, contenu="x"
+        )
+        assert s1.id == s2.id
+        assert c.stats.snapshots == 1
+        await db_session.commit()
+        assert await _count(db_session, MediaEvalSnapshot) == 1
+
+    async def test_contenu_different_nouveau_snapshot(
+        self, db_session, media_cnews, run_test
+    ):
+        c = await ouvrir_collecteur(db_session, media_cnews, run_test, COLLECTEUR)
+        await c.snapshot(
+            url="https://cnews.fr/a", type_page=TypePage.A_PROPOS, contenu="x"
+        )
+        await c.snapshot(
+            url="https://cnews.fr/a", type_page=TypePage.A_PROPOS, contenu="y"
+        )
+        assert c.stats.snapshots == 2
+
+
+class TestSignalCode:
+    async def test_insertion_voie_code(self, db_session, media_cnews, run_test):
+        c = await ouvrir_collecteur(db_session, media_cnews, run_test, COLLECTEUR)
+        signal = await c.signal(
+            critere="C5",
+            type_signal="mentions_legales",
+            statut=StatutSignal.PRESENT,
+            valeur={"complet": True},
+            source_urls=["https://cnews.fr/mentions-legales"],
+        )
+        await db_session.commit()
+        assert signal is not None
+        assert signal.voie == VoieCollecte.CODE
+        assert signal.collecteur == COLLECTEUR
+        assert c.stats.inseres == 1
+
+    async def test_dedupe_meme_signal(self, db_session, media_cnews, run_test):
+        c = await ouvrir_collecteur(db_session, media_cnews, run_test, COLLECTEUR)
+        kw = {
+            "critere": "C5",
+            "type_signal": "mentions_legales",
+            "statut": StatutSignal.PRESENT,
+            "source_urls": ["https://cnews.fr/mentions-legales"],
+        }
+        assert await c.signal(**kw) is not None
+        assert await c.signal(**kw) is None  # doublon
+        assert (c.stats.inseres, c.stats.doublons) == (1, 1)
+
+    async def test_validation_present_sans_source_leve(
+        self, db_session, media_cnews, run_test
+    ):
+        c = await ouvrir_collecteur(db_session, media_cnews, run_test, COLLECTEUR)
+        with pytest.raises(CollecteError, match="signal invalide"):
+            await c.signal(
+                critere="C5",
+                type_signal="mentions_legales",
+                statut=StatutSignal.PRESENT,
+                source_urls=[],  # present sans source → rejet
+            )
+
+    async def test_bloque_jamais_silencieux(self, db_session, media_cnews, run_test):
+        c = await ouvrir_collecteur(db_session, media_cnews, run_test, COLLECTEUR)
+        signal = await c.bloque(
+            critere="C1",
+            type_signal="sanction_arcom",
+            url="https://www.arcom.fr/recherche",
+            raison="anti-bot 403 après repli curl_cffi",
+        )
+        await db_session.commit()
+        assert signal is not None
+        assert signal.statut == StatutSignal.BLOQUE_ACCES
+        assert c.stats.bloques == 1
+
+    async def test_collision_voie_a_b_deux_lignes(
+        self, db_session, media_cnews, run_test
+    ):
+        """Un signal voie A (code) et un signal voie B (agent) sur le même
+        quadruplet coexistent — le préfixe ``code|`` les distingue (D2)."""
+        # Signal voie B (agent) inséré directement avec la clé voie B.
+        item = SignalArtifact(
+            media_domaine="cnews.fr",
+            critere="C8",
+            type_signal="charte_deontologique",
+            statut="present",
+            valeur={"substance": "charte détaillée, 12 principes"},
+            source_urls=["https://cnews.fr/charte"],
+        )
+        db_session.add(
+            MediaEvalSignal(
+                media_id=media_cnews.id,
+                critere="C8",
+                type_signal="charte_deontologique",
+                statut=StatutSignal.PRESENT,
+                valeur=item.valeur,
+                voie=VoieCollecte.AGENT,
+                collecteur="agent:media-eval-collecteur-gouvernance@v1",
+                source_urls=item.source_urls,
+                run_id=run_test.run_id,
+                dedupe_key=dedupe_key_signal(item),
+            )
+        )
+        await db_session.commit()
+
+        # Signal voie A (code) sur le MÊME quadruplet — ne doit pas être droppé.
+        c = await ouvrir_collecteur(db_session, media_cnews, run_test, COLLECTEUR)
+        signal_code = await c.signal(
+            critere="C8",
+            type_signal="charte_deontologique",
+            statut=StatutSignal.PRESENT,
+            valeur={"url": "https://cnews.fr/charte", "detection": "page_type"},
+            source_urls=["https://cnews.fr/charte"],
+        )
+        await db_session.commit()
+        assert signal_code is not None
+        assert await _count(db_session, MediaEvalSignal) == 2

--- a/packages/api/tests/scripts/media_eval/test_collect_cppap.py
+++ b/packages/api/tests/scripts/media_eval/test_collect_cppap.py
@@ -1,0 +1,100 @@
+"""Tests du collecteur CPPAP (collect_cppap.py) — open data (D5).
+
+Couvre : titre trouvé → present + numero_cppap ; recherche vide →
+absent_verifie ; dataset inaccessible → bloque_acces ; réponse non-JSON →
+bloque_acces (jamais d'exception).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sqlalchemy import select
+
+from app.models.media_eval import MediaEvalSignal, ModeAcces, StatutSignal
+from scripts.media_eval.collect_common import FetchResult
+from scripts.media_eval.collect_cppap import (
+    chercher_titre,
+    collecter,
+    cppap_url,
+    parse_cppap_records,
+)
+
+API = Path(__file__).resolve().parents[1] / "fixtures" / "media_eval" / "api"
+
+
+def _read(name: str) -> str:
+    return (API / name).read_text()
+
+
+def make_fetcher(status: int, texte: str):
+    async def _fetch(url: str) -> FetchResult:
+        if status == 403:
+            return FetchResult(url, 403, "", ModeAcces.BLOQUE, "HTTP 403")
+        return FetchResult(url, status, texte, ModeAcces.LIBRE, None)
+
+    return _fetch
+
+
+class TestParsePur:
+    def test_parse_records(self):
+        records = parse_cppap_records(_read("cppap_records.json"))
+        assert len(records) == 1
+        assert records[0]["numero_cppap"] == "0426 W 92142"
+
+    def test_chercher_titre(self):
+        records = parse_cppap_records(_read("cppap_records.json"))
+        assert chercher_titre("CNEWS", records) is not None
+        assert chercher_titre("Reporterre", records) is None
+
+    def test_parse_empty(self):
+        assert parse_cppap_records(_read("cppap_empty.json")) == []
+
+    def test_parse_records_v2(self):
+        """Forme Explore v2.1 : ``results`` à plat, champ ``ndeg_cppap``."""
+        records = parse_cppap_records(_read("cppap_records_v2.json"))
+        assert len(records) == 1
+        assert records[0]["titre"] == "CNEWS"
+        assert records[0]["numero_cppap"] == "0426 W 92142"
+        assert chercher_titre("CNEWS", records) is not None
+
+
+class TestCollecter:
+    async def test_present(self, db_session, media_cnews, run_test):
+        stats = await collecter(
+            db_session,
+            media_cnews,
+            run_test,
+            make_fetcher(200, _read("cppap_records.json")),
+        )
+        await db_session.commit()
+        assert stats.inseres == 1
+        signal = (await db_session.execute(select(MediaEvalSignal))).scalar_one()
+        assert signal.statut == StatutSignal.PRESENT
+        assert signal.valeur["numero_cppap"] == "0426 W 92142"
+
+    async def test_absent(self, db_session, media_reporterre, run_test):
+        stats = await collecter(
+            db_session,
+            media_reporterre,
+            run_test,
+            make_fetcher(200, _read("cppap_empty.json")),
+        )
+        await db_session.commit()
+        assert stats.inseres == 1
+        signal = (await db_session.execute(select(MediaEvalSignal))).scalar_one()
+        assert signal.statut == StatutSignal.ABSENT_VERIFIE
+
+    async def test_bloque_reponse_non_json(self, db_session, media_cnews, run_test):
+        stats = await collecter(
+            db_session, media_cnews, run_test, make_fetcher(200, "<html>captcha</html>")
+        )
+        await db_session.commit()
+        assert stats.bloques == 1
+        signal = (await db_session.execute(select(MediaEvalSignal))).scalar_one()
+        assert signal.statut == StatutSignal.BLOQUE_ACCES
+
+    def test_cppap_url_encode(self):
+        url = cppap_url("Le Monde")
+        assert "liste-des-publications-de-presse" in url
+        assert "%20" in url  # espace encodé dans la phrase entre guillemets

--- a/packages/api/tests/scripts/media_eval/test_collect_jti.py
+++ b/packages/api/tests/scripts/media_eval/test_collect_jti.py
@@ -1,0 +1,72 @@
+"""Tests du collecteur JTI (collect_jti.py).
+
+Couvre : média absent de l'annuaire → absent_verifie (cas pilotes) ; média
+certifié valide → present + en_cours_de_validite (déclenche le raccourci) ;
+certification expirée → validité fausse ; annuaire bloqué → bloque_acces.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sqlalchemy import select
+
+from app.models.media_eval import MediaEvalSignal, ModeAcces, StatutSignal
+from scripts.media_eval.collect_common import FetchResult
+from scripts.media_eval.collect_jti import (
+    URL_ANNUAIRE,
+    chercher_media,
+    collecter,
+    parse_jti_directory,
+)
+
+HTML = Path(__file__).resolve().parents[1] / "fixtures" / "media_eval" / "html"
+
+
+def _read(name: str) -> str:
+    return (HTML / name).read_text()
+
+
+def make_fetcher(status: int, name: str | None):
+    async def _fetch(url: str) -> FetchResult:
+        if status == 403:
+            return FetchResult(url, 403, "", ModeAcces.BLOQUE, "HTTP 403")
+        text = _read(name) if name else ""
+        return FetchResult(url, status, text, ModeAcces.LIBRE, None)
+
+    return _fetch
+
+
+class TestParsePur:
+    def test_parse_directory_validite(self):
+        entrees = parse_jti_directory(_read("jti_directory.html"))
+        afp = chercher_media("Agence France-Presse", entrees)
+        assert afp and afp["en_cours_de_validite"] is True
+        expire = chercher_media("La Voix du Nord", entrees)
+        assert expire and expire["en_cours_de_validite"] is False
+
+    def test_media_absent(self):
+        entrees = parse_jti_directory(_read("jti_directory.html"))
+        assert chercher_media("CNEWS", entrees) is None
+
+
+class TestCollecter:
+    async def test_absent_verifie_cnews(self, db_session, media_cnews, run_test):
+        stats = await collecter(
+            db_session, media_cnews, run_test, make_fetcher(200, "jti_directory.html")
+        )
+        await db_session.commit()
+        assert stats.inseres == 1
+        signal = (await db_session.execute(select(MediaEvalSignal))).scalar_one()
+        assert signal.type_signal == "certification_jti"
+        assert signal.statut == StatutSignal.ABSENT_VERIFIE
+        assert signal.sources_consultees == [URL_ANNUAIRE]
+
+    async def test_bloque(self, db_session, media_cnews, run_test):
+        stats = await collecter(
+            db_session, media_cnews, run_test, make_fetcher(403, None)
+        )
+        await db_session.commit()
+        assert stats.bloques == 1
+        signal = (await db_session.execute(select(MediaEvalSignal))).scalar_one()
+        assert signal.statut == StatutSignal.BLOQUE_ACCES

--- a/packages/api/tests/scripts/media_eval/test_collect_pages_types.py
+++ b/packages/api/tests/scripts/media_eval/test_collect_pages_types.py
@@ -1,0 +1,287 @@
+"""Tests du collecteur pages types (collect_pages_types.py).
+
+Zéro réseau : un ``fetcher`` fixture-driven lit des HTML/XML figés. Couvre :
+découverte footer+sitemap → détection présente ; épuisement → absent_verifie
+avec sources_consultees ; soft-404 et DOM cassé non significatifs (jamais
+d'exception) ; home bloquée → bloque_acces par signal ; idempotence.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sqlalchemy import func, select
+
+from app.models.media_eval import (
+    MediaEvalSignal,
+    MediaEvalSnapshot,
+    ModeAcces,
+    StatutSignal,
+    TypePage,
+)
+from scripts.media_eval.collect_common import FetchResult
+from scripts.media_eval.collect_pages_types import (
+    a_marqueurs_type,
+    classifier_url,
+    collecter,
+    extraire_texte_principal,
+    page_significative,
+    parse_liens_footer,
+    parse_sitemap,
+    ratio_liens_articles,
+    ressemble_a_home,
+)
+
+HTML = Path(__file__).resolve().parents[1] / "fixtures" / "media_eval" / "html"
+FOUND = "page_significative.html"
+
+
+def _read(name: str) -> str:
+    return (HTML / name).read_text()
+
+
+def _extraire(html: str) -> str:
+    return extraire_texte_principal(html)
+
+
+def make_fetcher(mapping: dict[str, tuple[int, str | None]]):
+    """Fetcher fixture-driven ; défaut = 404 dur (page absente)."""
+
+    async def _fetch(url: str) -> FetchResult:
+        status, name = mapping.get(url, (404, None))
+        text = _read(name) if name else ""
+        if status == 403:
+            return FetchResult(url, 403, "", ModeAcces.BLOQUE, "HTTP 403")
+        mode = ModeAcces.LIBRE
+        err = None if status == 200 else f"HTTP {status}"
+        return FetchResult(url, status, text, mode, err)
+
+    return _fetch
+
+
+def _reporterre_mapping() -> dict[str, tuple[int, str | None]]:
+    base = "https://reporterre.net"
+    return {
+        f"{base}/": (200, "reporterre_home.html"),
+        f"{base}/sitemap.xml": (200, "reporterre_sitemap.xml"),
+        # Chaque page porte les marqueurs lexicaux de son type (substance).
+        f"{base}/mentions-legales": (200, "mentions_legales_ok.html"),
+        f"{base}/spip.php?page=charte": (200, "charte_ok.html"),
+        f"{base}/nous-soutenir": (200, "dons_ok.html"),
+        f"{base}/spip.php?rubrique=qui-sommes-nous": (200, FOUND),
+        # soft-404 (200 mais contenu « page introuvable ») et DOM cassé :
+        f"{base}/manifeste": (200, "page_404_soft.html"),
+        f"{base}/publicite": (200, "dom_casse.html"),
+    }
+
+
+def _cnews_mapping() -> dict[str, tuple[int, str | None]]:
+    """Reproduit le piège cnews.fr : soft-404 (home servie) + flux taggés."""
+    base = "https://cnews.fr"
+    return {
+        f"{base}/": (200, "cnews_home_riche.html"),
+        f"{base}/sitemap.xml": (404, None),
+        f"{base}/mentions-legales": (200, "cnews_mentions_legales.html"),
+        # /charte et /ligne-editoriale renvoient la home → soft-404 silencieux.
+        f"{base}/charte": (200, "cnews_home_riche.html"),
+        f"{base}/ligne-editoriale": (200, "cnews_home_riche.html"),
+        # /dons et /publicite sont des fils d'articles taggés, pas institutionnels.
+        f"{base}/dons": (200, "cnews_flux_dons.html"),
+        f"{base}/publicite": (200, "cnews_flux_publicite.html"),
+    }
+
+
+async def _count(db_session, model) -> int:
+    return (await db_session.execute(select(func.count()).select_from(model))).scalar()
+
+
+async def _statuts(db_session) -> dict[str, int]:
+    rows = await db_session.execute(
+        select(MediaEvalSignal.statut, func.count()).group_by(MediaEvalSignal.statut)
+    )
+    return {(s.value if hasattr(s, "value") else s): n for s, n in rows.all()}
+
+
+class TestParsePur:
+    def test_parse_liens_footer_ignore_mailto_ancre(self):
+        liens = parse_liens_footer(_read("reporterre_home.html"))
+        hrefs = [h for h, _ in liens]
+        assert "/mentions-legales" in hrefs
+        assert not any(h.startswith(("mailto:", "#")) for h in hrefs)
+
+    def test_parse_sitemap(self):
+        urls = parse_sitemap(_read("reporterre_sitemap.xml"))
+        assert "https://reporterre.net/mentions-legales" in urls
+        assert len(urls) == 7
+
+    def test_classifier_url(self):
+        assert classifier_url("/mentions-legales") == TypePage.MENTIONS_LEGALES
+        assert classifier_url("/spip.php?page=charte") == TypePage.CHARTE
+        assert classifier_url("/nous-soutenir") == TypePage.DONS_FINANCEMENT
+        assert classifier_url("/article/quelconque") is None
+
+    def test_page_significative(self):
+        assert page_significative(_read(FOUND), 200) is True
+        assert page_significative(_read("page_404_soft.html"), 200) is False
+        assert page_significative(_read("dom_casse.html"), 200) is False
+        assert page_significative(_read(FOUND), 404) is False
+
+    def test_page_significative_soft_404_comme_home(self):
+        """Une page qui renvoie la home (même texte principal) est écartée."""
+        home = _read("cnews_home_riche.html")
+        assert page_significative(home, 200, home_texte="") is True  # sans réf
+        assert (
+            page_significative(
+                home,
+                200,
+                type_page=TypePage.CHARTE,
+                home_texte=_extraire(home),
+            )
+            is False
+        )
+
+    def test_page_significative_marqueurs_type(self):
+        """Sans marqueur lexical du type, la page n'est pas significative."""
+        # Le flux « /publicite » porte le mot « régie » mais reste un fil
+        # d'articles datés → écarté par la pénalité anti-flux.
+        assert (
+            page_significative(
+                _read("cnews_flux_publicite.html"), 200, type_page=TypePage.REGIE_PUB
+            )
+            is False
+        )
+        # La vraie page de mentions porte capital / RCS / SIREN → retenue.
+        assert (
+            page_significative(
+                _read("cnews_mentions_legales.html"),
+                200,
+                type_page=TypePage.MENTIONS_LEGALES,
+            )
+            is True
+        )
+
+    def test_ressemble_a_home(self):
+        home = _extraire(_read("cnews_home_riche.html"))
+        assert ressemble_a_home(_extraire(_read("cnews_home_riche.html")), home) is True
+        assert (
+            ressemble_a_home(_extraire(_read("mentions_legales_ok.html")), home)
+            is False
+        )
+        assert ressemble_a_home("texte", None) is False
+
+    def test_ratio_liens_articles(self):
+        assert ratio_liens_articles(_read("cnews_flux_dons.html")) > 0.5
+        assert ratio_liens_articles(_read("mentions_legales_ok.html")) <= 0.5
+
+    def test_a_marqueurs_type_flux_penalise(self):
+        # Marqueur « faire un don » présent, mais fil d'articles datés → écarté.
+        html = _read("cnews_flux_dons.html")
+        texte = _extraire(html)
+        assert "faire un don" in texte.lower()
+        assert a_marqueurs_type(texte, html, TypePage.DONS_FINANCEMENT) is False
+        # Une vraie page de dons (peu de liens) est retenue.
+        dons = _read("dons_ok.html")
+        assert (
+            a_marqueurs_type(_extraire(dons), dons, TypePage.DONS_FINANCEMENT) is True
+        )
+
+
+class TestCollecterNominal:
+    async def test_detection_et_absence(self, db_session, media_reporterre, run_test):
+        stats = await collecter(
+            db_session, media_reporterre, run_test, make_fetcher(_reporterre_mapping())
+        )
+        await db_session.commit()
+        # 3 present (mentions, charte, dons) + 2 absent (ligne édito, régie).
+        assert stats.inseres == 5
+        statuts = await _statuts(db_session)
+        assert statuts.get("present") == 3
+        assert statuts.get("absent_verifie") == 2
+
+        # Les absents portent la preuve de recherche.
+        absents = (
+            (
+                await db_session.execute(
+                    select(MediaEvalSignal).where(
+                        MediaEvalSignal.statut == StatutSignal.ABSENT_VERIFIE
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert all(a.sources_consultees for a in absents)
+
+    async def test_snapshots_dedupes(self, db_session, media_reporterre, run_test):
+        await collecter(
+            db_session, media_reporterre, run_test, make_fetcher(_reporterre_mapping())
+        )
+        await db_session.commit()
+        # home + mentions + charte + dons + a_propos = 5 (ours absent).
+        assert await _count(db_session, MediaEvalSnapshot) == 5
+
+
+class TestBloqueEtRobustesse:
+    async def test_home_bloquee_bloque_acces(
+        self, db_session, media_reporterre, run_test
+    ):
+        mapping = {"https://reporterre.net/": (403, None)}
+        stats = await collecter(
+            db_session, media_reporterre, run_test, make_fetcher(mapping)
+        )
+        await db_session.commit()
+        # 1 bloque_acces par signal attendu (5), aucune exception.
+        assert stats.bloques == 5
+        statuts = await _statuts(db_session)
+        assert statuts.get("bloque_acces") == 5
+
+    async def test_idempotence(self, db_session, media_reporterre, run_test):
+        fetcher = make_fetcher(_reporterre_mapping())
+        await collecter(db_session, media_reporterre, run_test, fetcher)
+        await db_session.commit()
+        n1 = await _count(db_session, MediaEvalSignal)
+        stats2 = await collecter(db_session, media_reporterre, run_test, fetcher)
+        await db_session.commit()
+        assert stats2.inseres == 0 and stats2.snapshots == 0
+        assert await _count(db_session, MediaEvalSignal) == n1
+
+
+class TestCnewsSoftFourCentEtFlux:
+    """Non-régression du diagnostic cnews.fr (hand-off pilote-2026-07b).
+
+    /charte + /ligne-editoriale renvoient la home (soft-404) et /dons +
+    /publicite sont des fils d'articles taggés : aucun ne doit produire un
+    ``present`` — seule la vraie page de mentions légales est retenue.
+    """
+
+    async def _signaux(self, db_session):
+        rows = await db_session.execute(
+            select(
+                MediaEvalSignal.critere,
+                MediaEvalSignal.type_signal,
+                MediaEvalSignal.statut,
+            )
+        )
+        return {
+            (c, t): (s.value if hasattr(s, "value") else s) for c, t, s in rows.all()
+        }
+
+    async def test_aucun_present_hors_mentions(self, db_session, media_cnews, run_test):
+        stats = await collecter(
+            db_session, media_cnews, run_test, make_fetcher(_cnews_mapping())
+        )
+        await db_session.commit()
+        statuts = await _statuts(db_session)
+        # Seule la page de mentions est réelle : 1 present, 4 absent_verifie.
+        assert statuts.get("present") == 1
+        assert statuts.get("absent_verifie") == 4
+        assert statuts.get("bloque_acces") is None
+        assert stats.snapshots == 2  # home + mentions légales uniquement
+
+        sig = await self._signaux(db_session)
+        # Les faux positifs du run initial sont désormais des absences vérifiées.
+        assert sig[("C8", "charte_deontologique")] == "absent_verifie"
+        assert sig[("C11", "ligne_editoriale_publiee")] == "absent_verifie"
+        assert sig[("C7", "regie_pub_identifiee")] == "absent_verifie"
+        assert sig[("C5", "transparence_financement")] == "absent_verifie"
+        assert sig[("C5", "mentions_legales")] == "present"

--- a/packages/api/tests/scripts/media_eval/test_collect_pappers.py
+++ b/packages/api/tests/scripts/media_eval/test_collect_pappers.py
@@ -1,0 +1,200 @@
+"""Tests du collecteur Pappers (collect_pappers.py).
+
+Couvre : parse v2 ; garde ``verifier_entreprise`` (match vs mismatch →
+CollecteError) ; 3 signaux present via Pappers ; **repli gratuit** sur
+recherche-entreprises.api.gouv.fr quand le token est absent OU épuisé (401) →
+1 present + 2 partiel ; tout inaccessible → 3 bloque_acces (exit 0).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import func, select
+
+from app.models.media_eval import MediaEvalSignal, ModeAcces, StatutSignal
+from scripts.media_eval.collect_common import CollecteError, FetchResult
+from scripts.media_eval.collect_pappers import (
+    collecter,
+    parse_pappers,
+    parse_recherche_entreprises,
+    recherche_entreprises_url,
+    verifier_entreprise,
+)
+
+API = Path(__file__).resolve().parents[1] / "fixtures" / "media_eval" / "api"
+
+
+def _read(name: str) -> str:
+    return (API / name).read_text()
+
+
+def make_fetcher(status: int, texte: str):
+    async def _fetch(url: str) -> FetchResult:
+        if status == 403:
+            return FetchResult(url, 403, "", ModeAcces.BLOQUE, "HTTP 403")
+        return FetchResult(url, status, texte, ModeAcces.LIBRE, None)
+
+    return _fetch
+
+
+def make_url_fetcher(mapping: dict[str, tuple[int, str]]):
+    """Fetcher qui route par fragment d'URL (pappers vs recherche-entreprises)."""
+
+    async def _fetch(url: str) -> FetchResult:
+        for frag, (status, texte) in mapping.items():
+            if frag in url:
+                if status in (401, 403):
+                    return FetchResult(
+                        url, status, "", ModeAcces.BLOQUE, f"HTTP {status}"
+                    )
+                return FetchResult(url, status, texte, ModeAcces.LIBRE, None)
+        return FetchResult(url, 404, "", ModeAcces.LIBRE, "HTTP 404")
+
+    return _fetch
+
+
+async def _count_statut(db_session, statut) -> int:
+    return (
+        await db_session.execute(
+            select(func.count())
+            .select_from(MediaEvalSignal)
+            .where(MediaEvalSignal.statut == statut)
+        )
+    ).scalar()
+
+
+class TestPur:
+    def test_parse_pappers(self):
+        info = parse_pappers(_read("pappers_sesi.json"))
+        assert info["siren"] == "501260034"
+        assert info["beneficiaires_effectifs"][0]["nom"] == "Vivendi SE"
+
+    def test_verifier_entreprise_ok(self):
+        import json
+
+        verifier_entreprise(
+            json.loads(_read("pappers_sesi.json")),
+            "SOCIETE D'EXPLOITATION D'UN SERVICE D'INFORMATION",
+        )  # ne lève pas
+
+    def test_verifier_entreprise_mismatch(self):
+        import json
+
+        with pytest.raises(CollecteError, match="raison sociale"):
+            verifier_entreprise(
+                json.loads(_read("pappers_mismatch.json")),
+                "SOCIETE D'EXPLOITATION D'UN SERVICE D'INFORMATION",
+            )
+
+    def test_recherche_entreprises_url_encode(self):
+        url = recherche_entreprises_url("412916215")
+        assert "recherche-entreprises.api.gouv.fr" in url
+        assert "412916215" in url
+
+    def test_parse_recherche_entreprises(self):
+        info = parse_recherche_entreprises(
+            _read("recherche_entreprises_sesi.json"), "412916215"
+        )
+        assert info is not None
+        assert info["nom"] == "SESI"
+        assert info["siren"] == "412916215"
+        assert info["dirigeants"][0]["qualite"] == "Gerant"
+        # SIREN non présent → None (aucun signal posé).
+        assert (
+            parse_recherche_entreprises(
+                _read("recherche_entreprises_sesi.json"), "000000000"
+            )
+            is None
+        )
+
+
+class TestCollecter:
+    async def test_pappers_trois_signaux_present(
+        self, db_session, media_cnews, run_test, monkeypatch
+    ):
+        monkeypatch.setenv("PAPPERS_API_TOKEN", "tok-test")
+        stats = await collecter(
+            db_session,
+            media_cnews,
+            run_test,
+            make_url_fetcher({"api.pappers.fr": (200, _read("pappers_sesi_snc.json"))}),
+        )
+        await db_session.commit()
+        assert stats.inseres == 3
+        assert await _count_statut(db_session, StatutSignal.PRESENT) == 3
+
+    async def test_token_absent_repli_gratuit(
+        self, db_session, media_cnews, run_test, monkeypatch
+    ):
+        """Sans token → API gratuite : 1 present + 2 partiel (au lieu de bloqué)."""
+        monkeypatch.delenv("PAPPERS_API_TOKEN", raising=False)
+        stats = await collecter(
+            db_session,
+            media_cnews,
+            run_test,
+            make_url_fetcher(
+                {
+                    "recherche-entreprises": (
+                        200,
+                        _read("recherche_entreprises_sesi.json"),
+                    )
+                }
+            ),
+        )
+        await db_session.commit()
+        assert stats.inseres == 3
+        assert await _count_statut(db_session, StatutSignal.PRESENT) == 1
+        assert await _count_statut(db_session, StatutSignal.PARTIEL) == 2
+        assert await _count_statut(db_session, StatutSignal.BLOQUE_ACCES) == 0
+
+    async def test_token_epuise_401_repli_gratuit(
+        self, db_session, media_cnews, run_test, monkeypatch
+    ):
+        """Token présent mais 401 (crédit épuisé) → repli gratuit, pas bloqué."""
+        monkeypatch.setenv("PAPPERS_API_TOKEN", "tok-vide")
+        await collecter(
+            db_session,
+            media_cnews,
+            run_test,
+            make_url_fetcher(
+                {
+                    "api.pappers.fr": (401, ""),
+                    "recherche-entreprises": (
+                        200,
+                        _read("recherche_entreprises_sesi.json"),
+                    ),
+                }
+            ),
+        )
+        await db_session.commit()
+        assert await _count_statut(db_session, StatutSignal.PRESENT) == 1
+        assert await _count_statut(db_session, StatutSignal.PARTIEL) == 2
+
+    async def test_tout_inaccessible_trois_bloque(
+        self, db_session, media_cnews, run_test, monkeypatch
+    ):
+        """Ni token ni API gratuite exploitable → 3 bloque_acces (exit 0)."""
+        monkeypatch.delenv("PAPPERS_API_TOKEN", raising=False)
+        stats = await collecter(
+            db_session,
+            media_cnews,
+            run_test,
+            make_url_fetcher({"recherche-entreprises": (200, "<html>captcha</html>")}),
+        )
+        await db_session.commit()
+        assert stats.bloques == 3
+        assert await _count_statut(db_session, StatutSignal.BLOQUE_ACCES) == 3
+
+    async def test_mismatch_leve(self, db_session, media_cnews, run_test, monkeypatch):
+        monkeypatch.setenv("PAPPERS_API_TOKEN", "tok-test")
+        with pytest.raises(CollecteError, match="raison sociale"):
+            await collecter(
+                db_session,
+                media_cnews,
+                run_test,
+                make_url_fetcher(
+                    {"api.pappers.fr": (200, _read("pappers_mismatch.json"))}
+                ),
+            )

--- a/packages/api/tests/scripts/media_eval/test_create_run.py
+++ b/packages/api/tests/scripts/media_eval/test_create_run.py
@@ -1,0 +1,78 @@
+"""Tests DB de create_run.py — création, idempotence, refus de mutation.
+
+``date_reference`` pilote la fraîcheur : sa mutation silencieuse casserait la
+rejouabilité, donc ``upsert_run`` la refuse (``RunConflit``).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlalchemy import func, select
+
+from app.models.media_eval import MediaEvalRun
+from scripts.media_eval.create_run import RunConflit, upsert_run
+
+
+async def _count(db_session) -> int:
+    return (
+        await db_session.execute(select(func.count()).select_from(MediaEvalRun))
+    ).scalar()
+
+
+async def _upsert(db_session, **kw):
+    base = {
+        "run_id": "run-x",
+        "date_reference": date(2026, 7, 10),
+        "libelle": "Pilote",
+        "medias": ["cnews.fr"],
+        "criteres": ["C1", "C5"],
+    }
+    base.update(kw)
+    return await upsert_run(db_session, **base)
+
+
+class TestUpsertRun:
+    async def test_creation(self, db_session):
+        action, _ = await _upsert(db_session)
+        await db_session.commit()
+        assert action == "cree"
+        assert await _count(db_session) == 1
+        run = (
+            await db_session.execute(
+                select(MediaEvalRun).where(MediaEvalRun.run_id == "run-x")
+            )
+        ).scalar_one()
+        assert run.date_reference == date(2026, 7, 10)
+        assert run.perimetre == {"medias": ["cnews.fr"], "criteres": ["C1", "C5"]}
+
+    async def test_idempotence(self, db_session):
+        await _upsert(db_session)
+        await db_session.commit()
+        action, _ = await _upsert(db_session)
+        await db_session.commit()
+        assert action == "inchange"
+        assert await _count(db_session) == 1
+
+    async def test_maj_libelle_et_perimetre(self, db_session):
+        await _upsert(db_session)
+        await db_session.commit()
+        action, _ = await _upsert(
+            db_session, libelle="Pilote v2", medias=["reporterre.net"]
+        )
+        await db_session.commit()
+        assert action == "maj"
+        run = (
+            await db_session.execute(
+                select(MediaEvalRun).where(MediaEvalRun.run_id == "run-x")
+            )
+        ).scalar_one()
+        assert run.libelle == "Pilote v2"
+        assert run.perimetre["medias"] == ["reporterre.net"]
+
+    async def test_refus_changement_date_reference(self, db_session):
+        await _upsert(db_session)
+        await db_session.commit()
+        with pytest.raises(RunConflit, match="date_reference"):
+            await _upsert(db_session, date_reference=date(2026, 7, 11))

--- a/packages/api/tests/scripts/media_eval/test_export_evaluations.py
+++ b/packages/api/tests/scripts/media_eval/test_export_evaluations.py
@@ -1,0 +1,67 @@
+"""Tests de l'export d'évaluations (export_evaluations.py).
+
+Couvre : transformation en GoldenSet ; inclusion du raccourci code:jti_shortcut
+et exclusion des préfixes non demandés ; erreur explicite sur (média, critère)
+dupliqué.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.media_eval.export_evaluations import evaluations_to_goldenset
+
+
+def _ev(
+    media,
+    critere,
+    statut="evaluee",
+    score=None,
+    niveau=None,
+    evaluateur="agent:media-eval-evaluateur@v1",
+):
+    return {
+        "media_domaine": media,
+        "critere": critere,
+        "statut": statut,
+        "score": score,
+        "niveau": niveau,
+        "evaluateur": evaluateur,
+    }
+
+
+class TestEvaluationsToGoldenset:
+    def test_nominal(self):
+        evals = [
+            _ev("cnews.fr", "C5", score=10),
+            _ev("cnews.fr", "C8", score=4, evaluateur="code:jti_shortcut"),
+            _ev("cnews.fr", "C9", score=5, niveau=1),
+        ]
+        gs = evaluations_to_goldenset(evals)
+        assert len(gs.entries) == 3
+        # Le raccourci code: est bien inclus.
+        assert any(e.critere == "C8" for e in gs.entries)
+
+    def test_filtre_prefixes(self):
+        evals = [
+            _ev("cnews.fr", "C5", score=10),
+            _ev("cnews.fr", "C1", statut="non_applicable", evaluateur="humain:laurin"),
+        ]
+        gs = evaluations_to_goldenset(evals, prefixes=("agent:", "code:"))
+        assert len(gs.entries) == 1
+        assert gs.entries[0].critere == "C5"
+
+    def test_doublon_media_critere_leve(self):
+        evals = [
+            _ev("cnews.fr", "C5", score=10),
+            _ev("cnews.fr", "C5", score=5, evaluateur="code:autre"),
+        ]
+        with pytest.raises(ValueError, match="deux évaluations"):
+            evaluations_to_goldenset(evals)
+
+    def test_na_score_null(self):
+        gs = evaluations_to_goldenset(
+            [_ev("reporterre.net", "C1", statut="non_applicable")]
+        )
+        assert gs.entries[0].statut == "non_applicable"
+        assert gs.entries[0].score is None

--- a/packages/api/tests/scripts/media_eval/test_export_snapshots.py
+++ b/packages/api/tests/scripts/media_eval/test_export_snapshots.py
@@ -1,0 +1,85 @@
+"""Tests de l'export des snapshots (export_snapshots.py).
+
+Couvre : nom de fichier déterministe + suffixe anti-collision ; en-tête de
+provenance ; lecture DB filtrée par run/média (voie A → fichiers pour la
+voie B, hand-off pilote-2026-07b).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from app.models.media_eval import MediaEvalSnapshot, ModeAcces, TypePage
+from scripts.media_eval.export_snapshots import (
+    charger_snapshots,
+    nom_fichier,
+    rendre_fichier,
+    slug,
+)
+
+
+class TestPur:
+    def test_slug(self):
+        assert slug("cnews.fr") == "cnews_fr"
+
+    def test_nom_fichier_collision(self):
+        vus: set[str] = set()
+        assert nom_fichier("cnews.fr", TypePage.AUTRE, vus) == "cnews_fr__autre.txt"
+        assert nom_fichier("cnews.fr", TypePage.AUTRE, vus) == "cnews_fr__autre__2.txt"
+        assert nom_fichier("cnews.fr", TypePage.AUTRE, vus) == "cnews_fr__autre__3.txt"
+
+    def test_rendre_fichier_entete(self):
+        snap = MediaEvalSnapshot(
+            url="https://cnews.fr/mentions-legales",
+            type_page=TypePage.MENTIONS_LEGALES,
+            contenu="Editeur du site SESI SNC ... RCS Nanterre 412 916 215",
+            hash="abc123",
+            http_status=200,
+            mode_acces=ModeAcces.LIBRE,
+            capture_at=datetime(2026, 7, 13, 8, 0, 0),
+        )
+        texte = rendre_fichier(snap)
+        assert "url: https://cnews.fr/mentions-legales" in texte
+        assert "type_page: mentions_legales" in texte
+        assert "http_status: 200" in texte
+        assert "mode_acces: libre" in texte
+        assert "hash: abc123" in texte
+        assert texte.rstrip().endswith("RCS Nanterre 412 916 215")
+
+
+class TestChargerSnapshots:
+    async def test_lecture_filtre_run(self, db_session, media_cnews, run_test):
+        db_session.add_all(
+            [
+                MediaEvalSnapshot(
+                    media_id=media_cnews.id,
+                    run_id=run_test.run_id,
+                    url="https://cnews.fr/",
+                    type_page=TypePage.AUTRE,
+                    contenu="home",
+                    hash="h1",
+                    http_status=200,
+                    mode_acces=ModeAcces.LIBRE,
+                ),
+                MediaEvalSnapshot(
+                    media_id=media_cnews.id,
+                    run_id=run_test.run_id,
+                    url="https://cnews.fr/mentions-legales",
+                    type_page=TypePage.MENTIONS_LEGALES,
+                    contenu="mentions",
+                    hash="h2",
+                    http_status=200,
+                    mode_acces=ModeAcces.LIBRE,
+                ),
+            ]
+        )
+        await db_session.commit()
+
+        snaps = await charger_snapshots(db_session, run_test.run_id, "cnews.fr")
+        assert len(snaps) == 2
+        assert all(domaine == "cnews.fr" for domaine, _ in snaps)
+        # Tri par url : la home (« / ») précède « /mentions-legales ».
+        assert snaps[0][1].url == "https://cnews.fr/"
+
+        vide = await charger_snapshots(db_session, "run-inexistant", None)
+        assert vide == []

--- a/packages/api/tests/scripts/media_eval/test_ingest_artifacts.py
+++ b/packages/api/tests/scripts/media_eval/test_ingest_artifacts.py
@@ -15,9 +15,9 @@ from sqlalchemy import func, select
 
 from app.models.media_eval import (
     MediaEvalDebunkage,
-    MediaEvalMedia,
     MediaEvalSignal,
-    TypeMedia,
+    StatutSignal,
+    VoieCollecte,
 )
 from scripts.media_eval.ingest_artifacts import (
     IngestError,
@@ -25,20 +25,11 @@ from scripts.media_eval.ingest_artifacts import (
     ingester,
     inserer_debunkages,
     inserer_signaux,
+    rapport_couverture,
 )
 from scripts.media_eval.schemas import DebunkageBatchArtifact, SignalBatchArtifact
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "media_eval"
-
-
-@pytest.fixture
-async def media_cnews(db_session) -> MediaEvalMedia:
-    media = MediaEvalMedia(
-        nom="CNEWS", domaine="cnews.fr", type_media=TypeMedia.AUDIOVISUEL
-    )
-    db_session.add(media)
-    await db_session.commit()
-    return media
 
 
 def _signaux_batch() -> SignalBatchArtifact:
@@ -134,6 +125,87 @@ class TestInsererDebunkages:
         await db_session.commit()
         assert second.inseres == 0 and second.doublons == 2
         assert await _count(db_session, MediaEvalDebunkage) == 2
+
+
+class TestVoieEtHorodatage:
+    async def test_voie_agent_par_defaut(self, db_session, media_cnews):
+        await inserer_signaux(db_session, _signaux_batch())
+        await db_session.commit()
+        signal = (
+            (await db_session.execute(select(MediaEvalSignal).limit(1)))
+            .scalars()
+            .first()
+        )
+        assert signal.voie == VoieCollecte.AGENT
+
+    async def test_collecte_at_egale_genere_at(self, db_session, media_cnews):
+        batch = _signaux_batch()
+        await inserer_signaux(db_session, batch)
+        await db_session.commit()
+        signal = (
+            (await db_session.execute(select(MediaEvalSignal).limit(1)))
+            .scalars()
+            .first()
+        )
+        # collecte_at = moment réel de collecte (≠ ingere_at = écriture DB).
+        assert signal.collecte_at == batch.genere_at
+        assert signal.version_prompt_collecteur == batch.version_prompt
+
+    async def test_voie_humain_par_prefixe(self, db_session, media_cnews):
+        """D6 : agent ``humain:…`` → VoieCollecte.HUMAIN (ouvre la voie C)."""
+        batch = _signaux_batch()
+        batch.agent = "humain:laurin"
+        await inserer_signaux(db_session, batch)
+        await db_session.commit()
+        signal = (
+            (await db_session.execute(select(MediaEvalSignal).limit(1)))
+            .scalars()
+            .first()
+        )
+        assert signal.voie == VoieCollecte.HUMAIN
+        assert signal.collecteur == "humain:laurin"
+
+
+class TestCouverture:
+    async def test_types_manquants_signales(self, db_session, media_cnews):
+        # Un seul type gouvernance présent → les autres sont « manquants ».
+        db_session.add(
+            MediaEvalSignal(
+                media_id=media_cnews.id,
+                critere="C8",
+                type_signal="charte_deontologique",
+                statut=StatutSignal.PRESENT,
+                valeur={"url": "https://cnews.fr/charte"},
+                voie=VoieCollecte.CODE,
+                collecteur="code:collect_pages_types@v1",
+                source_urls=["https://cnews.fr/charte"],
+                run_id="run-test",
+                dedupe_key="k-charte",
+            )
+        )
+        await db_session.commit()
+        batch = SignalBatchArtifact.model_validate(
+            {
+                "run_id": "run-test",
+                "agent": "agent:media-eval-collecteur-gouvernance@v1",
+                "genere_at": "2026-07-13T08:00:00",
+                "items": [
+                    {
+                        "media_domaine": "cnews.fr",
+                        "critere": "C8",
+                        "type_signal": "charte_deontologique",
+                        "statut": "present",
+                        "source_urls": ["https://cnews.fr/charte"],
+                    }
+                ],
+            }
+        )
+        manquants = await rapport_couverture(db_session, [batch])
+        # Le type présent n'est pas listé…
+        assert not any("charte_deontologique" in m for m in manquants)
+        # …mais les silences le sont (C9 société des journalistes, C7 politique).
+        assert any("C9/societe_journalistes" in m for m in manquants)
+        assert any("C7/politique_publicitaire" in m for m in manquants)
 
 
 class TestDryRun:

--- a/packages/api/tests/scripts/media_eval/test_ingest_evaluations.py
+++ b/packages/api/tests/scripts/media_eval/test_ingest_evaluations.py
@@ -17,7 +17,6 @@ from app.models.media_eval import (
     MediaEvalMedia,
     MediaEvalSignal,
     StatutSignal,
-    TypeMedia,
     VoieCollecte,
 )
 from scripts.media_eval.ingest_artifacts import IngestError
@@ -30,27 +29,7 @@ from scripts.media_eval.schemas import (
     EvaluationOutput,
 )
 
-RUN_ID = "run-test"
-
-
-@pytest.fixture
-async def media_cnews(db_session) -> MediaEvalMedia:
-    media = MediaEvalMedia(
-        nom="CNEWS", domaine="cnews.fr", type_media=TypeMedia.AUDIOVISUEL
-    )
-    db_session.add(media)
-    await db_session.commit()
-    return media
-
-
-@pytest.fixture
-async def media_reporterre(db_session) -> MediaEvalMedia:
-    media = MediaEvalMedia(
-        nom="Reporterre", domaine="reporterre.net", type_media=TypeMedia.PRESSE_EN_LIGNE
-    )
-    db_session.add(media)
-    await db_session.commit()
-    return media
+RUN_ID = "run-test"  # doit matcher conftest.RUN_ID (fixture run_test)
 
 
 async def make_signal(

--- a/packages/api/tests/scripts/media_eval/test_rapport_pilote.py
+++ b/packages/api/tests/scripts/media_eval/test_rapport_pilote.py
@@ -1,0 +1,420 @@
+"""Tests des rendus purs + preuve D4 du rapport pilote (rapport_pilote.py)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from scripts.media_eval.rapport_pilote import (
+    NOTE_ABSENT,
+    NOTE_BLOQUE,
+    NOTE_NA,
+    NOTE_PARTIEL,
+    NOTE_RICHE,
+    _accord_par_media,
+    _verifier_d4,
+    construire_metrics,
+    evaluer_proprete_donnees,
+    render_html,
+    tableau_signaux,
+    verdict_v0,
+)
+from scripts.media_eval.synthese_fiche import compute_fiche
+
+
+def _signal(media, critere, statut, voie="code", *, sources=None, consultees=None):
+    return {
+        "media": media,
+        "critere": critere,
+        "type_signal": "mentions_legales",
+        "statut": statut,
+        "voie": voie,
+        "citation": "extrait" if statut == "present" else None,
+        "source_urls": sources or [],
+        "sources_consultees": consultees or [],
+    }
+
+
+class TestRendusPurs:
+    def test_tableau_signaux_comptage(self):
+        signaux = [
+            {
+                "media": "cnews.fr",
+                "critere": "C5",
+                "type_signal": "mentions_legales",
+                "statut": "present",
+                "voie": "code",
+            },
+            {
+                "media": "cnews.fr",
+                "critere": "C5",
+                "type_signal": "structure_actionnariat",
+                "statut": "present",
+                "voie": "code",
+            },
+            {
+                "media": "cnews.fr",
+                "critere": "C1",
+                "type_signal": "sanction_arcom",
+                "statut": "present",
+                "voie": "code",
+            },
+        ]
+        rendu = tableau_signaux(signaux)
+        assert "cnews.fr" in rendu
+        assert "| 2 " in rendu  # 2 signaux C5 code present
+
+    def test_tableau_signaux_vide(self):
+        assert tableau_signaux([]) == "(aucun signal)"
+
+    def test_accord_par_media_parse(self):
+        report = {"par_media": {"cnews.fr": "5/6", "reporterre.net": "3/4"}}
+        assert _accord_par_media(report) == {"cnews.fr": 5, "reporterre.net": 3}
+
+
+class TestVerdictV0:
+    def _metrics(self, **kw):
+        base = {
+            "n_evaluations": 12,
+            "evaluations_valides": True,
+            "accord_par_media": {"cnews.fr": 5, "reporterre.net": 4},
+            "reporterre": {"c1_statut": "non_applicable", "max_applicable": 34.0},
+            "zero_ecriture_agent": True,
+        }
+        base.update(kw)
+        return base
+
+    def test_tous_pass(self):
+        crit = verdict_v0(self._metrics())
+        assert all(c["pass"] for c in crit)
+
+    def test_accord_insuffisant_fail(self):
+        crit = verdict_v0(
+            self._metrics(accord_par_media={"cnews.fr": 3, "reporterre.net": 4})
+        )
+        accord = next(c for c in crit if c["critere"].startswith("2."))
+        assert accord["pass"] is False
+
+    def test_reporterre_max_incorrect_fail(self):
+        crit = verdict_v0(
+            self._metrics(
+                reporterre={"c1_statut": "non_applicable", "max_applicable": 54.0}
+            )
+        )
+        rep = next(c for c in crit if c["critere"].startswith("3."))
+        assert rep["pass"] is False
+
+
+class TestConstruireMetrics:
+    def test_reporterre_c1_na_et_max(self):
+        evals = [
+            {
+                "media_domaine": "reporterre.net",
+                "critere": "C1",
+                "statut": "non_applicable",
+                "evaluateur": "agent:x",
+            },
+            {
+                "media_domaine": "reporterre.net",
+                "critere": "C9",
+                "statut": "evaluee",
+                "evaluateur": "agent:x",
+            },
+        ]
+        fiches = {"reporterre.net": {"score_max_applicable": 34.0}}
+        report = {"par_media": {"reporterre.net": "5/6"}}
+        metrics = construire_metrics(evals, report, fiches)
+        assert metrics["reporterre"]["c1_statut"] == "non_applicable"
+        assert metrics["reporterre"]["max_applicable"] == 34.0
+
+
+class TestD4:
+    def test_gold_avant_ok(self):
+        note = datetime(2026, 7, 10, 9, 0, tzinfo=UTC)
+        evalue = datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
+        assert _verifier_d4(note, evalue)["ok"] is True
+
+    def test_gold_apres_warning(self):
+        note = datetime(2026, 7, 10, 13, 0, tzinfo=UTC)
+        evalue = datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
+        d4 = _verifier_d4(note, evalue)
+        assert d4["ok"] is False
+        assert "WARNING" in d4["message"]
+
+    def test_gold_note_at_absent(self):
+        assert _verifier_d4(None, datetime(2026, 7, 10, tzinfo=UTC))["ok"] is False
+
+
+class TestPropreteDonnees:
+    def _note(self, proprete, media, critere):
+        cell = next(
+            c
+            for c in proprete["cellules"]
+            if c["media"] == media and c["critere"] == critere
+        )
+        return cell
+
+    def test_riche_corrobore_deux_domaines(self):
+        signaux = [
+            _signal(
+                "cnews.fr",
+                "C5",
+                "present",
+                sources=["https://cnews.fr/mentions", "https://pappers.fr/x"],
+            )
+        ]
+        prop = evaluer_proprete_donnees(signaux, [], {})
+        cell = self._note(prop, "cnews.fr", "C5")
+        assert cell["note"] == NOTE_RICHE
+        assert cell["corrobore"] is True
+        assert cell["n_sources"] == 2
+
+    def test_present_une_seule_source_est_partiel(self):
+        # Deux URLs mais un seul domaine → non corroboré → partiel.
+        signaux = [
+            _signal(
+                "cnews.fr",
+                "C7",
+                "present",
+                sources=["https://cnews.fr/a", "https://www.cnews.fr/b"],
+            )
+        ]
+        prop = evaluer_proprete_donnees(signaux, [], {})
+        cell = self._note(prop, "cnews.fr", "C7")
+        assert cell["note"] == NOTE_PARTIEL
+        assert cell["corrobore"] is False
+        assert cell["n_sources"] == 1
+
+    def test_bloque_est_un_trou_absent_est_propre(self):
+        signaux = [
+            _signal("cnews.fr", "C1", "bloque_acces"),
+            _signal(
+                "reporterre.net",
+                "C8",
+                "absent_verifie",
+                voie="agent",
+                consultees=["https://reporterre.net/charte", "https://cdjm.org"],
+            ),
+        ]
+        prop = evaluer_proprete_donnees(signaux, [], {})
+        assert self._note(prop, "cnews.fr", "C1")["note"] == NOTE_BLOQUE
+        assert self._note(prop, "reporterre.net", "C8")["note"] == NOTE_ABSENT
+        # La distinction se lit dans le rollup : bloque compté comme trou.
+        assert prop["par_media"]["cnews.fr"]["n_bloque"] == 1
+        assert prop["par_media"]["reporterre.net"]["n_bloque"] == 0
+
+    def test_eval_non_applicable_prime_sur_signaux(self):
+        signaux = [_signal("reporterre.net", "C1", "bloque_acces")]
+        evals = [
+            {
+                "media_domaine": "reporterre.net",
+                "critere": "C1",
+                "statut": "non_applicable",
+            }
+        ]
+        prop = evaluer_proprete_donnees(signaux, evals, {})
+        assert self._note(prop, "reporterre.net", "C1")["note"] == NOTE_NA
+
+    def test_cellule_sans_signal_ni_eval_ignoree(self):
+        prop = evaluer_proprete_donnees(
+            [_signal("cnews.fr", "C5", "present", sources=["https://cnews.fr/x"])],
+            [],
+            {},
+        )
+        criteres = {c["critere"] for c in prop["cellules"]}
+        assert criteres == {"C5"}  # les autres critères ne sont pas inventés
+
+    def test_rollup_global_agrege(self):
+        signaux = [
+            _signal(
+                "cnews.fr",
+                "C5",
+                "present",
+                sources=["https://cnews.fr/x", "https://pappers.fr/y"],
+            ),
+            _signal("cnews.fr", "C1", "bloque_acces"),
+        ]
+        prop = evaluer_proprete_donnees(signaux, [], {})
+        assert prop["global"]["n_signaux"] == 2
+        assert prop["global"]["n_corrobore"] == 1
+        assert prop["global"]["pct_corrobore"] == 1.0  # 1 corroboré / 1 avec donnée
+
+
+def _rapport_data_synthetique():
+    """Construit un RapportData réaliste (2 médias, N/A, bloque, désaccord)."""
+    signaux = [
+        _signal(
+            "cnews.fr",
+            "C5",
+            "present",
+            sources=["https://cnews.fr/mentions", "https://pappers.fr/x"],
+        ),
+        _signal(
+            "cnews.fr", "C7", "present", voie="agent", sources=["https://cnews.fr/pub"]
+        ),
+        _signal("cnews.fr", "C1", "bloque_acces"),
+        _signal(
+            "reporterre.net",
+            "C8",
+            "absent_verifie",
+            voie="agent",
+            consultees=["https://reporterre.net/charte"],
+        ),
+    ]
+    evals = [
+        {
+            "media_domaine": "cnews.fr",
+            "critere": "C5",
+            "statut": "evaluee",
+            "score": 10.0,
+            "niveau": None,
+            "flags": [],
+            "evaluateur": "agent:x",
+        },
+        {
+            "media_domaine": "cnews.fr",
+            "critere": "C7",
+            "statut": "evaluee",
+            "score": 2.0,
+            "niveau": None,
+            "flags": [],
+            "evaluateur": "agent:x",
+        },
+        {
+            "media_domaine": "reporterre.net",
+            "critere": "C1",
+            "statut": "non_applicable",
+            "score": None,
+            "niveau": None,
+            "flags": ["donnees_insuffisantes"],
+            "evaluateur": "agent:x",
+        },
+        {
+            "media_domaine": "reporterre.net",
+            "critere": "C8",
+            "statut": "evaluee",
+            "score": 4.0,
+            "niveau": None,
+            "flags": [],
+            "evaluateur": "agent:x",
+        },
+    ]
+    fiches = {}
+    par_media = {}
+    for e in evals:
+        par_media.setdefault(e["media_domaine"], []).append(e)
+    for media, evs in par_media.items():
+        fiches[media] = compute_fiche(evs)
+    accord = {
+        "n": 4,
+        "accord_global": 0.75,
+        "par_media": {"cnews.fr": "2/2", "reporterre.net": "1/2"},
+        "na_vs_score": 1,
+        "mae_scores": 1.5,
+        "desaccords": [
+            {
+                "media": "reporterre.net",
+                "critere": "C8",
+                "gold_statut": "evaluee",
+                "gen_statut": "non_applicable",
+                "gold_score": 4.0,
+                "gen_score": None,
+                "gold_niveau": None,
+                "gen_niveau": None,
+                "type_desaccord": "na_vs_score",
+                "delta": None,
+                "accord": False,
+            },
+        ],
+    }
+    return {
+        "run": {
+            "run_id": "pilote-2026-07",
+            "version_methodo": "v1.2",
+            "date_reference": "2026-07-08",
+            "perimetre": {"medias": ["cnews.fr", "reporterre.net"]},
+        },
+        "rubrics_sha": dict.fromkeys(("C1", "C5", "C7", "C8", "C9", "C11"), "0" * 64),
+        "d4": {"ok": True, "message": "OK — gold noté avant les évaluations."},
+        "signaux": signaux,
+        "evaluations": evals,
+        "garde_fous": {"bloque_acces": "oui (signaux bloqués présents)"},
+        "accord_report": accord,
+        "fiches": fiches,
+        "verdict": [
+            {"critere": "1. Artefacts valides", "pass": True, "preuve": "4 évals"},
+            {"critere": "2. Accord ≥ 4/6", "pass": False, "preuve": "reporterre: 1/6"},
+            {"critere": "3. Reporterre C1 = N/A", "pass": True, "preuve": "C1 N/A"},
+            {"critere": "4. Zéro écriture agent", "pass": True, "preuve": "ok"},
+        ],
+    }
+
+
+class TestRenderHtml:
+    def _html(self):
+        data = _rapport_data_synthetique()
+        prop = evaluer_proprete_donnees(
+            data["signaux"], data["evaluations"], data["fiches"]
+        )
+        return render_html(data, prop)
+
+    def test_document_autonome_valide(self):
+        page = self._html()
+        assert page.startswith("<!DOCTYPE html>")
+        assert page.rstrip().endswith("</html>")
+        assert "<style>" in page  # CSS inline, single-file
+        assert page.count("<html") == 1
+
+    def test_lentille_proprete_ouvre_le_rapport(self):
+        page = self._html()
+        i_prop = page.index('id="proprete"')
+        i_accord = page.index('id="accord"')
+        assert i_prop < i_accord  # propreté avant l'accord (ordre confirmé)
+        assert "trou d'accès" in page
+        assert "Absence confirmée" in page
+
+    def test_marqueurs_cles_presents(self):
+        page = self._html()
+        # Verdict global (ici FAIL car accord insuffisant).
+        assert "V0 non validé" in page
+        # Badges de voie.
+        assert "b-code" in page and "b-agent" in page
+        # Preuve D4.
+        assert "Preuve D4" in page
+        assert "gold noté avant les évaluations" in page
+        # Notes de complétude + accord.
+        assert "Riche" in page and "Bloqué" in page
+        assert "Accord global" in page
+
+    def test_desaccord_na_vs_score_surligne(self):
+        page = self._html()
+        assert "na_vs_score" in page
+        assert "row-warn" in page  # ligne surlignée
+
+    def test_voie_humain_rend_classe_css_valide(self):
+        # voie 'humain' (fr) → classe design system 'd-human'/'b-human' (en).
+        data = _rapport_data_synthetique()
+        data["signaux"].append(
+            _signal(
+                "cnews.fr",
+                "C9",
+                "present",
+                voie="humain",
+                sources=["https://cnews.fr/x", "https://sdj.fr/y"],
+            )
+        )
+        prop = evaluer_proprete_donnees(
+            data["signaux"], data["evaluations"], data["fiches"]
+        )
+        page = render_html(data, prop)
+        assert "d-human" in page and "b-human" in page
+        assert "d-humain" not in page  # pas de classe inexistante
+
+    def test_verdict_valide_si_tous_pass(self):
+        data = _rapport_data_synthetique()
+        for c in data["verdict"]:
+            c["pass"] = True
+        prop = evaluer_proprete_donnees(
+            data["signaux"], data["evaluations"], data["fiches"]
+        )
+        page = render_html(data, prop)
+        assert "V0 VALIDÉ" in page

--- a/scripts/healthcheck-agent-secrets.sh
+++ b/scripts/healthcheck-agent-secrets.sh
@@ -195,6 +195,31 @@ else
   fi
 fi
 
+# ─── Pappers (media-eval, optionnel) ────────────────────────────────────────
+hdr "Pappers — registre entreprises (PAPPERS_API_TOKEN, media-eval)"
+if [[ -z "${PAPPERS_API_TOKEN:-}" ]]; then
+  echo "  [SKIP] PAPPERS_API_TOKEN absent — repli API gratuite recherche-entreprises.api.gouv.fr (non bloquant)"
+  skip=$((skip+1))
+elif [[ $FAST -eq 1 ]]; then
+  echo "  [OK]   PAPPERS_API_TOKEN présent (requête test sautée en --fast)"
+  pass=$((pass+1))
+else
+  # 1 lookup peu coûteux (SESI, éditeur de cnews.fr) pour distinguer
+  # token valide (200) de token épuisé (401). Épuisé n'est PAS un FAIL :
+  # collect_pappers bascule sur l'API publique gratuite.
+  code=$(curl -sS -o /dev/null -w "%{http_code}" \
+    "https://api.pappers.fr/v2/entreprise?api_token=$PAPPERS_API_TOKEN&siren=412916215" 2>/dev/null)
+  if [[ "$code" == "200" ]]; then
+    ok "Pappers API 200 (token valide)"
+  elif [[ "$code" == "401" ]]; then
+    echo "  [SKIP] Pappers 401 (token épuisé) → repli API gratuite (non bloquant)"
+    skip=$((skip+1))
+  else
+    echo "  [SKIP] Pappers HTTP $code → repli API gratuite (non bloquant)"
+    skip=$((skip+1))
+  fi
+fi
+
 # ─── GitHub (session courante) ──────────────────────────────────────────────
 hdr "GitHub"
 if [[ -n "${GITHUB_ACTIONS:-}" ]]; then


### PR DESCRIPTION
# feat(media-eval): collecte vague 1 + orchestration + rapport (PR 2)

Complète la pipeline media-eval de bout en bout par-dessus les fondations
PR 1 (#944) : **6 collecteurs voie A** (code → DB), **3 sous-agents** (2
collecteurs web voie B + 1 évaluateur sans web), **1 commande d'orchestration**
(`/media-eval-run`), et l'outillage de **run pilote** (golden gate, export,
rapport avec verdict V0). Le run pilote `pilote-2026-07` lui-même est en
hand-off (accès réseau réel + `PAPPERS_API_TOKEN` + notation humaine en aveugle
+ `--allow-prod`).

## Bug latent PR 1 réparé
La FK `media_eval_signaux.run_id → media_eval_runs.run_id` n'était jamais
satisfaite (aucun run créé) ; les tests PR 1 passaient sur un conteneur test
« sale ». Réparé par le fixture `run_test` (conftest mutualisé) + `create_run.py`.
`build_eval_input` calait aussi la fraîcheur sur `now()` au lieu de
`MediaEvalRun.date_reference` (rejouabilité cassée) — corrigé via `require_run()`.

## Contenu
- **`collect_common.py`** : fetch httpx + repli curl_cffi (ne lève jamais),
  `require_run`, `Collecteur` (dédupe applicative + validation Pydantic), dédupe
  voie A préfixée `code|` (D2), harnais CLI `run_cli`.
- **6 collecteurs** : `collect_{pages_types,cdjm,jti,cppap,pappers,arcom}.py`
  (fonctions `parse_*` pures + `collecter` async, fixtures figées, zéro réseau
  en test). ARCOM auto-désactivé hors audiovisuel ; Pappers dégrade en 3
  `bloque_acces` si token absent (exit 0).
- **`create_run.py`** (D1), patchs moteur : `ingest_artifacts` (D6 voie
  `humain:`, `collecte_at`, `version_prompt_collecteur`),
  `evaluate_golden_agreement --out-dir`, `build_eval_input` (date_reference),
  `.gitignore` (`.context/`).
- **`export_evaluations.py`** + **`rapport_pilote.py`** (D7) : unique collecte DB
  (`collecter_donnees_rapport`) → **deux rendus** — `.md` ASCII git-diffable +
  **`.html` propre autonome** (lentille propreté data `evaluer_proprete_donnees`
  : trou d'accès vs absence confirmée ; `render_html` single-file CSS inline
  calqué sur le design system media-eval ; verdict V0).
- **`.claude/agents/media-eval-{collecteur-debunkages,evaluateur}.md`** +
  agents gouvernance (voir PR 2b) + **`.claude/commands/media-eval-run.md`** +
  `golden/gold_v0.template.json`.

## PR 2b — corrections collecte (diagnostic du run pilote initial)

Le run pilote cnews.fr a révélé des **faux positifs voie A** et une substance
capturée mais jamais exposée. Corrections incluses dans cette PR :

- **Anti soft-404 + filtre lexical** (`collect_pages_types.py`) : `present`
  seulement si le texte ≠ home (hash/similarité) **et** porte les marqueurs
  lexicaux du type ; pénalité anti-flux (dons/régie servis en fils d'articles).
  ⇒ les faux `present` C8/charte, C11/ligne-éditoriale, C7/régie,
  C5/transparence deviennent `absent_verifie` (test de non-régression cnews).
- **Substance exposée** (`build_eval_input.py`) : `serialiser_signal` joint
  `snapshot_extrait` (~4 000 c) + `snapshot_url` quand le signal a un `snapshot_id`.
- **`export_snapshots.py`** (nouveau) : dump des snapshots vers
  `.context/media_eval/<run_id>/snapshots/*.txt`, lus par la voie B (anti-403).
- **Pappers** : SIREN cnews.fr corrigé (SESI SNC **412 916 215**, éditeur du
  site) + **repli gratuit** `recherche-entreprises.api.gouv.fr` sans token
  (identification `present`, actionnariat `partiel`) au lieu de 3 `bloque_acces` ;
  pré-vol token dans le healthcheck + `/media-eval-run` §0.
- **CPPAP** : dataset réel confirmé (`liste-des-publications-de-presse`, Explore
  v2.1, champs `titre`/`ndeg_cppap`) + repli voie C documenté.
- **Couverture** (`ingest_artifacts.py`) : WARNING listant les `type_signal`
  gouvernance sans signal (anti-passivité).
- **Agents gouvernance découpés en 2** (`gouvernance-transparence` C5+C7,
  `gouvernance-independance` C8+C9+C11) : lisent les snapshots exportés, couvrent
  tout leur registre ; politique de mort d'agent + support antenne/site portés
  dans la commande et les prompts.

> **Non inclus** (attend le re-run corrigé `pilote-2026-07b` + GOLD GATE) :
> `docs/media-eval/fiches/cnews_fr_pilote-2026-07.md` (fiche du run buggé, à
> régénérer) et les artefacts `.context/` du run.

## Décisions de design D1–D7
D1 création de run explicite (refus mutation `date_reference`) · D2 dédupe voie
A préfixée `code|` (coexiste avec la voie B) · D3 évaluateur Read-only (réponse
= JSON) · D4 GOLD GATE anti-contamination + preuve horodatage · D5 CPPAP open
data (jamais le form POST) · D6 voie dérivée du préfixe `humain:` · D7 rapport
généré par script (chiffres auditables).

## Tests
- **191 tests** `tests/scripts/media_eval` verts sur DB propre (dont
  non-régression cnews soft-404/flux, repli Pappers gratuit, snapshot_extrait,
  couverture voie B), ruff clean (check + format).
- Smoke offline validé (create_run → seed → ingest → build_eval_input →
  ingest_evaluations → synthese → export → rapport).
- Pas de nouvelle migration (dédupe snapshots applicative) — `alembic heads` = 1.

Pas d'entrée changelog (outillage interne).
