### PR TITLE
feat(essentiel): « Rattraper » en signal contextuel (nudge éphémère + point rouge J-1)

### DIFF
--- a/.context/qa-handoff.md
+++ b/.context/qa-handoff.md
@@ -1,127 +1,79 @@
-# QA Handoff — Lettres passées à parité visuelle avec « Aujourd'hui »
+# QA Handoff — « Rattraper » : nudge éphémère + point rouge « pas à jour »
 
-> Input pour /validate-feature (Playwright Agent CLI, skill facteur-qa-web).
-> Viewport mobile 390×844, sémantique activée au boot (canvas Flutter web).
-> ⚠️ **Valider par HOT RESTART** (pas hot reload) : `editionEssentielProvider`
-> garde `state` + `_dayCache` à travers un reload. Sinon pull-to-refresh /
-> changement de sélection.
+> Rempli par l'agent dev. Input de /validate-feature. Story : `docs/stories/core/9.7.essentiel-rattraper-signal.md`.
+> (Handoff précédent « Lettres passées à parité visuelle » archivé dans
+> `.context/qa-handoff-lettres-parite.md`.)
 
-## Résumé
-Les lettres passées (« Hier » = jour passé, « Cette semaine » = rétro hebdo) de
-l'écran Essentiel (`FluxContinuScreen`) rendaient une lettre tronquée vs
-« Aujourd'hui ». Elles adoptent maintenant la **même grammaire visuelle** en
-lecture seule. Mobile-only, aucun changement backend.
+## Feature développée
 
-Nouvelle composition d'une lettre passée (`_singleDaySlivers`) :
-`héros → · → Actus → · → Bonnes Nouvelles → citation → carte de clôture`, où `·`
-est un point de passage (`_SectionPassageDot`, statique en passé).
+L'en-tête de la carte « Ton Essentiel » n'affiche plus « Rattraper » en
+permanence. En today à jour → icône ⏪ seule. Si l'édition d'hier (J-1) n'a pas
+été ouverte → point rouge persistant sur ⏪ + le texte « Rattraper ? » qui
+apparaît en fondu (~1 s), tient 2 s, disparaît en fondu, au plus 1×/jour. Sur
+une lettre passée → « Revenir » fixe (inchangé).
 
-Changements clés :
-1. **Bonnes Nouvelles réaffichées** (jour ET semaine) : la donnée serein
-   (`dual.serein.topics`) était déjà fetchée mais jetée ; ré-exposée via
-   `EditionEssentielState.bonnesTopics`.
-2. **Bannières de section à parité** : « Actus » et « Bonnes Nouvelles » portent
-   blurb + illustration comme la lettre du jour.
-3. **Carte de clôture** : `ClosingCardV18.readOnly` (coque météo « FIN DE TOURNÉE »
-   / « Tu es à jour » identique) remplace l'ancien bloc minimal. Action primaire =
-   **« Revenir à aujourd'hui »** + note de contexte. Plus de « Continuer à Flâner »
-   ni « Refermer » sur une lettre passée.
-4. **Points de passage** entre sections (rythme visuel du jour), calmes/statiques
-   en passé (pas de snap — choix délibéré, free-scroll).
-5. **Lecture seule** : aucun swipe/feedback/favori/see-all (chaque `SectionBlock`
-   ne reçoit que `onTapArticle`).
+## PR associée
 
-Limite assumée (Option A validée PO) : les sections **tournée personnalisées**
-(thèmes / sources / veille) ne sont **pas** rendues en passé — flux live non
-archivé par date, hors de portée d'un fix mobile.
+_(à compléter à l'ouverture de la PR)_
 
 ## Écrans impactés
-- `FluxContinuScreen` → `_buildPastEdition` / `_singleDaySlivers` (lettre passée).
-- `ClosingCardV18` (nouvelle variante `.readOnly`).
-- Provider `editionEssentielProvider` (champ `bonnesTopics`).
+
+| Écran | Route | Modifié / Nouveau |
+|-------|-------|-------------------|
+| Flux Continu — carte « Ton Essentiel » (en-tête, déclencheur rewind) | onglet Essentiel | Modifié |
 
 ## Scénarios de test
 
-### Happy path — comparer côte à côte
-1. Ouvrir Essentiel → header carte « Ton Essentiel » → rewind (timeline).
-2. Sélectionner **« Hier »** : vérifier la présence, dans l'ordre, de
-   héros Essentiel → point de passage → section **« Actus du jour »** (bannière
-   avec blurb + illustration) → point de passage → section **« Bonnes Nouvelles »**
-   (bannière verte) → **citation** → carte de clôture **« FIN DE TOURNÉE » /
-   « Tu es à jour »** avec bouton **« Revenir à aujourd'hui »** + note
-   « Tu lis la lettre du … ».
-3. Sélectionner **« Cette semaine »** : même grammaire ; label **« Actus de la
-   semaine »** ; **Bonnes Nouvelles** présentes (agrégées) ; **pas de citation** ;
-   même carte de clôture (note « rétro de la semaine »).
-4. Repasser à **« Aujourd'hui »** : la page complète (avec sections tournée)
-   revient normalement.
-5. Comparaison visuelle « Aujourd'hui » vs « Hier » vs « Cette semaine » :
-   cartes de section, espacements, points de passage, carte de clôture cohérents.
+> ⚠️ L'état « en retard » dépend des streaks (J-1 `opened == false`), difficile
+> à forcer sur le build web sans backend/streaks peuplés. **La preuve principale
+> = les widget tests** (`essentiel_hi_fi_card_test.dart`,
+> `ephemeral_rattraper_label_test.dart`, `edition_read_status_provider_test.dart`).
+> Playwright couvre surtout le rendu « à jour » et le tap ⏪ → timeline.
 
-### Lecture seule (invariant critique)
-6. Sur « Hier » / « Cette semaine », tenter un **swipe** sur une carte → **aucune
-   action** (pas de feedback chips, pas de dismiss). Pas d'étoile favori active,
-   pas de « voir tout ».
-7. Tap sur un article → ouvre le reader normalement (seule interaction permise).
-8. Bouton **« Revenir à aujourd'hui »** de la carte de clôture → resélectionne
-   « Aujourd'hui ».
+### Scénario 1 : à jour (happy path) — header épuré
+**Parcours** :
+1. Ouvrir l'app, onglet Essentiel (today), utilisateur à jour.
+2. Observer l'en-tête à droite du titre « Ton Essentiel ».
+**Résultat attendu** : icône ⏪ **seule**, aucun texte « Rattraper », aucun point
+rouge. Tap sur ⏪ → la timeline « Remonter le temps » s'ouvre.
 
-### Edge cases
-9. **Jour stale / vide** (édition absente) : rendu = état vide `_BackToTodayBlock`
-   (« Pas d'édition pour … » + « Revenir à aujourd'hui » + « Choisir un autre
-   jour »). Pas de demi-lettre.
-10. **Mode serein activé** puis rewind sur un jour passé : Bonnes Nouvelles
-    toujours cohérentes (bonnesTopics dérivent toujours du digest serein,
-    indépendamment du toggle).
-11. Jour passé **sans Bonnes Nouvelles** (serein vide) : la section Bonnes est
-    simplement absente, pas de bannière vide ni de point de passage orphelin.
+### Scénario 2 : en retard — point rouge + nudge éphémère
+**Parcours** :
+1. Utilisateur ayant manqué l'édition d'hier (J-1 non ouverte).
+2. Ouvrir l'onglet Essentiel (today).
+**Résultat attendu** : **point rouge** vif sur ⏪ (persistant) ; **~1 s** après,
+« Rattraper ? » apparaît en fondu, **tient 2 s**, disparaît en fondu. Ne se
+rejoue **pas** dans la journée (gate 1×/jour). Le point rouge, lui, reste.
 
-## Critères d'acceptation
-- [ ] « Hier » et « Cette semaine » lues comme « la même lettre, un autre jour ».
-- [ ] Bonnes Nouvelles visibles jour + semaine.
-- [ ] Carte de clôture présente (variante lecture seule, « Revenir à aujourd'hui »).
-- [ ] Aucune mutation possible (swipe/feedback/favori) en passé.
-- [ ] Aucune erreur console, aucun 4xx/5xx inattendu.
+### Scénario 3 : lettre passée — « Revenir » fixe
+**Parcours** :
+1. Ouvrir la timeline, sélectionner « Hier ».
+**Résultat attendu** : l'en-tête montre « Revenir » **fixe** (sans point rouge,
+sans animation).
 
-## Vérifs déjà faites (dev)
-- `flutter analyze lib test` : 0 erreur/warning sur les fichiers touchés.
-- `flutter test test/features/flux_continu/` : **360 tests verts**, dont :
-  - provider `bonnesTopics` jour (serein / vide / stale) + semaine (agrégation),
-  - widget `ClosingCardV18.readOnly` (coque préservée, CTA, note, tap).
-- Non couvert par les tests unitaires : la **composition d'écran** (c'est l'objet
-  de cette validation Playwright/device).
-# QA Handoff — Paywalls Premium « Fact·eur·isse » (PR 2 mobile)
-
-## Contexte
-
-Implémentation de la maquette « Paywalls Premium » : écran **Soutien** (porte 1, lettre des fondateurs), **murs de feature** (porte 2 : veille plein écran + sheets sources/analyses/serein), gating client-side (cap 30 sources, veille premium, quota 1 analyse/jour, personnalisation serein), confirmation « lien envoyé ». Le CTA n'ouvre jamais un paiement : il déclenche `POST /api/checkout/send-link` (magic link Supabase par email, PR backend #954).
-
-⚠️ **Web = état free uniquement** : RevenueCat est null sur web (`customerInfoProvider` → null → non-premium). Ne pas tester les états premium en web.
-
-⚠️ Les photos fondateurs sont des **placeholders** (aplats de couleur) en attendant les vraies images.
-
-## Écrans impactés
-
-- Réglages (bottom sheet) : tuile « Nous soutenir », badge `N/30` sur Mes sources, stamp `PREMIUM` sur Ma veille/Crée ta veille, sous-row « Personnaliser mes bonnes nouvelles » (lock).
-- `/soutien` : écran Soutien complet.
-- `/soutien/veille-wall` : mur veille.
-- `/soutien/lien-envoye` : confirmation.
-- Intro veille : stamp « RÉSERVÉ AUX FACT·EUR·ISSES » + CTA verrouillé.
-- Ajout de source : pill « N / 30 médias suivis ».
-- Perspectives / Analyse Facteur : gate quota 1/jour (bannière quota épuisé sous le CTA en free).
-
-## Scénarios
-
-1. **Happy path Soutien** : Réglages → « Nous soutenir » → écran Soutien (eyebrow, headline, lettre 2 §, carte bonus avec 2 stamps BIENTÔT, 3 réassurances, prix 3 €/mois, CTA « Reçois ton lien pour nous rejoindre », disclaimer stores). Tap CTA → soit confirmation « Ton lien est en route. » (backend avec send-link), soit toast d'erreur propre, jamais de crash.
-2. **Mur veille** : Réglages → « Crée ta veille » (compte free sans veille) → mur veille (3 bénéfices, MissionCard « Notre histoire → » → Soutien, prix, CTA).
-3. **Intro veille gated** : deep-link `/veille/config` en free → redirection mur veille.
-4. **Cap sources** : ajout de source → pill « N / 30 médias suivis » au-dessus de la recherche (absente en mode veille).
-5. **Serein** : Réglages → sous-row « Personnaliser mes bonnes nouvelles » avec cadenas → tap → PaywallSheet variante serein (« Un mode serein à ton image »).
-6. **Lien envoyé** : « Renvoyer le lien » 2× de suite → le second affiche « Patiente une minute avant de renvoyer. » (429) si backend actif.
-7. **Console/réseau** : pas d'erreurs console inattendues, pas de 4xx/5xx hors 429 attendu.
+### Scénario 4 : reduce-motion / accessibilité
+**Parcours** :
+1. Activer « Réduire les animations » (OS), état « en retard ».
+**Résultat attendu** : le point rouge reste (signal immobile) ; le texte animé
+« Rattraper ? » **n'est pas joué**.
 
 ## Critères d'acceptation
 
-- Aucune copy avec em-dash « — ».
-- Aucun crash sur images manquantes (fallback monogramme).
-- Navigation retour cohérente (swipe back plein écran).
+- [ ] À jour → icône ⏪ seule (ni libellé fixe, ni point, ni nudge).
+- [ ] En retard → point rouge persistant + « Rattraper ? » fondu-in ~1 s / tient
+  2 s / fondu-out, au plus 1×/jour.
+- [ ] Lettre passée → « Revenir » fixe, sans point.
+- [ ] ⏪ toujours tappable (ouvre la timeline) dans tous les états ; cible ≥ 24 px.
+- [ ] Reduce-motion → pas d'animation de texte.
+- [ ] Aucun faux positif au cold-boot / nouvel utilisateur (streaks indispo).
+
+## Zones de risque
+
+- Frontière de jour 07h30 Paris vs off-by-one streaks (déjà assumé par la
+  timeline existante ; cf. `.context/streaks-health-handoff.md`).
+- Gate 1×/jour persisté au moment du fondu-in (prefs
+  `essentiel_rattraper_nudge_last_shown_v1`).
+
+## Dépendances
+
+- Aucun endpoint / migration. Réutilise `editionReadStatusProvider` (streaks).

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Essentiel",
+      "summary": "En-tête épuré : « Rattraper » ne s'affiche plus en permanence. Quand tu as manqué l'édition d'hier, un petit point rouge apparaît sur l'icône rewind et l'invite « Rattraper ? » se montre un court instant, une fois par jour."
+    },
+    {
       "tag": "Ma Tournée",
       "summary": "Tes sources et thèmes rangés dans l'Essentiel y restent : leur place est désormais sauvegardée et retrouvée sur chaque appareil, même après réinstallation."
     },

--- a/apps/mobile/lib/features/flux_continu/providers/edition_read_status_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/edition_read_status_provider.dart
@@ -116,6 +116,20 @@ class EditionReadStatus {
         return true;
     }
   }
+
+  /// L'utilisateur a-t-il **manqué l'édition d'hier** (J-1 non ouverte) ? Base du
+  /// signal contextuel « Rattraper ? » de l'en-tête Essentiel (point rouge +
+  /// nudge éphémère).
+  ///
+  /// Dégradation gracieuse : renvoie `false` dès que le statut est indisponible
+  /// ([available] == false — streaks en chargement/erreur ou gamification off) →
+  /// aucun faux positif au cold-boot ni pour un nouvel utilisateur sans
+  /// historique. Pur et testable ; `now` injectable.
+  bool missedYesterday({DateTime? now}) {
+    if (!available) return false;
+    final yesterday = editionPastDays(1, now: now).first;
+    return !isEditionRead(EditionPastDay(yesterday), now: now);
+  }
 }
 
 /// Statut lu/non-lu dérivé : union des jours `opened` de streaks et du set local

--- a/apps/mobile/lib/features/flux_continu/widgets/edition_timeline_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/edition_timeline_sheet.dart
@@ -335,22 +335,98 @@ class _ReadStatusPill extends StatelessWidget {
   }
 }
 
-/// Déclencheur « rewind » de l'en-tête de la carte Essentiel : ⏪ ocre + libellé
-/// du scope courant (sans cadre). Tap → [onTap] (ouvre [EditionTimelineSheet]).
-/// Toujours affiché (today **et** passé).
+/// Déclencheur « rewind » de l'en-tête de la carte Essentiel : ⏪ ocre. Tap →
+/// [onTap] (ouvre [EditionTimelineSheet]). Toujours affiché (today **et** passé).
+///
+/// Trois états (décision PO « header épuré à jour ») :
+/// - à jour ([label] `null`, [ephemeralLabel] `null`) ⇒ **icône seule** ;
+/// - lettre passée ([label] `'Revenir'`) ⇒ icône + libellé **fixe** ;
+/// - en retard (édition d'hier non ouverte) ⇒ un [ephemeralLabel] animé
+///   (« Rattraper ? » qui apparaît en fondu puis disparaît, cf.
+///   `EphemeralRattraperLabel`) + un **point rouge** persistant sur ⏪.
+///
+/// Le point rouge est dérivé de la présence de [ephemeralLabel] : c'est le même
+/// état « en retard » (pas un knob séparé). [ephemeralLabel] prime sur [label]
+/// (mode « en retard ») et gère lui-même son gap de gauche ; [label] porte l'état
+/// de navigation « lettre passée » (« Revenir »).
 class EditionRewindTrigger extends StatelessWidget {
-  final String label;
+  final String? label;
+  final Widget? ephemeralLabel;
   final VoidCallback onTap;
 
   const EditionRewindTrigger({
     super.key,
-    required this.label,
+    this.label,
+    this.ephemeralLabel,
     required this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
+
+    // Point rouge « pas à jour » = état « en retard », dérivé de la présence du
+    // nudge éphémère (même signal, une seule source de vérité).
+    final showBadge = ephemeralLabel != null;
+
+    // Icône ⏪ dans un slot 24×24 : garantit une cible tactile confortable même
+    // en mode « icône seule » (header épuré à jour).
+    Widget icon = SizedBox(
+      width: 24,
+      height: 24,
+      child: Center(
+        child: Icon(
+          PhosphorIcons.rewind(PhosphorIconsStyle.fill),
+          size: 15,
+          color: colors.primary,
+        ),
+      ),
+    );
+    // Point rouge « pas à jour » empilé sur l'icône (repère calme, persistant).
+    // Pattern repris de `update_button.dart` : disque `colors.error` + fin anneau
+    // `colors.surface` pour détacher le point du fond.
+    if (showBadge) {
+      icon = Stack(
+        clipBehavior: Clip.none,
+        children: [
+          icon,
+          Positioned(
+            top: 2,
+            right: 2,
+            child: Container(
+              width: 7,
+              height: 7,
+              decoration: BoxDecoration(
+                color: colors.error,
+                shape: BoxShape.circle,
+                border: Border.all(color: colors.surface, width: 1),
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+
+    // Slot droit : l'éphémère (animé) prime ; sinon le libellé fixe ; sinon rien.
+    Widget? trailing;
+    if (ephemeralLabel != null) {
+      trailing = ephemeralLabel;
+    } else if (label != null) {
+      trailing = Padding(
+        padding: const EdgeInsets.only(left: 4),
+        child: Text(
+          label!,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: GoogleFonts.dmSans(
+            fontSize: 12.5,
+            fontWeight: FontWeight.w700,
+            color: colors.primary,
+          ),
+        ),
+      );
+    }
+
     return Material(
       color: Colors.transparent,
       child: InkWell(
@@ -364,22 +440,8 @@ class EditionRewindTrigger extends StatelessWidget {
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Icon(
-                PhosphorIcons.rewind(PhosphorIconsStyle.fill),
-                size: 15,
-                color: colors.primary,
-              ),
-              const SizedBox(width: 4),
-              Text(
-                label,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: GoogleFonts.dmSans(
-                  fontSize: 12.5,
-                  fontWeight: FontWeight.w700,
-                  color: colors.primary,
-                ),
-              ),
+              icon,
+              if (trailing != null) trailing,
             ],
           ),
         ),

--- a/apps/mobile/lib/features/flux_continu/widgets/ephemeral_rattraper_label.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/ephemeral_rattraper_label.dart
@@ -1,0 +1,128 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../config/theme.dart';
+
+/// Clé SharedPreferences : dernier `dayKey` (`YYYY-MM-DD`, frontière 07h30 Paris)
+/// où le nudge éphémère « Rattraper ? » a été joué. Gate « au plus 1×/jour ».
+const String kRattraperNudgeLastShownPrefsKey =
+    'essentiel_rattraper_nudge_last_shown_v1';
+
+/// Nudge **éphémère** « Rattraper ? » posé à droite de l'icône ⏪ de l'en-tête
+/// Essentiel quand l'utilisateur a manqué l'édition d'hier.
+///
+/// Idiome auto-contenu (cf. `FabNudgeBubble`) : lit un flag prefs async puis joue
+/// l'animation via des `Timer`. Séquence, jouée **une seule fois par montage** et
+/// **au plus 1×/jour** : fondu-in (~1 s après le montage) → tient 2 s → fondu-out.
+/// Le montage lui-même est conditionné à « en retard » côté carte : ce widget
+/// n'est monté que dans ce cas (« actif » == « monté »).
+///
+/// Reduce-motion (`MediaQuery.disableAnimations`) : l'animation n'est pas jouée
+/// (le point rouge immobile, lui, porte déjà le signal). Miroir de
+/// `welcome_banner.dart`.
+class EphemeralRattraperLabel extends StatefulWidget {
+  /// Clé du jour-tournée courant (`YYYY-MM-DD`, frontière 07h30 Paris). Sert de
+  /// gate « déjà joué aujourd'hui ? » dans les prefs.
+  final String dayKey;
+
+  const EphemeralRattraperLabel({super.key, required this.dayKey});
+
+  @override
+  State<EphemeralRattraperLabel> createState() =>
+      _EphemeralRattraperLabelState();
+}
+
+class _EphemeralRattraperLabelState extends State<EphemeralRattraperLabel>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _animation;
+  Timer? _enterTimer;
+  Timer? _exitTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    // Un seul contrôleur pilote largeur (SizeTransition) ET opacité
+    // (FadeTransition) → révélation/repli synchronisés.
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 250),
+    );
+    _animation = CurvedAnimation(parent: _controller, curve: Curves.easeOut);
+    _maybePlay();
+  }
+
+  Future<void> _maybePlay() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final last = prefs.getString(kRattraperNudgeLastShownPrefsKey);
+      if (!mounted) return;
+      if (last == widget.dayKey) return; // déjà joué aujourd'hui → rien.
+    } catch (_) {
+      // Prefs indisponibles (ex. tests sans mock) → on tente quand même.
+    }
+    if (!mounted) return;
+    _enterTimer = Timer(const Duration(seconds: 1), () {
+      if (!mounted) return;
+      _controller.forward();
+      // Marqué « vu » au moment exact du fondu-in (gate 1×/jour aligné sur la
+      // visibilité réelle) ; best-effort.
+      _persistShown();
+      _exitTimer = Timer(const Duration(seconds: 2), () {
+        if (!mounted) return;
+        _controller.reverse();
+      });
+    });
+  }
+
+  Future<void> _persistShown() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(kRattraperNudgeLastShownPrefsKey, widget.dayKey);
+    } catch (_) {
+      // best-effort : l'état mémoire de la session suffit à ne pas rejouer.
+    }
+  }
+
+  @override
+  void dispose() {
+    _enterTimer?.cancel();
+    _exitTimer?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Reduce-motion : ne rien animer ni afficher (le point rouge porte le signal).
+    if (MediaQuery.of(context).disableAnimations) {
+      return const SizedBox.shrink();
+    }
+    final colors = context.facteurColors;
+    return SizeTransition(
+      axis: Axis.horizontal,
+      axisAlignment: -1,
+      sizeFactor: _animation,
+      child: FadeTransition(
+        opacity: _animation,
+        child: Padding(
+          padding: const EdgeInsets.only(left: 4),
+          child: Text(
+            // Typo FR : espace avant « ? ». Aucun em-dash.
+            'Rattraper ?',
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: GoogleFonts.dmSans(
+              fontSize: 12.5,
+              fontWeight: FontWeight.w700,
+              color: colors.primary,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -12,10 +12,13 @@ import '../../settings/models/display_mode_spec.dart';
 import '../../settings/providers/display_mode_provider.dart';
 import '../models/flux_continu_models.dart';
 import '../models/weather_snapshot.dart';
+import '../providers/edition_read_status_provider.dart';
 import '../providers/selected_edition_date_provider.dart';
 import '../providers/weather_provider.dart';
+import '../services/tournee_progress_service.dart';
 import '../utils/theme_color_mapping.dart';
 import 'edition_timeline_sheet.dart';
+import 'ephemeral_rattraper_label.dart';
 import 'long_press_grow.dart';
 import 'weather_condition_icon.dart';
 import 'weather_detail_sheet.dart';
@@ -52,14 +55,21 @@ class EssentielHiFiCard extends ConsumerWidget {
     // l'unique héros Essentiel rendu dans les deux vues (live + passée), le
     // brancher ici le fait apparaître partout.
     //
-    // Le bouton porte un libellé **fixe** (verbe d'action, pas la date) : le
-    // scope courant (« Aujd »/« Hier »…) prenait trop de place et restait peu
-    // clair. En today → « Rattraper » (invite à remonter le temps) ; sur une
-    // lettre passée → « Revenir » (retour à aujourd'hui). Le titre de la section
-    // porte, lui, la date sélectionnée (« Hier » vs « Ton Essentiel »).
+    // « Rattraper » n'est plus un libellé fixe mais un **signal contextuel**
+    // (décision PO « header épuré à jour ») :
+    // - à jour → icône ⏪ seule (toujours tappable, ouvre la timeline) ;
+    // - édition d'hier non ouverte → **point rouge** persistant sur ⏪ + le nudge
+    //   éphémère « Rattraper ? » (fondu-in ~1 s / tient 2 s / fondu-out, ≤1×/j) ;
+    // - lettre passée → « Revenir » fixe (état de navigation, inchangé).
+    // Le titre de la section porte, lui, la date sélectionnée (« Hier » vs
+    // « Ton Essentiel »).
     final selection = ref.watch(selectedEditionDateProvider);
     final isToday = selection is EditionToday;
-    final rewindLabel = isToday ? 'Rattraper' : 'Revenir';
+    // « En retard » = today ET édition d'hier (J-1) non ouverte. Dégradation
+    // gracieuse : `missedYesterday()` renvoie `false` si les streaks sont
+    // indisponibles → aucun faux positif au cold-boot.
+    final missedYesterday =
+        isToday && ref.watch(editionReadStatusProvider).missedYesterday();
     final headerTitle = isToday ? 'Ton Essentiel' : editionPillLabel(selection);
 
     return KeyedSubtree(
@@ -92,8 +102,17 @@ class EssentielHiFiCard extends ConsumerWidget {
               accent: accent,
               title: headerTitle,
               rewind: EditionRewindTrigger(
-                label: rewindLabel,
                 onTap: () => EditionTimelineSheet.show(context),
+                // today à jour → icône seule ; lettre passée → « Revenir » fixe.
+                label: isToday ? null : 'Revenir',
+                // En retard → nudge éphémère « Rattraper ? » ; le point rouge
+                // persistant est dérivé de sa présence côté trigger.
+                ephemeralLabel: missedYesterday
+                    ? EphemeralRattraperLabel(
+                        dayKey:
+                            TourneeProgressService.dayKey(DateTime.now()),
+                      )
+                    : null,
               ),
             ),
             // Compaction « cartes ≤ écran » (passe 2, validée UX) : gap

--- a/apps/mobile/test/features/flux_continu/providers/edition_read_status_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/edition_read_status_provider_test.dart
@@ -56,6 +56,37 @@ void main() {
     });
   });
 
+  group('EditionReadStatus.missedYesterday — signal « pas à jour »', () {
+    test('indisponible (available == false) → false (aucun faux positif)', () {
+      const status = EditionReadStatus.unavailable();
+      expect(status.missedYesterday(now: now), isFalse);
+    });
+
+    test('J-1 non lu → true', () {
+      // readDayKeys vide (mais available) → hier n'est pas lu.
+      const status = EditionReadStatus(available: true);
+      expect(status.missedYesterday(now: now), isTrue);
+    });
+
+    test('J-1 lu (opened côté streaks) → false', () {
+      final status = EditionReadStatus(
+        available: true,
+        readDayKeys: {editionDayKey(past[0])}, // J-1 lu
+      );
+      expect(status.missedYesterday(now: now), isFalse);
+    });
+
+    test('J-1 rattrapé localement (∈ readDayKeys) → false', () {
+      // `readDayKeys` = union streaks ∪ set local « rattrapé » : un J-1 rattrapé
+      // à la main compte comme lu.
+      final status = EditionReadStatus(
+        available: true,
+        readDayKeys: {editionDayKey(past[0])},
+      );
+      expect(status.missedYesterday(now: now), isFalse);
+    });
+  });
+
   group('editionReadStatusProvider — dégradation gracieuse', () {
     test('streaks vides (gamification off) → available == false', () async {
       final container = ProviderContainer(overrides: [

--- a/apps/mobile/test/features/flux_continu/widgets/ephemeral_rattraper_label_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/ephemeral_rattraper_label_test.dart
@@ -1,0 +1,113 @@
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/flux_continu/widgets/ephemeral_rattraper_label.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() => GoogleFonts.config.allowRuntimeFetching = false);
+
+  const dayKey = '2026-07-17';
+
+  /// Monte le nudge dans un MaterialApp minimal. [disableAnimations] simule le
+  /// réglage d'accessibilité « réduire les animations ».
+  Future<void> pumpLabel(
+    WidgetTester tester, {
+    bool disableAnimations = false,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(extensions: [FacteurPalettes.light]),
+        home: MediaQuery(
+          data: MediaQueryData(disableAnimations: disableAnimations),
+          child: const Scaffold(
+            body: Center(child: EphemeralRattraperLabel(dayKey: dayKey)),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Opacité courante du FadeTransition du nudge (0 = masqué, 1 = révélé).
+  double fadeOpacity(WidgetTester tester) {
+    final ft = tester.widget<FadeTransition>(
+      find.descendant(
+        of: find.byType(EphemeralRattraperLabel),
+        matching: find.byType(FadeTransition),
+      ),
+    );
+    return ft.opacity.value;
+  }
+
+  testWidgets(
+      'séquence : masqué au montage → fondu-in après ~1 s → fondu-out après 2 s',
+      (tester) async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    await pumpLabel(tester);
+    await tester.pump(); // résout la lecture prefs async
+
+    // Masqué juste après le montage (le Timer d'entrée n'a pas encore fait feu).
+    expect(fadeOpacity(tester), 0.0);
+
+    // t ≈ 1 s : le fondu-in démarre ; +300 ms le termine (durée 250 ms).
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(fadeOpacity(tester), 1.0);
+    expect(find.text('Rattraper ?'), findsOneWidget);
+
+    // Tient 2 s puis fondu-out : +2 s (déclenche reverse) puis +300 ms.
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(fadeOpacity(tester), 0.0);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('gate 1×/jour : prefs déjà à dayKey → jamais révélé',
+      (tester) async {
+    SharedPreferences.setMockInitialValues(
+      <String, Object>{kRattraperNudgeLastShownPrefsKey: dayKey},
+    );
+    await pumpLabel(tester);
+    await tester.pump(); // résout la lecture prefs → early-return
+
+    // Même après la fenêtre où le nudge se serait joué, l'opacité reste à 0.
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(fadeOpacity(tester), 0.0);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('reduce-motion → aucune animation (le point rouge porte le signal)',
+      (tester) async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    await pumpLabel(tester, disableAnimations: true);
+    await tester.pump();
+
+    // Rien n'est rendu (SizedBox.shrink) : ni FadeTransition propre au nudge,
+    // ni le texte. (On scope aux descendants : les transitions de route
+    // MaterialPageRoot ne comptent pas.)
+    expect(
+      find.descendant(
+        of: find.byType(EphemeralRattraperLabel),
+        matching: find.byType(FadeTransition),
+      ),
+      findsNothing,
+    );
+    expect(find.text('Rattraper ?'), findsNothing);
+
+    // Même en avançant le temps, aucune révélation.
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(find.text('Rattraper ?'), findsNothing);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+}

--- a/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
@@ -9,14 +9,19 @@ import 'package:facteur/config/theme.dart';
 import 'package:facteur/features/flux_continu/models/flux_continu_models.dart';
 import 'package:facteur/features/flux_continu/models/weather_location.dart';
 import 'package:facteur/features/flux_continu/models/weather_snapshot.dart';
+import 'package:facteur/features/flux_continu/providers/selected_edition_date_provider.dart';
 import 'package:facteur/features/flux_continu/providers/weather_location_provider.dart';
 import 'package:facteur/features/flux_continu/providers/weather_provider.dart';
 import 'package:facteur/features/flux_continu/widgets/edition_timeline_sheet.dart';
+import 'package:facteur/features/flux_continu/widgets/ephemeral_rattraper_label.dart';
 import 'package:facteur/features/flux_continu/widgets/essentiel_hi_fi_card.dart';
 import 'package:facteur/features/flux_continu/widgets/long_press_grow.dart';
+import 'package:facteur/features/gamification/models/streak_activity_model.dart';
+import 'package:facteur/features/gamification/providers/streak_activity_provider.dart';
 import 'package:facteur/features/settings/models/display_mode_spec.dart';
 import 'package:facteur/features/settings/providers/display_mode_provider.dart';
 import 'package:facteur/widgets/design/facteur_thumbnail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 Widget _wrap(Widget child, {List<Override> overrides = const []}) {
   return ProviderScope(
@@ -111,6 +116,10 @@ void main() {
   setUpAll(() {
     GoogleFonts.config.allowRuntimeFetching = false;
   });
+
+  // Prefs mockées : le set local « rattrapé » (editionCaughtUpProvider) et le
+  // nudge éphémère lisent SharedPreferences au montage.
+  setUp(() => SharedPreferences.setMockInitialValues(<String, Object>{}));
 
   group('EssentielHiFiCard', () {
     testWidgets('renders title, subtitle and the lead article', (tester) async {
@@ -253,24 +262,68 @@ void main() {
     });
 
     testWidgets(
-        'affiche le déclencheur rewind avec un libellé fixe '
-        '(défaut = today → « Rattraper »)', (tester) async {
-      // EPIC « Lettre du jour » — refonte timeline overlay : le déclencheur
-      // « rewind » vit dans l'en-tête de la carte (sélection par défaut = today).
-      // Le libellé est un verbe d'action fixe (plus la date) : « Rattraper » en
-      // today, « Revenir » sur une lettre passée.
+        'à jour (today, streaks indispo) → header épuré : icône seule, '
+        'ni libellé, ni point rouge, ni nudge', (tester) async {
+      // EPIC « Lettre du jour » — « Rattraper » est désormais un signal
+      // contextuel : en today, si les streaks sont indisponibles (défaut du
+      // wrap → editionReadStatus « unavailable »), le déclencheur est l'icône ⏪
+      // seule (label null, pas de point, pas de nudge éphémère).
       await tester.pumpWidget(_wrap(
         EssentielHiFiCard(
           articles: [_article(rank: 1)],
           onTapArticle: (_) {},
         ),
       ));
+      await tester.pumpAndSettle();
 
       expect(find.byType(EditionRewindTrigger), findsOneWidget);
       final trigger = tester.widget<EditionRewindTrigger>(
         find.byType(EditionRewindTrigger),
       );
-      expect(trigger.label, 'Rattraper');
+      expect(trigger.label, isNull);
+      // Pas de nudge → pas de point rouge (le badge est dérivé de sa présence).
+      expect(trigger.ephemeralLabel, isNull);
+      expect(find.byType(EphemeralRattraperLabel), findsNothing);
+    });
+
+    testWidgets(
+        'en retard (today, édition d\'hier non ouverte) → point rouge + '
+        'nudge « Rattraper ? » monté', (tester) async {
+      // Streaks disponibles avec J-1 `opened == false` (et set local vide) ⇒
+      // missedYesterday == true → point rouge persistant + EphemeralRattraperLabel.
+      final today = editionTodayDate();
+      final past = editionPastDays(kEditionMaxPastDays); // J-1 (Hier)
+      final activity = StreakActivityModel(
+        currentStreak: 1,
+        longestStreak: 1,
+        days: [
+          StreakActivityDay(date: today, opened: true),
+          StreakActivityDay(date: past.first, opened: false), // Hier non lu
+        ],
+      );
+
+      await tester.pumpWidget(_wrap(
+        EssentielHiFiCard(
+          articles: [_article(rank: 1)],
+          onTapArticle: (_) {},
+        ),
+        overrides: [
+          streakActivityProvider.overrideWith((ref) async => activity),
+        ],
+      ));
+      // Laisse le FutureProvider streaks se résoudre → editionReadStatus dispo.
+      await tester.pumpAndSettle();
+
+      final trigger = tester.widget<EditionRewindTrigger>(
+        find.byType(EditionRewindTrigger),
+      );
+      // ephemeralLabel présent → point rouge dérivé + nudge monté.
+      expect(trigger.ephemeralLabel, isNotNull);
+      expect(find.byType(EphemeralRattraperLabel), findsOneWidget);
+
+      // Purge des timers du nudge (fondu-in ~1 s) avant la fin du test.
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpAndSettle();
     });
 
     testWidgets('le déclencheur rewind est présent, sans bouton perso',

--- a/docs/stories/core/9.7.essentiel-rattraper-signal.md
+++ b/docs/stories/core/9.7.essentiel-rattraper-signal.md
@@ -1,0 +1,66 @@
+# Story 9.7 — « Rattraper » : nudge éphémère + point rouge « pas à jour »
+
+**Type** : Feature (UI, frontend-only, 0 migration)
+**Epic** : Lettre du jour (Essentiel)
+**Statut** : ✅ Code + tests
+
+## Contexte
+
+À droite du titre « Ton Essentiel », le déclencheur de la timeline
+(`EditionRewindTrigger`) affichait **en permanence** l'icône ⏪ + le mot
+« Rattraper » (today) / « Revenir » (lettre passée). Ce label fixe encombrait le
+header sans porter d'information : il était là même quand l'utilisateur était
+parfaitement à jour.
+
+## Objectif
+
+Transformer « Rattraper » en **signal contextuel discret**, actif seulement
+quand l'utilisateur **n'a pas ouvert l'édition d'hier (J-1)** :
+
+1. À jour → header épuré : **juste l'icône ⏪** (toujours tappable, ouvre la
+   timeline).
+2. En retard → **point rouge** persistant sur ⏪ (repère calme) **+** le texte
+   « Rattraper ? » qui **apparaît en fondu après ~1 s, tient 2 s, puis disparaît
+   en fondu**, joué **au plus 1×/jour**.
+3. Sur une lettre passée → « Revenir » reste affiché en permanence (inchangé).
+
+Décisions PO : header épuré à jour ; seuil = **édition d'hier (J-1) non
+ouverte** ; **point rouge vif** (`colors.error`) ; fréquence **1×/jour**.
+
+## Détection (aucune dépendance back-end)
+
+Réutilise `editionReadStatusProvider` (dérive les éditions ouvertes via streaks
+`days[].opened`, uni au set local « rattrapé »). Nouvelle méthode pure
+`EditionReadStatus.missedYesterday({now})` =
+`available && !isEditionRead(EditionPastDay(J-1), now)`.
+
+**Dégradation gracieuse** : streaks en chargement / off → `available == false`
+→ `missedYesterday == false` → aucun signal (pas de faux positif au cold-boot ni
+pour un nouvel utilisateur sans historique).
+
+## Changements
+
+| Fichier | Change |
+|---|---|
+| `providers/edition_read_status_provider.dart` | + `missedYesterday({now})` (pure) |
+| `widgets/edition_timeline_sheet.dart` | `EditionRewindTrigger` : `label` → nullable ; + `showBadge` (point rouge, pattern `update_button.dart`) ; + `ephemeralLabel` (slot droit) ; icône dans slot 24×24 (cible tactile) |
+| `widgets/ephemeral_rattraper_label.dart` | **Nouveau** : nudge stateful auto-contenu (idiome `FabNudgeBubble`). `SizeTransition(horizontal)` + `FadeTransition` (1 contrôleur, 250 ms). Gate 1×/jour via prefs `essentiel_rattraper_nudge_last_shown_v1`. Reduce-motion → pas d'animation |
+| `widgets/essentiel_hi_fi_card.dart` | Câblage : `missedYesterday = isToday && readStatus.missedYesterday()` → `label` (null/`Revenir`), `showBadge`, `ephemeralLabel` |
+
+## Tests
+
+- `edition_read_status_provider_test.dart` : `missedYesterday` (available/loading,
+  J-1 lu vs non-lu, rattrapé local).
+- `ephemeral_rattraper_label_test.dart` : séquence fondu-in/tient/fondu-out ;
+  gate 1×/jour (prefs pré-remplies → jamais révélé) ; reduce-motion → rien.
+- `essentiel_hi_fi_card_test.dart` : à jour (streaks indispo) → icône seule
+  (label null, pas de point, pas de nudge) ; en retard → point rouge + nudge monté.
+- `edition_timeline_sheet_test.dart` : rétro-compat `label` reste vert.
+
+## Notes
+
+- Copy : « Rattraper ? » (espace avant « ? », typo FR ; aucun em-dash).
+- Analytics : non câblé (le point rouge durable porte le signal principal ; le
+  widget reste un `StatefulWidget` pur, sans dépendance Riverpod). Ajoutable
+  plus tard si le PO veut mesurer le taux de rattrapage.
+- Backend / Alembic : **aucun** changement.


### PR DESCRIPTION
## Quoi

L'en-tête de la carte « Ton Essentiel » n'affiche plus « Rattraper » en permanence. Le déclencheur de la timeline (⏪) devient un **signal contextuel discret** à trois états (décision PO « header épuré à jour ») :

- **à jour** → icône ⏪ **seule** (toujours tappable, ouvre la timeline « Remonter le temps ») ;
- **édition d'hier (J-1) non ouverte** → **point rouge** persistant sur ⏪ + le nudge éphémère **« Rattraper ? »** (fondu-in ~1 s → tient 2 s → fondu-out, joué au plus **1×/jour**) ;
- **lettre passée** → « Revenir » **fixe** (inchangé).

## Pourquoi

Le libellé « Rattraper » était affiché en permanence, même quand l'utilisateur était parfaitement à jour : il encombrait le header sans porter d'information. On le transforme en signal actif **seulement** quand il y a quelque chose à rattraper (J-1 manqué).

## Comment ça marche

- Détection **sans back-end** : `EditionReadStatus.missedYesterday()` (union des jours `opened` de streaks ∪ set local « rattrapé »). Dégradation gracieuse → `false` dès que le statut est indisponible (streaks en chargement/erreur, gamification off) ⇒ **aucun faux positif** au cold-boot ni pour un nouvel utilisateur.
- Gate 1×/jour persisté en `SharedPreferences` (`essentiel_rattraper_nudge_last_shown_v1`), aligné sur la frontière de jour 07h30 Paris (`TourneeProgressService.dayKey`).
- **Reduce-motion** (`MediaQuery.disableAnimations`) → seul le point rouge (immobile) porte le signal ; le texte animé n'est pas joué.

## Comment ça a été vérifié

- [x] `flutter test test/features/flux_continu/` → **419 tests OK** (0 échec)
- [x] `flutter analyze` sur les fichiers touchés → **0 issue**
- [x] Nouveaux tests : `ephemeral_rattraper_label_test` (séquence fondu / gate 1×/jour / reduce-motion), `edition_read_status_provider_test` (`missedYesterday`), `essentiel_hi_fi_card_test` (états à jour / en retard)
- [x] `/simplify` passé : collapse du double-encodage `showBadge`/`ephemeralLabel` (le point rouge est dérivé de la présence du nudge), `Row(min,[gap,Text])` → `Padding(left)`
- ⚠️ L'état « en retard » dépend de streaks J-1 peuplés, non forçable sur le build web → la preuve principale = les widget tests (cf. `.context/qa-handoff.md`)

## Zones à risque

- Frontière de jour 07h30 Paris vs off-by-one streaks (déjà assumé par la timeline existante).
- **Aucun** changement back-end, **aucune** migration Alembic. Frontend-only.

Story : `docs/stories/core/9.7.essentiel-rattraper-signal.md`