### PR TITLE
fix(mobile): crash reader (extra null) + lecture ref post-dispose au login

### DIFF
--- a/apps/mobile/lib/config/routes.dart
+++ b/apps/mobile/lib/config/routes.dart
@@ -570,7 +570,20 @@ final routerProvider = Provider<GoRouter>((ref) {
         name: RouteNames.contentExternal,
         parentNavigatorKey: NotificationService.navigatorKey,
         pageBuilder: (context, state) {
-          final p = state.extra as Perspective;
+          final p = state.extra as Perspective?;
+          if (p == null) {
+            // extra perdu (deep-link/notif après kill, ou restauration OS) :
+            // on annule au lieu de planter la construction (FLUTTER-Y).
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              final router = GoRouter.of(context);
+              if (router.canPop()) {
+                router.pop();
+              } else {
+                router.go(RoutePaths.feed);
+              }
+            });
+            return const FullSwipeCupertinoPage(child: SizedBox.shrink());
+          }
           return FullSwipeCupertinoPage(
             child: ContentDetailScreen.external(
               url: p.url,

--- a/apps/mobile/lib/features/auth/screens/login_screen.dart
+++ b/apps/mobile/lib/features/auth/screens/login_screen.dart
@@ -92,6 +92,10 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
           rememberMe: _rememberMe);
     }
 
+    // Le widget peut avoir été disposed pendant l'appel réseau (l'utilisateur
+    // a navigué ailleurs) — lire ref après dispose plante (FLUTTER-1).
+    if (!mounted) return;
+
     // Only trigger the "Save password?" OS prompt if auth succeeded.
     // On failure, errors are caught inside authNotifier (no rethrow),
     // so we check state.error to avoid saving wrong credentials.


### PR DESCRIPTION
## Quoi
Deux fixes de crash mobile ciblés :
- **Reader** : la route `contentExternal` castait `state.extra as Perspective` (non-null). Quand `extra` est perdu (deep-link/notif après kill du process, restauration OS), la construction plantait. Elle tolère désormais `null` → `pop()` si possible, sinon repli sur le feed.
- **Login** : ajout d'une garde `!mounted` après l'appel réseau d'auth, avant de lire `ref` — lire `ref` après dispose (utilisateur ayant navigué ailleurs pendant l'appel) plantait.

## Pourquoi
Crashs remontés (FLUTTER-Y reader, FLUTTER-1 login). Aucun changement de comportement dans le cas nominal.

## Comment ça a été vérifié
- [x] `flutter analyze` sur les 2 fichiers : 0 erreur (info-lints pré-existants only)
- [x] `flutter test` auth (router_redirection + auth_state) : All tests passed
- [x] /simplify passé — code déjà propre, guard route-spécifique (pas de helper partagé applicable)
- [ ] Backend/migration : N/A (mobile-only)

## Zones à risque
- Router (`routes.dart`) : nouvelle branche null gérée via `addPostFrameCallback` pour éviter navigation pendant build.
- Auth (`login_screen.dart`) : garde `!mounted` standard post-await.