### PR TITLE
fix(methodologie): débordement hero + saut de scroll accordéon sur mobile

### DIFF
--- a/apps/landing/public/js/methodologie.js
+++ b/apps/landing/public/js/methodologie.js
@@ -6,7 +6,13 @@
     var API_URL = 'https://facteur-production.up.railway.app';
 
     // ─── Scroll FX ───────────────────────────────────────────────────────
-    if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    // Désactivé sur écrans tactiles (mobile/tablette) : la fenêtre de focus
+    // scroll-lié y est trop étroite et le collapse de l'accordéon provoque un
+    // saut de page. Filet de sécurité déjà présent dans le CSS : sans
+    // data-scrollfx, les critères s'affichent statiquement, tous dépliés.
+    var wantsScrollFx = !window.matchMedia('(prefers-reduced-motion: reduce)').matches
+        && window.matchMedia('(pointer: fine)').matches;
+    if (wantsScrollFx) {
         document.documentElement.setAttribute('data-scrollfx', '1');
 
         var pinned = null;

--- a/apps/landing/public/methodologie.html
+++ b/apps/landing/public/methodologie.html
@@ -64,6 +64,8 @@
     [data-signals]{margin:0;padding:0;list-style:none;display:grid;gap:6px;font-size:14px;line-height:1.45}
     [data-signals] li{display:flex;align-items:flex-start;gap:8px}
     [data-signals] li i{font-size:13px;color:var(--acc-ink);flex:none;margin-top:3px}
+    .pillar-bar--sub{width:64%}
+    @media (max-width:480px){.pillar-bar--sub{width:100%}}
     </style>
 </head>
 
@@ -99,23 +101,23 @@
             <span style="font-weight:700;font-size:16.5px;line-height:1.25">Rigueur informationnelle</span>
             <span style="font-family:var(--font-mono);font-size:11px;letter-spacing:0.5px;color:#5D5B5A">5 critères · C1–C5</span>
           </span>
-          <span style="font-family:var(--font-mono);font-weight:700;font-size:21px;color:var(--acc-ink);white-space:nowrap">60<span style="font-size:12px;font-weight:700"> pts</span></span>
+          <span style="font-family:var(--font-mono);font-weight:700;font-size:21px;color:var(--acc-ink);white-space:nowrap;flex:none">60<span style="font-size:12px;font-weight:700"> pts</span></span>
         </div>
-        <div style="width:64%;background:color-mix(in srgb,var(--acc) 10%,white);border-radius:14px;padding:16px 18px;display:flex;align-items:center;gap:14px">
+        <div class="pillar-bar--sub" style="background:color-mix(in srgb,var(--acc) 10%,white);border-radius:14px;padding:16px 18px;display:flex;align-items:center;gap:14px">
           <span aria-hidden="true" style="width:46px;height:46px;border-radius:12px;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,0.08);display:flex;align-items:center;justify-content:center;flex:none"><i class="ph ph-eye" style="font-size:26px;color:var(--acc-ink)"></i></span>
           <span style="flex:1;min-width:0;display:grid;gap:2px">
             <span style="font-weight:700;font-size:16.5px;line-height:1.25">Transparence</span>
             <span style="font-family:var(--font-mono);font-size:11px;letter-spacing:0.5px;color:#5D5B5A">3 critères · C6–C8</span>
           </span>
-          <span style="font-family:var(--font-mono);font-weight:700;font-size:21px;color:var(--acc-ink);white-space:nowrap">20<span style="font-size:12px;font-weight:700"> pts</span></span>
+          <span style="font-family:var(--font-mono);font-weight:700;font-size:21px;color:var(--acc-ink);white-space:nowrap;flex:none">20<span style="font-size:12px;font-weight:700"> pts</span></span>
         </div>
-        <div style="width:64%;background:color-mix(in srgb,var(--acc) 6%,white);border-radius:14px;padding:16px 18px;display:flex;align-items:center;gap:14px">
+        <div class="pillar-bar--sub" style="background:color-mix(in srgb,var(--acc) 6%,white);border-radius:14px;padding:16px 18px;display:flex;align-items:center;gap:14px">
           <span aria-hidden="true" style="width:46px;height:46px;border-radius:12px;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,0.08);display:flex;align-items:center;justify-content:center;flex:none"><i class="ph ph-scales" style="font-size:26px;color:var(--acc-ink)"></i></span>
           <span style="flex:1;min-width:0;display:grid;gap:2px">
             <span style="font-weight:700;font-size:16.5px;line-height:1.25">Indépendance et engagements</span>
             <span style="font-family:var(--font-mono);font-size:11px;letter-spacing:0.5px;color:#5D5B5A">2 critères · C9–C10</span>
           </span>
-          <span style="font-family:var(--font-mono);font-weight:700;font-size:21px;color:var(--acc-ink);white-space:nowrap">20<span style="font-size:12px;font-weight:700"> pts</span></span>
+          <span style="font-family:var(--font-mono);font-weight:700;font-size:21px;color:var(--acc-ink);white-space:nowrap;flex:none">20<span style="font-size:12px;font-weight:700"> pts</span></span>
         </div>
       </div>
       <div aria-hidden="true" style="display:flex;align-items:center"><i class="ph-bold ph-arrow-right" style="font-size:22px;color:#c9b797"></i></div>
@@ -646,7 +648,7 @@
   </div>
 </footer>
 
-<script src="js/methodologie.js?v=1"></script>
+<script src="js/methodologie.js?v=2"></script>
 </body>
 
 </html>

--- a/docs/bugs/bug-methodologie-mobile-display.md
+++ b/docs/bugs/bug-methodologie-mobile-display.md
@@ -1,0 +1,79 @@
+# Bug — page `/methodologie` cassée sur mobile
+
+## Symptômes rapportés
+
+1. Les 3 barres "piliers" du hero (Rigueur / Transparence / Indépendance) débordent
+   de leur encart, notamment les pastilles de points ("60 pts", "20 pts"...).
+2. La révélation "critère par critère" (accordéon qui s'ouvre au scroll) n'est pas
+   fluide sur mobile : fenêtre de lisibilité trop petite, scroll qui accompagne
+   l'ouverture fait sortir le haut de la carte de l'écran.
+
+## Contexte
+
+La page publique `/methodologie` (PR #980, commit `20ce30ef`) est une page statique
+(`apps/landing/public/methodologie.html` + `js/methodologie.js`, servie par nginx)
+construite "desktop-first", très riche en effets scroll-liés. Elle n'a jamais été
+adaptée au mobile : aucune media query `max-width` (juste `prefers-reduced-motion`).
+
+## Root cause
+
+- **Bug 1** : dans le bloc hero (`methodologie.html` lignes 93-136), les 3 lignes de
+  piliers sont des flex-rows `align-items:center;gap:14px` **sans `flex-wrap`**.
+  L'icône est `flex:none` (46px fixe), le libellé est `flex:1;min-width:0` (peut se
+  réduire), mais la pastille de points (lignes 102, 110, 118) est en
+  `white-space:nowrap` **sans `flex:none`** — contrairement à la pastille équivalente
+  des cartes de critères plus bas (ex. ligne 162 `...white-space:nowrap;flex:none`)
+  qui, elle, a le bon traitement. Résultat : sur mobile, la pastille se fait
+  comprimer par flexbox (flex-shrink:1 par défaut) mais son texte ne peut pas
+  s'enrouler (`nowrap`) → le texte déborde visuellement de sa pastille. Les 2e/3e
+  barres (`width:64%`) sont en plus artificiellement plus étroites que la colonne
+  parente déjà réduite sur petit viewport, ce qui aggrave le manque de place.
+
+- **Bug 2** : `js/methodologie.js` (lignes 1-103) implémente un effet "scroll FX"
+  maison en `requestAnimationFrame` + `getBoundingClientRect()` : un seul critère
+  "focus" à la fois, déterminé par la distance entre le milieu de son en-tête et une
+  ligne focale fixée à 42% de la hauteur de viewport, sans aucune hystérésis — dès
+  qu'un autre critère devient marginalement plus proche de cette ligne, le focus
+  bascule instantanément. C'est ce qui rend la fenêtre "lisible" trop petite et les
+  transitions saccadées. Par ailleurs, perdre le focus déclenche l'effondrement de
+  l'accordéon (`max-height:900px → 0`, ligne 53-54 du `<style>`), ce qui change
+  réellement la hauteur du document ; si ça arrive alors que la carte est encore
+  visible ou juste au-dessus du viewport, le contenu visible se décale brutalement
+  vers le haut — c'est le "scroll automatique" ressenti par l'utilisateur.
+
+  La page a déjà un filet de sécurité intégré : le JS n'active l'attribut
+  `data-scrollfx` sur `<html>` que si `prefers-reduced-motion` n'est pas actif
+  (ligne 9-10). Sans cet attribut, tout le CSS scroll-lié (lignes 47-62) ne
+  s'applique pas : les critères s'affichent immédiatement, statiquement, pleinement
+  dépliés et lisibles.
+
+## Fix
+
+### Fix 1 — barres piliers du hero (`methodologie.html`)
+
+1. Ajouter `flex:none` aux 3 pastilles de points du hero, pour les aligner sur le
+   traitement déjà correct des pastilles de critères.
+2. Sortir la largeur `width:64%` des 2e/3e barres de leur `style` inline vers une
+   classe `.pillar-bar--sub`, avec media query mobile qui la ramène à `100%`.
+
+### Fix 2 — accordéon critère par critère (`js/methodologie.js`)
+
+Désactiver l'effet scroll-lié maison sur mobile/tactile en réutilisant le filet de
+sécurité déjà présent dans le code (état statique, tout déplié, sans animation) :
+condition d'activation étendue avec `(pointer: fine)`, qui exclut les écrans
+tactiles tout en gardant l'effet scroll-lié sur desktop/trackpad.
+
+Fichiers modifiés : `apps/landing/public/methodologie.html`,
+`apps/landing/public/js/methodologie.js` (cache-bust `?v=1` → `?v=2`).
+
+## Vérification
+
+Page statique sans dépendance backend pour ces sections. Vérifié via Playwright
+Agent CLI en viewport mobile (390x844, émulation tactile) :
+
+- Hero : aucun débordement horizontal / aucune pastille "pts" hors de son encart,
+  aux largeurs 375px, 390px, 414px.
+- Section "La grille" : `<html>` sans `data-scrollfx` en émulation tactile ; tous
+  les critères (C1-C10) visibles et dépliés sans interaction de scroll.
+- Non-régression desktop : viewport large + pointeur souris → `data-scrollfx`
+  toujours actif, effet d'accordéon scroll-lié inchangé.


### PR DESCRIPTION
## Quoi
Corrige 2 bugs d'affichage mobile sur la page publique `/methodologie` (PR #980) :
1. Les pastilles "pts" des 3 barres piliers du hero débordaient de leur encart.
2. L'accordéon "critère par critère" provoquait un saut de scroll brutal en se repliant, avec une fenêtre de lecture trop étroite.

## Pourquoi
La page a été construite desktop-first sans media query mobile. Root cause détaillée dans `docs/bugs/bug-methodologie-mobile-display.md` :
- Bug 1 : les pastilles de points du hero avaient `white-space:nowrap` sans `flex:none` (contrairement aux pastilles équivalentes des cartes de critères plus bas), donc flexbox les comprimait sous leur contenu.
- Bug 2 : l'effet scroll-lié maison (`js/methodologie.js`) réduit la hauteur de l'accordéon replié à 0 quand un critère perd le focus, ce qui décale brutalement le contenu visible — la page a déjà un filet de sécurité (`data-scrollfx` absent → tout affiché statiquement déplié), simplement jamais activé sur mobile.

## Comment ça a été vérifié
Page statique, pas de dépendance backend pour ces sections. Vérifié via Playwright CLI (`apps/landing/public` servi en local) :
- [x] Hero sans débordement horizontal ni pastille "pts" hors de son encart, à 375px/390px/414px/480px
- [x] `<html>` sans `data-scrollfx` en émulation tactile (viewport 390x844) → les 10 critères (C1-C10) s'affichent statiquement dépliés, sans interaction de scroll
- [x] Non-régression desktop (1280px, pointeur souris) → `data-scrollfx` toujours actif, accordéon scroll-lié inchangé
- [x] Aucune erreur console
- [x] /simplify passé (diff de 15 lignes déjà minimal, rien à simplifier)

## Zones à risque
Aucune — page statique servie par nginx, sans dépendance backend/DB/mobile pour les sections modifiées.