### PR TITLE
fix(api): inserts race-safe pour progression lettres + profil user (PYTHON-3K/5R)

### DIFF
--- a/packages/api/app/services/letters/service.py
+++ b/packages/api/app/services/letters/service.py
@@ -16,6 +16,7 @@ from uuid import UUID
 
 import structlog
 from sqlalchemy import func, or_, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.analytics import AnalyticsEvent
@@ -309,22 +310,36 @@ async def _get_rows(user_id: UUID, db: AsyncSession) -> dict[str, UserLetterProg
 
 
 async def _init_progress(user_id: UUID, db: AsyncSession) -> None:
-    """Crée toutes les rows initiales pour un nouveau user."""
+    """Crée toutes les rows initiales pour un nouveau user (race-safe).
+
+    Deux GET /api/letters concurrents pour un user neuf voient tous deux
+    « aucune row » et tentent l'init : la perdante viole
+    pk_user_letter_progress. On encapsule les INSERT dans un savepoint pour
+    qu'un IntegrityError ne rollback QUE ces inserts (pas la transaction
+    entière) ; l'appelant `_ensure_rows` relira l'état complet écrit par la
+    requête gagnante. (Sentry PYTHON-3K)
+    """
     from app.services.user_service import UserService
 
     await UserService(db).get_or_create_profile(str(user_id))
     now = datetime.now(UTC)
-    for catalog in LETTERS_ORDER:
-        default_status = catalog["default_status"]
-        row = UserLetterProgress(
-            user_id=user_id,
-            letter_id=catalog["id"],
-            status=default_status,
-            completed_actions=[],
-            started_at=now if default_status == "active" else None,
-            archived_at=now if default_status == "archived" else None,
-        )
-        db.add(row)
+    try:
+        async with db.begin_nested():
+            for catalog in LETTERS_ORDER:
+                default_status = catalog["default_status"]
+                row = UserLetterProgress(
+                    user_id=user_id,
+                    letter_id=catalog["id"],
+                    status=default_status,
+                    completed_actions=[],
+                    started_at=now if default_status == "active" else None,
+                    archived_at=now if default_status == "archived" else None,
+                )
+                db.add(row)
+            await db.flush()
+    except IntegrityError:
+        # Another concurrent request won the race and inserted the rows first.
+        logger.info("letter_progress_already_exists", user_id=str(user_id))
     await db.commit()
 
 

--- a/packages/api/app/services/user_service.py
+++ b/packages/api/app/services/user_service.py
@@ -66,14 +66,28 @@ class UserService:
         return result.scalar_one_or_none()
 
     async def create_profile(self, user_id: str) -> UserProfile:
-        """Crée un nouveau profil utilisateur."""
-        profile = UserProfile(
-            id=uuid4(),
-            user_id=UUID(user_id),
-            onboarding_completed=False,
-        )
-        self.db.add(profile)
-        await self.db.flush()
+        """Crée un nouveau profil utilisateur, en gérant les race conditions.
+
+        Uses a savepoint so that an IntegrityError (a concurrent request already
+        inserted the profile) only rolls back the INSERT, not the entire
+        transaction. On conflict, re-reads and returns the row created by the
+        winning request. (Sentry PYTHON-5R — user_profiles_user_id_key)
+        """
+        try:
+            async with self.db.begin_nested():
+                profile = UserProfile(
+                    id=uuid4(),
+                    user_id=UUID(user_id),
+                    onboarding_completed=False,
+                )
+                self.db.add(profile)
+                await self.db.flush()
+        except IntegrityError:
+            # Another concurrent request won the race; re-read its row.
+            logger.info(
+                f"Profile already exists for user {user_id} (race condition handled)"
+            )
+            profile = await self.get_profile(user_id)
 
         await self._ensure_streak_exists(user_id)
 

--- a/packages/api/tests/test_letters_race.py
+++ b/packages/api/tests/test_letters_race.py
@@ -1,0 +1,66 @@
+"""Régression Sentry PYTHON-3K — race condition pk_user_letter_progress.
+
+L'ancien `_init_progress` faisait un check-then-insert (`_ensure_rows` : si
+aucune row → init complet). Sous concurrence (deux GET /api/letters quasi
+simultanés pour un user tout juste créé), les deux requêtes voyaient « aucune
+row » et inséraient toute la progression → IntegrityError sur
+pk_user_letter_progress → 500, ce qui bloquait la lecture de L'Édition.
+
+Le fix encapsule les INSERT de `_init_progress` dans un savepoint (`begin_nested`)
++ catch IntegrityError ; `_ensure_rows` relit ensuite l'état complet écrit par
+la requête gagnante. La requête « perdante » d'une course emprunte la branche
+catch — c'est exactement ce qu'exerce ici un second appel séquentiel sur le
+même user.
+
+NB : la fixture `db_session` isole chaque test dans une connexion unique +
+savepoints (cf. conftest), donc une vraie concurrence 2-connexions n'est pas
+reproductible ici ; on valide le chemin savepoint → catch de façon déterministe
+(même approche que tests/test_interest_weight_concurrency.py).
+"""
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import func, select
+
+from app.models.user_letter_progress import UserLetterProgress
+from app.services.letters.catalog import LETTERS_ORDER
+from app.services.letters.service import _ensure_rows, _get_rows, _init_progress
+
+
+@pytest.mark.asyncio
+async def test_init_progress_twice_no_integrity_error(db_session):
+    """2e _init_progress pour le même user → aucune exception, une row par
+    lettre, aucun doublon."""
+    user_id = uuid4()
+
+    await _init_progress(user_id, db_session)
+    # Requête « perdante » : mêmes (user_id, letter_id) → viole
+    # pk_user_letter_progress sur le flush du savepoint → catch.
+    await _init_progress(user_id, db_session)
+
+    rows = await _get_rows(user_id, db_session)
+    assert len(rows) == len(LETTERS_ORDER)
+    assert set(rows.keys()) == {catalog["id"] for catalog in LETTERS_ORDER}
+
+    total = await db_session.scalar(
+        select(func.count())
+        .select_from(UserLetterProgress)
+        .where(UserLetterProgress.user_id == user_id)
+    )
+    assert total == len(LETTERS_ORDER), "aucun doublon : la PK tient"
+
+
+@pytest.mark.asyncio
+async def test_ensure_rows_coherent_after_double_init(db_session):
+    """Après un double init racé, `_ensure_rows` retourne un état cohérent :
+    une row par lettre, statuts par défaut du catalogue préservés."""
+    user_id = uuid4()
+
+    await _init_progress(user_id, db_session)
+    await _init_progress(user_id, db_session)
+
+    rows = await _ensure_rows(user_id, db_session)
+    assert len(rows) == len(LETTERS_ORDER)
+    for catalog in LETTERS_ORDER:
+        assert rows[catalog["id"]].status == catalog["default_status"]

--- a/packages/api/tests/test_user_service_race.py
+++ b/packages/api/tests/test_user_service_race.py
@@ -1,0 +1,74 @@
+"""Régression Sentry PYTHON-5R — race condition user_profiles_user_id_key.
+
+L'ancien `create_profile` faisait un check-then-insert (get_profile ; si absent →
+add() + flush). Sous concurrence (deux GET /api/notification-preferences/ quasi
+simultanés pour un user tout juste créé), les deux requêtes voyaient « aucun
+profil » et inséraient → IntegrityError sur user_profiles_user_id_key → 500.
+
+Le fix encapsule l'INSERT dans un savepoint (`begin_nested`) + catch
+IntegrityError + re-read de la row écrite par la requête gagnante. La requête
+« perdante » d'une course emprunte la branche re-read — c'est exactement ce
+qu'exerce ici un second appel séquentiel sur le même user_id.
+
+NB : la fixture `db_session` isole chaque test dans une connexion unique +
+savepoints (cf. conftest), donc une vraie concurrence 2-connexions n'est pas
+reproductible ici ; on valide le chemin savepoint → catch → re-read de façon
+déterministe (même approche que tests/test_interest_weight_concurrency.py).
+"""
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import func, select
+
+from app.models.user import UserProfile
+from app.services.user_service import UserService
+
+
+@pytest.mark.asyncio
+async def test_create_profile_twice_no_integrity_error(db_session):
+    """2e create_profile pour le même user_id → aucune exception, re-read de la
+    row gagnante, une seule row en DB."""
+    service = UserService(db_session)
+    user_id = str(uuid4())
+
+    p1 = await service.create_profile(user_id)
+    await db_session.commit()
+
+    # Requête « perdante » : même user_id → viole user_profiles_user_id_key sur
+    # le flush du savepoint → catch → re-read de la row de la gagnante.
+    p2 = await service.create_profile(user_id)
+    await db_session.commit()
+
+    assert p1 is not None
+    assert p2 is not None
+    assert str(p2.user_id) == user_id
+    assert p2.user_id == p1.user_id
+
+    count = await db_session.scalar(
+        select(func.count())
+        .select_from(UserProfile)
+        .where(UserProfile.user_id == p1.user_id)
+    )
+    assert count == 1, "aucun doublon : la contrainte unique tient"
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_profile_idempotent(db_session):
+    """Deux get_or_create_profile → même profil, aucune exception, une row."""
+    service = UserService(db_session)
+    user_id = str(uuid4())
+
+    p1 = await service.get_or_create_profile(user_id)
+    await db_session.commit()
+    p2 = await service.get_or_create_profile(user_id)
+    await db_session.commit()
+
+    assert p1.user_id == p2.user_id
+
+    count = await db_session.scalar(
+        select(func.count())
+        .select_from(UserProfile)
+        .where(UserProfile.user_id == p1.user_id)
+    )
+    assert count == 1, "aucun doublon : la contrainte unique tient"


### PR DESCRIPTION
## Quoi

Deux inserts « check-then-insert » deviennent race-safe :
- `_init_progress` (`letters/service.py`) — création des rows `UserLetterProgress`
- `create_profile` (`user_service.py`) — création du `UserProfile`

Chacun encapsule ses INSERT dans un savepoint (`db.begin_nested()`) + catch
`IntegrityError`, sur le même modèle que `_ensure_streak_exists` déjà en place.
La requête « perdante » d'une course relit l'état écrit par la gagnante ; la
transaction externe reste intacte (aucune perte des rows déjà flushées).

## Pourquoi

Deux GET concurrents pour un user tout juste créé (`GET /api/letters`,
`GET /api/notification-preferences/`) voyaient tous deux « aucune row » et
inséraient : la requête perdante violait `pk_user_letter_progress` /
`user_profiles_user_id_key` → **500**, ce qui bloquait la lecture de L'Édition
et des préférences de notification. (Sentry **PYTHON-3K** et **PYTHON-5R**.)

## Comment ça a été vérifié

- [x] `pytest` — suite complète **2265 passed, 18 skipped, 2 xfailed**
- [x] Tests de régression déterministes ajoutés (`test_letters_race.py`,
  `test_user_service_race.py`) : le 2e appel séquentiel sur le même user exerce
  la branche « perdante » (savepoint → catch), vérifie l'absence de doublon et
  la cohérence de l'état relu.
- [x] `/simplify` passé (trim de commentaires redondants uniquement)
- N/A Mobile / Playwright — changement backend-only
- N/A Alembic — aucune migration

## Zones à risque

- **DB / transactions** : usage de savepoints `begin_nested` dans un contexte
  requête déjà partiellement flushé. Le pattern est déjà éprouvé dans
  `_ensure_streak_exists` (même fichier) ; le fix reste cohérent avec lui plutôt
  que d'introduire un second idiome (`on_conflict_do_nothing`).