### PR TITLE
feat(flux): haptique de section au snap commit (rigid, réactif)

### DIFF
--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -141,13 +141,13 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   final ValueNotifier<bool> _stickyVisible = ValueNotifier(false);
   final ValueNotifier<int> _activeIndex = ValueNotifier(0);
 
-  /// Active section index captured at the *start* of the current scroll
-  /// gesture. The section haptic is now emitted once, at settle
-  /// (`ScrollEndNotification`), only when the gesture actually changed section
-  /// vs. this snapshot — so a drag-then-snapback (which flips `_activeIndex`
-  /// mid-drag then recadres the origin section) fires **zero** buzz instead of
-  /// two. `null` until the first gesture starts.
-  int? _gestureStartActiveIndex;
+  /// Guards the section haptic to **one buzz per gesture**. The haptic is now
+  /// fired at snap *commit* — the instant the fling engages a spring toward a
+  /// *different* section ([_SectionSnapPhysics.onSnapCommit]) — so it precedes
+  /// the pose animation instead of trailing it at settle («&nbsp;trop tard&nbsp;»).
+  /// Reset on `ScrollStartNotification`. A drag-then-snapback commits back to
+  /// the origin section (target index == active index) → no buzz.
+  bool _snapHapticFiredThisGesture = false;
 
   final List<GlobalKey> _sectionKeys = [];
 
@@ -374,30 +374,41 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
   bool _onScrollNotification(ScrollNotification n) {
     if (n is ScrollStartNotification) {
       _scheduleAnchorRecompute();
-      // Snapshot the section we start on. The settle handler compares against
-      // it so a gesture that nets no section change (drag-puis-snapback) stays
-      // silent.
-      _gestureStartActiveIndex = _activeIndex.value;
-    } else if (n is ScrollEndNotification) {
-      // One buzz per gesture, at rest: only when the sticky bar is visible
-      // (skip the initial top-of-page scroll) and the settle landed on a
-      // different section than the gesture started on. Covers both the reader's
-      // fling/snap and programmatic tab nav (which also settles here).
-      if (_stickyVisible.value &&
-          _gestureStartActiveIndex != null &&
-          _activeIndex.value != _gestureStartActiveIndex) {
-        unawaited(_triggerSectionChangeHaptic());
-      }
-      _gestureStartActiveIndex = _activeIndex.value;
+      // New gesture → re-arm the section haptic. It fires at snap commit
+      // (`_onSnapCommit`), not at settle.
+      _snapHapticFiredThisGesture = false;
     }
     return false;
   }
 
+  /// Called by [_SectionSnapPhysics] the instant a fling commits a snap toward
+  /// [committedTarget] (finger lift), *before* the pose animation runs. Fires a
+  /// single crisp haptic when — and only when — the target frames a *different*
+  /// section than the one currently active. This lands the buzz at the moment
+  /// of passage (leads the animation → « réactif ») instead of at settle.
+  ///
+  /// Gated so it stays silent on:
+  /// - the initial top-of-page scroll (sticky bar hidden);
+  /// - a `top → bottom` re-frame inside the same tall section (same index);
+  /// - a deadband pull-back to the origin section (target index == active);
+  /// - repeat `createBallisticSimulation` calls within one gesture
+  ///   ([_snapHapticFiredThisGesture]).
+  void _onSnapCommit(double committedTarget) {
+    if (_snapHapticFiredThisGesture || !_stickyVisible.value) return;
+    final targetIndex = frameIndexOfTarget(_snapAnchors.values, committedTarget);
+    if (targetIndex < 0 || targetIndex == _activeIndex.value) return;
+    _snapHapticFiredThisGesture = true;
+    unawaited(_triggerSectionChangeHaptic());
+  }
+
   Future<void> _triggerSectionChangeHaptic() async {
     try {
-      await Haptics.vibrate(HapticsType.heavy, usage: HapticsUsage.touch);
+      // `rigid` = a sharp, dense single click (Android PRIMITIVE_CLICK ~34ms /
+      // iOS rigid style) — marks the exact moment of passage. `heavy` was a
+      // diffuse THUD that felt weak and « étalée ».
+      await Haptics.vibrate(HapticsType.rigid, usage: HapticsUsage.touch);
     } catch (_) {
-      await HapticFeedback.heavyImpact();
+      await HapticFeedback.mediumImpact();
     }
   }
 
@@ -1261,7 +1272,10 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen> {
           // resting position. AlwaysScrollable keeps the page scrollable even
           // when content is short.
           physics: AlwaysScrollableScrollPhysics(
-            parent: _SectionSnapPhysics(anchors: _snapAnchors),
+            parent: _SectionSnapPhysics(
+              anchors: _snapAnchors,
+              onSnapCommit: _onSnapCommit,
+            ),
           ),
           slivers: [
             // NB : le header (logo · streak · réglages) vit dans le scaffold de
@@ -1889,11 +1903,25 @@ class _SnapAnchors {
 class _SectionSnapPhysics extends ScrollPhysics {
   final _SnapAnchors anchors;
 
-  const _SectionSnapPhysics({required this.anchors, super.parent});
+  /// Fired with the committed resting offset the instant a fling resolves a
+  /// snap (finger lift), *before* the spring runs — lets the screen land the
+  /// section haptic at the moment of passage instead of at settle. Preserved
+  /// through [applyTo] so the platform-wrapped physics keeps calling it.
+  final void Function(double committedTarget)? onSnapCommit;
+
+  const _SectionSnapPhysics({
+    required this.anchors,
+    this.onSnapCommit,
+    super.parent,
+  });
 
   @override
   _SectionSnapPhysics applyTo(ScrollPhysics? ancestor) {
-    return _SectionSnapPhysics(anchors: anchors, parent: buildParent(ancestor));
+    return _SectionSnapPhysics(
+      anchors: anchors,
+      onSnapCommit: onSnapCommit,
+      parent: buildParent(ancestor),
+    );
   }
 
   @override
@@ -1904,6 +1932,7 @@ class _SectionSnapPhysics extends ScrollPhysics {
     final natural = super.createBallisticSimulation(position, velocity);
     final target = _resolveTarget(position, velocity, natural);
     if (target == null) return natural;
+    onSnapCommit?.call(target);
     return ScrollSpringSimulation(
       kSnapSpring,
       position.pixels,

--- a/apps/mobile/lib/features/flux_continu/utils/section_snap.dart
+++ b/apps/mobile/lib/features/flux_continu/utils/section_snap.dart
@@ -161,6 +161,29 @@ double? resolveSnapTarget({
   return _commit(prev ?? _nearest(points, currentPixels), currentPixels);
 }
 
+/// Index of the section whose framing offset the snap committed to, or `-1`
+/// when [target] matches no frame edge (e.g. a value clamped to a scroll
+/// extremity). A target equals a section's [top] **or** its [bottom] (for a
+/// tall section) — both belong to the same section index, so a `top → bottom`
+/// move inside one tall section maps to the *same* index and reads as "no
+/// section change".
+///
+/// Used by the screen to decide, **at snap commit** (finger lift), whether the
+/// fling advances to a *different* section than the one currently framed — the
+/// gate for firing exactly one settle-independent haptic at the moment the
+/// passage is engaged. Reuses [kSnapEpsilon] for the edge match. Pure.
+int frameIndexOfTarget(List<SectionFrame> frames, double target) {
+  for (var i = 0; i < frames.length; i++) {
+    final f = frames[i];
+    if ((target - f.top).abs() <= kSnapEpsilon) return i;
+    if (f.bottom > f.top + kSnapEpsilon &&
+        (target - f.bottom).abs() <= kSnapEpsilon) {
+      return i;
+    }
+  }
+  return -1;
+}
+
 /// The snap points of a frame list, sorted ascending: each section [top], plus
 /// the [bottom] of every section taller than the viewport (its last-cards
 /// resting offset). A section shorter than the viewport collapses

--- a/apps/mobile/test/features/flux_continu/utils/section_snap_test.dart
+++ b/apps/mobile/test/features/flux_continu/utils/section_snap_test.dart
@@ -47,6 +47,58 @@ void main() {
     });
   });
 
+  group('frameIndexOfTarget', () {
+    test('a section top maps to that section index', () {
+      expect(frameIndexOfTarget(frames, 0.0), 0);
+      expect(frameIndexOfTarget(frames, 300.0), 1);
+      expect(frameIndexOfTarget(frames, 1200.0), 2);
+    });
+
+    test('a tall section bottom maps to the SAME index as its top', () {
+      // 300 (top) and 600 (bottom) are the same tall section → index 1. So a
+      // top→bottom move inside it reads as "no section change" (no haptic).
+      expect(frameIndexOfTarget(frames, 600.0), 1);
+    });
+
+    test('matches within kSnapEpsilon of an edge', () {
+      expect(frameIndexOfTarget(frames, 300.0 + kSnapEpsilon / 2), 1);
+      expect(frameIndexOfTarget(frames, 600.0 - kSnapEpsilon / 2), 1);
+    });
+
+    test('a short section contributes only its top (bottom == top)', () {
+      // The short section @1200 has bottom == top; the tall bottom 600 belongs
+      // to index 1, never to a short one.
+      expect(frameIndexOfTarget(frames, 1200.0), 2);
+    });
+
+    test('an off-edge / clamped target maps to -1 (no reliable section)', () {
+      expect(frameIndexOfTarget(frames, 150.0), -1);
+      expect(frameIndexOfTarget(frames, 5000.0), -1);
+    });
+
+    test('empty frames map to -1', () {
+      expect(frameIndexOfTarget(const [], 0.0), -1);
+    });
+
+    test('every committed snap target resolves to a valid section index', () {
+      // Anti-regression for the commit-time haptic gate: whatever the fling,
+      // the resolved target must belong to some frame (never -1) so the gate
+      // can compare it against the active section.
+      for (final start in [10.0, 320.0, 650.0, 900.0]) {
+        final target = resolveSnapTarget(
+          currentPixels: start,
+          naturalLanding: start + beyond,
+          velocity: 2000,
+          scrollDirection: 1,
+          frames: frames,
+        );
+        if (target != null) {
+          expect(frameIndexOfTarget(frames, target), isNonNegative);
+        }
+      }
+    });
+  });
+
   group('resolveSnapTarget', () {
     test(
         'free while inside a tall section on descent/idle (it fills the screen)',


### PR DESCRIPTION
## Quoi
Le haptique de changement de section du Flux Continu passe du *settle*
(`ScrollEndNotification`) au *snap commit* (lift du doigt,
`_SectionSnapPhysics.onSnapCommit`), pour que le buzz **précède** l'animation
de pose au lieu de la suivre. Le style passe de `HapticsType.heavy` (thud
diffus, « étalé ») à `rigid` (clic sec unique), fallback `mediumImpact`.

Nouvelle fonction pure `frameIndexOfTarget(frames, target)` (utils/section_snap)
qui mappe l'offset commité vers un index de section, en repliant top/bottom
d'une section haute sur le même index (un `top → bottom` interne = pas de
changement de section, donc pas de buzz). Le gate 1-buzz/geste est porté par
`_snapHapticFiredThisGesture`, ré-armé au `ScrollStartNotification`.

## Pourquoi
L'ancien haptique arrivait au repos, ressenti « trop tard » et « étalé ». En le
tirant au moment où le fling engage un ressort vers une section différente, le
retour tactile marque l'instant du passage → « réactif ».

## Comment ça a été vérifié
- [x] `flutter test test/features/flux_continu/` → 418/418 OK
- [x] `flutter test .../section_snap_test.dart` → 30/30 (dont 7 nouveaux cas
  `frameIndexOfTarget` + anti-régression du gate commit-time)
- [x] `flutter analyze` sur les 3 fichiers → 0 issue
- [x] `/simplify` passé (reuse/simplification/efficiency clean ; findings
  altitude notés puis skippés — voir Zones à risque)

## Zones à risque
- Gestes de scroll du Flux Continu (physics de snap). Aucun backend, aucune
  migration Alembic.
- Choix d'altitude assumé : le haptique est émis depuis `createBallisticSimulation`
  (dédupliqué par `_snapHapticFiredThisGesture`) plutôt que via une notification.
  C'est délibéré — tirer au commit *lead* l'animation, ce qui est tout le point
  de la feature ; 3 approches alternatives ont déjà été essayées et rejetées.