### PR TITLE
fix(digest): rollback session batch si une variante éditoriale échoue (PYTHON-4R)

### DIFF
--- a/packages/api/app/jobs/digest_generation_job.py
+++ b/packages/api/app/jobs/digest_generation_job.py
@@ -342,6 +342,16 @@ class DigestGenerationJob:
                                     mode=mode,
                                     error=str(mode_err),
                                 )
+                                # Une erreur DB/LLM pour UNE variante laisse la
+                                # session batch partagée en PENDING_ROLLBACK → le
+                                # commit final de run_digest_generation plante
+                                # (PYTHON-4R). Même protection que les except
+                                # englobants (PYTHON-5G) : on nettoie la tx et
+                                # re-pousse les SET LOCAL timeouts sur la
+                                # prochaine tx.
+                                with contextlib.suppress(Exception):
+                                    await session.rollback()
+                                    await apply_session_timeouts(session)
                     else:
                         logger.warning(
                             "digest_generation_editorial_no_global_candidates",

--- a/packages/api/tests/test_digest_generation_job.py
+++ b/packages/api/tests/test_digest_generation_job.py
@@ -669,3 +669,160 @@ class TestAxeCBatchTxRelease:
         mock_session.rollback.assert_awaited_once()
         mock_apply.assert_awaited_once()
         assert mock_apply.await_args.args[0] is mock_session
+
+
+class TestEditorialModeFailureRollback:
+    """Régression PYTHON-4R: si le pré-calcul éditorial d'une variante échoue
+    (`compute_global_context` lève), l'except INTERNE de la boucle
+    `for mode in (...)` doit rollback + re-pousser les timeouts, sinon la
+    session batch partagée reste PENDING_ROLLBACK et le commit final de
+    `run_digest_generation` plante.
+    """
+
+    def _fake_trending_ctx(self):
+        from app.jobs.digest_generation_job import GlobalTrendingContext
+
+        return GlobalTrendingContext(
+            trending_content_ids=set(),
+            une_content_ids=set(),
+            computed_at=datetime.datetime.now(datetime.UTC),
+        )
+
+    @pytest.mark.asyncio
+    async def test_mode_failure_rolls_back_shared_batch_session(self, mock_session):
+        from contextlib import asynccontextmanager
+
+        import app.jobs.digest_generation_job as job_mod
+        from app.jobs.digest_generation_job import DigestGenerationJob
+
+        job = DigestGenerationJob(batch_size=10)
+        # Non-empty user list → on entre dans le corps du pré-calcul éditorial
+        # (qui exige `user_ids`). Les étapes lourdes sont stubbées pour isoler
+        # le chemin d'erreur de la variante.
+        job._get_active_users = AsyncMock(return_value=[uuid4()])
+        job._prune_old_highlights = AsyncMock()
+        job._match_grille_featured_article = AsyncMock()
+        job._process_batch = AsyncMock()
+        job._get_batch_followed_source_ids = AsyncMock(return_value=set())
+        job._get_global_candidates = AsyncMock(return_value=[object()])
+
+        cov_session = AsyncMock()
+        cov_session.scalar = AsyncMock(return_value=0)
+
+        @asynccontextmanager
+        async def fake_cov_sm():
+            yield cov_session
+
+        mock_session.rollback = AsyncMock()
+
+        with (
+            patch.object(job_mod, "DigestSelector") as mock_sel_cls,
+            patch.object(
+                job_mod, "state_mark_pending", new_callable=AsyncMock
+            ),
+            patch.object(
+                job_mod, "apply_session_timeouts", new_callable=AsyncMock
+            ) as mock_apply,
+            patch(
+                "app.services.editorial.pipeline.EditorialPipelineService"
+            ) as mock_pipe_cls,
+            patch.object(
+                job_mod, "safe_async_session", side_effect=lambda: fake_cov_sm()
+            ),
+        ):
+            mock_sel = MagicMock()
+            mock_sel._build_global_trending_context = AsyncMock(
+                return_value=self._fake_trending_ctx()
+            )
+            mock_sel_cls.return_value = mock_sel
+
+            mock_pipe = MagicMock()
+            mock_pipe.llm.is_ready = True
+            mock_pipe.close = AsyncMock()
+            # La variante échoue au pré-calcul éditorial → except `mode_err`.
+            mock_pipe.compute_global_context = AsyncMock(
+                side_effect=RuntimeError("mode boom")
+            )
+            mock_pipe_cls.return_value = mock_pipe
+
+            # Ne doit PAS lever : l'erreur de variante est absorbée + nettoyée.
+            await job.run(mock_session, datetime.date.today())
+
+        # Discriminant : sur ce chemin (succès trending), un SEUL rollback+timeouts
+        # « Axe C » fire toujours (release de tx avant le LLM). L'except interne
+        # AJOUTE un rollback+timeouts par variante échouée (2 ici) → sans le fix
+        # PYTHON-4R on resterait à 1. `>= 2` prouve donc que l'except interne a
+        # bien nettoyé la session batch partagée.
+        assert mock_session.rollback.await_count >= 2
+        assert mock_apply.await_count >= 2
+        # Les timeouts sont re-poussés sur la session batch (pas une autre).
+        assert all(
+            call.args and call.args[0] is mock_session
+            for call in mock_apply.await_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_final_commit_succeeds_despite_mode_failure(self, mock_session):
+        """Bout en bout : `run_digest_generation()` commit sans PendingRollbackError
+        même quand une variante du pré-calcul éditorial échoue."""
+        from contextlib import asynccontextmanager
+
+        import app.jobs.digest_generation_job as job_mod
+        from app.jobs.digest_generation_job import (
+            DigestGenerationJob,
+            run_digest_generation,
+        )
+
+        job = DigestGenerationJob(batch_size=10)
+        job._get_active_users = AsyncMock(return_value=[uuid4()])
+        job._prune_old_highlights = AsyncMock()
+        job._match_grille_featured_article = AsyncMock()
+        job._process_batch = AsyncMock()
+        job._get_batch_followed_source_ids = AsyncMock(return_value=set())
+        job._get_global_candidates = AsyncMock(return_value=[object()])
+
+        mock_session.rollback = AsyncMock()
+
+        @asynccontextmanager
+        async def fake_sm():
+            yield mock_session
+
+        with (
+            patch(
+                "app.services.generation_state.is_generation_running",
+                return_value=False,
+            ),
+            patch("app.services.generation_state.mark_generation_started"),
+            patch("app.services.generation_state.mark_generation_finished"),
+            patch.object(job_mod, "DigestGenerationJob", return_value=job),
+            patch.object(job_mod, "safe_async_session", side_effect=lambda: fake_sm()),
+            patch.object(job_mod, "DigestSelector") as mock_sel_cls,
+            patch.object(job_mod, "state_mark_pending", new_callable=AsyncMock),
+            patch.object(job_mod, "apply_session_timeouts", new_callable=AsyncMock),
+            patch(
+                "app.services.editorial.pipeline.EditorialPipelineService"
+            ) as mock_pipe_cls,
+        ):
+            mock_sel = MagicMock()
+            mock_sel._build_global_trending_context = AsyncMock(
+                return_value=self._fake_trending_ctx()
+            )
+            mock_sel_cls.return_value = mock_sel
+
+            mock_pipe = MagicMock()
+            mock_pipe.llm.is_ready = True
+            mock_pipe.close = AsyncMock()
+            mock_pipe.compute_global_context = AsyncMock(
+                side_effect=RuntimeError("mode boom")
+            )
+            mock_pipe_cls.return_value = mock_pipe
+
+            result = await run_digest_generation(target_date=datetime.date.today())
+
+        # Le run va au bout et retourne des stats (pas de skip, pas de raise).
+        assert result is not None
+        assert not result.get("skipped")
+        # La variante a bien été nettoyée par l'except interne (>= 2 : Axe C + mode).
+        assert mock_session.rollback.await_count >= 2
+        # ...et le commit final de run_digest_generation a réussi.
+        mock_session.commit.assert_awaited()


### PR DESCRIPTION
## Quoi

L'except interne de la boucle `for mode in (...)` du pré-calcul éditorial de `DigestGenerationJob.run` absorbait l'erreur d'une variante mais laissait la **session batch partagée en `PENDING_ROLLBACK`**. Le commit final de `run_digest_generation` plantait alors (PYTHON-4R). On applique la même protection que les except englobants (PYTHON-5G) : `rollback()` de la tx + re-push des `SET LOCAL` timeouts via `apply_session_timeouts`, le tout sous `contextlib.suppress`.

## Pourquoi

Une seule variante en échec (erreur DB/LLM) faisait échouer tout le run de génération de digest au commit final, alors que l'erreur était censée être isolée à cette variante.

## Comment ça a été vérifié

- [x] `pytest` — suite complète : **2263 passed, 18 skipped, 2 xfailed**
- [x] 2 tests de régression ajoutés (`TestEditorialModeFailureRollback`) : rollback+timeouts re-poussés sur la session batch, et commit final OK malgré l'échec de variante
- [x] `/simplify` : code déjà propre (réutilise `contextlib.suppress` + `apply_session_timeouts`, calque le handler PYTHON-5G)
- N/A Flutter (backend-only), N/A migration Alembic

## Zones à risque

`packages/api/app/jobs/digest_generation_job.py` — job de génération de digest (worker prod-only). Changement additif (nettoyage de tx dans un except déjà existant), pas de changement de comportement du chemin nominal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)