### PR TITLE
feat(premium): sources illimitées en free + magic link via page-pont facteur.app

### DIFF
--- a/apps/landing/public/checkout-redirect.html
+++ b/apps/landing/public/checkout-redirect.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="fr">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex, nofollow">
+    <title>Redirection · Facteur</title>
+    <link rel="icon" type="image/png" href="/favicon.png">
+    <link rel="stylesheet" href="/css/style.css?v=5">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <style>
+        .redirect {
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            text-align: center;
+            padding: 24px;
+        }
+
+        .redirect__inner {
+            max-width: 420px;
+        }
+
+        .redirect__title {
+            font-size: 1.5rem;
+            font-weight: 700;
+            margin: 0 0 12px;
+        }
+
+        .redirect__text {
+            color: #555;
+            line-height: 1.6;
+            margin: 0 0 20px;
+        }
+    </style>
+</head>
+
+<body>
+    <main class="redirect">
+        <div class="redirect__inner">
+            <p class="redirect__title" id="title">Redirection en cours&hellip;</p>
+            <p class="redirect__text" id="text">
+                On t'emm&egrave;ne vers la page pour finaliser ton soutien &agrave; Facteur.
+            </p>
+            <p class="redirect__fallback" id="fallback" hidden>
+                <a href="/premium.html">Revenir sur Facteur &rarr;</a>
+            </p>
+        </div>
+    </main>
+
+    <script>
+        (function () {
+            // Garde anti open-redirect : on ne forwarde que vers les liens de
+            // paiement RevenueCat. Toute autre valeur (ou absence) affiche un
+            // fallback plutôt que de rediriger vers un domaine arbitraire.
+            var ALLOWED_PREFIX = 'https://pay.rev.cat/';
+            var next = new URLSearchParams(window.location.search).get('next');
+
+            if (next && next.indexOf(ALLOWED_PREFIX) === 0) {
+                // Supabase appose un fragment #access_token=… au retour du magic
+                // link : RevenueCat n'en a pas besoin (l'entitlement est lié à
+                // app_user_id), on forwarde l'URL telle quelle.
+                window.location.replace(next);
+                return;
+            }
+
+            document.getElementById('title').textContent = 'Lien invalide';
+            document.getElementById('text').textContent =
+                "Ce lien de redirection n'est pas valide. Reviens sur Facteur pour réessayer.";
+            document.getElementById('fallback').hidden = false;
+        })();
+    </script>
+</body>
+
+</html>

--- a/apps/mobile/lib/features/settings/widgets/settings_sheet.dart
+++ b/apps/mobile/lib/features/settings/widgets/settings_sheet.dart
@@ -473,25 +473,12 @@ class _ContentShortcuts extends ConsumerWidget {
     // sinon → libellé incitatif vers la création.
     final hasVeille = ref.watch(veilleActiveConfigProvider).valueOrNull != null;
     final gate = ref.watch(premiumGateProvider);
-    final colors = context.facteurColors;
     return _SheetCard(
       child: Column(
         children: [
           _ShortcutTile(
             icon: PhosphorIcons.bookOpen(PhosphorIconsStyle.regular),
             label: 'Mes sources',
-            // Badge de plafond free : N/30 (couleur primaire quand le cap est
-            // atteint). Les Fact·eur·isses n'ont pas de limite → pas de badge.
-            trailing: gate.isPremium
-                ? null
-                : Text(
-                    '${gate.followedSourcesCount}/$kFreeSourceCap',
-                    style: FacteurTypography.stamp(
-                      gate.sourceCapReached
-                          ? colors.primary
-                          : colors.textTertiary,
-                    ),
-                  ),
             onTap: () => context.pushNamed(RouteNames.sources),
           ),
           const _Divider(),

--- a/apps/mobile/lib/features/sources/widgets/source_add_panel.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_add_panel.dart
@@ -10,9 +10,6 @@ import '../../../core/providers/analytics_provider.dart';
 import '../../../core/ui/notification_service.dart';
 import '../../my_interests/models/user_interests_state.dart';
 import '../../my_interests/providers/user_sources_state_provider.dart';
-import '../../soutien/providers/premium_gate_provider.dart';
-import '../../soutien/soutien_copy.dart';
-import '../../soutien/widgets/paywall_sheet.dart';
 import '../models/smart_search_result.dart';
 import '../models/source_model.dart';
 import '../providers/sources_providers.dart';
@@ -193,12 +190,6 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
   }
 
   Future<void> _addSource(SmartSearchResult result) async {
-    // Cap free à 30 sources suivies (gating client-side « Fact·eur·isse »).
-    // Le mode veille gère ses propres sources → pas concerné.
-    if (!widget.veilleMode && ref.read(premiumGateProvider).sourceCapReached) {
-      PaywallSheet.show(context, PaywallWallVariant.sources);
-      return;
-    }
     try {
       final sourceId = result.sourceId;
       final hasCatalogId =
@@ -383,10 +374,6 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
           _buildSearchIntro(colors),
           const SizedBox(height: FacteurSpacing.space6),
         ],
-        if (!widget.veilleMode) ...[
-          _buildCapPill(colors),
-          const SizedBox(height: FacteurSpacing.space3),
-        ],
         _buildBreathingSearch(colors),
         SizedBox(
           height: _currentQuery.isEmpty
@@ -406,36 +393,6 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
     return SingleChildScrollView(
       padding: widget.padding,
       child: content,
-    );
-  }
-
-  /// Pill de plafond : « N / 30 médias suivis » pour les free (couleur
-  /// primaire au cap), « Sources illimitées · Fact·eur·isse » (verte) pour
-  /// les premium.
-  Widget _buildCapPill(FacteurColors colors) {
-    final gate = ref.watch(premiumGateProvider);
-    final isPremium = gate.isPremium;
-    final accent =
-        isPremium ? const Color(0xFF2E7D32) : colors.textSecondary;
-    final color = !isPremium && gate.sourceCapReached ? colors.primary : accent;
-    final label = isPremium
-        ? SoutienCopy.sourcesPillPremium
-        : '${gate.followedSourcesCount} / $kFreeSourceCap '
-            '${SoutienCopy.sourcesPillFree}';
-    return Align(
-      alignment: Alignment.centerLeft,
-      child: Container(
-        padding: const EdgeInsets.symmetric(
-          horizontal: FacteurSpacing.space3,
-          vertical: 4,
-        ),
-        decoration: BoxDecoration(
-          color: color.withValues(alpha: 0.08),
-          borderRadius: BorderRadius.circular(999),
-          border: Border.all(color: color.withValues(alpha: 0.3)),
-        ),
-        child: Text(label, style: FacteurTypography.stamp(color)),
-      ),
     );
   }
 

--- a/apps/mobile/lib/features/soutien/providers/premium_gate_provider.dart
+++ b/apps/mobile/lib/features/soutien/providers/premium_gate_provider.dart
@@ -2,48 +2,30 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../config/constants.dart';
 import '../../premium/premium_provider.dart';
-import '../../sources/providers/sources_providers.dart';
-
-/// Plafond de sources suivies pour les comptes free.
-const kFreeSourceCap = 30;
 
 /// Façade de gating premium « Fact·eur·isse » — client-side uniquement
 /// (décision produit : pas d'enforcement backend).
 class PremiumGate {
   final bool isPremium;
-  final int followedSourcesCount;
 
   const PremiumGate({
     required this.isPremium,
-    required this.followedSourcesCount,
   });
 
-  bool get sourceCapReached =>
-      !isPremium && followedSourcesCount >= kFreeSourceCap;
   bool get canCreateVeille => isPremium;
   bool get canCustomizeSerein => isPremium;
 
-  // Égalité par valeur : `premiumGateProvider` se recompose à chaque émission
-  // de `userSourcesProvider` (follow/unfollow/refresh) ; sans ceci, les
-  // watchers de l'objet entier se rebuild même quand rien de pertinent n'a
-  // changé.
   @override
   bool operator ==(Object other) =>
-      other is PremiumGate &&
-      other.isPremium == isPremium &&
-      other.followedSourcesCount == followedSourcesCount;
+      other is PremiumGate && other.isPremium == isPremium;
 
   @override
-  int get hashCode => Object.hash(isPremium, followedSourcesCount);
+  int get hashCode => isPremium.hashCode;
 }
 
 final premiumGateProvider = Provider<PremiumGate>((ref) {
   final isPremium = ref.watch(isPremiumProvider);
-  final sources = ref.watch(userSourcesProvider).valueOrNull ?? const [];
-  return PremiumGate(
-    isPremium: isPremium,
-    followedSourcesCount: sources.length,
-  );
+  return PremiumGate(isPremium: isPremium);
 });
 
 /// Date de souscription (« Fact·eur·isse depuis mois année »). Null si

--- a/apps/mobile/lib/features/soutien/screens/soutien_screen.dart
+++ b/apps/mobile/lib/features/soutien/screens/soutien_screen.dart
@@ -150,10 +150,6 @@ class _BonusCard extends StatelessWidget {
             body: SoutienCopy.bonusVeilleBody,
           ),
           const _BonusItem(
-            title: SoutienCopy.bonusSourcesTitle,
-            body: SoutienCopy.bonusSourcesBody,
-          ),
-          const _BonusItem(
             title: SoutienCopy.bonusAnalysesTitle,
             body: SoutienCopy.bonusAnalysesBody,
           ),

--- a/apps/mobile/lib/features/soutien/soutien_copy.dart
+++ b/apps/mobile/lib/features/soutien/soutien_copy.dart
@@ -36,8 +36,6 @@ class SoutienCopy {
   static const bonusVeilleTitle =
       'Ne rate plus rien sur les sujets qui comptent pour toi';
   static const bonusVeilleBody = 'crée autant de veilles que tu veux.';
-  static const bonusSourcesTitle = 'Suis autant de médias que tu veux';
-  static const bonusSourcesBody = 'plus de limite à 30 sources.';
   static const bonusAnalysesTitle =
       'Comprends comment chaque sujet est vraiment couvert';
   static const bonusAnalysesBody = 'analyses de couverture sans compter.';
@@ -86,12 +84,6 @@ class SoutienCopy {
   static const veilleWallPriceNote = 'résiliable en un geste';
 
   // Murs en sheet
-  static const sourcesWallEyebrow = 'Sources · 30/30';
-  static const sourcesWallHeadline = 'Suis autant de médias que tu veux';
-  static const sourcesWallBody =
-      "Tes 30 places sont prises, et ta curiosité n'a aucune raison de "
-      "s'arrêter là. En passant Fact·eur·isse, tu ajoutes des sources sans "
-      'limite.';
   static const analysesWallEyebrow = 'Analyse Facteur · 1/1 aujourd\'hui';
   static const analysesWallHeadline =
       'Comprends comment chaque sujet est vraiment couvert';
@@ -110,8 +102,6 @@ class SoutienCopy {
   // ─── Gates aux touchpoints ───
   static const veilleGateStamp = 'RÉSERVÉ AUX FACT·EUR·ISSES';
   static const veilleGateCta = 'Créer ma première veille';
-  static const sourcesPillFree = 'médias suivis'; // « N / 30 médias suivis »
-  static const sourcesPillPremium = 'Sources illimitées · Fact·eur·isse';
   static const analysesQuotaBanner =
       'Chaque analyse Facteur a un coût réel de génération. On te la laisse '
       'quand tu en as besoin. Si tu veux nous aider à financer une info sans '

--- a/apps/mobile/lib/features/soutien/widgets/paywall_sheet.dart
+++ b/apps/mobile/lib/features/soutien/widgets/paywall_sheet.dart
@@ -11,7 +11,7 @@ import 'price_row.dart';
 
 /// Les trois murs de feature affichés en bottom sheet (la veille a son écran
 /// dédié : [VeilleWallScreen]).
-enum PaywallWallVariant { sources, analyses, serein }
+enum PaywallWallVariant { analyses, serein }
 
 /// Mur de feature « porte 2 » : eyebrow mono, headline Fraunces, argumentaire,
 /// fil mission vers Soutien, prix, CTA email. Zéro urgence, zéro
@@ -33,11 +33,6 @@ class PaywallSheet extends StatelessWidget {
   /// Copy de la variante en une passe (un seul `switch` au lieu de trois).
   ({String eyebrow, String headline, String body}) get _copy =>
       switch (variant) {
-        PaywallWallVariant.sources => (
-            eyebrow: SoutienCopy.sourcesWallEyebrow,
-            headline: SoutienCopy.sourcesWallHeadline,
-            body: SoutienCopy.sourcesWallBody,
-          ),
         PaywallWallVariant.analyses => (
             eyebrow: SoutienCopy.analysesWallEyebrow,
             headline: SoutienCopy.analysesWallHeadline,

--- a/apps/mobile/test/features/soutien/paywall_sheet_test.dart
+++ b/apps/mobile/test/features/soutien/paywall_sheet_test.dart
@@ -20,16 +20,7 @@ Future<void> _pumpSheet(WidgetTester tester, PaywallWallVariant variant) async {
 }
 
 void main() {
-  testWidgets('variante sources : headline + CTA + mission', (tester) async {
-    await _pumpSheet(tester, PaywallWallVariant.sources);
-
-    expect(find.text(SoutienCopy.sourcesWallHeadline), findsOneWidget);
-    expect(find.text(SoutienCopy.wallCta), findsOneWidget);
-    expect(find.text(SoutienCopy.missionLinkLabel), findsOneWidget);
-    expect(find.text(SoutienCopy.wallDisclaimer), findsOneWidget);
-  });
-
-  testWidgets('variante analyses : copy quota épuisé', (tester) async {
+  testWidgets('variante analyses : headline + CTA + mission', (tester) async {
     await _pumpSheet(tester, PaywallWallVariant.analyses);
 
     expect(find.text(SoutienCopy.analysesWallHeadline), findsOneWidget);
@@ -37,6 +28,9 @@ void main() {
       find.text(SoutienCopy.analysesWallEyebrow.toUpperCase()),
       findsOneWidget,
     );
+    expect(find.text(SoutienCopy.wallCta), findsOneWidget);
+    expect(find.text(SoutienCopy.missionLinkLabel), findsOneWidget);
+    expect(find.text(SoutienCopy.wallDisclaimer), findsOneWidget);
   });
 
   testWidgets('variante serein : headline dédiée', (tester) async {

--- a/apps/mobile/test/features/soutien/premium_gate_provider_test.dart
+++ b/apps/mobile/test/features/soutien/premium_gate_provider_test.dart
@@ -1,34 +1,12 @@
 import 'package:facteur/features/premium/premium_provider.dart';
-import 'package:facteur/features/sources/models/source_model.dart';
-import 'package:facteur/features/sources/providers/sources_providers.dart';
 import 'package:facteur/features/soutien/providers/premium_gate_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class _FakeSourcesNotifier extends UserSourcesNotifier {
-  _FakeSourcesNotifier(this.count);
-
-  final int count;
-
-  @override
-  Future<List<Source>> build() async => List.generate(
-        count,
-        (i) => Source(
-          id: 'src-$i',
-          name: 'Source $i',
-          type: SourceType.article,
-        ),
-      );
-}
-
-ProviderContainer _makeContainer({
-  required bool isPremium,
-  required int sourceCount,
-}) {
+ProviderContainer _makeContainer({required bool isPremium}) {
   final container = ProviderContainer(
     overrides: [
       isPremiumProvider.overrideWithValue(isPremium),
-      userSourcesProvider.overrideWith(() => _FakeSourcesNotifier(sourceCount)),
     ],
   );
   addTearDown(container.dispose);
@@ -36,31 +14,18 @@ ProviderContainer _makeContainer({
 }
 
 void main() {
-  test('free sous le cap : ajout possible, veille et serein verrouillés',
-      () async {
-    final container = _makeContainer(isPremium: false, sourceCount: 12);
-    await container.read(userSourcesProvider.future);
-    final gate = container.read(premiumGateProvider);
+  test('free : veille et serein verrouillés', () {
+    final gate = _makeContainer(isPremium: false).read(premiumGateProvider);
 
-    expect(gate.followedSourcesCount, 12);
-    expect(gate.sourceCapReached, isFalse);
+    expect(gate.isPremium, isFalse);
     expect(gate.canCreateVeille, isFalse);
     expect(gate.canCustomizeSerein, isFalse);
   });
 
-  test('free à 30 sources : cap atteint', () async {
-    final container = _makeContainer(isPremium: false, sourceCount: 30);
-    await container.read(userSourcesProvider.future);
+  test('premium : veille et serein débloqués', () {
+    final gate = _makeContainer(isPremium: true).read(premiumGateProvider);
 
-    expect(container.read(premiumGateProvider).sourceCapReached, isTrue);
-  });
-
-  test('premium : jamais de cap, veille et serein débloqués', () async {
-    final container = _makeContainer(isPremium: true, sourceCount: 45);
-    await container.read(userSourcesProvider.future);
-    final gate = container.read(premiumGateProvider);
-
-    expect(gate.sourceCapReached, isFalse);
+    expect(gate.isPremium, isTrue);
     expect(gate.canCreateVeille, isTrue);
     expect(gate.canCustomizeSerein, isTrue);
   });

--- a/apps/mobile/test/features/veille/veille_intro_gate_test.dart
+++ b/apps/mobile/test/features/veille/veille_intro_gate_test.dart
@@ -10,7 +10,7 @@ Widget _host({required bool isPremium}) {
   return ProviderScope(
     overrides: [
       premiumGateProvider.overrideWithValue(
-        PremiumGate(isPremium: isPremium, followedSourcesCount: 0),
+        PremiumGate(isPremium: isPremium),
       ),
     ],
     child: MaterialApp(

--- a/packages/api/app/routers/checkout.py
+++ b/packages/api/app/routers/checkout.py
@@ -43,6 +43,13 @@ logger = structlog.get_logger()
 DEFAULT_WEB_BILLING_BASE_URL = "https://pay.rev.cat/facteur-premium"
 FOUNDER_WEB_BILLING_BASE_URL = "https://pay.rev.cat/facteur-founder"
 
+# Page-pont statique servie par la landing (domaine qu'on contrôle) vers laquelle
+# le magic link Supabase redirige. Supabase n'honore un `redirect_to` que s'il
+# matche l'allow-list « Redirect URLs » : une entrée unique et stable (notre
+# domaine) plutôt que le domaine tiers `pay.rev.cat`. La page-pont forwarde
+# ensuite vers l'URL RevenueCat passée en `next`.
+CHECKOUT_REDIRECT_BASE_URL = "https://facteur.app/checkout-redirect.html"
+
 
 async def _supabase_admin_lookup_user_by_email(email: str) -> str | None:
     """Retourne le user_id Supabase pour cet email, ou None s'il n'existe pas."""
@@ -128,6 +135,16 @@ def _build_checkout_url(offering: str, user_id: str) -> str:
     )
     params = urlencode({"app_user_id": user_id})
     return f"{base}?{params}"
+
+
+def _build_bridge_url(checkout_url: str) -> str:
+    """Enveloppe l'URL RevenueCat dans la page-pont `facteur.app`.
+
+    Le magic link Supabase pointe vers `checkout-redirect.html?next=<url RC>` ;
+    la page-pont forwarde vers `next`. `_build_checkout_url` reste la seule
+    source de vérité de l'URL RevenueCat.
+    """
+    return f"{CHECKOUT_REDIRECT_BASE_URL}?{urlencode({'next': checkout_url})}"
 
 
 @router.post("/start-passwordless", response_model=CheckoutStartResponse)
@@ -259,7 +276,7 @@ async def send_link(
         )
 
     checkout_url = _build_checkout_url(request.offering, user_id)
-    await _supabase_send_magic_link(email, checkout_url)
+    await _supabase_send_magic_link(email, _build_bridge_url(checkout_url))
 
     service = SubscriptionService(db)
     await service._get_or_create_subscription(user_id)

--- a/packages/api/tests/routers/test_checkout_send_link.py
+++ b/packages/api/tests/routers/test_checkout_send_link.py
@@ -1,6 +1,7 @@
 """Tests pour POST /api/checkout/send-link."""
 
 from unittest.mock import AsyncMock, patch
+from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
 
 import pytest
@@ -9,7 +10,26 @@ from fastapi.testclient import TestClient
 
 from app.database import get_db
 from app.dependencies import get_current_user_id
-from app.routers.checkout import router
+from app.routers.checkout import (
+    CHECKOUT_REDIRECT_BASE_URL,
+    _build_bridge_url,
+    router,
+)
+
+
+def _bridged_next(redirect_url: str) -> str:
+    """Extrait le paramètre `next` (URL RevenueCat) de l'URL-pont."""
+    return parse_qs(urlparse(redirect_url).query)["next"][0]
+
+
+def test_build_bridge_url_wraps_checkout_in_next():
+    bridge = _build_bridge_url("https://pay.rev.cat/facteur-premium?app_user_id=abc")
+
+    assert bridge.startswith(f"{CHECKOUT_REDIRECT_BASE_URL}?")
+    # L'URL RevenueCat est encodée dans `next`, décodable telle quelle.
+    assert (
+        _bridged_next(bridge) == "https://pay.rev.cat/facteur-premium?app_user_id=abc"
+    )
 
 
 def _make_client(db_session, user_id: str) -> TestClient:
@@ -40,11 +60,14 @@ async def test_send_link_happy_path(db_session):
     assert body["sent"] is True
     assert body["email"] == "user@example.com"
 
-    # Le redirect_to du magic link est l'URL de checkout avec l'app_user_id.
+    # Le redirect_to du magic link est l'URL-pont facteur.app ; l'URL de
+    # checkout RevenueCat (avec l'app_user_id) est encodée dans `next`.
     email_arg, redirect_arg = send_mock.await_args.args
     assert email_arg == "user@example.com"
-    assert redirect_arg.startswith("https://pay.rev.cat/facteur-premium")
-    assert f"app_user_id={user_id}" in redirect_arg
+    assert redirect_arg.startswith(CHECKOUT_REDIRECT_BASE_URL)
+    next_url = _bridged_next(redirect_arg)
+    assert next_url.startswith("https://pay.rev.cat/facteur-premium")
+    assert f"app_user_id={user_id}" in next_url
 
 
 @pytest.mark.asyncio
@@ -64,7 +87,8 @@ async def test_send_link_founder_offering(db_session):
 
     assert resp.status_code == 200
     _, redirect_arg = send_mock.await_args.args
-    assert redirect_arg.startswith("https://pay.rev.cat/facteur-founder")
+    assert redirect_arg.startswith(CHECKOUT_REDIRECT_BASE_URL)
+    assert _bridged_next(redirect_arg).startswith("https://pay.rev.cat/facteur-founder")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Quoi

Deux changements produit « Fact·eur·isse » :

1. **Sources illimitées en free** — retrait du plafond client-side de 30 sources suivies (décision produit : plus de cap free). Le gating « sources » est supprimé de bout en bout : `PremiumGate.followedSourcesCount` / `sourceCapReached` / `kFreeSourceCap`, badge N/30 des réglages, pill + garde du panneau d'ajout de source, mur paywall `PaywallWallVariant.sources` et sa copy.
2. **Fix du magic link de checkout** — le lien Supabase pointait vers le domaine tiers `pay.rev.cat`, jamais présent dans l'allow-list « Redirect URLs » (donc `redirect_to` ignoré). On introduit une page-pont statique `facteur.app/checkout-redirect.html?next=<url RevenueCat>` (domaine qu'on contrôle → une entrée unique et stable dans l'allow-list) qui forwarde vers RevenueCat, avec garde anti open-redirect (prefix `https://pay.rev.cat/`). `_build_checkout_url` reste la seule source de vérité de l'URL RevenueCat.

## Pourquoi

- Le cap 30 sources bridait des free sans réel bénéfice produit → on l'ouvre.
- Sans page-pont, le magic link de checkout n'emmenait pas l'utilisateur vers RevenueCat (redirect_to non honoré par Supabase) → parcours de souscription cassé.

## Comment ça a été vérifié

- [x] `pytest tests/routers/test_checkout_send_link.py` → **6 passed** (couvre le pont via `_build_bridge_url` + happy path / founder / resend).
- [x] `flutter test` sur les 3 tests touchés (paywall_sheet, premium_gate_provider, veille_intro_gate) → **6 passed**.
- [x] `flutter analyze` sur les dirs touchés → seulement des `info` lints préexistants, 0 erreur, aucune référence pendante aux symboles retirés.
- [x] `/simplify` passé (4 agents) → 1 fix appliqué : CSS redondante de la page-pont qui empêchait l'affichage du fallback « lien invalide ».

## Zones à risque / suivi ops (hors code)

- La page-pont `checkout-redirect.html` doit être **déployée sur la landing** ET l'URL `https://facteur.app/checkout-redirect.html` ajoutée à l'allow-list Supabase « Redirect URLs ».
- Gating premium reste **client-side** (décision produit, pas d'enforcement backend). Aucune migration Alembic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)