### PR TITLE
feat(notifs): gouverneur de budget push + push quotidien « coup d'œil » (story 30.1, Epic 30 PR 1)

### DIFF
--- a/apps/mobile/lib/core/services/push_notification_service.dart
+++ b/apps/mobile/lib/core/services/push_notification_service.dart
@@ -684,10 +684,15 @@ class PushNotificationService {
     return scheduled;
   }
 
-  /// Seam de test : remplace l'émetteur d'analytics au tap d'une notif locale
-  /// (défaut = PostHog `notif_opened`).
+  /// Émetteur d'analytics au tap d'une notif locale — seam de test
+  /// (réassignable), défaut = PostHog `notif_opened`.
   @visibleForTesting
-  static void Function(String route)? notifOpenedTracker;
+  static void Function(String route) notifOpenedTracker = (route) => unawaited(
+        PostHogService().capture(
+          event: 'notif_opened',
+          properties: {'type': 'local', 'route': route},
+        ),
+      );
 
   static void _onNotificationTapped(NotificationResponse response) {
     final payload = response.payload;
@@ -696,18 +701,8 @@ class PushNotificationService {
     );
 
     final route = _routeFromPayload(payload);
-    final track = notifOpenedTracker ?? _trackNotifOpened;
-    track(route);
+    notifOpenedTracker(route);
     openRoute(route);
-  }
-
-  static void _trackNotifOpened(String route) {
-    unawaited(
-      PostHogService().capture(
-        event: 'notif_opened',
-        properties: {'type': 'local', 'route': route},
-      ),
-    );
   }
 
   static String _routeFromPayload(String? payload) {

--- a/apps/mobile/lib/core/services/push_notification_service.dart
+++ b/apps/mobile/lib/core/services/push_notification_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
@@ -14,6 +15,7 @@ import 'package:flutter_timezone/flutter_timezone.dart';
 import '../../config/routes.dart';
 import '../../features/flux_continu/services/tournee_progress_service.dart';
 import '../api/notification_preferences_api_service.dart';
+import 'posthog_service.dart';
 
 /// Variante de copy de la notification quotidienne.
 ///
@@ -182,13 +184,16 @@ class PushNotificationService {
   ///
   /// - [variantB] requiert au moins un teaser dans [teasers]. Le titre complet
   ///   du premier teaser est utilisé pour le body collapsed (l'OS l'ellipsise
-  ///   sur une ligne) ; les 2 premiers titres sont rendus en bullets dans le
+  ///   sur une ligne) ; les 3 premiers titres sont rendus en bullets dans le
   ///   bigText Android, suivis d'une ligne CTA renvoyant vers l'app.
   /// - [serene] bascule l'en-tête et le CTA sur un ton apaisé (mode Serein).
+  /// - [intro] (push serveur « coup d'œil », `data['intro']`) remplace
+  ///   l'en-tête par défaut du bigText quand il est fourni non vide.
   static ({String title, String body, String bigText}) buildCopy({
     required NotifVariant variant,
     List<String>? teasers,
     bool serene = false,
+    String? intro,
   }) {
     switch (variant) {
       case NotifVariant.variantA:
@@ -198,11 +203,14 @@ class PushNotificationService {
             .map((t) => t.trim())
             .where((t) => t.isNotEmpty)
             .toList();
-        final cleaned = all.take(2).toList();
+        final cleaned = all.take(3).toList();
         if (cleaned.isEmpty) {
           return (title: defaultTitle, body: defaultBody, bigText: defaultBody);
         }
-        final header = serene ? digestHeaderSerene : digestHeader;
+        final trimmedIntro = intro?.trim();
+        final header = (trimmedIntro != null && trimmedIntro.isNotEmpty)
+            ? trimmedIntro
+            : (serene ? digestHeaderSerene : digestHeader);
         // Nombre d'articles « à la une » non rendus en bullets : la ligne CTA
         // les annonce (« + N autres ! »). Pile 1-2 teasers → aucun reste →
         // on garde le CTA générique (apaisé ou non).
@@ -573,7 +581,11 @@ class PushNotificationService {
     final String body;
     final String bigText;
     if (teasers.isNotEmpty) {
-      final copy = buildCopy(variant: NotifVariant.variantB, teasers: teasers);
+      final copy = buildCopy(
+        variant: NotifVariant.variantB,
+        teasers: teasers,
+        intro: data['intro'] as String?,
+      );
       title = copy.title;
       body = copy.body;
       bigText = copy.bigText;
@@ -672,6 +684,11 @@ class PushNotificationService {
     return scheduled;
   }
 
+  /// Seam de test : remplace l'émetteur d'analytics au tap d'une notif locale
+  /// (défaut = PostHog `notif_opened`).
+  @visibleForTesting
+  static void Function(String route)? notifOpenedTracker;
+
   static void _onNotificationTapped(NotificationResponse response) {
     final payload = response.payload;
     debugPrint(
@@ -679,7 +696,18 @@ class PushNotificationService {
     );
 
     final route = _routeFromPayload(payload);
+    final track = notifOpenedTracker ?? _trackNotifOpened;
+    track(route);
     openRoute(route);
+  }
+
+  static void _trackNotifOpened(String route) {
+    unawaited(
+      PostHogService().capture(
+        event: 'notif_opened',
+        properties: {'type': 'local', 'route': route},
+      ),
+    );
   }
 
   static String _routeFromPayload(String? payload) {

--- a/apps/mobile/lib/core/services/server_push_service.dart
+++ b/apps/mobile/lib/core/services/server_push_service.dart
@@ -247,7 +247,32 @@ class ServerPushService {
   }
 
   void _openMessage(RemoteMessage message) {
-    final route = message.data['route'] as String? ?? '/digest';
+    final data = message.data;
+    final route = data['route'] as String? ?? '/digest';
+    final timeToOpen = timeToOpenSeconds(
+      data['sent_at'] as String?,
+      DateTime.now().toUtc(),
+    );
+    unawaited(
+      PostHogService().capture(
+        event: 'push_opened',
+        properties: {
+          'kind': data['kind'] as String? ?? 'daily_digest',
+          if (timeToOpen != null) 'time_to_open': timeToOpen,
+        },
+      ),
+    );
     PushNotificationService.openRoute(route);
+  }
+
+  /// Délai (secondes) entre l'envoi serveur (`data['sent_at']`, ISO UTC) et
+  /// l'ouverture. Null si absent, illisible, ou incohérent (horloge en avance).
+  @visibleForTesting
+  static int? timeToOpenSeconds(String? sentAtRaw, DateTime nowUtc) {
+    if (sentAtRaw == null || sentAtRaw.isEmpty) return null;
+    final sentAt = DateTime.tryParse(sentAtRaw);
+    if (sentAt == null) return null;
+    final seconds = nowUtc.difference(sentAt.toUtc()).inSeconds;
+    return seconds < 0 ? null : seconds;
   }
 }

--- a/apps/mobile/test/core/services/push_notification_service_copy_test.dart
+++ b/apps/mobile/test/core/services/push_notification_service_copy_test.dart
@@ -26,26 +26,40 @@ void main() {
       );
     });
 
-    test('variant B caps at 2 titles + "+ N autres" line in bigText', () {
+    test('variant B caps at 3 titles + "+ N autres" line in bigText', () {
       final copy = PushNotificationService.buildCopy(
         variant: NotifVariant.variantB,
-        teasers: ['Trump', 'Climat', 'Marseille', 'Quatrième'],
+        teasers: ['Trump', 'Climat', 'Marseille', 'Quatrième', 'Cinquième'],
       );
       expect(copy.body, 'Trump');
       expect(
         copy.bigText,
-        "À la une dans l'Essentiel :\n• Trump\n• Climat\n+ 2 autres !",
+        "À la une dans l'Essentiel :\n• Trump\n• Climat\n• Marseille\n"
+        '+ 2 autres !',
       );
     });
 
-    test('variant B with exactly 3 teasers shows "+ 1 autre !" (singular)', () {
+    test('variant B with exactly 4 teasers shows "+ 1 autre !" (singular)', () {
+      final copy = PushNotificationService.buildCopy(
+        variant: NotifVariant.variantB,
+        teasers: ['Trump', 'Climat', 'Marseille', 'Quatrième'],
+      );
+      expect(
+        copy.bigText,
+        "À la une dans l'Essentiel :\n• Trump\n• Climat\n• Marseille\n"
+        '+ 1 autre !',
+      );
+    });
+
+    test('variant B with exactly 3 teasers keeps the generic CTA', () {
       final copy = PushNotificationService.buildCopy(
         variant: NotifVariant.variantB,
         teasers: ['Trump', 'Climat', 'Marseille'],
       );
       expect(
         copy.bigText,
-        "À la une dans l'Essentiel :\n• Trump\n• Climat\n+ 1 autre !",
+        "À la une dans l'Essentiel :\n• Trump\n• Climat\n• Marseille\n"
+        "${PushNotificationService.digestCta}",
       );
     });
 
@@ -64,14 +78,39 @@ void main() {
     test('variant B serene: rest line "+ N autres", header stays serene', () {
       final copy = PushNotificationService.buildCopy(
         variant: NotifVariant.variantB,
-        teasers: ['Trump', 'Climat', 'Marseille'],
+        teasers: ['Trump', 'Climat', 'Marseille', 'Quatrième'],
         serene: true,
       );
       expect(copy.body, 'Trump');
       expect(
         copy.bigText,
-        'Du calme dans ton actu :\n• Trump\n• Climat\n+ 1 autre !',
+        'Du calme dans ton actu :\n• Trump\n• Climat\n• Marseille\n+ 1 autre !',
       );
+    });
+
+    test('variant B intro overrides the default header (server push)', () {
+      final copy = PushNotificationService.buildCopy(
+        variant: NotifVariant.variantB,
+        teasers: ['Trump', 'Climat', 'Marseille'],
+        intro: "À retenir aujourd'hui :",
+      );
+      expect(
+        copy.bigText,
+        "À retenir aujourd'hui :\n• Trump\n• Climat\n• Marseille\n"
+        "${PushNotificationService.digestCta}",
+      );
+    });
+
+    test('variant B empty/absent intro keeps the default header (rétrocompat)',
+        () {
+      for (final intro in [null, '', '   ']) {
+        final copy = PushNotificationService.buildCopy(
+          variant: NotifVariant.variantB,
+          teasers: ['Trump'],
+          intro: intro,
+        );
+        expect(copy.bigText, startsWith("À la une dans l'Essentiel :"));
+      }
     });
 
     test('variant B serene with exactly 2 teasers keeps serene CTA', () {

--- a/apps/mobile/test/core/services/server_push_service_test.dart
+++ b/apps/mobile/test/core/services/server_push_service_test.dart
@@ -1,0 +1,31 @@
+import 'package:facteur/core/services/server_push_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ServerPushService.timeToOpenSeconds', () {
+    final now = DateTime.utc(2026, 7, 18, 8, 0, 0);
+
+    test('computes delay from ISO UTC sent_at', () {
+      expect(
+        ServerPushService.timeToOpenSeconds('2026-07-18T07:58:30+00:00', now),
+        90,
+      );
+    });
+
+    test('null or empty sent_at returns null', () {
+      expect(ServerPushService.timeToOpenSeconds(null, now), isNull);
+      expect(ServerPushService.timeToOpenSeconds('', now), isNull);
+    });
+
+    test('unparseable sent_at returns null (vieux payloads)', () {
+      expect(ServerPushService.timeToOpenSeconds('pas-une-date', now), isNull);
+    });
+
+    test('sent_at in the future returns null (horloge décalée)', () {
+      expect(
+        ServerPushService.timeToOpenSeconds('2026-07-18T08:05:00+00:00', now),
+        isNull,
+      );
+    });
+  });
+}

--- a/docs/brainstorming/2026-07-18-notifs-intelligentes-decisions.md
+++ b/docs/brainstorming/2026-07-18-notifs-intelligentes-decisions.md
@@ -1,0 +1,95 @@
+# Notifs intelligentes — Micro-rapport de décision (pré-brief PM)
+
+**Date :** 2026-07-18
+**Source :** [rapport de brainstorming du même jour](2026-07-18-notifs-intelligentes.md) + arbitrages PO (Laurin)
+**Usage :** document d'entrée pour le brief PM BMAD (Epic 30)
+
+---
+
+## 1. Les arbitrages, et comment ils ont été tranchés
+
+| Question | Décision | Raisonnement |
+|---|---|---|
+| **Freemium** : l'alerte sujet est-elle premium ? | **Free en V1.** | On est en phase de preuve de valeur et d'adoption : monétiser une feature dont le geste ("poser une alerte") n'existe pas encore chez les utilisateurs tuerait l'apprentissage. La monétisation (persona Pro, RAS quotidien, budget réglable) reste une **option ouverte pour plus tard**, une fois l'usage prouvé. |
+| **Seuil « source rare »** | **< 1 article/semaine** (plus strict que la proposition initiale < 3/sem). Plafond de cloches actives : **5**, inchangé. | Le PO durcit volontairement le seuil : la promesse V1 est « la revue mensuelle qu'on rate », pas « le blog hebdo ». Un seuil strict garantit que chaque alerte source reste un événement (~1 à 4 notifs/mois max par cloche) et rend le risque spam nul par construction. Élargir le seuil plus tard est trivial ; le resserrer après coup casserait des cloches posées. |
+| **Skip du push les jours pauvres** | **Pas tranché — remonté au PM comme question produit plus profonde.** V1 : le push quotidien reste quotidien. | Le PO juge l'idée « entendable » mais elle révèle une vraie question : propose-t-on à un utilisateur de venir « garder sa streak » un jour faible, alors que la valeur éditoriale du jour est basse ? C'est un arbitrage rituel-vs-honnêteté qui dépasse le scope notifs → à instruire dans le brief (voir §4). |
+| **Naming** | **« Alerte »**, tout simplement. | Simplicité et compréhension immédiate priment sur la poésie facteur. La métaphore (📯, « ça n'arrive qu'une fois par mois ») vit dans le *contenu* des notifs, pas dans le nom de l'objet. Dans l'UI : « Poser une alerte », « Mes alertes » (dans « Mes intérêts »), section « Tes alertes » en tête de Tournée. |
+
+**Rappel des décisions déjà tranchées par le brainstorm** (inchangées) : pas de time picker en V1 (le créneau matin/soir est le contrat), différé par défaut partout (l'immédiat n'existe pas en V1), pas d'inbox dédiée, budget serveur non contournable ≤ 2 push/jour et ≤ 6/semaine, jamais de push sur match mot-clé brut.
+
+---
+
+## 2. À quoi ressemblent les notifs du plan
+
+> **Révision PO du 18/07 (v2).** Le modèle initial (« tout coalescer dans le push quotidien ») optimisait le nombre de notifs au détriment de la clarté : bullets mélangés = CTA flou, info diluée, réglages illisibles. Nouveau principe : **une info = une notif claire ; séparation dans l'affichage, groupement dans le temps.** Chaque type de notif garde son identité, son CTA unique et son réglage propre ; mais toutes arrivent au créneau choisi et seule la tournée sonne (les alertes sont silencieuses, elles s'ajoutent dans le tiroir). L'anti-spam n'est plus la fusion : c'est la rareté des déclencheurs + le budget serveur.
+
+### Notif 1 — Le push quotidien « coup d'œil » (PR #1)
+
+Son job, et son seul job : montrer **en un coup d'œil ce qu'il y a eu d'important aujourd'hui** (la faiblesse actuelle de la notif). Les bullets deviennent les 3 faits saillants du jour, ordonnés par les intérêts de l'utilisateur, écrits comme des faits et non comme des teasers. Aucune mention d'alertes dedans : CTA unique = ouvrir la tournée.
+
+```
+🌅 Ta tournée est prête                   ← titre/son/canal actuels, intouchés
+─────────────────────────────────────────
+Ce matin, il faut retenir :
+• Retraites : accord trouvé à l'Assemblée
+• Nestlé Waters : le procès s'ouvre à Paris
+• Nvidia franchit les 5 000 milliards
+```
+
+### Notif 2 — L'alerte source rare (PR #2, kind `source_alert`)
+
+Notif **distincte et reconnaissable** (📯 + préfixe « Alerte »), silencieuse, livrée au même créneau que la tournée. Sa rareté est garantie par construction (source < 1/sem, soit ~1 notif/mois). CTA unique = lire la publication.
+
+```
+Canal « Alertes » (silencieux)
+─────────────────────────────────────────
+📯 Alerte : Le 1 Hebdo vient de publier
+Son numéro de juillet est disponible.
+Ça n'arrive qu'une fois par mois.
+
+[ Lire ]  [ Régler cette alerte ]          ← réglage propre à CETTE alerte, en 1 tap
+```
+
+### Notif 3 — L'alerte sujet cluster-gated (PR #3, sur preuve d'usage de #2)
+
+Même logique : notif distincte (🔔 + nom de l'alerte), silencieuse, au créneau. Jamais sur un match mot-clé seul : uniquement quand plusieurs sources confirment. Un événement = une notif, mise à jour silencieusement s'il grossit.
+
+```
+Canal « Alertes » (silencieux)
+─────────────────────────────────────────
+🔔 Alerte « glyphosate » : du nouveau
+3 sources en parlent aujourd'hui, dont
+Le Monde et Reporterre.
+
+[ Voir ]  [ Régler cette alerte ]
+```
+
+### Le modèle de réglage (rendu lisible par la séparation)
+
+Chaque alerte a sa fiche (dans « Mes intérêts ») avec 2 réglages simples : **quand** (à mon créneau, par défaut / récap hebdo / immédiat, pas en V1) et **désactiver**. « Régler cette alerte » dans la notif y mène directement. Le push quotidien, lui, garde ses réglages actuels : les deux mondes ne se mélangent jamais.
+
+### Matin type d'un utilisateur avec 2 alertes actives
+
+Une seule vibration (la tournée), et dans le tiroir : la notif tournée + 0 à 2 cartes d'alerte silencieuses, chacune lisible et actionnable indépendamment. Les jours sans signal (la grande majorité) : la tournée seule, comme aujourd'hui.
+
+### Ce qui n'est PAS une notif (mais fait partie du contrat)
+
+- **Le devis de bruit à la création** (in-app) : « Ce mot aurait déclenché ~14 alertes ces 30 derniers jours 🔴. Conseillé : dans ta prochaine tournée. » La digue principale contre la sur-souscription.
+- **Le silence comme preuve** (in-app, fiche de l'alerte) : « En veille active. Rien d'important sur ce sujet depuis 3 semaines, et c'est vérifié. »
+- **Le gouverneur invisible** : si le budget du jour est atteint ou qu'un push rituel part dans les 4h, l'alerte attend l'édition suivante au lieu de sonner.
+
+---
+
+## 3. Impact sur le plan d'exécution (top 3 confirmé)
+
+| PR | Contenu | Ajustements issus des arbitrages |
+|---|---|---|
+| **#1 Gouverneur + push « coup d'œil »** (S/M) | Composeur unique, budget, canal séparé, bullets « faits saillants du jour », `push_opened` | Les bullets ne mentionnent plus les alertes : ils deviennent le résumé du jour en un coup d'œil (v2 PO). |
+| **#2 Alerte source rare + devis** (S) | Colonne `notify` sur `user_sources`, badge de rythme, kind `source_alert` | Seuil d'éligibilité **< 1/sem** (au lieu de < 3), plafond **5 alertes actives**, naming UI « Alerte ». |
+| **#3 Alerte sujet cluster-gated** (M) | Custom-topics-only, gate cluster, chips d'expansion | **Free** (pas de gating premium à prévoir dans l'architecture V1 ; garder le hook pour plus tard). |
+
+---
+
+## 4. À instruire dans le brief PM (nouveau)
+
+**La question streak / jour pauvre.** Le skip du push les jours faibles pose une question que le PO veut voir traitée en tant que telle : *quand la valeur éditoriale du jour est basse, est-il honnête d'inviter l'utilisateur à venir « garder sa streak » ?* Pistes à évaluer : streak "gelée" les jours pauvres (le silence ne casse pas la série), wording du push qui assume un jour léger, ou statu quo. Hors scope des 3 PRs ; à traiter comme réflexion rituel/rétention séparée.

--- a/docs/brainstorming/2026-07-18-notifs-intelligentes-visuel.html
+++ b/docs/brainstorming/2026-07-18-notifs-intelligentes-visuel.html
@@ -1,0 +1,282 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Facteur : la notif intelligente</title>
+<style>
+  :root {
+    --paper: #faf6ef;
+    --ink: #2b2620;
+    --ink-soft: #6b6259;
+    --accent: #c0392b;
+    --card: #ffffff;
+    --line: #e8e0d3;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: var(--paper);
+    color: var(--ink);
+    line-height: 1.55;
+    padding: 48px 20px 80px;
+  }
+  .wrap { max-width: 860px; margin: 0 auto; }
+  .kicker {
+    text-transform: uppercase; letter-spacing: 0.14em; font-size: 12px;
+    color: var(--accent); font-weight: 700; margin-bottom: 10px;
+  }
+  h1 { font-size: 34px; line-height: 1.2; margin-bottom: 14px; letter-spacing: -0.01em; }
+  .lede { font-size: 18px; color: var(--ink-soft); max-width: 640px; margin-bottom: 8px; }
+  .section { margin-top: 64px; }
+  h2 { font-size: 23px; margin-bottom: 6px; letter-spacing: -0.01em; }
+  .sub { color: var(--ink-soft); font-size: 15px; margin-bottom: 24px; max-width: 620px; }
+
+  .principle {
+    background: var(--ink); color: var(--paper);
+    border-radius: 16px; padding: 28px 32px; margin-top: 40px;
+  }
+  .principle p { font-size: 19px; line-height: 1.5; }
+  .principle strong { color: #f5c66f; }
+
+  .phones { display: flex; flex-wrap: wrap; gap: 28px; align-items: flex-start; }
+  .phone {
+    flex: 1 1 260px; max-width: 320px;
+    background: #1c1a17; border-radius: 28px; padding: 14px 12px 18px;
+    box-shadow: 0 10px 30px rgba(43,38,32,0.18);
+  }
+  .phone .clock {
+    color: #cfc9c0; text-align: center; font-size: 12px; margin-bottom: 10px;
+    letter-spacing: 0.05em;
+  }
+  .notif {
+    background: var(--card); border-radius: 14px; padding: 13px 15px;
+    margin-bottom: 9px; font-size: 13.5px;
+  }
+  .notif .app {
+    display: flex; align-items: center; gap: 6px;
+    font-size: 11px; color: var(--ink-soft); margin-bottom: 6px;
+  }
+  .notif .dot { width: 14px; height: 14px; border-radius: 4px; background: var(--accent);
+    display: inline-flex; align-items: center; justify-content: center;
+    color: #fff; font-size: 9px; font-weight: 700; }
+  .notif .title { font-weight: 700; margin-bottom: 3px; font-size: 14px; }
+  .notif .body { color: #46403a; }
+  .notif ul { list-style: none; margin-top: 5px; }
+  .notif li { padding-left: 14px; position: relative; margin-bottom: 2px; }
+  .notif li::before { content: "•"; position: absolute; left: 2px; color: var(--accent); }
+  .notif .actions { display: flex; gap: 14px; margin-top: 10px; }
+  .notif .actions span {
+    font-size: 12px; font-weight: 700; color: var(--accent);
+    text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .caption { margin-top: 14px; font-size: 13.5px; color: var(--ink-soft); padding: 0 4px; }
+  .caption strong { color: var(--ink); }
+
+  .rules { display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); gap: 16px; }
+  .rule {
+    background: var(--card); border: 1px solid var(--line); border-radius: 14px;
+    padding: 20px;
+  }
+  .rule .emoji { font-size: 26px; margin-bottom: 10px; }
+  .rule h3 { font-size: 15px; margin-bottom: 6px; }
+  .rule p { font-size: 13.5px; color: var(--ink-soft); }
+
+  .settings {
+    background: var(--card); border: 1px solid var(--line); border-radius: 16px;
+    max-width: 360px; padding: 22px 24px; font-size: 14px;
+  }
+  .settings .s-title { font-weight: 700; font-size: 16px; margin-bottom: 2px; }
+  .settings .s-sub { color: var(--ink-soft); font-size: 12.5px; margin-bottom: 16px; }
+  .settings .row {
+    display: flex; justify-content: space-between; align-items: center;
+    padding: 11px 0; border-top: 1px solid var(--line);
+  }
+  .settings .row .val { color: var(--accent); font-weight: 600; font-size: 13px; }
+  .settings .row.off .val { color: var(--ink-soft); font-weight: 400; }
+
+  .steps { counter-reset: step; }
+  .step {
+    display: flex; gap: 18px; padding: 18px 0; border-top: 1px solid var(--line);
+  }
+  .step .num {
+    counter-increment: step; flex: 0 0 34px; height: 34px; border-radius: 50%;
+    background: var(--ink); color: var(--paper); display: flex; align-items: center;
+    justify-content: center; font-weight: 700; font-size: 15px;
+  }
+  .step .num::before { content: counter(step); }
+  .step h3 { font-size: 16px; margin-bottom: 3px; }
+  .step p { font-size: 14px; color: var(--ink-soft); max-width: 560px; }
+  .footer { margin-top: 70px; font-size: 12.5px; color: var(--ink-soft); border-top: 1px solid var(--line); padding-top: 18px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="kicker">Facteur · prochain chantier</div>
+  <h1>La notif intelligente</h1>
+  <p class="lede">Aujourd'hui, Facteur envoie une seule notification, toujours la même, qui dit juste « ta tournée est prête ». Elle ne montre pas ce qui s'est passé d'important, et elle ne sait pas prévenir quand un sujet ou une source qui compte pour toi bouge enfin.</p>
+  <p class="lede">Voici ce qu'on veut construire, en trois notifications et quatre règles.</p>
+
+  <div class="principle">
+    <p><strong>Le principe :</strong> une info = une notif claire, avec son bouton et son réglage. Mais tout arrive au même moment de la journée, et une seule fait du bruit. On ne multiplie pas les interruptions, on clarifie chaque message.</p>
+  </div>
+
+  <div class="section">
+    <h2>Un matin type, sur l'écran verrouillé</h2>
+    <p class="sub">Une seule vibration : la tournée. Les alertes, quand il y en a (c'est rare), s'ajoutent en silence juste en dessous. La plupart des jours, il n'y a que la première.</p>
+
+    <div class="phones">
+      <div class="phone">
+        <div class="clock">7:30</div>
+        <div class="notif">
+          <div class="app"><span class="dot">F</span> Facteur · maintenant</div>
+          <div class="title">🌅 Ta tournée est prête</div>
+          <div class="body">
+            <ul>
+              <li>Retraites : accord trouvé à l'Assemblée</li>
+              <li>Nestlé Waters : le procès s'ouvre à Paris</li>
+              <li>Nvidia franchit les 5 000 milliards</li>
+            </ul>
+          </div>
+        </div>
+        <div class="notif">
+          <div class="app"><span class="dot">F</span> Facteur · maintenant</div>
+          <div class="title">Le 1 Hebdo vient de publier 🔔</div>
+          <div class="body">Son numéro de juillet est disponible. Ça n'arrive qu'une fois par mois.</div>
+          <div class="actions"><span>Lire</span><span>Régler cette alerte</span></div>
+        </div>
+        <div class="notif">
+          <div class="app"><span class="dot">F</span> Facteur · maintenant</div>
+          <div class="title">« glyphosate » : du nouveau 🔔</div>
+          <div class="body">3 sources en parlent aujourd'hui, dont Le Monde et Reporterre.</div>
+          <div class="actions"><span>Voir</span><span>Régler cette alerte</span></div>
+        </div>
+      </div>
+    </div>
+    <p class="caption"><strong>Un jour exceptionnel</strong> avec les 3 en même temps. En réalité : la tournée tous les jours, une alerte source environ 1 fois par mois et par cloche posée, une alerte sujet seulement quand plusieurs sources confirment un événement. La cloche 🔔 en fin de titre suffit à signaler une alerte.</p>
+  </div>
+
+  <div class="section">
+    <h2>Les 3 notifications, une par une</h2>
+
+    <div class="phones" style="margin-top: 26px;">
+      <div style="flex: 1 1 260px; max-width: 320px;">
+        <div class="phone">
+          <div class="clock">Tous les jours</div>
+          <div class="notif">
+            <div class="app"><span class="dot">F</span> Facteur</div>
+            <div class="title">🌅 Ta tournée est prête</div>
+            <div class="body">
+              <ul>
+                <li>Retraites : accord trouvé à l'Assemblée</li>
+                <li>Nestlé Waters : le procès s'ouvre</li>
+                <li>Nvidia franchit les 5 000 milliards</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <p class="caption"><strong>1. La tournée, version « coup d'œil ».</strong> Le vrai fix de notre faiblesse actuelle : la notif montre enfin l'important du jour, choisi selon tes intérêts, écrit comme des faits. Un seul geste : ouvrir la tournée.</p>
+      </div>
+
+      <div style="flex: 1 1 260px; max-width: 320px;">
+        <div class="phone">
+          <div class="clock">Environ 1 fois par mois</div>
+          <div class="notif">
+            <div class="app"><span class="dot">F</span> Facteur</div>
+            <div class="title">Le 1 Hebdo vient de publier 🔔</div>
+            <div class="body">Son numéro de juillet est disponible. Ça n'arrive qu'une fois par mois.</div>
+            <div class="actions"><span>Lire</span><span>Régler cette alerte</span></div>
+          </div>
+        </div>
+        <p class="caption"><strong>2. L'alerte source.</strong> Tu poses une cloche sur une publication rare (moins d'un article par semaine) que tu rates toujours : la revue mensuelle, la newsletter trimestrielle. Le spam est impossible : c'est la rareté de la source qui fait la rareté de l'alerte.</p>
+      </div>
+
+      <div style="flex: 1 1 260px; max-width: 320px;">
+        <div class="phone">
+          <div class="clock">Quand ça bouge vraiment</div>
+          <div class="notif">
+            <div class="app"><span class="dot">F</span> Facteur</div>
+            <div class="title">« glyphosate » : du nouveau 🔔</div>
+            <div class="body">3 sources en parlent aujourd'hui, dont Le Monde et Reporterre.</div>
+            <div class="actions"><span>Voir</span><span>Régler cette alerte</span></div>
+          </div>
+        </div>
+        <p class="caption"><strong>3. L'alerte sujet.</strong> Tu suis un sujet précis ; Facteur ne sonne que quand plusieurs sources en parlent en même temps, jamais sur un simple mot-clé repéré dans un titre. Un événement = une seule notif, même si 10 articles sortent.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>Les 4 règles qui empêchent le spam</h2>
+    <p class="sub">Le pari : si Facteur notifie rarement, recevoir une notif Facteur devient en soi une information. Cette rareté n'est pas une promesse, elle est garantie par le système.</p>
+    <div class="rules">
+      <div class="rule">
+        <div class="emoji">🧮</div>
+        <h3>Un budget dur, côté serveur</h3>
+        <p>Jamais plus de 2 notifications par jour et 6 par semaine, tous types confondus. Aucun réglage ne peut le dépasser. Si le budget est atteint, l'alerte attend la tournée suivante.</p>
+      </div>
+      <div class="rule">
+        <div class="emoji">🕰️</div>
+        <h3>Ton créneau, pas le leur</h3>
+        <p>Une alerte est livrée à ton moment (matin ou soir), pas à la seconde où l'article sort. La vitesse est le produit des autres ; le bon moment est le nôtre.</p>
+      </div>
+      <div class="rule">
+        <div class="emoji">🔇</div>
+        <h3>Une seule notif sonne</h3>
+        <p>La tournée garde son son et son identité, pour toujours. Les alertes sont silencieuses et vivent sur un canal séparé : en désactiver une ne touche jamais le rituel quotidien.</p>
+      </div>
+      <div class="rule">
+        <div class="emoji">🚪</div>
+        <h3>La sortie en 1 tap</h3>
+        <p>« Régler cette alerte » est dans la notif elle-même. Avant même de créer une alerte, Facteur annonce sa fréquence estimée (« ce mot aurait sonné 14 fois ce mois-ci 🔴 »).</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>Ce que l'utilisateur contrôle</h2>
+    <p class="sub">Chaque alerte a sa fiche, simple, dans « Mes intérêts ». Maximum 5 alertes actives. Le silence y est montré comme un service rendu, pas comme une panne.</p>
+    <div class="settings">
+      <div class="s-title">« glyphosate » 🔔</div>
+      <div class="s-sub">En veille active · rien d'important depuis 3 semaines, et c'est vérifié</div>
+      <div class="row"><span>Quand me prévenir</span><span class="val">Dans ma tournée</span></div>
+      <div class="row off"><span>Récap hebdo</span><span class="val">Non</span></div>
+      <div class="row off"><span>Désactiver l'alerte</span><span class="val">›</span></div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>Comment on le construit</h2>
+    <div class="steps">
+      <div class="step">
+        <div class="num"></div>
+        <div>
+          <h3>Le chef d'orchestre + la tournée « coup d'œil »</h3>
+          <p>D'abord le système central qui compte, groupe et plafonne toutes les notifs (le « gouverneur »), et la refonte du contenu du push quotidien. Zéro notif ajoutée, effet mesurable immédiatement sur l'ouverture.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="num"></div>
+        <div>
+          <h3>L'alerte source rare</h3>
+          <p>Le cas d'usage le plus « facteur » et le plus sûr : impossible à transformer en spam. Il installe le geste « poser une alerte » et le devis de fréquence qui serviront à tout le reste.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="num"></div>
+        <div>
+          <h3>L'alerte sujet</h3>
+          <p>Le cœur « intelligent », gardé pour la fin : on ne l'ouvre qu'une fois le garde-fou en place et le geste validé par l'usage. Gratuite au lancement : on prouve la valeur avant de penser monétisation.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="footer">
+    Facteur · notif intelligente · synthèse du brainstorming du 18 juillet 2026 · maquettes indicatives, textes non définitifs
+  </div>
+
+</div>
+</body>
+</html>

--- a/docs/brainstorming/2026-07-18-notifs-intelligentes.md
+++ b/docs/brainstorming/2026-07-18-notifs-intelligentes.md
@@ -1,0 +1,165 @@
+# Brainstorming Session Results — « Notification intelligente »
+
+**Session Date:** 2026-07-18
+**Facilitator:** Claude (session agent-driven BMAD)
+**Participant:** Laurin (PO)
+
+---
+
+## Executive Summary
+
+**Topic :** La « notif intelligente » (heure choisie + sujets + apprentissage) comme levier n°1 de rétention/adoption pour le prochain step de Facteur.
+
+**Session Goals :** Diverger largement (5 perspectives BMAD en parallèle) puis converger vers les solutions au meilleur ratio confiance-impact utilisateur / coût / risque-spam. Contrainte cardinale : être sollicité uniquement sur de l'hyper-pertinent, jamais de notifs « spam » ou régulières.
+
+**Techniques Used :** First Principles + What If (analyst), SCAMPER sur les briques existantes (PM), Role Playing personas + parcours (UX), Assumption Reversal + Provocation (avocat du diable), carte de faisabilité/coût (architect).
+
+**Total Ideas Generated :** ~55 idées brutes, convergées en 11 familles cotées et un top 3 d'exécution.
+
+### Les 4 découvertes structurantes de la session
+
+1. **L'infra est un bus de notifications qui s'ignore.** `push_deliveries` + le champ `kind` (idempotence `(device_id, target_date, kind)`) forment déjà un bus générique avec anti-doublon par jour et audit trail. Le dispatcher tourne toutes les 5 min avec résolution par timezone. Ajouter un type de notif = ajouter un `kind`, zéro migration. La « notification intelligente » n'est pas un nouveau système : c'est 2-3 nouveaux kinds + un gouverneur.
+2. **Découpler détection et livraison.** Presque tout le spam vient de la confusion « ça vient d'arriver » = « il faut le dire maintenant ». Détection en continu (ingestion ~30 min), livraison au rituel (matin/soir). On garde ~100 % de la valeur informationnelle en supprimant ~95 % de l'intrusivité. La métaphore du facteur n'est pas du branding, c'est l'architecture : tournée à heure fixe, boîte persistante, recommandé exceptionnel.
+3. **La version la plus sûre de cette feature n'envoie presque aucune notif nouvelle** : elle rend le push quotidien existant plus digne d'être ouvert (alerte fusionnée dans les bullets du push du matin). 80 % de la valeur pour 20 % du risque — et le risque évité est terminal (désactivation OS globale = mort du push quotidien qui porte le rituel).
+4. **La rareté est le message.** Si Facteur notifie rarement, recevoir une notif Facteur est en soi une information (« ça sonne, donc c'est important »). C'est un actif de marque qu'aucun média à volume ne peut copier. Il doit être garanti structurellement (budget serveur, caps, canal séparé), pas espéré comportementalement.
+
+---
+
+## Technique Sessions
+
+### 1. First Principles + What If — Mary (analyst)
+
+**Principes premiers dégagés :**
+- P1 : une notif n'a de valeur que si son absence aurait coûté quelque chose → le défaut est le silence.
+- P2 : « bienvenue » vs « intrusive » n'est pas une propriété du contenu mais du **contrat** — l'utilisateur a écrit la règle (cloche posée), l'IA l'exécute et la raffine, jamais ne l'invente.
+- P3 : le bon moment = le moment de disponibilité, pas le moment de l'événement.
+- P4 : la confiance est un stock ; un service digne de confiance devient plus silencieux quand son solde baisse (inverse du re-engagement classique).
+- P5 : la rareté est le message.
+
+**Idées marquantes :** timbres hebdo (budget de notifs visible), « recommandé avec accusé » (chaque push explique son pourquoi en 1 tap + bouton de recalibrage), cloche sur source discrète, devis de fréquence à la création, recommandé d'événement cluster-gated, « fenêtre du facteur » (livraison groupée à la fenêtre apprise/déclarée), RAS quotidien (« rien d'important sur vos sujets » comme livrable premium), « j'ai failli vous prévenir » (calibration in-app zéro push), cloche contextuelle « suivre cette affaire » auto-expirante, sourdine automatique après 3 non-ouvertures.
+
+### 2. SCAMPER sur l'existant — John (PM)
+
+**Constat d'ancrage :** le dispatcher est généralisable par `kind` — c'est LE point de levier.
+
+**Idées marquantes :** micro-récap personnalisé dans les bullets du push existant (0 notif ajoutée, coût S — le levier CTR le moins cher) ; alerte mot-clé = veille_keywords × dispatcher (S/M mais spam garanti sans garde-fous) ; warning fréquence à la création (S, anti-spam by design) ; push événement groupé via `find_hot_cluster` (compresseur : 1 événement = 1 notif) ; expansion sémantique = les keywords LLM des custom topics existent déjà, il manque juste l'UI de validation ; rotation 23.1 portée côté serveur comme gouverneur central ; cloche source réservée aux sources < N/semaine ; compteur de notifs visible (« 4 envoyées / budget 7 ») ; preset minimaliste/curieux comme matrice d'autorisation des kinds ; push data-only silencieux comme préchargeur du rituel (vitesse, pas interruption) ; skip du push les jours pauvres.
+
+**Top 5 PM :** bullets personnalisés → gouverneur → alerte mot-clé + warning → événement groupé → budget visible/réglable.
+
+### 3. Role Playing personas + parcours — Sally (UX)
+
+**Scènes clés :** la Curieuse dont le sujet dormant « bouge enfin » (fusion dans la notif du rituel, une seule vibration) ; le Pro qui a choisi l'immédiat pour UNE alerte (vue événement 60 s, 3 perspectives, jamais 3 notifs pour 3 articles) ; l'utilisatrice au mot trop chaud (le warning aurait dû avoir lieu à la création ; en rattrapage, la notif propose elle-même de passer en récap hebdo) ; la cloche sur source mensuelle (« ça n'arrive qu'une fois par mois » — le MVP émotionnel, zéro risque par construction) ; le silence de 3 semaines (in-app : « en veille active, silence normal » — le silence devient une preuve de tri).
+
+**Parcours :** cloche contextuelle dans le reader (entités pré-remplies) ; recherche sans résultat = « créer l'alerte » (la frustration devient une promesse) ; badge de rythme sur chaque source ; step Progression N+4 « Pose ta première cloche » ; devis de bruit vivant à la création avec 3 modes ordonnés (Immédiat grisé si mot trop chaud / **Dans ma prochaine tournée = défaut** / Récap hebdo) ; chips d'expansion sémantique opt-in avec impact fréquence ; re-demande de permission OS au moment du besoin avec fallback in-app assumé ; mise à jour silencieuse de la même notif Android quand l'événement grossit ; section « 🔔 Ton courrier suivi » en tête de Tournée (1-3 cartes, meurt avec l'édition — **jamais d'inbox infinie, jamais de badge rouge cumulatif**) ; les alertes vivent DANS « Mes intérêts » (la cloche est un état d'un intérêt, pas un objet à part) ; action « Moins souvent » native dans la notif elle-même ; plafond doux narré (« un facteur ne sonne pas 6 fois par jour »).
+
+**3 principes UX :** (1) une alerte augmente une notif existante avant d'en créer une nouvelle ; (2) montrer le coût avant, le pourquoi après ; (3) le silence est un service, et la sortie est plus facile que l'entrée.
+
+### 4. Assumption Reversal + Provocation — avocat du diable
+
+**Renversements clés :** chaque notif supplémentaire érode la rétention même pertinente (la variable protectrice est la *prévisibilité*, pas la pertinence) ; l'utilisateur sur-souscrit toujours → **alertes à durée de vie** (expiration 30 j renouvelable en 1 tap) ; l'utilisateur ne veut pas choisir l'heure, il veut que Facteur tienne parole → l'intelligence = *quoi* mettre dans le créneau, jamais *quand* sonner ; la lenteur est le produit de Facteur (le temps réel est le produit des concurrents) ; l'apprentissage invisible = la boîte noire que le persona fuit → apprentissage propositionnel, jamais exécutif ; KPI inversés (succès = non-désactivation OS + rétention du rituel, jamais le CTR des alertes).
+
+**Modes de destruction de confiance → garde-fous :** fatigue → désactivation OS globale (canal Android séparé + budget serveur) ; faux positifs ILIKE (l'audit veille 07/2026 a mesuré 60 % de hors-sujet au seuil 48 : jamais de push sur match brut) ; doublon 7h30/7h34 (fenêtre d'exclusion ±4h, fusion dans le payload) ; rafale d'une source (cap 1 notif/source/24h + mode digest-only auto) ; sur-souscription J1 (warning + plafond de cloches actives) ; cannibalisation de l'Essentiel par les récaps (la notif teaser, jamais le contenu) ; réglages-usine (un écran, 3 décisions max) ; perte du caractère sacré du push quotidien (wording/son/canal du rituel inchangés à vie, alertes silencieuses par défaut).
+
+**Les 5 garde-fous non négociables :**
+1. Budget global serveur, tous types confondus : **≤ 2 push/jour, ≤ 6/semaine**, appliqué avant FCM, non contournable par aucun réglage.
+2. **Différé par défaut** : toute alerte est coalescée dans l'édition du créneau existant. Le temps réel n'existe pas en V1 ; s'il arrive, quota dur ~2/mois + seuil multi-sources.
+3. **Canal OS séparé** pour les alertes, silencieux par défaut, « Ne plus recevoir ça » en 1 tap depuis la notif — une alerte ratée ne doit jamais pouvoir tuer le push quotidien.
+4. **Aucun push sur match mot-clé ILIKE seul** — confirmation cluster/classification obligatoire ; le brut reste in-app. Cap anti-rafale 1 notif/source/24h.
+5. **Apprentissage propositionnel et transparent uniquement** ; métrique de succès = rétention du rituel + non-désactivation OS, jamais le taux de clic.
+
+### 5. Carte de faisabilité/coût — Winston (architect)
+
+Constats vérifiés dans le code : dispatcher 5 min par timezone (`push_dispatcher.py`, `scheduler.py:616`), `push_deliveries` multi-kind sans migration, matching mot-clé écrit (`services/veille/feed_filter.py`), iOS = alert APNS simple (rendu riche Android-first), ingestion RSS/30 min (le « temps réel » est en réalité ~30-35 min).
+
+| Rang | Famille | Coût | Note |
+|---|---|---|---|
+| 1 | **C** Alerte source (rare) | **S** | 1 colonne additive `notify` sur `user_sources`, job batch commun |
+| 2 | **F** Warning/devis de fréquence | **S** | Endpoint preview ILIKE 30 j ; à livrer AVEC B, jamais après |
+| 3 | **H** Budget/coalescing V1 | **S→M** | L'unicité `(device,date,kind)` donne 80 % gratuitement si les producteurs créent des candidats au lieu d'envoyer |
+| 4 | **B** Alerte mot-clé/sujet | **M** | Version custom-topics-only = S ; matching article-major, jamais user-major |
+| 5 | **A** Heure libre | **M** | Dispatcher prêt ; le coût est le CHECK `time_slot` (expand-contract 2 cycles) + 4 notifs locales en dur |
+| 6 | **G** Expansion sémantique validée | **S/M** | L'enrichissement LLM custom topics existe déjà ; il manque l'UI chips |
+| 7 | **J** Gating Progression | **S** | Trivial ; décision produit |
+| 8 | **E** Cluster chaud → push événement | **M** | Cluster-major obligatoire ; calibration = le vrai coût caché |
+| 9 | **I** UI dédiée de conso | **M/L** | V1 = deep-link ; le scope enfle vite (onglet vs section = ×3) |
+| 10 | **D** Micro-récap LLM | **L** | Coût LLM = le mur ; version template d'abord, récap LLM partagé par thème (O(thèmes), pas O(users)) ensuite |
+| 11 | **K** Apprentissage | **L/XL** | V1 = instrumentation seule (`push_opened` non tracké aujourd'hui) |
+
+**3 pièges d'architecture :** (1) livrer B/C/E comme chemins d'envoi indépendants — dès la première alerte, les producteurs créent des candidats dans `push_deliveries`, un unique composeur (le dispatcher étendu) applique le budget et fusionne ; (2) toucher le CHECK `time_slot` ou tout DDL notif en une étape (DB partagée staging/prod → additif + nullable + 2 cycles hebdo) ; (3) matching user-major ou LLM par user×thème (max_connections=60, budget Mistral) — toujours article-major/cluster-major/thème-major.
+
+---
+
+## Idea Categorization
+
+### Immediate Opportunities (prêtes à implémenter)
+
+1. **Bullets personnalisés du push quotidien** — les teasers BigText mentionnent les sujets suivis (« ⚡ 2 articles sur [ton sujet] »). 0 notif ajoutée, coût S, agit sur le CTR de LA notif de rétention. Quick win de mesure.
+2. **Cloche sur source rare** — cloche proposée uniquement si cadence < N/semaine (badge de rythme affiché), push « 📯 [Source] vient de publier — ça n'arrive qu'une fois par mois », deep-link reader. Spam-proof par construction, coût S, MVP émotionnel de la métaphore facteur.
+3. **Devis de bruit à la création** — count ILIKE 30 j → « ~14 alertes/sem 🔴 / ~1/mois 🟢 », modes ordonnés par fréquence, Immédiat grisé si mot chaud. Coût S, la digue principale.
+4. **Gouverneur V1 (architecture jour 1)** — producteurs → candidats `push_deliveries`, composeur unique, budget ≤ 2/jour et ≤ 6/semaine, canal Android séparé, fenêtre d'exclusion ±4h autour du push rituel.
+5. **Instrumentation `push_opened`** — coût S, prérequis de tout apprentissage futur.
+
+### Future Innovations (nécessitent développement/preuve d'usage)
+
+- **Alerte sujet (cloche sur custom topic)** avec expansion sémantique en chips opt-in et gate cluster/classification avant push ; mode immédiat opt-in par alerte, plafonné, quiet hours 8h-21h.
+- **Push événement groupé** (cluster chaud ∩ sujets suivis, cluster-major, mise à jour silencieuse de la même notif).
+- **CTA contextuels** : cloche dans le reader (entités pré-remplies), empty state de recherche « créer l'alerte », step Progression N+4 « Pose ta première cloche ».
+- **Section « Ton courrier suivi »** en tête de Tournée (1-3 cartes, meurt avec l'édition) + fiche de vie de l'alerte dans « Mes intérêts » (rythme constaté, 5 derniers signaux avec leur pourquoi, « en veille active », snooze).
+- **Récap hebdo « lettre d'alerte »** (1/semaine, pipeline lettres, ton épistolaire) pour les sujets à fort volume.
+- **Alertes à durée de vie** (expiration 30 j renouvelable 1 tap) + sourdine automatique après 3 non-ouvertures.
+- **Compteur de sobriété visible** (« Facteur t'a envoyé 6 notifs ce mois-ci » + budget réglable).
+
+### Moonshots
+
+- **Le RAS quotidien** : vendre au Pro une garantie de silence vérifiable (« rien d'important sur vos sujets aujourd'hui » en badge passif) — le silence comme livrable premium.
+- **« J'ai failli vous prévenir »** : le facteur montre in-app les candidats retenus au bord du seuil et demande « j'aurais dû sonner ? » — calibration active à zéro push.
+- **Fenêtre du facteur apprise** : livraison à la fenêtre d'ouverture réelle apprise (borné ±90 min autour du slot choisi), sans jamais exposer de time picker.
+- **Heure d'envoi auto** (`time_slot=auto`) pilotée par les données `push_opened`.
+
+### Insights & Learnings
+
+- Le contrat avant l'algorithme : l'IA exécute et raffine des règles écrites par l'utilisateur, elle n'en invente pas. Seule posture compatible avec un persona qui « se méfie des algos ».
+- Le push quotidien est un actif sacré : wording/son/canal inchangés, tout le reste est silencieux par défaut et séparé.
+- Ne pas mesurer la feature au CTR des alertes : succès = rétention du rituel + non-désactivation OS + zéro plainte volume. Prévoir une cohorte A/B sans alertes : si sa rétention est égale, la feature est du bruit.
+- Le précédent interne existe déjà deux fois : la rotation « Notif du jour » 23.1 (max 3/jour, déterministe) et l'audit veille 07/2026 (60 % hors-sujet au seuil 48) — le premier donne l'architecture du gouverneur, le second interdit le push sur ILIKE brut.
+
+---
+
+## Action Planning — Top 3 priorisé
+
+### #1 — PR fondation : « Gouverneur + push quotidien enrichi » (coût S/M)
+
+**Rationale :** c'est le 80/20 identifié par 4 agents sur 5 — rendre la notif de rétention existante plus digne d'être ouverte, et poser le contrat d'architecture avant d'ouvrir le moindre nouveau kind. Zéro risque spam (aucune notif ajoutée), mesurable immédiatement.
+**Contenu :** composeur unique étendu dans `push_dispatcher.py` (producteurs → candidats → budget ≤ 2/jour, ≤ 6/semaine, fenêtre ±4h) ; canal Android « Alertes » séparé silencieux ; bullets BigText personnalisés par sujets suivis ; instrumentation `push_opened` ; compteur de notifs envoyées lisible depuis `push_deliveries`.
+**Next steps :** brief PM (Epic 30, story 30.1), mesurer le CTR du push quotidien avant/après sur 2 semaines.
+
+### #2 — « La cloche » V1 : alerte source rare + devis de bruit (coût S)
+
+**Rationale :** meilleur ratio simplicité/valeur/sécurité de toute la session (rang 1 et 2 de la carte des coûts). Le cas d'usage (la revue mensuelle qu'on rate toujours) est le plus « facteur » de tous, le risque spam est nul par construction (la rareté de la source EST le garde-fou), et il installe le geste « poser une cloche » + le devis de bruit qui serviront à tout le reste.
+**Contenu :** colonne additive `notify` sur `user_sources` ; badge de rythme (« ~1/mois ») sur les sources ; cloche 1-tap réservée aux sources < N/semaine ; job batch article-major ; kind `source_alert` coalescé dans la tournée par défaut ; endpoint preview de fréquence ; re-demande de permission OS au moment du besoin avec fallback in-app.
+**Next steps :** story 30.2 ; définir le seuil N (proposition : < 3 articles/semaine) ; migration additive (1 cycle, nullable).
+
+### #3 — « La cloche » V2 : alerte sujet cluster-gated (coût M, sur preuve d'usage de #2)
+
+**Rationale :** le cœur « intelligent » demandé (et candidat monétisation pour le Professionnel Efficace), mais le plus dangereux — donc dernier, une fois le gouverneur en place et le geste cloche validé. Custom-topics-only (les keywords LLM existent déjà), jamais de push sur ILIKE seul (gate cluster multi-sources ou classification concordante), expansion sémantique en chips opt-in, mode immédiat = opt-in par alerte, plafonné, quiet hours.
+**Next steps :** story 30.3+ ; calibrer le gate cluster sur données réelles avant tout envoi (log interne des candidats pendant 2 semaines, revue des faux positifs — pattern audit veille) ; décider ensuite E (push événement) et le récap hebdo selon les métriques.
+
+### Questions tranchées par le brainstorm
+
+- **Heure libre (time picker) : NON en V1.** Convergence unanime analyst/reversal/UX : le créneau matin/soir n'est pas une limitation, c'est le contrat de prévisibilité. L'intelligence porte sur le *contenu* du créneau. Ouverture future : `time_slot=auto` appris des données `push_opened` — sans jamais exposer de picker.
+- **Temps réel vs regroupé : différé par défaut, partout.** L'immédiat n'existe qu'en opt-in par alerte, réservé aux signaux structurellement rares, plafonné, quiet hours 8h-21h — et pas en V1.
+- **Progression : oui comme surface de découverte** (step « Pose ta première cloche »), non comme prérequis bloquant. Coût S, à glisser dans #2.
+- **UI dédiée : pas d'inbox.** Section éphémère en tête de Tournée + gestion dans « Mes intérêts ». V1 = deep-link.
+
+### Questions ouvertes pour le brief
+
+> **Tranchées le 2026-07-18** — voir le [micro-rapport de décision](2026-07-18-notifs-intelligentes-decisions.md) : free en V1, seuil < 1/sem, plafond 5, naming « Alerte », skip jours pauvres remonté comme question produit séparée.
+
+1. Positionnement freemium : l'alerte sujet (#3) est-elle un argument premium (persona Pro payeur) ou un standard d'adoption ?
+2. Seuil « source rare » (N/semaine) et plafond de cloches actives (proposition : 5).
+3. Le skip du push les jours pauvres (E2 de John) : compatible avec le rituel/streak ou sacrilège ?
+4. Naming : « cloche », « courrier suivi », « le facteur garde un œil » — à tester.
+
+---
+
+*Session facilitée avec les méthodes BMAD (facilitate-brainstorming-session, brainstorming-techniques) — agents analyst, pm, ux-expert, architect + lentille adversariale.*

--- a/docs/stories/core/30.1.push-coup-doeil-gouverneur.md
+++ b/docs/stories/core/30.1.push-coup-doeil-gouverneur.md
@@ -1,0 +1,112 @@
+# Story 30.1 — Notifs intelligentes PR #1 : gouverneur + push « coup d'œil »
+
+> Epic 30 — Notifs intelligentes. Brainstorm + arbitrages PO du 18/07/2026
+> (`docs/brainstorming/2026-07-18-notifs-intelligentes-decisions.md`).
+> Plan et spec UX validés point par point par le PO le 18/07/2026.
+
+## Objectif
+
+Poser les fondations serveur des Alertes : un **gouverneur de budget push**
+par utilisateur (plafonds glissants + territoire du rituel) et un push
+quotidien « coup d'œil » enrichi (intro neutre + 3 bullets titres bruts,
+`sent_at` pour mesurer le time-to-open). Aucune migration Alembic.
+
+## Arbitrages (validés PO)
+
+- Bullets = titres bruts des 3 premiers articles de l'Essentiel (pas de LLM au
+  dispatch), déjà ordonnés par intérêts et filtrés du racolage.
+- Intro unique neutre « À retenir aujourd'hui : » ; titre/son/canal du push
+  tournée intouchés ; pas d'em-dash.
+- Budgets : 2 pushes/24h, 6/7j (fenêtres glissantes UTC, comptage par
+  `(user, target_date, kind)` distincts — multi-devices = 1). Règle 4h : un
+  kind non rituel est refusé à moins de 4h d'un rituel envoyé ou à venir ;
+  le kind rituel (`daily_digest`) est exempt du cooldown mais soumis aux
+  budgets. Refus gouverneur = `skipped` définitif (`error_code = reason`).
+- Vieux clients Android : ignorent `data['intro']` → bullets sans intro,
+  zéro casse. iOS : alert APNS statique, body = intro + 1er titre.
+
+## Tasks
+
+- [x] `app/services/push_composer.py` : `ComposedPush`, `compose_daily_digest`
+      (3 teasers, intro, body iOS), `_truncate_fact` (90c, coupe au mot + "...").
+- [x] `app/services/push_governor.py` : `check_push_budget` →
+      `GovernorDecision(allowed, reason)` ; budgets 2j/6sem, règle 4h
+      (`ritual_cooldown` / `ritual_upcoming`), exclusion du push logique
+      courant (`target_date`) pour ne pas bloquer les autres devices.
+- [x] `app/services/push_dispatcher.py` : composition via composer,
+      `data['sent_at']` ISO UTC, gouverneur avant envoi (refus → `skipped` +
+      métrique `governed` + PostHog `push_suppressed`), succès →
+      `analytics_events.push_sent` + PostHog `push_sent`.
+- [x] Mobile `push_notification_service.dart` : `buildCopy` passe à 3 bullets
+      + param `intro` (le push serveur remplace l'en-tête) ;
+      `showRemoteNotification` lit `data['intro']` (fallback = comportement
+      actuel) ; tap notif locale → PostHog `notif_opened` (seam de test).
+- [x] Mobile `server_push_service.dart` : `_openMessage` → PostHog
+      `push_opened` `{kind, time_to_open}` depuis `data['sent_at']`
+      (helper pur `timeToOpenSeconds`, null-safe, horloge décalée → null).
+- [x] Tests : `test_push_composer.py` (8), `test_push_governor.py` (10),
+      `test_push_dispatcher.py` adapté (payload intro+3 teasers+sent_at,
+      skipped gouverneur définitif, event push_sent) ; mobile copy test à
+      3 bullets + intro + rétrocompat, `server_push_service_test.dart`.
+
+## Fichiers modifiés
+
+- `packages/api/app/services/push_composer.py` (nouveau)
+- `packages/api/app/services/push_governor.py` (nouveau)
+- `packages/api/app/services/push_dispatcher.py`
+- `packages/api/tests/services/test_push_composer.py` (nouveau)
+- `packages/api/tests/services/test_push_governor.py` (nouveau)
+- `packages/api/tests/services/test_push_dispatcher.py`
+- `apps/mobile/lib/core/services/push_notification_service.dart`
+- `apps/mobile/lib/core/services/server_push_service.dart`
+- `apps/mobile/test/core/services/push_notification_service_copy_test.dart`
+- `apps/mobile/test/core/services/server_push_service_test.dart` (nouveau)
+
+## Référence — Spec UX Alertes (alimente PR #2/#3)
+
+Validée point par point par le PO le 18/07/2026.
+
+### Le geste d'activation (toujours intentionnel, jamais auto-activé)
+
+1. **Fiche source** (`source_detail_modal.dart`, `_FsSettings`) : ligne
+   « 📯 Activer la cloche » sur toutes les sources suivies. Éligible
+   (< 1 article/semaine via `articles_30d` + `oldest_content_at`) : toggle
+   actif, justifié par le rythme du header. Non éligible : toggle grisé +
+   redirection pédagogique vers les alertes de sujet (`EntityAddSheet`).
+2. **Fiche sujet** (« Mes intérêts », `_TopicRow`) : cloche par sujet custom,
+   ouvre le devis de bruit avant confirmation (« ~14 alertes ces 30 derniers
+   jours. Conseillé : dans ta prochaine tournée. »).
+3. **« Mes alertes » = écran dédié**, accessible depuis « Mes intérêts » et
+   les réglages notifs : liste x/5, fiche par alerte (créneau / récap hebdo /
+   désactiver), « silence comme preuve » (« En veille active. Rien
+   d'important depuis 3 semaines, et c'est vérifié. »).
+
+### Découvrabilité (4 moments)
+
+- **Moment chaud** : post-tap « Suivre » d'une source éligible → mini-sheet
+  dédiée (« Cette source publie environ 1 fois par mois. Être alerté à chaque
+  parution ? »).
+- **Rappel passif** : nudge `inlineBanner` (`NudgeId.alertsIntro`) sur la
+  fiche des sources rares suivies sans cloche ; 1 affichage, dismissable.
+- **Teaser onboarding (V1)** : badge « rare » dans `sources_question.dart` +
+  mention de la capacité (pas d'activation à ce stade).
+- **Preuve d'existence** : section « Tes alertes » en tête de Tournée quand
+  une alerte a du nouveau (après l'`EssentielSection` dans
+  `flux_continu_provider._compose`, `sectionKey` exemptée du cap).
+
+Permission OS : réutiliser `notification_activation_modal.dart` avec un
+nouveau `ActivationTrigger.alert`.
+
+### Répartition
+
+| Élément | PR |
+|---|---|
+| Gouverneur + push coup d'œil + analytics | **#1 (cette story)** |
+| Toggle fiche source, mini-sheet post-suivi, écran « Mes alertes », nudge, badge onboarding, section « Tes alertes », kind `source_alert`, canal Android « Alertes » silencieux | #2 |
+| Cloche sujet + devis de bruit + gate cluster (`topic_alert`), chips d'expansion | #3 (sur preuve d'usage de #2) |
+
+## Vérification
+
+- `pytest tests/services/test_push_composer.py tests/services/test_push_governor.py tests/services/test_push_dispatcher.py` : 27 passed.
+- `flutter test` (copy + server_push) : 21 passed ; `flutter analyze` : pas de
+  nouvelle erreur (infos style pré-existantes).

--- a/packages/api/app/services/push_composer.py
+++ b/packages/api/app/services/push_composer.py
@@ -1,0 +1,55 @@
+"""Composition du push quotidien « coup d'œil » (Epic 30, PR #1).
+
+Bullets = titres bruts des 3 premiers articles de l'Essentiel (déjà ordonnés
+par intérêts et filtrés du racolage en amont) ; intro unique neutre. Aucun LLM
+au dispatch. iOS ne rend qu'un alert APNS statique : le body est donc
+« intro + 1er titre » ; Android reconstruit les bullets côté client depuis
+`data["teasers"]` + `data["intro"]` (vieux clients : `intro` ignorée, zéro
+casse).
+"""
+
+import json
+from dataclasses import dataclass
+from datetime import date
+
+PUSH_TITLE = "Facteur"
+DAILY_DIGEST_INTRO = "À retenir aujourd'hui :"
+MAX_TEASERS = 3
+MAX_FACT_LEN = 90
+
+
+@dataclass(frozen=True)
+class ComposedPush:
+    title: str
+    body: str
+    data: dict[str, str]
+
+
+def _truncate_fact(title: str, max_len: int = MAX_FACT_LEN) -> str:
+    """Tronque un titre au mot le plus proche sous `max_len`, avec "..."."""
+    cleaned = " ".join(title.split())
+    if len(cleaned) <= max_len:
+        return cleaned
+    cut = cleaned[: max_len - 3]
+    if " " in cut:
+        cut = cut.rsplit(" ", 1)[0]
+    return cut.rstrip() + "..."
+
+
+def compose_daily_digest(essentiel, target_date: date) -> ComposedPush:
+    """Compose le push digest quotidien depuis la réponse Essentiel exacte."""
+    teasers = [
+        _truncate_fact(article.title) for article in essentiel.articles[:MAX_TEASERS]
+    ]
+    body = f"{DAILY_DIGEST_INTRO} {teasers[0]}"
+    return ComposedPush(
+        title=PUSH_TITLE,
+        body=body,
+        data={
+            "route": "/digest",
+            "target_date": target_date.isoformat(),
+            "kind": "daily_digest",
+            "intro": DAILY_DIGEST_INTRO,
+            "teasers": json.dumps(teasers, ensure_ascii=False),
+        },
+    )

--- a/packages/api/app/services/push_dispatcher.py
+++ b/packages/api/app/services/push_dispatcher.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
 from app.database import safe_async_session
+from app.models.analytics import AnalyticsEvent
 from app.models.daily_digest import DailyDigest
 from app.models.push_notification import PushDelivery, PushDevice
 from app.models.user_notification_preferences import UserNotificationPreferences
@@ -24,6 +25,9 @@ from app.services.essentiel_service import (
     build_essentiel_response,
     fetch_user_essentiel_context,
 )
+from app.services.posthog_client import get_posthog_client
+from app.services.push_composer import compose_daily_digest
+from app.services.push_governor import check_push_budget
 
 logger = structlog.get_logger()
 settings = get_settings()
@@ -176,10 +180,22 @@ async def dispatch_daily_essentiel_pushes(
     """Send due pushes once per device/day, retrying morning gaps until noon."""
     if sender is _send_fcm and not _firebase_configured():
         logger.info("push_dispatch_disabled", reason="firebase_not_configured")
-        return {"sent": 0, "retried": 0, "skipped": 0, "invalid_tokens": 0}
+        return {
+            "sent": 0,
+            "retried": 0,
+            "skipped": 0,
+            "governed": 0,
+            "invalid_tokens": 0,
+        }
 
     utc_now = (now or datetime.now(UTC)).astimezone(UTC)
-    metrics = {"sent": 0, "retried": 0, "skipped": 0, "invalid_tokens": 0}
+    metrics = {
+        "sent": 0,
+        "retried": 0,
+        "skipped": 0,
+        "governed": 0,
+        "invalid_tokens": 0,
+    }
 
     async with safe_async_session() as session:
         rows = (
@@ -243,22 +259,40 @@ async def dispatch_daily_essentiel_pushes(
                     metrics["retried"] += 1
                 continue
 
-            teasers = [article.title for article in essentiel.articles[:2]]
-            body = teasers[0]
+            decision = await check_push_budget(
+                session,
+                user_id=device.user_id,
+                kind=PUSH_KIND,
+                now=utc_now,
+                target_date=target_date,
+            )
+            if not decision.allowed:
+                delivery.status = "skipped"
+                delivery.skipped_at = utc_now
+                delivery.error_code = decision.reason
+                metrics["governed"] += 1
+                logger.info(
+                    "push_governed",
+                    device_id=str(device.device_id),
+                    reason=decision.reason,
+                )
+                get_posthog_client().capture(
+                    device.user_id,
+                    "push_suppressed",
+                    {"kind": PUSH_KIND, "reason": decision.reason},
+                )
+                continue
+
+            composed = compose_daily_digest(essentiel, target_date)
             delivery.attempt_count += 1
             delivery.last_attempt_at = utc_now
             try:
                 await asyncio.to_thread(
                     sender,
                     device.fcm_token,
-                    "Facteur",
-                    body,
-                    {
-                        "route": "/digest",
-                        "target_date": target_date.isoformat(),
-                        "kind": PUSH_KIND,
-                        "teasers": json.dumps(teasers, ensure_ascii=False),
-                    },
+                    composed.title,
+                    composed.body,
+                    {**composed.data, "sent_at": utc_now.isoformat()},
                 )
             except Exception as exc:
                 delivery.status = "failed"
@@ -282,6 +316,24 @@ async def dispatch_daily_essentiel_pushes(
                 delivery.error_code = None
                 delivery.error_message = None
                 metrics["sent"] += 1
+                # Ajout direct (sans AnalyticsService.log_event, qui commit
+                # immédiatement) : un commit mid-loop expirerait les objets ORM
+                # de la boucle. Persisté par le commit final.
+                session.add(
+                    AnalyticsEvent(
+                        user_id=device.user_id,
+                        event_type="push_sent",
+                        event_data={
+                            "kind": PUSH_KIND,
+                            "target_date": target_date.isoformat(),
+                        },
+                    )
+                )
+                get_posthog_client().capture(
+                    device.user_id,
+                    "push_sent",
+                    {"kind": PUSH_KIND, "target_date": target_date.isoformat()},
+                )
 
         await session.commit()
 

--- a/packages/api/app/services/push_dispatcher.py
+++ b/packages/api/app/services/push_dispatcher.py
@@ -178,17 +178,6 @@ async def dispatch_daily_essentiel_pushes(
     sender: PushSender = _send_fcm,
 ) -> dict[str, int]:
     """Send due pushes once per device/day, retrying morning gaps until noon."""
-    if sender is _send_fcm and not _firebase_configured():
-        logger.info("push_dispatch_disabled", reason="firebase_not_configured")
-        return {
-            "sent": 0,
-            "retried": 0,
-            "skipped": 0,
-            "governed": 0,
-            "invalid_tokens": 0,
-        }
-
-    utc_now = (now or datetime.now(UTC)).astimezone(UTC)
     metrics = {
         "sent": 0,
         "retried": 0,
@@ -196,6 +185,11 @@ async def dispatch_daily_essentiel_pushes(
         "governed": 0,
         "invalid_tokens": 0,
     }
+    if sender is _send_fcm and not _firebase_configured():
+        logger.info("push_dispatch_disabled", reason="firebase_not_configured")
+        return metrics
+
+    utc_now = (now or datetime.now(UTC)).astimezone(UTC)
 
     async with safe_async_session() as session:
         rows = (
@@ -214,6 +208,8 @@ async def dispatch_daily_essentiel_pushes(
         ).all()
 
         digest_cache: dict[tuple[Any, date], Any] = {}
+        governor_cache: dict[tuple[Any, date], Any] = {}
+        composed_cache: dict[tuple[Any, date], Any] = {}
         for device, prefs in rows:
             try:
                 local_now = utc_now.astimezone(ZoneInfo(prefs.timezone))
@@ -259,13 +255,18 @@ async def dispatch_daily_essentiel_pushes(
                     metrics["retried"] += 1
                 continue
 
-            decision = await check_push_budget(
-                session,
-                user_id=device.user_id,
-                kind=PUSH_KIND,
-                now=utc_now,
-                target_date=target_date,
-            )
+            # Décision et composition stables par (user, target_date) dans un
+            # run : mutualisées entre les devices d'un même utilisateur (le
+            # gouverneur exclut déjà le push logique courant de ses budgets).
+            if cache_key not in governor_cache:
+                governor_cache[cache_key] = await check_push_budget(
+                    session,
+                    user_id=device.user_id,
+                    kind=PUSH_KIND,
+                    now=utc_now,
+                    target_date=target_date,
+                )
+            decision = governor_cache[cache_key]
             if not decision.allowed:
                 delivery.status = "skipped"
                 delivery.skipped_at = utc_now
@@ -283,7 +284,11 @@ async def dispatch_daily_essentiel_pushes(
                 )
                 continue
 
-            composed = compose_daily_digest(essentiel, target_date)
+            if cache_key not in composed_cache:
+                composed_cache[cache_key] = compose_daily_digest(
+                    essentiel, target_date
+                )
+            composed = composed_cache[cache_key]
             delivery.attempt_count += 1
             delivery.last_attempt_at = utc_now
             try:

--- a/packages/api/app/services/push_governor.py
+++ b/packages/api/app/services/push_governor.py
@@ -1,0 +1,86 @@
+"""Gouverneur de budget push par utilisateur (Epic 30, PR #1).
+
+Fenêtres glissantes 24h/7j en UTC sur les livraisons `sent`, comptées par
+`(user, target_date, kind)` distincts (multi-devices = 1 seul push logique).
+Règle des 4h : un kind non rituel est refusé si un push rituel a été envoyé il
+y a moins de 4h, ou si le prochain créneau rituel tombe dans moins de 4h — le
+rituel (tournée) garde son territoire. Le kind rituel n'est jamais bloqué par
+le cooldown mais reste soumis aux budgets.
+"""
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.push_notification import PushDelivery, PushDevice
+
+DAILY_BUDGET = 2
+WEEKLY_BUDGET = 6
+RITUAL_COOLDOWN = timedelta(hours=4)
+RITUAL_KINDS = {"daily_digest"}
+
+
+@dataclass(frozen=True)
+class GovernorDecision:
+    allowed: bool
+    reason: str | None = None
+
+
+async def check_push_budget(
+    session: AsyncSession,
+    *,
+    user_id: UUID,
+    kind: str,
+    now: datetime,
+    target_date: date | None = None,
+    next_ritual_at: datetime | None = None,
+) -> GovernorDecision:
+    """Décide si un push `kind` peut partir maintenant pour `user_id`.
+
+    `target_date` identifie le push logique en cours : ses livraisons déjà
+    `sent` (autres devices du même utilisateur) ne comptent pas dans les
+    budgets, sinon le 2e device serait bloqué par le 1er.
+    """
+    week_ago = now - timedelta(days=7)
+    day_ago = now - timedelta(hours=24)
+
+    rows = (
+        await session.execute(
+            select(
+                PushDelivery.target_date,
+                PushDelivery.kind,
+                func.max(PushDelivery.sent_at).label("last_sent_at"),
+            )
+            .join(PushDevice, PushDevice.device_id == PushDelivery.device_id)
+            .where(
+                PushDevice.user_id == user_id,
+                PushDelivery.status == "sent",
+                PushDelivery.sent_at >= week_ago,
+            )
+            .group_by(PushDelivery.target_date, PushDelivery.kind)
+        )
+    ).all()
+
+    if kind not in RITUAL_KINDS:
+        if any(
+            row.kind in RITUAL_KINDS and row.last_sent_at >= now - RITUAL_COOLDOWN
+            for row in rows
+        ):
+            return GovernorDecision(allowed=False, reason="ritual_cooldown")
+        if next_ritual_at is not None and now <= next_ritual_at < now + RITUAL_COOLDOWN:
+            return GovernorDecision(allowed=False, reason="ritual_upcoming")
+
+    budget_rows = [
+        row
+        for row in rows
+        if not (row.kind == kind and row.target_date == target_date)
+    ]
+    daily_count = sum(1 for row in budget_rows if row.last_sent_at >= day_ago)
+    if daily_count >= DAILY_BUDGET:
+        return GovernorDecision(allowed=False, reason="daily_budget_exceeded")
+    if len(budget_rows) >= WEEKLY_BUDGET:
+        return GovernorDecision(allowed=False, reason="weekly_budget_exceeded")
+    return GovernorDecision(allowed=True)

--- a/packages/api/tests/services/test_push_composer.py
+++ b/packages/api/tests/services/test_push_composer.py
@@ -1,0 +1,69 @@
+import json
+from datetime import date
+from types import SimpleNamespace
+
+from app.services.push_composer import (
+    DAILY_DIGEST_INTRO,
+    ComposedPush,
+    _truncate_fact,
+    compose_daily_digest,
+)
+
+TARGET = date(2026, 7, 18)
+
+
+def _essentiel(titles: list[str]):
+    return SimpleNamespace(articles=[SimpleNamespace(title=t) for t in titles])
+
+
+def test_compose_caps_teasers_at_three_and_keeps_order():
+    composed = compose_daily_digest(
+        _essentiel(["Un", "Deux", "Trois", "Quatre"]), TARGET
+    )
+    assert json.loads(composed.data["teasers"]) == ["Un", "Deux", "Trois"]
+
+
+def test_compose_body_is_intro_plus_first_title_for_ios_alert():
+    composed = compose_daily_digest(_essentiel(["Titre phare", "Deux"]), TARGET)
+    assert composed.body == "À retenir aujourd'hui : Titre phare"
+    assert composed.title == "Facteur"
+
+
+def test_compose_data_payload_contract():
+    composed = compose_daily_digest(_essentiel(["Un"]), TARGET)
+    assert isinstance(composed, ComposedPush)
+    assert composed.data["route"] == "/digest"
+    assert composed.data["kind"] == "daily_digest"
+    assert composed.data["target_date"] == "2026-07-18"
+    assert composed.data["intro"] == DAILY_DIGEST_INTRO
+
+
+def test_compose_with_fewer_than_three_articles():
+    composed = compose_daily_digest(_essentiel(["Seul"]), TARGET)
+    assert json.loads(composed.data["teasers"]) == ["Seul"]
+    assert composed.body == "À retenir aujourd'hui : Seul"
+
+
+def test_truncate_fact_keeps_short_title_intact():
+    assert _truncate_fact("Titre court") == "Titre court"
+
+
+def test_truncate_fact_cuts_at_word_boundary_with_ellipsis():
+    long_title = "mot " * 40  # 160 chars
+    truncated = _truncate_fact(long_title)
+    assert truncated.endswith("...")
+    assert len(truncated) <= 90
+    # Coupe au mot : pas de mot tronqué au milieu.
+    assert truncated.removesuffix("...").split(" ")[-1] == "mot"
+
+
+def test_truncate_fact_collapses_whitespace():
+    assert _truncate_fact("Un   titre\n aéré") == "Un titre aéré"
+
+
+def test_compose_truncates_long_teasers():
+    long_title = "A" * 200
+    composed = compose_daily_digest(_essentiel([long_title]), TARGET)
+    teaser = json.loads(composed.data["teasers"])[0]
+    assert teaser.endswith("...")
+    assert len(teaser) <= 90

--- a/packages/api/tests/services/test_push_dispatcher.py
+++ b/packages/api/tests/services/test_push_dispatcher.py
@@ -1,3 +1,4 @@
+import json
 from datetime import UTC, date, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
@@ -6,6 +7,7 @@ from uuid import uuid4
 import pytest
 from sqlalchemy import select
 
+from app.models.analytics import AnalyticsEvent
 from app.models.push_notification import PushDelivery, PushDevice
 from app.models.user import UserProfile
 from app.models.user_notification_preferences import UserNotificationPreferences
@@ -86,6 +88,105 @@ async def test_dispatch_is_idempotent_per_device_and_local_date(
     assert delivery is not None
     assert delivery.status == "sent"
     assert delivery.target_date == date(2026, 6, 15)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_sends_composed_payload_with_intro_and_sent_at(
+    db_session, fake_session_maker
+):
+    user_id, _ = await _seed_push_user(db_session)
+    sender = Mock(return_value="message-id")
+
+    def sync_sender(*args):
+        return sender(*args)
+
+    essentiel = SimpleNamespace(
+        articles=[
+            SimpleNamespace(title="Un"),
+            SimpleNamespace(title="Deux"),
+            SimpleNamespace(title="Trois"),
+            SimpleNamespace(title="Quatre"),
+        ]
+    )
+    now = datetime(2026, 6, 15, 6, 35, tzinfo=UTC)
+    with (
+        patch(
+            "app.services.push_dispatcher.safe_async_session",
+            fake_session_maker,
+        ),
+        patch(
+            "app.services.push_dispatcher._build_exact_essentiel",
+            new=AsyncMock(return_value=essentiel),
+        ),
+    ):
+        metrics = await dispatch_daily_essentiel_pushes(now=now, sender=sync_sender)
+
+    assert metrics["sent"] == 1
+    token, title, body, data = sender.call_args.args
+    assert title == "Facteur"
+    assert body == "À retenir aujourd'hui : Un"
+    assert data["intro"] == "À retenir aujourd'hui :"
+    assert json.loads(data["teasers"]) == ["Un", "Deux", "Trois"]
+    assert data["kind"] == "daily_digest"
+    assert data["sent_at"] == now.isoformat()
+    # Event serveur push_sent journalisé pour l'utilisateur.
+    event = await db_session.scalar(
+        select(AnalyticsEvent).where(
+            AnalyticsEvent.user_id == user_id,
+            AnalyticsEvent.event_type == "push_sent",
+        )
+    )
+    assert event is not None
+    assert event.event_data["kind"] == "daily_digest"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_skips_definitively_when_governor_refuses(
+    db_session, fake_session_maker
+):
+    _, device_id = await _seed_push_user(db_session)
+    sender = Mock(return_value="message-id")
+
+    from app.services.push_governor import GovernorDecision
+
+    with (
+        patch(
+            "app.services.push_dispatcher.safe_async_session",
+            fake_session_maker,
+        ),
+        patch(
+            "app.services.push_dispatcher._build_exact_essentiel",
+            new=AsyncMock(
+                return_value=SimpleNamespace(articles=[SimpleNamespace(title="Un")])
+            ),
+        ),
+        patch(
+            "app.services.push_dispatcher.check_push_budget",
+            new=AsyncMock(
+                return_value=GovernorDecision(allowed=False, reason="daily_budget_exceeded")
+            ),
+        ),
+    ):
+        metrics = await dispatch_daily_essentiel_pushes(
+            now=datetime(2026, 6, 15, 6, 35, tzinfo=UTC),
+            sender=lambda *args: sender(*args),
+        )
+        # Second run : le skipped est définitif, pas de retry.
+        second = await dispatch_daily_essentiel_pushes(
+            now=datetime(2026, 6, 15, 7, 0, tzinfo=UTC),
+            sender=lambda *args: sender(*args),
+        )
+
+    assert metrics["governed"] == 1
+    assert second["governed"] == 0
+    assert sender.call_count == 0
+    delivery = await db_session.scalar(
+        select(PushDelivery).where(PushDelivery.device_id == device_id)
+    )
+    assert delivery is not None
+    assert delivery.status == "skipped"
+    assert delivery.error_code == "daily_budget_exceeded"
+    assert delivery.skipped_at is not None
 
 
 @pytest.mark.asyncio

--- a/packages/api/tests/services/test_push_governor.py
+++ b/packages/api/tests/services/test_push_governor.py
@@ -1,0 +1,266 @@
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from app.models.push_notification import PushDelivery, PushDevice
+from app.models.user import UserProfile
+from app.services.push_governor import check_push_budget
+
+NOW = datetime(2026, 7, 18, 12, 0, tzinfo=UTC)
+
+
+async def _seed_user(db_session, *, devices=1):
+    user_id = uuid4()
+    db_session.add(
+        UserProfile(
+            user_id=user_id,
+            display_name="Governor User",
+            onboarding_completed=True,
+        )
+    )
+    await db_session.flush()
+    device_ids = []
+    for i in range(devices):
+        device_id = uuid4()
+        device_ids.append(device_id)
+        db_session.add(
+            PushDevice(
+                device_id=device_id,
+                user_id=user_id,
+                fcm_token=f"governor-token-{i}",
+                platform="android",
+                timezone="Europe/Paris",
+            )
+        )
+    await db_session.flush()
+    return user_id, device_ids
+
+
+def _delivery(device_id, *, kind, sent_at, status="sent"):
+    return PushDelivery(
+        device_id=device_id,
+        target_date=sent_at.date(),
+        kind=kind,
+        status=status,
+        sent_at=sent_at if status == "sent" else None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_allows_first_push_of_the_day(db_session):
+    user_id, _ = await _seed_user(db_session)
+    await db_session.commit()
+
+    decision = await check_push_budget(
+        db_session, user_id=user_id, kind="daily_digest", now=NOW
+    )
+    assert decision.allowed
+
+
+@pytest.mark.asyncio
+async def test_daily_budget_blocks_third_push_in_24h(db_session):
+    user_id, (device_id,) = await _seed_user(db_session)
+    db_session.add_all(
+        [
+            _delivery(device_id, kind="daily_digest", sent_at=NOW - timedelta(hours=5)),
+            _delivery(
+                device_id, kind="source_alert", sent_at=NOW - timedelta(hours=10)
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    decision = await check_push_budget(
+        db_session, user_id=user_id, kind="topic_alert", now=NOW
+    )
+    assert not decision.allowed
+    assert decision.reason == "daily_budget_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_daily_window_is_sliding_not_calendar(db_session):
+    user_id, (device_id,) = await _seed_user(db_session)
+    # 2 pushes il y a 25h : hors fenêtre 24h, mais dans la fenêtre 7j.
+    db_session.add_all(
+        [
+            _delivery(
+                device_id, kind="daily_digest", sent_at=NOW - timedelta(hours=25)
+            ),
+            _delivery(
+                device_id, kind="source_alert", sent_at=NOW - timedelta(hours=26)
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    decision = await check_push_budget(
+        db_session, user_id=user_id, kind="source_alert", now=NOW
+    )
+    assert decision.allowed
+
+
+@pytest.mark.asyncio
+async def test_weekly_budget_blocks_seventh_push(db_session):
+    user_id, (device_id,) = await _seed_user(db_session)
+    db_session.add_all(
+        [
+            _delivery(
+                device_id, kind="daily_digest", sent_at=NOW - timedelta(days=d, hours=6)
+            )
+            for d in range(1, 7)
+        ]
+    )
+    await db_session.commit()
+
+    decision = await check_push_budget(
+        db_session, user_id=user_id, kind="source_alert", now=NOW
+    )
+    assert not decision.allowed
+    assert decision.reason == "weekly_budget_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_multi_devices_same_logical_push_count_once(db_session):
+    user_id, device_ids = await _seed_user(db_session, devices=3)
+    sent_at = NOW - timedelta(hours=6)
+    for device_id in device_ids:
+        db_session.add(_delivery(device_id, kind="daily_digest", sent_at=sent_at))
+    await db_session.commit()
+
+    # 3 devices = 1 push logique → le budget quotidien (2) n'est pas atteint.
+    decision = await check_push_budget(
+        db_session, user_id=user_id, kind="source_alert", now=NOW
+    )
+    assert decision.allowed
+
+
+@pytest.mark.asyncio
+async def test_same_logical_push_does_not_block_its_other_devices(db_session):
+    user_id, device_ids = await _seed_user(db_session, devices=2)
+    # Device 1 déjà servi aujourd'hui + un autre kind dans la fenêtre 24h :
+    # le device 2 du MÊME push logique (target_date, kind) doit passer.
+    db_session.add_all(
+        [
+            _delivery(
+                device_ids[0], kind="daily_digest", sent_at=NOW - timedelta(minutes=10)
+            ),
+            _delivery(
+                device_ids[0], kind="source_alert", sent_at=NOW - timedelta(hours=10)
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    decision = await check_push_budget(
+        db_session,
+        user_id=user_id,
+        kind="daily_digest",
+        now=NOW,
+        target_date=NOW.date(),
+    )
+    assert decision.allowed
+
+
+@pytest.mark.asyncio
+async def test_non_ritual_blocked_within_4h_after_ritual(db_session):
+    user_id, (device_id,) = await _seed_user(db_session)
+    db_session.add(
+        _delivery(device_id, kind="daily_digest", sent_at=NOW - timedelta(hours=3))
+    )
+    await db_session.commit()
+
+    decision = await check_push_budget(
+        db_session, user_id=user_id, kind="source_alert", now=NOW
+    )
+    assert not decision.allowed
+    assert decision.reason == "ritual_cooldown"
+
+
+@pytest.mark.asyncio
+async def test_non_ritual_blocked_when_ritual_upcoming_within_4h(db_session):
+    user_id, _ = await _seed_user(db_session)
+    await db_session.commit()
+
+    decision = await check_push_budget(
+        db_session,
+        user_id=user_id,
+        kind="source_alert",
+        now=NOW,
+        next_ritual_at=NOW + timedelta(hours=2),
+    )
+    assert not decision.allowed
+    assert decision.reason == "ritual_upcoming"
+
+
+@pytest.mark.asyncio
+async def test_non_ritual_allowed_when_ritual_far_enough(db_session):
+    user_id, (device_id,) = await _seed_user(db_session)
+    db_session.add(
+        _delivery(device_id, kind="daily_digest", sent_at=NOW - timedelta(hours=5))
+    )
+    await db_session.commit()
+
+    decision = await check_push_budget(
+        db_session,
+        user_id=user_id,
+        kind="source_alert",
+        now=NOW,
+        next_ritual_at=NOW + timedelta(hours=6),
+    )
+    assert decision.allowed
+
+
+@pytest.mark.asyncio
+async def test_ritual_kind_exempt_from_cooldown_but_not_from_budgets(db_session):
+    user_id, (device_id,) = await _seed_user(db_session)
+    # Un rituel envoyé il y a 1h ne bloque pas un autre envoi rituel (autre
+    # target_date, ex. rattrapage) par le cooldown...
+    db_session.add(
+        _delivery(device_id, kind="daily_digest", sent_at=NOW - timedelta(hours=1))
+    )
+    await db_session.commit()
+
+    decision = await check_push_budget(
+        db_session, user_id=user_id, kind="daily_digest", now=NOW
+    )
+    assert decision.allowed
+
+    # ... mais les budgets s'appliquent : 2 pushes distincts en 24h → refus.
+    db_session.add(
+        _delivery(device_id, kind="source_alert", sent_at=NOW - timedelta(hours=2))
+    )
+    await db_session.commit()
+    decision = await check_push_budget(
+        db_session, user_id=user_id, kind="daily_digest", now=NOW
+    )
+    assert not decision.allowed
+    assert decision.reason == "daily_budget_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_ignores_non_sent_and_other_users(db_session):
+    user_id, (device_id,) = await _seed_user(db_session)
+    other_user, (other_device,) = await _seed_user(db_session)
+    db_session.add_all(
+        [
+            _delivery(
+                device_id,
+                kind="daily_digest",
+                sent_at=NOW - timedelta(hours=1),
+                status="skipped",
+            ),
+            _delivery(
+                other_device, kind="daily_digest", sent_at=NOW - timedelta(hours=1)
+            ),
+            _delivery(
+                other_device, kind="source_alert", sent_at=NOW - timedelta(hours=2)
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    decision = await check_push_budget(
+        db_session, user_id=user_id, kind="source_alert", now=NOW
+    )
+    assert decision.allowed


### PR DESCRIPTION
## Quoi
Fondations serveur des Alertes (Epic 30, PR #1) : gouverneur de budget push par utilisateur (2/24h, 6/7j glissants UTC, règle 4h autour du rituel) + push quotidien enrichi « coup d'œil » (intro neutre « À retenir aujourd'hui : » + 3 titres bruts, `sent_at` pour le time-to-open). Aucune migration Alembic.

## Pourquoi
Brainstorm notifs intelligentes + arbitrages PO du 18/07 (docs/brainstorming/). Le push quotidien ne montrait pas l'important du jour, et les futures alertes (PR #2/#3) exigent un anti-spam serveur en place d'abord. Story : `docs/stories/core/30.1.push-coup-doeil-gouverneur.md` (inclut la spec UX Alertes validée, référence pour PR #2/#3).

## Comment
- `push_composer.py` : `compose_daily_digest` (3 teasers tronqués 90c au mot, intro, body iOS), `ComposedPush`.
- `push_governor.py` : `check_push_budget` → budgets glissants comptés par `(user, target_date, kind)` distincts (multi-devices = 1, le push logique courant ne se bloque pas lui-même) ; `ritual_cooldown`/`ritual_upcoming` ; kind rituel exempt du cooldown mais soumis aux budgets.
- `push_dispatcher.py` : gouverneur avant envoi (refus → `skipped` définitif + métrique `governed` + PostHog `push_suppressed`), `sent_at` ISO UTC, succès → `analytics_events.push_sent` + PostHog. Décision/composition mutualisées par (user, date) dans un run.
- Mobile : `buildCopy` passe à 3 bullets + intro serveur (rétrocompat : intro absente → en-tête actuel), `push_opened` `{kind, time_to_open}` à l'ouverture d'un push serveur, `notif_opened` au tap d'une notif locale.

## Comment ça a été vérifié
- [x] pytest complet : 2282 passed (dont 27 nouveaux tests composer/gouverneur/dispatcher)
- [x] flutter test : suites push OK (21) ; 27 échecs pré-existants hors périmètre (connus, CI ne lance pas flutter test) ; flutter analyze : 0 erreur
- [x] /simplify passé (caches par user, metrics unique, seam de test direct)
- [ ] Playwright : N/A (services push, pas de surface UI web)

## Zones à risque
`push_dispatcher.py` (envoi FCM quotidien) : idempotence `(device_id, target_date, kind)` inchangée, refus gouverneur = skipped définitif ; titre/son/canal du push tournée intouchés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)