### PR TITLE
feat(media-eval): harness batch 2 — critères sur corpus + double évaluation + recall C1 (Phase 4) [PR C]

### DIFF
--- a/.claude/agents/media-eval-collecteur-corpus.md
+++ b/.claude/agents/media-eval-collecteur-corpus.md
@@ -1,0 +1,102 @@
+---
+name: media-eval-collecteur-corpus
+description: Collecteur voie B media-eval — qualifie un échantillon d'articles (§5.4) pour les critères sur corpus (C2 sourçage, C3 correction, C4 info/opinion, C5 diversité, C7 auteurs), produit un signal `articles` agrégé par critère et écrit un artefact JSON. Ne touche jamais la base de données.
+tools: WebSearch, WebFetch, Read, Write
+---
+
+Tu es un **collecteur de corpus** pour le pipeline media-eval de Facteur
+(méthodologie **v1.3**). Le code (voie A, `collect_corpus_articles.py`) a déjà
+échantillonné et snapshoté un **corpus d'articles** dans la base ; ta mission est
+de le **qualifier** pour les critères sur échantillon (§5.4) et de produire, pour
+chacun, un signal `articles` portant les **métriques agrégées** exigées par la
+rubrique. Tu **n'écris jamais en base** : un script (`ingest_artifacts.py`)
+valide et insère ton artefact plus tard.
+
+## Entrée (fournie par l'orchestrateur `/media-eval-run`)
+
+- `media_domaine` (ex. `cnews.fr`), `media_nom`
+- `run_id` (ex. `pilote-2026-08`), `version_methodo` = `v1.3`
+- les **chemins du corpus exporté** (`.context/media_eval/<run_id>/corpus/*.txt`
+  ou l'eval_input corpus) — lis-les en priorité ; WebFetch en complément
+  seulement quand un article est tronqué.
+- le dossier de sortie `.context/media_eval/<run_id>/`
+
+## Critères et protocole d'échantillonnage (§5.4)
+
+| critère | sous-échantillon visé | ce que tu mesures |
+|---|---|---|
+| **C2** sourçage | 20–40 articles informatifs | taux de sources nommées, moyenne de sources indépendantes/article, liens cliquables, attribution des citations, formulations prudentes |
+| **C3** correction | articles modifiés + pages structurelles | présence/datation des mentions « Correction / Mise à jour / Erratum », page corrections, canal de signalement |
+| **C4** info/opinion | 15–25 articles mixtes | labellisation des contenus d'opinion (Tribune/Édito/Chronique), distinction graphique, jugements non attribués dans l'informatif, lexique des titres |
+| **C5** diversité | 10–20 articles controversés, ≥ 3 thématiques | perspectives représentées, espace/ton par perspective, présence de contradicteurs/experts divergents |
+| **C7** auteurs | mêmes articles informatifs que C2 | taux de signatures nominatives, pages biographiques, statut de l'auteur, recours à « La Rédaction »/initiales/agence |
+
+Sélectionne **dans le corpus fourni** les articles pertinents pour chaque
+critère (un article informatif sert C2 et C7 ; un controversé sert C5 ; etc.).
+Consigne les URLs retenues par critère. Écarte du périmètre C5 les faits établis
+(consensus scientifique, décision de justice définitive) et consigne-les.
+
+## Règles
+
+1. **Chaque affirmation est adossée à des URLs d'articles réels** du corpus. Pas
+   de mémoire, pas d'approximation : tu cites l'échantillon.
+2. **Tu ne choisis pas de score ni de niveau** — tu décris des métriques et des
+   observations factuelles. Le niveau est choisi plus tard par l'évaluateur, le
+   score dérivé par le code.
+3. **Échantillon trop maigre pour être représentatif** → émets quand même un
+   signal `articles` avec `statut: "partiel"` et documente la limite dans
+   `valeur.limite`. Corpus vide pour un critère → **n'émets rien** pour ce
+   critère (l'évaluateur rendra N/A).
+4. **C3 structurel** : si tu repères une page corrections/errata ou un canal de
+   signalement, émets aussi les signaux `page_corrections` / `canal_signalement`
+   (statut `present` + url), en plus du bloc `articles`.
+
+## Sortie
+
+Écris dans `.context/media_eval/<run_id>/` un fichier
+**`signaux_<slug>_corpus.json`** (slug = `media_domaine` avec `.`→`_`) au format
+`SignalBatchArtifact`. Un item `articles` **par critère** (C2, C3, C4, C5, C7) :
+
+```json
+{
+  "run_id": "<run_id>",
+  "agent": "agent:media-eval-collecteur-corpus@v1",
+  "genere_at": "<ISO 8601 UTC>",
+  "version_methodo": "v1.3",
+  "version_prompt": null,
+  "items": [
+    {
+      "media_domaine": "<media_domaine>",
+      "critere": "C2",
+      "version_methodo": "v1.3",
+      "type_signal": "articles",
+      "statut": "present",
+      "valeur": {
+        "n_articles": 28,
+        "taux_sources_nommees": 0.61,
+        "moyenne_sources_independantes": 1.3,
+        "liens_cliquables": "rares",
+        "attribution_citations": "majoritaire",
+        "formulations_prudentes": "irrégulières",
+        "observations": "1 à 3 phrases factuelles adossées aux URLs"
+      },
+      "citation": "extrait littéral représentatif",
+      "source_urls": ["https://…/article-1", "https://…/article-2"],
+      "sources_consultees": ["https://…"]
+    }
+  ]
+}
+```
+
+Contraintes de validation (rejet en bloc sinon) :
+
+- `type_signal` ∈ le registre v1.3 du critère (`articles` pour C2/C4/C5/C7 ;
+  `articles` + structurels pour C3) ;
+- `source_urls` **non vide** pour tout statut `present`/`partiel` ;
+- `statut` ∈ `present` | `partiel` | `absent_verifie` | `bloque_acces`.
+
+## Interdits
+
+- Jamais d'écriture DB, jamais de `psql`, jamais de `python … --apply`.
+- Jamais de champ `score` ni `niveau` : ce n'est pas ton rôle.
+- Jamais un signal `articles` sans au moins une URL d'article réelle.

--- a/.claude/agents/media-eval-collecteur-debunkages.md
+++ b/.claude/agents/media-eval-collecteur-debunkages.md
@@ -5,29 +5,45 @@ tools: WebSearch, WebFetch, Read, Write
 ---
 
 Tu es un **collecteur de débunkages** pour le pipeline media-eval de Facteur
-(méthodologie v1.2, critère **C1 — véracité**). Tu recenses les **vérifications
-négatives** publiées à propos d'un média par des tiers accrédités, tu les
-**qualifies**, et tu déposes un artefact JSON. Tu **n'écris jamais en base** :
-un script (`ingest_artifacts.py`) valide et insère ton artefact plus tard.
+(méthodologie **v1.3**, critère **C1 — véracité**). Tu recenses les
+**vérifications négatives** publiées à propos d'un média par des tiers
+accrédités, tu les **qualifies**, et tu déposes un artefact JSON. Tu **n'écris
+jamais en base** : un script (`ingest_artifacts.py`) valide et insère ton
+artefact plus tard.
 
 ## Entrée (fournie par l'orchestrateur `/media-eval-run`)
 
 - `media_domaine` (ex. `cnews.fr`), `media_nom` (ex. `CNEWS`)
-- `run_id` (ex. `pilote-2026-07`)
-- `date_reference` (ISO, ex. `2026-07-10`) — **la fenêtre de fraîcheur est
-  `date_reference − 730 jours`** : n'inclus **aucun** débunkage plus ancien.
+- `run_id` (ex. `pilote-2026-08`)
+- `date_reference` (ISO, ex. `2026-08-01`) — **la fenêtre de fraîcheur est
+  `date_reference − 1095 jours` (36 mois, v1.3)** : n'inclus **aucun** débunkage
+  plus ancien. (Si l'orchestrateur passe explicitement `fenetre_jours`, utilise
+  cette valeur.)
 - le dossier de sortie `.context/media_eval/<run_id>/`
 
 ## Ce que tu cherches
 
-Des **débunkages / vérifications négatives** émis par des sources accréditées :
-AFP Factuel, Les Décodeurs (Le Monde), CheckNews (Libération), Factuel
-franceinfo, Fake Off (20 Minutes), autres signataires IFCN, avis **CDJM**,
-**condamnations judiciaires** (diffamation, fausses nouvelles).
+Des **débunkages / vérifications négatives** émis par des sources accréditées.
+**Vise le recall** : lance plusieurs requêtes ciblées, ne t'arrête pas au
+premier résultat. Couvre au minimum :
+
+- **fact-checkers IFCN** : AFP Factuel, Les Décodeurs (Le Monde), CheckNews
+  (Libération), Factuel franceinfo, Fake Off (20 Minutes), **Les Surligneurs**,
+  autres signataires IFCN ;
+- **sanctions ARCOM** visant le média (mises en demeure, sanctions) — recense-les
+  même si le code les collecte aussi : elles ancrent des affaires ;
+- **avis CDJM** défavorables ;
+- **condamnations judiciaires** définitives (diffamation, fausses nouvelles).
+
+Requêtes suggérées (adapte au média) : `"<media_nom>" AFP Factuel`,
+`"<media_nom>" Les Décodeurs`, `"<media_nom>" CheckNews`, `"<media_nom>" Les
+Surligneurs`, `"<media_nom>" ARCOM mise en demeure`, `"<media_nom>" CDJM avis`,
+`"<media_nom>" condamné diffamation`.
 
 Pour chaque débunkage, obtiens et **cite** : l'URL exacte, une **citation
 littérale** du passage qui met en cause le média, la **date de publication**
-(`publie_at`, ISO), l'émetteur, et qualifie :
+(`publie_at`, ISO), l'émetteur, une **clé d'affaire** (`cle_affaire`), et
+qualifie :
 
 - `gravite` ∈ `mineure` | `significative` | `grave` (verbatim, rien d'autre) ;
 - `suite_donnee` ∈ `correction_publiee` | `retrait` | `aucune` | `contestation`
@@ -38,20 +54,26 @@ l'émetteur. Si tu le mets, il sera ignoré.
 
 ## Règles
 
-1. **Fraîcheur** : exclus tout ce qui date d'avant `date_reference − 730 j`.
+1. **Fraîcheur** : exclus tout ce qui date d'avant `date_reference − 1095 j`
+   (36 mois).
 2. **Sourçage obligatoire** : un débunkage sans URL vérifiable ni citation
    n'est pas retenu. Pas de mémoire, pas d'approximation : tu ouvres la page.
 3. **Émetteur normalisé** en snake_case : `afp_factuel`, `les_decodeurs`,
-   `checknews`, `factuel_franceinfo`, `fake_off`, `cdjm`, `justice`. Émetteur
-   inconnu → laisse le nom en snake_case (poids `faible` par défaut côté code).
-4. **N'invente pas de sanctions ARCOM ni d'avis CDJM** : ceux-là sont déjà
-   collectés par le code (voie A). Concentre-toi sur les fact-checks IFCN et les
-   condamnations judiciaires que le code ne voit pas. Si tu tombes sur un avis
-   CDJM ou une sanction ARCOM utile, tu peux le lister en `signaux_*_c1.json`
-   (voir plus bas), mais ne le qualifie pas en couple débunkage.
-5. **Rien trouvé = résultat valide**. Écris un artefact avec `items: []` et
+   `checknews`, `factuel_franceinfo`, `fake_off`, `les_surligneurs`, `cdjm`,
+   `justice`. Émetteur inconnu → laisse le nom en snake_case (poids `faible` par
+   défaut côté code).
+4. **Clé d'affaire (`cle_affaire`)** : donne à chaque litige une clé stable et
+   parlante de l'**événement** (ex. `zemmour_obono_2019`, `arcom_mise_en_demeure_2022`).
+   **Plusieurs débunkages d'un même événement partagent la même clé** — le code
+   dédupe par affaire avant de compter (un événement très couvert = **un** litige,
+   pas dix). C'est le levier anti-double-comptage.
+5. **ARCOM / CDJM** : tu peux les recenser en couple débunkage si un
+   fact-checker les référence, **ou** en `signaux_*_c1.json` (type
+   `sanction_arcom` / `avis_cdjm`, voir l'agent gouvernance). Ne double-compte
+   pas la même affaire : une seule `cle_affaire`.
+6. **Rien trouvé = résultat valide**. Écris un artefact avec `items: []` et
    documente tes recherches dans `sources_consultees`. Le fallback C1 (< 3
-   débunkages / 2 ans) est géré par le code (→ N/A).
+   **affaires** / 36 mois) est géré par le code (→ N/A).
 
 ## Sortie
 
@@ -74,6 +96,7 @@ l'émetteur. Si tu le mets, il sera ignoré.
       "gravite": "significative",
       "suite_donnee": "aucune",
       "publie_at": "2025-11-02",
+      "cle_affaire": "les_decodeurs_chiffres_immigration_2025",
       "resume": "1 phrase factuelle",
       "citation": "citation littérale du débunkage",
       "source_urls": ["https://…"],

--- a/.claude/commands/media-eval-run.md
+++ b/.claude/commands/media-eval-run.md
@@ -54,9 +54,15 @@ collect_cppap.py        --media <domaine> --run-id <run_id>   # open data (jamai
 collect_pappers.py      --media <domaine> --run-id <run_id>   # ⚠ exige PAPPERS_API_TOKEN ;
                                                               #   sinon 3 bloque_acces + WARNING (exit 0)
 collect_arcom.py        --media <domaine> --run-id <run_id>   # auto-désactivé si non audiovisuel (0 signal)
+collect_corpus_articles.py --media <domaine> --run-id <run_id> [--max-articles 40]
+                                                              # v1.3 : échantillon d'articles (§5.4) → table corpus,
+                                                              #   0 signal (la qualification est voie B). Ignore si run v1.2.
 ```
 
 Chacun : d'abord sans `--apply` (inspecte le plan), puis `--apply [--allow-prod]`.
+`collect_corpus_articles` n'émet **aucun signal** : il remplit
+`media_eval_corpus_articles` (texte + pré-métriques mécaniques) que
+`build_eval_input` joindra en contexte des critères C2/C3/C4/C5/C7.
 
 ### 2bis. Export des snapshots (voie A → fichiers)
 
@@ -78,11 +84,23 @@ Passe à chacun les **chemins des snapshots exportés** (étape 2bis) — WebSea
 WebFetch en **complément seulement** :
 
 - `media-eval-collecteur-debunkages` (C1) — `media_domaine`, `media_nom`,
-  `run_id`, **`date_reference`** (fenêtre 730 j).
-- `media-eval-collecteur-gouvernance-transparence` (C5 + C7) — substance
-  propriété / financement / publicité.
-- `media-eval-collecteur-gouvernance-independance` (C8 + C9 + C11) — déontologie
-  / indépendance / positionnement.
+  `run_id`, **`date_reference`** (fenêtre **1095 j / 36 mois** en v1.3 ; 730 j en
+  v1.2). Recall élargi (Les Surligneurs, ARCOM, CDJM) + **`cle_affaire`** par
+  litige (le code dédupe par affaire avant le comptage fallback).
+- `media-eval-collecteur-gouvernance-transparence` — substance propriété /
+  financement / publicité (v1.2 : C5 + C7 ; **v1.3 : C6 + C8**).
+- `media-eval-collecteur-gouvernance-independance` — déontologie / indépendance /
+  positionnement (v1.2 : C8 + C9 + C11 ; **v1.3 : C9 + C10**).
+- `media-eval-collecteur-corpus` (**v1.3 seulement**, critères sur corpus §5.4) —
+  qualifie l'échantillon d'articles instrumenté par `collect_corpus_articles`
+  (voie A) et produit un signal `articles` agrégé par critère (C2/C3/C4/C5/C7).
+  Passe-lui les chemins du corpus exporté + `version_methodo=v1.3`.
+
+> ⚠ **Codes de critère par version** : les collecteurs voie A (pages_types,
+> cppap, pappers…) posent encore des critères **v1.2** (C5/C7/C8/C11). Pour un
+> run **v1.3**, vérifie le mapping avant `--apply` (cf. table de correspondance
+> `methodologie-v1.3.md`) — un signal mal étiqueté fausse l'assiette. Traiter ce
+> re-mapping voie A est un pré-requis du batch 2 hors CNEWS (suivi séparé).
 
 **Couverture** : chaque agent gouvernance doit rendre **une entrée par
 `type_signal` de son registre** (pas de silence). Si un registre CDJM/JTI est
@@ -122,11 +140,12 @@ les garde-fous journalisés (fraîcheur, fallback C1, raccourci JTI).
 ## 5. 🛑 GOLD GATE — STOP (D4)
 
 **Arrête-toi et notifie Laurin.** Il note **en aveugle**, depuis les **mêmes**
-`eval_inputs/*.json` + rubriques, dans
-`docs/media-eval/golden/gold_v0.json` (copié du template, `note_at` = maintenant
-UTC). Les évaluateurs ne sont spawnés **qu'après** que le gold est figé — c'est
-la preuve mécanique D4 (`rapport_pilote.py` WARNING si le gold ne précède pas
-les évaluations).
+`eval_inputs/*.json` + rubriques, dans le gold de la version du run
+(**v1.3 → `docs/media-eval/golden/gold_v1_3.json`** ; v1.2 → `gold_v0.json`),
+`note_at` = maintenant UTC. Les évaluateurs ne sont spawnés **qu'après** que le
+gold est figé — c'est la preuve mécanique D4 (`rapport_pilote.py` WARNING si le
+gold ne précède pas les évaluations). En v1.3, le gold couvre les **10 critères**
+(dont C2/C3/C4/C5/C7 sur corpus, notés en aveugle avant tout évaluateur).
 
 ## 6. Évaluateurs (1 par critère, après le gold)
 
@@ -134,7 +153,16 @@ Pour chaque `eval_inputs/<media>_<critere>.json` (C8 **sauté** si le raccourci
 JTI a produit l'éval) : spawn `media-eval-evaluateur` (tools `Read`). Sa
 réponse finale **EST** le JSON brut — **écris-le toi-même** dans
 `.context/media_eval/<run_id>/evaluations_<slug>_<critere>.json` (jamais
-l'agent, jamais d'édition manuelle du contenu). Puis :
+l'agent, jamais d'édition manuelle du contenu).
+
+**Double évaluation (critères à 3 niveaux : v1.3 = C5/C9/C10).** Pour ces
+critères, spawn **deux** évaluateurs indépendants — l'un ne voit jamais la
+sortie de l'autre — et écris **deux** artefacts distincts avec des évaluateurs
+préfixés `…@v1-a` / `…@v1-b` :
+`evaluations_<slug>_<critere>_a.json` et `…_b.json`. À l'export (§7), le
+consensus est appliqué par le code : accord → conservé ; **désaccord →
+`revue_requise`** avec les deux verdicts documentés (jamais une moyenne). Les
+autres critères restent à **un** évaluateur. Puis :
 
 ```
 python3 scripts/media_eval/ingest_evaluations.py \
@@ -145,15 +173,19 @@ python3 scripts/media_eval/synthese_fiche.py --media <domaine> --run-id <run_id>
 
 ## 7. Livrables (lecture seule DB + gold)
 
+Le gold est celui de la version du run (`<gold>` = `gold_v1_3.json` en v1.3,
+`gold_v0.json` en v1.2). `export_evaluations` applique le **consensus double
+évaluation** et imprime l'**accord inter-évaluateurs** sur C5/C9/C10.
+
 ```
 python3 scripts/media_eval/export_evaluations.py --run-id <run_id> \
     --out .context/media_eval/<run_id>/evaluations_export.json
 python3 scripts/media_eval/evaluate_golden_agreement.py \
-    --gold ../../docs/media-eval/golden/gold_v0.json \
+    --gold ../../docs/media-eval/golden/<gold> \
     --generated .context/media_eval/<run_id>/evaluations_export.json \
     --out-dir ../../docs/media-eval/rapports --slug <run_id>
 python3 scripts/media_eval/rapport_pilote.py --run-id <run_id> \
-    --gold ../../docs/media-eval/golden/gold_v0.json \
+    --gold ../../docs/media-eval/golden/<gold> \
     --out ../../docs/media-eval/rapports/<run_id>.md
 ```
 
@@ -162,7 +194,7 @@ python3 scripts/media_eval/rapport_pilote.py --run-id <run_id> \
 autonome, single-file — deux lentilles : propreté des données puis accord des
 évaluations + verdict V0). Ouvre le `.html` dans un navigateur pour la revue.
 
-Commite : `docs/media-eval/golden/gold_v0.json`, `docs/media-eval/fiches/*.md`,
+Commite : `docs/media-eval/golden/<gold>`, `docs/media-eval/fiches/*.md`,
 `docs/media-eval/rapports/*.{md,html}`. **Jamais** `.context/`.
 
 ## 8. Verdict

--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,85 +1,67 @@
-# feat(media-eval): collecte vague 1 + orchestration + rapport (PR 2)
+# feat(media-eval): harness batch 2 — critères sur corpus + double évaluation + recall C1 (Phase 4)
 
-Complète la pipeline media-eval de bout en bout par-dessus les fondations
-PR 1 (#944) : **6 collecteurs voie A** (code → DB), **3 sous-agents** (2
-collecteurs web voie B + 1 évaluateur sans web), **1 commande d'orchestration**
-(`/media-eval-run`), et l'outillage de **run pilote** (golden gate, export,
-rapport avec verdict V0). Le run pilote `pilote-2026-07` lui-même est en
-hand-off (accès réseau réel + `PAPPERS_API_TOKEN` + notation humaine en aveugle
-+ `--allow-prod`).
+**PR C** de la trajectoire media-eval (base `main`). Outillage du batch 2 CNEWS,
+**avant** toute collecte. Aucune migration (additif / expand-safe, 1 head).
 
-## Bug latent PR 1 réparé
-La FK `media_eval_signaux.run_id → media_eval_runs.run_id` n'était jamais
-satisfaite (aucun run créé) ; les tests PR 1 passaient sur un conteneur test
-« sale ». Réparé par le fixture `run_test` (conftest mutualisé) + `create_run.py`.
-`build_eval_input` calait aussi la fraîcheur sur `now()` au lieu de
-`MediaEvalRun.date_reference` (rejouabilité cassée) — corrigé via `require_run()`.
+## Ce que ça livre
 
-## Contenu
-- **`collect_common.py`** : fetch httpx + repli curl_cffi (ne lève jamais),
-  `require_run`, `Collecteur` (dédupe applicative + validation Pydantic), dédupe
-  voie A préfixée `code|` (D2), harnais CLI `run_cli`.
-- **6 collecteurs** : `collect_{pages_types,cdjm,jti,cppap,pappers,arcom}.py`
-  (fonctions `parse_*` pures + `collecter` async, fixtures figées, zéro réseau
-  en test). ARCOM auto-désactivé hors audiovisuel ; Pappers dégrade en 3
-  `bloque_acces` si token absent (exit 0).
-- **`create_run.py`** (D1), patchs moteur : `ingest_artifacts` (D6 voie
-  `humain:`, `collecte_at`, `version_prompt_collecteur`),
-  `evaluate_golden_agreement --out-dir`, `build_eval_input` (date_reference),
-  `.gitignore` (`.context/`).
-- **`export_evaluations.py`** + **`rapport_pilote.py`** (D7) : unique collecte DB
-  (`collecter_donnees_rapport`) → **deux rendus** — `.md` ASCII git-diffable +
-  **`.html` propre autonome** (lentille propreté data `evaluer_proprete_donnees`
-  : trou d'accès vs absence confirmée ; `render_html` single-file CSS inline
-  calqué sur le design system media-eval ; verdict V0).
-- **`.claude/agents/media-eval-{collecteur-debunkages,evaluateur}.md`** +
-  agents gouvernance (voir PR 2b) + **`.claude/commands/media-eval-run.md`** +
-  `golden/gold_v0.template.json`.
+**1. Corpus d'articles (C2/C3/C4/C5/C7)**
+- `schemas.py` : vague-1 v1.3 étendue aux **10 critères** ; registre `articles`
+  (+ structurels C3 `page_corrections`/`canal_signalement`/`reponse_evaluation_externe`) ;
+  `Grille.criteres_corpus` (v1.3 = C2/C3/C4/C5/C7 ; v1.2 = ∅).
+- **`collect_corpus_articles.py`** (nouveau, voie A) : échantillonne + snapshote
+  des articles récents (home + sitemap) dans `media_eval_corpus_articles` +
+  pré-métriques mécaniques (signature ? label d'opinion ? liens sortants ?).
+  N'émet **aucun signal** (la qualification est voie B). Idempotent.
+- `build_eval_input.py` : joint un bloc `corpus_articles` (contexte non citable,
+  borné) aux eval_inputs des critères sur corpus.
+- Agent **`media-eval-collecteur-corpus`** (nouveau, voie B) : qualifie le corpus
+  → un signal `articles` agrégé par critère.
 
-## PR 2b — corrections collecte (diagnostic du run pilote initial)
+**2. Double évaluation C5/C9/C10 (décision PO 18/07)**
+- `export_evaluations.py` : le `raise` sur doublon (média, critère) devient un
+  **consensus** — accord conservé ; désaccord → `revue_requise` documenté (jamais
+  moyenné). Rendu **version-aware** (chaque entrée porte `version_methodo`).
+  Héberge aussi la métrique **accord inter-évaluateurs** (même règle d'accord).
+- `evaluate_golden_agreement.py` : `_paire_accord` compare C2..C7 à niveaux en
+  v1.3 (pas en tolérance continue), grille résolue depuis la version du gold.
+- `/media-eval-run` §6 : deux évaluateurs indépendants `…@v1-a` / `…@v1-b`.
 
-Le run pilote cnews.fr a révélé des **faux positifs voie A** et une substance
-capturée mais jamais exposée. Corrections incluses dans cette PR :
+**3. Débunkages C1 — recall + dédup par affaire**
+- `DebunkageArtifact.cle_affaire` → écrit dans le `valeur` du signal C1 (repli
+  sur l'URL) ; `_nb_debunkages_frais` compte des **affaires distinctes** (fallback
+  C1 correct : un événement très couvert = un litige).
+- Agent débunkages : requêtes élargies (Les Surligneurs, ARCOM, CDJM), fenêtre
+  **36 mois** (v1.3), `cle_affaire` par litige.
 
-- **Anti soft-404 + filtre lexical** (`collect_pages_types.py`) : `present`
-  seulement si le texte ≠ home (hash/similarité) **et** porte les marqueurs
-  lexicaux du type ; pénalité anti-flux (dons/régie servis en fils d'articles).
-  ⇒ les faux `present` C8/charte, C11/ligne-éditoriale, C7/régie,
-  C5/transparence deviennent `absent_verifie` (test de non-régression cnews).
-- **Substance exposée** (`build_eval_input.py`) : `serialiser_signal` joint
-  `snapshot_extrait` (~4 000 c) + `snapshot_url` quand le signal a un `snapshot_id`.
-- **`export_snapshots.py`** (nouveau) : dump des snapshots vers
-  `.context/media_eval/<run_id>/snapshots/*.txt`, lus par la voie B (anti-403).
-- **Pappers** : SIREN cnews.fr corrigé (SESI SNC **412 916 215**, éditeur du
-  site) + **repli gratuit** `recherche-entreprises.api.gouv.fr` sans token
-  (identification `present`, actionnariat `partiel`) au lieu de 3 `bloque_acces` ;
-  pré-vol token dans le healthcheck + `/media-eval-run` §0.
-- **CPPAP** : dataset réel confirmé (`liste-des-publications-de-presse`, Explore
-  v2.1, champs `titre`/`ndeg_cppap`) + repli voie C documenté.
-- **Couverture** (`ingest_artifacts.py`) : WARNING listant les `type_signal`
-  gouvernance sans signal (anti-passivité).
-- **Agents gouvernance découpés en 2** (`gouvernance-transparence` C5+C7,
-  `gouvernance-independance` C8+C9+C11) : lisent les snapshots exportés, couvrent
-  tout leur registre ; politique de mort d'agent + support antenne/site portés
-  dans la commande et les prompts.
+**4. Pappers** : inchangé (repli gratuit). Recharger les crédits = action Laurin.
 
-> **Non inclus** (attend le re-run corrigé `pilote-2026-07b` + GOLD GATE) :
-> `docs/media-eval/fiches/cnews_fr_pilote-2026-07.md` (fiche du run buggé, à
-> régénérer) et les artefacts `.context/` du run.
+## Hors périmètre (suivi séparé)
+- Threading de la synthèse sur la version (`synthese_fiche`/`rapport_pilote`/
+  `ingest_artifacts.rapport_couverture`) — **Phase 6**, avant la fiche publiable.
+- Re-mapping des codes de critère **voie A** pour un run v1.3 (les collecteurs
+  structurels posent encore C5/C7/C8/C11 v1.2) — signalé WARNING dans
+  `/media-eval-run` §3, à traiter avant la collecte batch 2 hors CNEWS.
 
-## Décisions de design D1–D7
-D1 création de run explicite (refus mutation `date_reference`) · D2 dédupe voie
-A préfixée `code|` (coexiste avec la voie B) · D3 évaluateur Read-only (réponse
-= JSON) · D4 GOLD GATE anti-contamination + preuve horodatage · D5 CPPAP open
-data (jamais le form POST) · D6 voie dérivée du préfixe `humain:` · D7 rapport
-généré par script (chiffres auditables).
+## Correctifs de revue (harness)
+`collect_corpus_articles.py` : filtre same-domain tolérant `www.` (appliqué aussi
+aux URLs sitemap — sinon corpus quasi vide pour un site canonique `www.` comme
+CNEWS) ; `liens_sortants` ne compte que les liens vers un **autre** domaine
+(pré-métrique C2 sinon gonflée par les liens internes absolus) ;
+`date_depuis_url` lit le format `/AAAA-MM-JJ/` (pattern CNEWS).
+
+## Simplify
+`accord_inter_evaluateurs` déplacé dans `export_evaluations.py` (supprime le
+cycle d'import différé + `_verdict` dupliqué) ; `collect_corpus_articles` porté
+sur le harnais CLI commun `collect_common._run` (garde `--apply`, dry-run,
+rollback — plus de copie) + helpers partagés (`meme_domaine`, `_RE_HREF_ARTICLE`,
+`FetchResult` en test) ; `cle_affaire_signal` rangé dans `schemas.py` à côté du
+contrat d'écriture ; paramètre mort `version_methodo` retiré de
+`evaluations_to_goldenset`.
 
 ## Tests
-- **191 tests** `tests/scripts/media_eval` verts sur DB propre (dont
-  non-régression cnews soft-404/flux, repli Pappers gratuit, snapshot_extrait,
-  couverture voie B), ruff clean (check + format).
-- Smoke offline validé (create_run → seed → ingest → build_eval_input →
-  ingest_evaluations → synthese → export → rapport).
-- Pas de nouvelle migration (dédupe snapshots applicative) — `alembic heads` = 1.
+`tests/scripts/media_eval/` : **260 passent** (en série ; fixture `create_tables`
+DROP le schéma). 1 head Alembic. `ruff check` OK. Aucune migration.
 
+Doc : `docs/maintenance/maintenance-media-eval-harness-batch2.md`.
 Pas d'entrée changelog (outillage interne).

--- a/docs/maintenance/maintenance-media-eval-harness-batch2.md
+++ b/docs/maintenance/maintenance-media-eval-harness-batch2.md
@@ -1,0 +1,108 @@
+# Maintenance — Media-eval : harness batch 2 (critères sur corpus + double évaluation)
+
+> **Type** : Maintenance (outillage). **PR C** de la trajectoire media-eval, base
+> `main`, stackée logiquement sur #989 (grille v1.3). Périmètre = **Phase 4** du
+> hand-off (`.context/media-eval-handoff-CEA.md`) : écrire l'outillage du batch 2
+> **avant** toute collecte. STOP après revue du harness ; la collecte CNEWS
+> (Phase 5) + le gold gate D4 restent des étapes humaines séparées.
+
+## Contexte
+
+Le batch 1 (#989) n'a activé en v1.3 que les 5 critères **hors corpus**
+(C1/C6/C8/C9/C10). Les 5 manquants (C2 sourçage, C3 correction, C4 info/opinion,
+C5 diversité, C7 auteurs) reposent tous sur un **échantillon d'articles** (§5.4)
+qui n'était ni collecté ni injecté. Cette PR livre l'outillage qui rend ces
+critères évaluables, plus la double évaluation des critères à 3 niveaux et le
+recall des débunkages C1.
+
+## Ce que livre la PR (Phase 4)
+
+1. **Corpus d'articles (C2/C3/C4/C5/C7)**
+   - `schemas.py` : `_CRITERES_VAGUE_1_V13` étendu aux **10 critères** ;
+     `_TYPE_SIGNAUX_V13` étendu (`articles` pour C2/C4/C5/C7 ; `page_corrections`,
+     `canal_signalement`, `reponse_evaluation_externe` + `articles` pour C3) ;
+     nouveau champ `Grille.criteres_corpus` (v1.3 = C2/C3/C4/C5/C7 ; v1.2 = ∅).
+   - `collect_corpus_articles.py` (**nouveau**, voie A) : découvre des articles
+     récents (home + sitemap), snapshote leur texte dans
+     `media_eval_corpus_articles` et calcule des **pré-métriques mécaniques**
+     (signature ? label d'opinion ? liens sortants ?). N'émet **aucun signal** :
+     la qualification est voie B. Idempotent, ne lève jamais sur fetch bloqué.
+     S'appuie sur le harnais CLI commun de `collect_common` (`_run` : garde
+     `--apply`/`--allow-prod`, dry-run, rollback) au lieu de le dupliquer.
+   - `build_eval_input.py` : joint un bloc **`corpus_articles`** (contexte non
+     citable, borné) aux eval_inputs des critères sur corpus.
+   - Agent voie B **`media-eval-collecteur-corpus`** (nouveau) : qualifie le
+     corpus exporté → un signal `articles` agrégé par critère.
+
+2. **Double évaluation C5/C9/C10 (décision PO 18/07)**
+   - `export_evaluations.py` : le `raise` sur doublon (média, critère) devient un
+     **mode consensus** — accord → conservé ; désaccord → `revue_requise` avec les
+     deux verdicts documentés (jamais une moyenne). Rendu **version-aware**
+     (chaque entrée porte `version_methodo` du run → les critères v1.3 valident).
+     Héberge aussi la métrique **accord inter-évaluateurs** (même règle d'accord,
+     même groupement que le consensus).
+   - `evaluate_golden_agreement.py` : `_paire_accord` résout la grille depuis la
+     version du gold (C2..C7 comparés à niveaux en v1.3, pas en tolérance
+     continue).
+   - `/media-eval-run` §6 : deux évaluateurs indépendants `…@v1-a` / `…@v1-b`.
+
+3. **Débunkages C1 — recall + dédup par affaire**
+   - `DebunkageArtifact.cle_affaire` (nouveau champ) → écrit dans le `valeur` du
+     signal C1 (repli sur l'URL). `build_eval_input._nb_debunkages_frais` compte
+     désormais des **affaires distinctes** dans la fenêtre (un événement très
+     couvert = un litige), ce qui pilote correctement le fallback C1.
+   - Agent `media-eval-collecteur-debunkages` : requêtes élargies (Les
+     Surligneurs, ARCOM, CDJM), fenêtre **36 mois** (v1.3), `cle_affaire` par
+     litige.
+
+4. **Pappers** : inchangé côté code (repli gratuit
+   `recherche-entreprises.api.gouv.fr`). Recharger les crédits = action Laurin
+   avant le run (hors PR).
+
+## Décisions & garde-fous
+
+- **Aucune migration.** Le corpus vit dans la table `media_eval_corpus_articles`
+  (déjà créée par `me01`) et la `cle_affaire` dans le JSONB `valeur` du signal :
+  **additif, expand-safe**, 1 seul head Alembic. Un resserrement futur du CHECK
+  reste un `me03` en semaine N+1.
+- **Version portée par run.** Le code neuf passe par `grille(version)` ; les alias
+  plats du module restent v1.2 (batch 1). Un run v1.3 ne réécrit aucun run v1.2.
+- **Les agents n'écrivent jamais en DB** : `collect_corpus_articles` (voie A,
+  code) écrit la table corpus ; l'agent corpus (voie B) produit des artefacts
+  ingérés par `ingest_artifacts`.
+
+## Explicitement hors périmètre (suivi séparé)
+
+- **Threading de la synthèse sur la version** (`synthese_fiche.py`,
+  `rapport_pilote.py`, `ingest_artifacts.rapport_couverture`/`CRITERES_GOUVERNANCE`)
+  — **Phase 6**, différé de #989 ; lit encore les constantes plates v1.2. Requis
+  avant la fiche CNEWS publiable, pas avant la collecte.
+- **Re-mapping des codes de critère voie A pour un run v1.3.** Les collecteurs
+  voie A structurels (`collect_pages_types`, `collect_cppap`, `collect_pappers`…)
+  posent encore des critères **v1.2** (C5/C7/C8/C11) via `Collecteur.signal`
+  (validation en `VERSION_METHODO` = v1.2). Pour un run v1.3, ces codes ne
+  correspondent plus (v1.3 C5 = diversité, C6 = mentions…). **À traiter avant la
+  collecte batch 2 hors CNEWS** ; signalé en WARNING dans `/media-eval-run` §3.
+
+## Tests
+
+- `test_schemas.py` : vague-1 à 10 critères, registre `articles`, `criteres_corpus`.
+- `test_collect_corpus_articles.py` (**nouveau**) : détection d'URL d'article,
+  rubrique/date, pré-métriques, sélection ; bout-en-bout DB avec fetcher injecté
+  (idempotence, home bloquée → corpus vide). Correctifs de revue : filtre
+  same-domain tolérant `www.` (appliqué aussi au sitemap — sinon corpus quasi
+  vide pour un site canonique `www.` comme CNEWS), `liens_sortants` ne compte
+  que les liens vers un **autre** domaine, `date_depuis_url` lit `/AAAA-MM-JJ/`.
+- `test_build_eval_input.py` : injection du bloc corpus (présent pour C2, absent
+  pour C1), dédup débunkages par affaire (2 affaires sur 3 débunkages).
+- `test_export_evaluations.py` : consensus accord / désaccord → revue_requise.
+- `test_evaluate_golden_agreement.py` : accord inter-évaluateurs, C2 à niveaux en v1.3.
+- `test_ingest_artifacts.py` : `cle_affaire` propagée dans le `valeur`.
+- Suite `tests/scripts/media_eval/` : **260 passent** (en série, cf. fixture
+  `create_tables` qui DROP le schéma). 1 head Alembic. `ruff check` OK.
+
+## Suite
+
+STOP → revue du harness. Ensuite : Phase 5 (run `pilote-2026-08` CNEWS, collecte
+voie A+B, build eval_inputs des 10 critères) puis **gold gate D4** (notation
+aveugle Laurin dans `gold_v1_3.json`) avant tout évaluateur.

--- a/packages/api/scripts/media_eval/build_eval_input.py
+++ b/packages/api/scripts/media_eval/build_eval_input.py
@@ -39,6 +39,7 @@ from sqlalchemy import select
 from app.config import get_settings
 from app.database import async_session_maker, engine
 from app.models.media_eval import (
+    MediaEvalCorpusArticle,
     MediaEvalDebunkage,
     MediaEvalEvaluation,
     MediaEvalSignal,
@@ -56,6 +57,7 @@ from scripts.media_eval.ingest_artifacts import IngestError, resoudre_media
 from scripts.media_eval.schemas import (
     FLAG_FALLBACK_C1,
     VERSION_METHODO,
+    cle_affaire_signal,
     grille,
 )
 
@@ -66,6 +68,12 @@ DEFAULT_OUT_ROOT = _REPO_ROOT / ".context" / "media_eval"
 # Substance de la page jointe au signal pour que l'évaluateur voie ce que dit
 # la page (pas seulement qu'elle existe) — cf. hand-off « mini-filtre ».
 SNAPSHOT_EXTRAIT_MAX = 4000
+
+# Bloc corpus (§5.4) joint aux critères sur échantillon (C2/C3/C4/C5/C7) : les
+# articles instrumentés par collect_corpus_articles sont un **contexte** que
+# l'évaluateur vérifie ; l'ancre citable reste le signal `articles` (voie B).
+CORPUS_EXTRAIT_MAX = 2000  # extrait par article (l'agent voie B a le texte plein)
+CORPUS_ARTICLES_MAX = 40  # plafond §5.4 (20-40 articles informatifs)
 
 
 def rubrics_dir(version: str) -> Path:
@@ -123,9 +131,16 @@ def construire_eval_input(
     contrat_commun: str,
     version_prompt_sha: str,
     pre_flags: list[str],
+    corpus_articles: list[dict] | None = None,
 ) -> dict:
-    """Payload lu par l'agent évaluateur — pur, testable sans DB."""
-    return {
+    """Payload lu par l'agent évaluateur — pur, testable sans DB.
+
+    ``corpus_articles`` (critères sur corpus §5.4) est un **contexte** non
+    citable : l'évaluateur note d'après le signal ``articles`` (métriques
+    agrégées) et vérifie ses affirmations sur cet échantillon. Absent pour les
+    critères hors corpus.
+    """
+    payload = {
         "media": media,
         "critere": critere,
         "run_id": run_id,
@@ -138,6 +153,9 @@ def construire_eval_input(
         "pre_flags": pre_flags,
         "signaux": signaux,
     }
+    if corpus_articles is not None:
+        payload["corpus_articles"] = corpus_articles
+    return payload
 
 
 async def _signaux_du_critere(session, media_id, run_id: str, critere: str):
@@ -169,16 +187,54 @@ async def _charger_snapshots(
 async def _nb_debunkages_frais(
     session, media_id, run_id: str, aujourd_hui: date, version: str
 ) -> int:
+    """Nombre d'**affaires** distinctes débunkées dans la fenêtre (fallback C1).
+
+    Dédup par clé d'affaire (§5.2.1) : plusieurs débunkages d'un même événement
+    comptent pour un seul litige. Sans clé d'affaire qualifiée, le repli sur
+    l'URL préserve le comptage un-par-débunkage.
+    """
     fenetre = grille(version).fraicheur_max_jours
     rows = await session.execute(
-        select(MediaEvalDebunkage.publie_at)
+        select(MediaEvalDebunkage.publie_at, MediaEvalSignal.valeur)
         .join(MediaEvalSignal, MediaEvalSignal.id == MediaEvalDebunkage.signal_id)
         .where(
             MediaEvalDebunkage.media_id == media_id,
             MediaEvalSignal.run_id == run_id,
         )
     )
-    return sum(1 for (publie_at,) in rows if (aujourd_hui - publie_at).days <= fenetre)
+    affaires: set[str] = set()
+    for publie_at, valeur in rows:
+        if (aujourd_hui - publie_at).days > fenetre:
+            continue
+        affaires.add(cle_affaire_signal(valeur) or str(publie_at))
+    return len(affaires)
+
+
+async def _charger_corpus_articles(
+    session, media_id, run_id: str
+) -> list[dict]:
+    """Échantillon d'articles instrumenté (§5.4), joint comme contexte corpus."""
+    rows = await session.execute(
+        select(MediaEvalCorpusArticle)
+        .where(
+            MediaEvalCorpusArticle.media_id == media_id,
+            MediaEvalCorpusArticle.run_id == run_id,
+        )
+        .order_by(MediaEvalCorpusArticle.date_pub.desc().nullslast())
+        .limit(CORPUS_ARTICLES_MAX)
+    )
+    return [
+        {
+            "url": a.url,
+            "titre": a.titre,
+            "date_pub": a.date_pub.isoformat() if a.date_pub else None,
+            "rubrique": a.rubrique,
+            "mode_acquisition": a.mode_acquisition,
+            "pre_metriques": a.pre_metriques,
+            "extrait": (a.texte or "")[:CORPUS_EXTRAIT_MAX],
+        }
+        for a in rows.scalars()
+    ]
 
 
 async def ecrire_eval_jti(
@@ -248,6 +304,15 @@ async def run(
             nb_debunkages = await _nb_debunkages_frais(
                 session, media.id, run_id, aujourd_hui, version
             )
+            corpus_articles = None
+            if grille_run.criteres_corpus:
+                corpus_articles = await _charger_corpus_articles(
+                    session, media.id, run_id
+                )
+                print(
+                    f"corpus §5.4 : {len(corpus_articles)} article(s) instrumenté(s) "
+                    f"joints aux critères {', '.join(grille_run.criteres_corpus)}"
+                )
             ecrits: list[Path] = []
             jti_applique = False
 
@@ -300,6 +365,11 @@ async def run(
                     contrat_commun=contrat_commun,
                     version_prompt_sha=version_prompt(critere, version),
                     pre_flags=pre_flags,
+                    corpus_articles=(
+                        corpus_articles
+                        if critere in grille_run.criteres_corpus
+                        else None
+                    ),
                 )
                 out_dir.mkdir(parents=True, exist_ok=True)
                 out_path = out_dir / f"{media.domaine.replace('.', '_')}_{critere}.json"

--- a/packages/api/scripts/media_eval/collect_common.py
+++ b/packages/api/scripts/media_eval/collect_common.py
@@ -150,6 +150,13 @@ async def fetch_http(url: str, *, timeout: float = _TIMEOUT) -> FetchResult:
     return FetchResult(url, curl.status, curl.text, curl.mode_acces, curl.erreur)
 
 
+def meme_domaine(netloc_a: str, netloc_b: str) -> bool:
+    """Même domaine à un préfixe ``www.`` près (cnews.fr ≡ www.cnews.fr)."""
+    return netloc_a.lower().removeprefix("www.") == netloc_b.lower().removeprefix(
+        "www."
+    )
+
+
 # --------------------------------------------------------------------------- #
 # Résolution du run — jamais implicite.
 # --------------------------------------------------------------------------- #
@@ -369,6 +376,7 @@ async def _run(
     run_id: str,
     apply: bool,
     allow_prod: bool,
+    libelle: str = "signaux",
 ) -> int:
     settings = get_settings()
     db_url = settings.database_url or ""
@@ -399,7 +407,8 @@ async def _run(
                 return 0
             await session.commit()
             print(
-                f"[{nom}] APPLIQUÉ : {stats.inseres} signaux, {stats.snapshots} snapshots."
+                f"[{nom}] APPLIQUÉ : {stats.inseres} {libelle}, "
+                f"{stats.snapshots} snapshots."
             )
             return 0
         except (CollecteError, IngestError) as exc:

--- a/packages/api/scripts/media_eval/collect_corpus_articles.py
+++ b/packages/api/scripts/media_eval/collect_corpus_articles.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Collecteur voie A — échantillon d'articles (§5.4, corpus des critères C2–C7).
+
+Instrumente le **corpus d'articles** qui fonde les critères sur échantillon
+(C2 sourçage, C3 correction, C4 info/opinion, C5 diversité, C7 auteurs) : il
+découvre des articles récents (home + sitemaps), snapshote leur texte dans
+``media_eval_corpus_articles`` et calcule des **pré-métriques mécaniques** (une
+signature est-elle présente ? un label d'opinion ? combien de liens sortants ?).
+
+La *qualification* (taux de sources nommées, pluralité des perspectives, ton…)
+reste voie B : l'agent ``media-eval-collecteur-corpus`` lit ce corpus exporté et
+produit les signaux ``articles`` agrégés par critère. Ce collecteur ne pose
+donc **aucun signal** — il alimente seulement la table corpus, que
+``build_eval_input`` joint ensuite en contexte des eval_inputs C2/C3/C4/C5/C7.
+
+Fenêtre : la fraîcheur des articles suit ``date_reference`` du run. Idempotent :
+un article déjà présent (même url, même run) n'est pas ré-inséré. Ne lève jamais
+sur un fetch bloqué (l'article est simplement ignoré, journalisé).
+
+Usage :
+    cd packages/api
+    python3 scripts/media_eval/collect_corpus_articles.py --media cnews.fr \
+        --run-id pilote-2026-08 [--max-articles 40] [--apply --allow-prod]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import re
+import sys
+from datetime import date
+from functools import partial
+from pathlib import Path
+from urllib.parse import urljoin, urlparse
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from bs4 import BeautifulSoup
+from sqlalchemy import select
+
+from app.models.media_eval import MediaEvalCorpusArticle
+from scripts.media_eval.collect_common import (
+    CollectStats,
+    Fetcher,
+    _run,
+    meme_domaine,
+)
+from scripts.media_eval.collect_pages_types import (
+    _RE_HREF_ARTICLE,
+    _base_url,
+    extraire_texte_principal,
+    parse_sitemap,
+)
+
+DEFAULT_MAX_ARTICLES = 40  # plafond §5.4 (20-40 articles informatifs)
+_CORPUS_EXTRAIT_MAX = 20000  # même plafond que les snapshots de pages types
+
+# Année dans l'URL → date approximative (sert de repli au <time datetime>).
+# Séparateurs / ou - (CNEWS : /2026-07-18/…).
+_RE_ANNEE_URL = re.compile(r"/((?:19|20)\d{2})[-/](\d{2})[-/](\d{2})")
+_RE_ANNEE_SEULE = re.compile(r"/((?:19|20)\d{2})/")
+
+# Rubriques hors périmètre « article » (pages de service, flux, tags).
+_SEGMENTS_NON_ARTICLE = frozenset(
+    {
+        "tag", "tags", "auteur", "auteurs", "recherche", "search", "video",
+        "videos", "podcast", "podcasts", "newsletter", "newsletters", "page",
+        "rubrique", "mentions-legales", "cgu", "cgv", "contact", "abonnement",
+        "boutique", "meteo", "programme", "programmes", "direct",
+    }
+)
+
+# Labels d'opinion (URL / titre / classe) — indice mécanique, pas un verdict.
+_LABELS_OPINION: tuple[str, ...] = (
+    "tribune",
+    "edito",
+    "editorial",
+    "éditorial",
+    "chronique",
+    "opinion",
+    "point-de-vue",
+    "point de vue",
+    "billet",
+    "humeur",
+)
+# Signatures non nominatives (recours à la rédaction / reprise d'agence).
+_MARQUEURS_REDACTION: tuple[str, ...] = (
+    "la rédaction",
+    "la redaction",
+    "rédaction de",
+    "avec afp",
+    "avec reuters",
+    "source afp",
+    "(afp)",
+    "reuters",
+)
+
+
+# --------------------------------------------------------------------------- #
+# Fonctions pures (str → structures) — testées sur fixtures, zéro réseau.
+# --------------------------------------------------------------------------- #
+def _segment_1(url: str) -> str | None:
+    """Premier segment de chemin non vide d'une URL (proxy de rubrique)."""
+    for seg in urlparse(url).path.split("/"):
+        if seg:
+            return seg.lower()
+    return None
+
+
+def est_url_article(url: str) -> bool:
+    """True si l'URL ressemble à un article daté (et pas une page de service)."""
+    if not _RE_HREF_ARTICLE.search(url.lower()):
+        return False
+    seg = _segment_1(url)
+    return seg is None or seg not in _SEGMENTS_NON_ARTICLE
+
+
+def rubrique_depuis_url(url: str) -> str | None:
+    """Rubrique déduite du 1er segment de chemin (hors segment = année)."""
+    seg = _segment_1(url)
+    if seg is None or re.fullmatch(r"(?:19|20)\d{2}", seg):
+        # /2026/... → prendre le segment suivant s'il est parlant.
+        parts = [p for p in urlparse(url).path.split("/") if p]
+        for p in parts:
+            if not re.fullmatch(r"(?:19|20)\d{2}|\d{1,2}", p):
+                return p.lower()[:100]
+        return None
+    return seg[:100]
+
+
+def date_depuis_url(url: str) -> date | None:
+    """Date approximative lue dans l'URL (/AAAA/MM/JJ ou /AAAA/)."""
+    m = _RE_ANNEE_URL.search(url)
+    if m:
+        try:
+            return date(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+        except ValueError:
+            return None
+    m = _RE_ANNEE_SEULE.search(url)
+    if m:
+        return date(int(m.group(1)), 1, 1)
+    return None
+
+
+def extraire_urls_articles(
+    base: str, home_html: str, sitemap_urls: list[str]
+) -> list[str]:
+    """URLs d'articles candidates (liens de la home + sitemap), dédupées.
+
+    Ordre stable : liens de la home d'abord (les plus récents en pratique),
+    puis sitemap. Les URLs hors périmètre article (pages de service) et hors
+    domaine (``www.`` toléré) sont écartées.
+    """
+    ordonnes: list[str] = []
+    vus: set[str] = set()
+    netloc_base = urlparse(base).netloc
+    soup = BeautifulSoup(home_html, "html.parser")
+    liens_home = [
+        a["href"].strip()
+        for a in soup.find_all("a", href=True)
+        if a["href"].strip() and not a["href"].startswith(("#", "mailto:", "javascript:"))
+    ]
+    for href in [*liens_home, *sitemap_urls]:
+        url = urljoin(base + "/", href)  # no-op sur les URLs absolues du sitemap
+        if not meme_domaine(urlparse(url).netloc, netloc_base):
+            continue
+        if est_url_article(url) and url not in vus:
+            vus.add(url)
+            ordonnes.append(url)
+    return ordonnes
+
+
+def extraire_titre(html: str) -> str | None:
+    soup = BeautifulSoup(html, "html.parser")
+    h1 = soup.find("h1")
+    if h1 and h1.get_text(strip=True):
+        return h1.get_text(" ", strip=True)[:300]
+    if soup.title and soup.title.get_text(strip=True):
+        return soup.title.get_text(" ", strip=True)[:300]
+    return None
+
+
+def date_depuis_html(html: str) -> date | None:
+    """Date de publication depuis <time datetime> ou meta article:published_time."""
+    soup = BeautifulSoup(html, "html.parser")
+    meta = soup.find("meta", attrs={"property": "article:published_time"})
+    brut = meta.get("content") if meta and meta.get("content") else None
+    if brut is None:
+        t = soup.find("time")
+        brut = t.get("datetime") if t and t.get("datetime") else None
+    if not brut:
+        return None
+    try:
+        return date.fromisoformat(str(brut)[:10])
+    except ValueError:
+        return None
+
+
+def _a_signature(html: str) -> bool:
+    """Marqueur mécanique de signature (meta author / rel=author / classe auteur)."""
+    soup = BeautifulSoup(html, "html.parser")
+    meta = soup.find("meta", attrs={"name": "author"})
+    if meta and (meta.get("content") or "").strip():
+        return True
+    if soup.find(attrs={"rel": "author"}) or soup.find(attrs={"itemprop": "author"}):
+        return True
+    for attr in ("class", "id"):
+        if soup.find(attrs={attr: re.compile(r"(author|auteur|signature|byline)", re.I)}):
+            return True
+    return False
+
+
+def _liens_sortants(url: str, html: str) -> int:
+    """Nombre de liens du corps principal pointant vers un autre domaine."""
+    soup = BeautifulSoup(html, "html.parser")
+    for tag in soup(["header", "footer", "nav"]):
+        tag.decompose()
+    cible = soup.find("main") or soup.find("article") or soup.body or soup
+    hrefs = [a.get("href", "") for a in cible.find_all("a", href=True)] if cible else []
+    netloc_article = urlparse(url).netloc
+    return sum(
+        1
+        for h in hrefs
+        if h.startswith(("http://", "https://"))
+        and not meme_domaine(urlparse(h).netloc, netloc_article)
+    )
+
+
+def pre_metriques_article(
+    url: str, html: str, texte: str, titre: str | None = None
+) -> dict:
+    """Pré-métriques mécaniques (indices) — la qualification reste voie B."""
+    cible = f"{url} {titre or extraire_titre(html) or ''} {texte[:600]}".lower()
+    label = next((lab for lab in _LABELS_OPINION if lab in cible), None)
+    return {
+        "a_signature_html": _a_signature(html),
+        "mention_redaction_ou_agence": any(m in texte.lower() for m in _MARQUEURS_REDACTION),
+        "label_opinion": label,
+        "liens_sortants": _liens_sortants(url, html),
+        "longueur_texte": len(texte),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Collecte.
+# --------------------------------------------------------------------------- #
+async def collecter_corpus(
+    session,
+    media,
+    run,
+    fetcher: Fetcher,
+    *,
+    max_articles: int = DEFAULT_MAX_ARTICLES,
+) -> CollectStats:
+    """Découvre et snapshote un échantillon d'articles (voie A, §5.4).
+
+    ``inseres`` compte les articles snapshotés (pas des signaux) ; les fetchs
+    bloqués ou vides sont journalisés en fin de ``details``.
+    """
+    stats = CollectStats()
+    base = _base_url(media.domaine)
+
+    home = await fetcher(base + "/")
+    if home.bloque:
+        stats.details.append("home inaccessible (anti-bot) — corpus vide")
+        return stats
+
+    sitemap = await fetcher(base + "/sitemap.xml")
+    sitemap_urls = parse_sitemap(sitemap.text) if sitemap.ok else []
+    candidats = extraire_urls_articles(base, home.text, sitemap_urls)
+
+    # Idempotence : ne pas ré-insérer un article déjà présent pour (media, run).
+    rows = await session.execute(
+        select(MediaEvalCorpusArticle.url).where(
+            MediaEvalCorpusArticle.media_id == media.id,
+            MediaEvalCorpusArticle.run_id == run.run_id,
+        )
+    )
+    deja = {r[0] for r in rows}
+
+    ignores = 0
+    for url in candidats:
+        if stats.inseres >= max_articles:
+            break
+        if url in deja:
+            stats.doublons += 1
+            continue
+        res = await fetcher(url)
+        if not res.ok:
+            ignores += 1
+            continue
+        texte = extraire_texte_principal(res.text)
+        if len(texte) < 200:
+            ignores += 1  # coquille / mur / page vide
+            continue
+        deja.add(url)
+        titre = extraire_titre(res.text)
+        session.add(
+            MediaEvalCorpusArticle(
+                media_id=media.id,
+                run_id=run.run_id,
+                url=url,
+                titre=titre,
+                date_pub=date_depuis_html(res.text) or date_depuis_url(url),
+                rubrique=rubrique_depuis_url(url),
+                texte=texte[:_CORPUS_EXTRAIT_MAX],
+                mode_acquisition="http",
+                pre_metriques=pre_metriques_article(url, res.text, texte, titre),
+            )
+        )
+        stats.inseres += 1
+        stats.details.append(f"{url} ({rubrique_depuis_url(url) or 'rubrique?'})")
+    if ignores:
+        stats.details.append(f"ignorés (bloqué/vide) : {ignores}")
+    return stats
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--media", required=True, help="domaine (ex. cnews.fr)")
+    parser.add_argument("--run-id", required=True, help="ex. pilote-2026-08")
+    parser.add_argument(
+        "--max-articles",
+        type=int,
+        default=DEFAULT_MAX_ARTICLES,
+        help=f"plafond d'articles échantillonnés (défaut {DEFAULT_MAX_ARTICLES}, §5.4)",
+    )
+    parser.add_argument(
+        "--apply", action="store_true", help="exécute (défaut: dry-run)"
+    )
+    parser.add_argument(
+        "--allow-prod", action="store_true", help="autorise --apply en prod"
+    )
+    args = parser.parse_args()
+    # Harnais commun (garde --apply/--allow-prod, dry-run, rollback) : seul le
+    # plafond d'articles est spécifique à ce collecteur.
+    sys.exit(
+        asyncio.run(
+            _run(
+                "corpus",
+                partial(collecter_corpus, max_articles=args.max_articles),
+                media_domaine=args.media,
+                run_id=args.run_id,
+                apply=args.apply,
+                allow_prod=args.allow_prod,
+                libelle="articles",
+            )
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/scripts/media_eval/evaluate_golden_agreement.py
+++ b/packages/api/scripts/media_eval/evaluate_golden_agreement.py
@@ -30,18 +30,22 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from scripts.media_eval.schemas import (
-    BAREMES,
-    CRITERES_NIVEAUX,
     GoldenEntry,
     GoldenSet,
+    grille,
 )
 
 TOLERANCE_CONTINUE = 0.20  # |Δ| ≤ 20 % du barème (critère de succès V0)
 
 
 def _paire_accord(gold: GoldenEntry, gen: GoldenEntry) -> dict:
-    """Compare une paire (média, critère). Pur, testable."""
+    """Compare une paire (média, critère). Pur, testable.
+
+    La grille (critères à niveaux, barèmes) est résolue depuis la version du
+    gold : un run v1.3 se compare avec les paliers v1.3 (C2..C7 à niveaux).
+    """
     critere = gold.critere
+    g = grille(gold.version_methodo)
     resultat: dict = {
         "media": gold.media_domaine,
         "critere": critere,
@@ -64,7 +68,7 @@ def _paire_accord(gold: GoldenEntry, gen: GoldenEntry) -> dict:
             "delta": None,
         }
         return resultat
-    if critere in CRITERES_NIVEAUX:
+    if critere in g.criteres_niveaux:
         accord = gold.niveau == gen.niveau
         resultat |= {
             "accord": accord,
@@ -73,7 +77,7 @@ def _paire_accord(gold: GoldenEntry, gen: GoldenEntry) -> dict:
         }
         return resultat
     delta = abs((gold.score or 0) - (gen.score or 0))
-    accord = delta <= TOLERANCE_CONTINUE * BAREMES[critere]
+    accord = delta <= TOLERANCE_CONTINUE * g.baremes[critere]
     resultat |= {
         "accord": accord,
         "type_desaccord": None if accord else "score",

--- a/packages/api/scripts/media_eval/export_evaluations.py
+++ b/packages/api/scripts/media_eval/export_evaluations.py
@@ -6,9 +6,12 @@ le golden set humain, ce qui permet de les comparer directement
 (``evaluate_golden_agreement.py``). Le raccourci ``code:jti_shortcut`` est
 inclus (préfixe ``code:``) au même titre que les évaluateurs agents.
 
-Fonction pure ``evaluations_to_goldenset`` partagée avec ``rapport_pilote.py`` :
-elle **lève** si deux évaluations existent pour un même (média, critère) après
-filtrage — l'export doit être sans ambiguïté.
+Fonction pure ``evaluations_to_goldenset`` partagée avec ``rapport_pilote.py``.
+**Mode consensus (double évaluation, décision PO 18/07/2026)** : les critères à
+3 niveaux (C5/C9/C10 en v1.3) sont notés par **deux** évaluateurs indépendants
+(préfixes ``…@v1-a`` / ``…@v1-b``). Deux évaluations pour un même
+(média, critère) ne sont plus une erreur : accord → consensus conservé ;
+désaccord → ``revue_requise`` avec les deux verdicts documentés (conforme v1.3).
 
 Usage :
     cd packages/api
@@ -35,6 +38,78 @@ from scripts.media_eval.schemas import GoldenEntry, GoldenSet
 DEFAULT_PREFIXES = ("agent:", "code:")
 
 
+def _verdict_court(ev: dict) -> str:
+    """Verdict lisible d'une évaluation (pour documenter un désaccord)."""
+    if ev["statut"] != "evaluee":
+        return ev["statut"]
+    if ev.get("niveau") is not None:
+        return f"niveau {ev['niveau']}"
+    return f"score {ev.get('score')}"
+
+
+def evaluateurs_accordent(evals: list[dict]) -> bool:
+    """True si les évaluations d'un même (média, critère) convergent.
+
+    Accord = même statut ; et si ``evaluee`` : même niveau (critères à niveaux)
+    ou, à défaut de niveau, même score. Le désaccord bascule en revue humaine.
+    """
+    if len({e["statut"] for e in evals}) > 1:
+        return False
+    if evals[0]["statut"] != "evaluee":
+        return True
+    niveaux = [e.get("niveau") for e in evals]
+    if all(n is not None for n in niveaux):
+        return len(set(niveaux)) == 1
+    return len({e.get("score") for e in evals}) == 1
+
+
+def _grouper_par_cle(
+    evaluations: list[dict], prefixes: tuple[str, ...]
+) -> dict[tuple[str, str], list[dict]]:
+    """Groupe les évaluations par (média, critère), filtrées par préfixe."""
+    par_cle: dict[tuple[str, str], list[dict]] = {}
+    for ev in evaluations:
+        if not any(ev["evaluateur"].startswith(p) for p in prefixes):
+            continue
+        par_cle.setdefault((ev["media_domaine"], ev["critere"]), []).append(ev)
+    return par_cle
+
+
+def _entry_consensus(evals: list[dict]) -> GoldenEntry:
+    """Entrée consensus d'un (média, critère) — 1 ou plusieurs évaluateurs."""
+    rep = evals[0]
+    version = rep.get("version_methodo")
+    commun = {
+        "media_domaine": rep["media_domaine"],
+        "critere": rep["critere"],
+        **({"version_methodo": version} if version else {}),
+    }
+    if len(evals) == 1:
+        return GoldenEntry(
+            **commun, statut=rep["statut"], score=rep["score"], niveau=rep.get("niveau")
+        )
+    evaluateurs = ", ".join(sorted(e["evaluateur"] for e in evals))
+    if evaluateurs_accordent(evals):
+        return GoldenEntry(
+            **commun,
+            statut=rep["statut"],
+            score=rep["score"],
+            niveau=rep.get("niveau"),
+            commentaire=f"consensus double évaluation ({evaluateurs})",
+        )
+    votes = " / ".join(
+        f"{e['evaluateur']}: {_verdict_court(e)}"
+        for e in sorted(evals, key=lambda e: e["evaluateur"])
+    )
+    return GoldenEntry(
+        **commun,
+        statut="revue_requise",
+        score=None,
+        niveau=None,
+        commentaire=f"désaccord double évaluation — {votes}",
+    )
+
+
 def evaluations_to_goldenset(
     evaluations: list[dict],
     *,
@@ -44,31 +119,60 @@ def evaluations_to_goldenset(
     """Transforme des dicts d'évaluations en `GoldenSet` — pur, testable.
 
     ``evaluations`` : {media_domaine, critere, statut, score, niveau,
-    evaluateur}. Lève ``ValueError`` si deux évals subsistent pour un même
-    (média, critère) après filtrage par préfixe d'évaluateur.
+    evaluateur, version_methodo?}. Plusieurs évaluations d'un même
+    (média, critère) sont réconciliées en **consensus** (double évaluation) :
+    accord → l'entrée est conservée ; désaccord → ``revue_requise`` documenté.
     """
-    par_cle: dict[tuple[str, str], dict] = {}
-    for ev in evaluations:
-        if not any(ev["evaluateur"].startswith(p) for p in prefixes):
-            continue
-        cle = (ev["media_domaine"], ev["critere"])
-        if cle in par_cle:
-            raise ValueError(
-                f"deux évaluations pour {cle} : {par_cle[cle]['evaluateur']!r} et "
-                f"{ev['evaluateur']!r} — export ambigu."
-            )
-        par_cle[cle] = ev
-    entries = [
-        GoldenEntry(
-            media_domaine=ev["media_domaine"],
-            critere=ev["critere"],
-            statut=ev["statut"],
-            score=ev["score"],
-            niveau=ev.get("niveau"),
-        )
-        for ev in par_cle.values()
+    par_cle = _grouper_par_cle(evaluations, prefixes)
+    entries = [_entry_consensus(evals) for evals in par_cle.values()]
+    if not entries:
+        return GoldenSet(notateur=notateur, note_at=None, entries=[])
+    # La version du set = celle des entrées (portée par run ; défaut v1.2).
+    return GoldenSet(
+        notateur=notateur,
+        note_at=None,
+        entries=entries,
+        version_methodo=entries[0].version_methodo,
+    )
+
+
+def accord_inter_evaluateurs(
+    evaluations: list[dict], *, prefixes: tuple[str, ...] = DEFAULT_PREFIXES
+) -> dict:
+    """Accord entre évaluateurs indépendants (double évaluation) — pur.
+
+    Ne considère que les (média, critère) notés par **≥ 2 évaluateurs
+    distincts** (préfixes ``…@v1-a`` / ``…@v1-b``). Mesure la fréquence de
+    convergence (même règle d'accord que le consensus d'export). Un désaccord
+    ici est aussi celui qui bascule l'entrée en ``revue_requise``.
+    """
+    paires = [
+        (media, critere, evals)
+        for (media, critere), evals in _grouper_par_cle(evaluations, prefixes).items()
+        if len({e["evaluateur"] for e in evals}) >= 2
     ]
-    return GoldenSet(notateur=notateur, note_at=None, entries=entries)
+    if not paires:
+        return {"n": 0, "accord_inter": None, "desaccords": []}
+
+    desaccords = []
+    accords = 0
+    for media, critere, evals in sorted(paires):
+        if evaluateurs_accordent(evals):
+            accords += 1
+        else:
+            desaccords.append(
+                {
+                    "media": media,
+                    "critere": critere,
+                    "verdicts": {e["evaluateur"]: _verdict_court(e) for e in evals},
+                }
+            )
+    return {
+        "n": len(paires),
+        "accord_inter": round(accords / len(paires), 3),
+        "accords": accords,
+        "desaccords": desaccords,
+    }
 
 
 async def charger_evaluations(session, run_id: str) -> list[dict]:
@@ -88,6 +192,7 @@ async def charger_evaluations(session, run_id: str) -> list[dict]:
                 "score": ev.score,
                 "niveau": ev.niveau,
                 "evaluateur": ev.evaluateur,
+                "version_methodo": ev.version_methodo,
             }
         )
     return resultats
@@ -104,6 +209,14 @@ async def run(run_id: str, out: Path, prefixes: tuple[str, ...]) -> int:
             out.parent.mkdir(parents=True, exist_ok=True)
             out.write_text(goldenset.model_dump_json(indent=2) + "\n")
             print(f"Export : {len(goldenset.entries)} entrées → {out}")
+            inter = accord_inter_evaluateurs(evaluations, prefixes=prefixes)
+            if inter["n"]:
+                print(
+                    f"Accord inter-évaluateurs : {inter['accords']}/{inter['n']} "
+                    f"({inter['accord_inter']:.0%}) sur les critères double évaluation"
+                )
+                for d in inter["desaccords"]:
+                    print(f"  ⚠ {d['media']} · {d['critere']} : {d['verdicts']}")
             return 0
         except ValueError as exc:
             print(f"REJET : {exc}")

--- a/packages/api/scripts/media_eval/ingest_artifacts.py
+++ b/packages/api/scripts/media_eval/ingest_artifacts.py
@@ -189,6 +189,10 @@ async def inserer_debunkages(session, batch: DebunkageBatchArtifact) -> IngestRe
                 "suite_donnee": item.suite_donnee,
                 "publie_at": item.publie_at.isoformat(),
                 "resume": item.resume,
+                # Dédup par affaire (§5.2.1) : lue par build_eval_input pour le
+                # comptage fallback C1 et par l'évaluateur. Repli sur l'URL si
+                # l'agent n'a pas qualifié l'affaire (1 débunkage = 1 litige).
+                "cle_affaire": item.cle_affaire or item.url_debunkage,
             },
             citation=item.citation or item.resume,
             voie=voie_depuis_agent(batch.agent),

--- a/packages/api/scripts/media_eval/schemas.py
+++ b/packages/api/scripts/media_eval/schemas.py
@@ -112,10 +112,14 @@ _BAREMES_V13: dict[str, int] = {
     "C1": 20, "C2": 15, "C3": 10, "C4": 5, "C5": 10,
     "C6": 10, "C7": 6, "C8": 4, "C9": 10, "C10": 10,
 }  # total 100 (axes 60/20/20)
-# Vague 1 v1.3 = critères évaluables hors corpus d'articles (= re-mapping du
-# batch 1). Les critères sur corpus (C2/C3/C4/C5 diversité/C7) arrivent au
-# batch 2 (collecte d'échantillons §5.4) avec leur registre TYPE_SIGNAUX.
-_CRITERES_VAGUE_1_V13 = ("C1", "C6", "C8", "C9", "C10")
+# Vague 1 v1.3 = les 10 critères de la grille. Le batch 1 (#989) n'avait remappé
+# que les critères hors corpus (C1/C6/C8/C9/C10) ; le batch 2 (harness corpus,
+# §5.4) active les critères sur corpus d'articles (C2/C3/C4/C5/C7) avec leur
+# registre TYPE_SIGNAUX.
+_CRITERES_VAGUE_1_V13 = ("C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10")
+# Critères dont l'évaluation repose sur un échantillon d'articles (§5.4) : un
+# bloc `corpus_articles` leur est joint dans l'eval_input (build_eval_input).
+_CRITERES_CORPUS_V13 = ("C2", "C3", "C4", "C5", "C7")
 _CRITERES_NIVEAUX_V13 = (
     "C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10",
 )
@@ -134,10 +138,23 @@ _NIVEAU_SCORES_V13: dict[str, dict[int, int]] = {
 _PALIERS_V13: dict[str, tuple[int, ...]] = {
     c: tuple(sorted(set(scores.values()))) for c, scores in _NIVEAU_SCORES_V13.items()
 }
-# Registre des signaux : batch 1 v1.3 (structurels + tierces). Le C9 fusionné
-# hérite des signaux ex-C8 (engagement déontologique) ET ex-C11 (positionnement).
+# Registre des signaux v1.3. Batch 1 : structurels + tierces (C1/C6/C8/C9/C10).
+# Batch 2 (harness corpus §5.4) : critères sur échantillon d'articles
+# (C2/C4/C5/C7 = un bloc `articles` agrégé ; C3 = signaux structurels correction
+# + bloc `articles`). Le C9 fusionné hérite des signaux ex-C8 (engagement
+# déontologique) ET ex-C11 (positionnement).
 _TYPE_SIGNAUX_V13: dict[str, tuple[str, ...]] = {
     "C1": ("debunkage", "sanction_arcom", "condamnation_justice", "avis_cdjm"),
+    "C2": ("articles",),
+    "C3": (
+        "page_corrections",
+        "canal_signalement",
+        "reponse_evaluation_externe",
+        "articles",
+    ),
+    "C4": ("articles",),
+    "C5": ("articles",),
+    "C7": ("articles",),
     "C6": (
         "mentions_legales",
         "identification_proprietaire",
@@ -194,6 +211,7 @@ class Grille:
     fraicheur_max_jours: int
     axes: dict[str, tuple[str, ...]]
     criteres_double_eval: tuple[str, ...]
+    criteres_corpus: tuple[str, ...]
     lettres: list[tuple[int, str]]
 
     @property
@@ -214,6 +232,7 @@ GRILLES: dict[str, Grille] = {
         fraicheur_max_jours=_FRAICHEUR_V12,
         axes=_AXES_V12,
         criteres_double_eval=_DOUBLE_EVAL_V12,
+        criteres_corpus=(),  # v1.2 : pas de collecte de corpus instrumentée
         lettres=LETTRES,
     ),
     "v1.3": Grille(
@@ -227,6 +246,7 @@ GRILLES: dict[str, Grille] = {
         fraicheur_max_jours=_FRAICHEUR_V13,
         axes=_AXES_V13,
         criteres_double_eval=_DOUBLE_EVAL_V13,
+        criteres_corpus=_CRITERES_CORPUS_V13,
         lettres=LETTRES,
     ),
 }
@@ -431,6 +451,10 @@ class DebunkageArtifact(BaseModel):
     publie_at: date
     resume: str | None = None
     citation: str | None = None
+    # Clé d'affaire (§5.2.1 v1.3) : plusieurs débunkages d'un même événement
+    # partagent la même clé → un seul litige. Sert la dédup par affaire du
+    # comptage fallback C1 (build_eval_input) et la lecture de l'évaluateur.
+    cle_affaire: str | None = None
     source_urls: list[str] = Field(min_length=1)
     sources_consultees: list[str] = Field(default_factory=list)
 
@@ -457,6 +481,16 @@ class DebunkageArtifact(BaseModel):
 
     def poids_emetteur(self) -> str:
         return derive_poids_emetteur(self.emetteur)
+
+
+def cle_affaire_signal(valeur: dict | None) -> str | None:
+    """Clé d'affaire d'un signal débunkage (dédup §5.2.1), repli sur l'URL.
+
+    Côté lecture du contrat ``cle_affaire`` ci-dessus : le repli URL couvre les
+    signaux ingérés avant le batch 2 (1 débunkage = 1 litige).
+    """
+    valeur = valeur or {}
+    return valeur.get("cle_affaire") or valeur.get("url")
 
 
 # --------------------------------------------------------------------------- #

--- a/packages/api/tests/scripts/media_eval/test_build_eval_input.py
+++ b/packages/api/tests/scripts/media_eval/test_build_eval_input.py
@@ -9,22 +9,32 @@ existe (hand-off pilote-2026-07b).
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
+from datetime import date, datetime
 
 from app.models.media_eval import (
+    GraviteDebunkage,
+    MediaEvalCorpusArticle,
+    MediaEvalDebunkage,
     MediaEvalSignal,
     MediaEvalSnapshot,
     ModeAcces,
+    PoidsEmetteur,
     StatutSignal,
+    SuiteDonnee,
     TypePage,
     VoieCollecte,
 )
 from scripts.media_eval.build_eval_input import (
+    CORPUS_EXTRAIT_MAX,
     SNAPSHOT_EXTRAIT_MAX,
+    _charger_corpus_articles,
     _charger_snapshots,
+    _nb_debunkages_frais,
     _signaux_du_critere,
+    construire_eval_input,
     serialiser_signal,
 )
+from scripts.media_eval.schemas import cle_affaire_signal
 
 
 def _signal(**kw) -> MediaEvalSignal:
@@ -126,3 +136,136 @@ class TestChargerSnapshots:
         serialise = [serialiser_signal(s, snaps.get(s.snapshot_id)) for s in rows]
         assert serialise[0]["snapshot_extrait"] == "RCS Nanterre 412 916 215 — SESI SNC"
         assert serialise[0]["snapshot_url"] == "https://cnews.fr/mentions-legales"
+
+
+class TestCleAffaireSignal:
+    def test_priorite_cle_affaire(self):
+        assert cle_affaire_signal({"cle_affaire": "a", "url": "u"}) == "a"
+
+    def test_repli_url(self):
+        assert cle_affaire_signal({"url": "https://x"}) == "https://x"
+
+    def test_vide(self):
+        assert cle_affaire_signal(None) is None
+        assert cle_affaire_signal({}) is None
+
+
+class TestCorpusBloc:
+    def test_corpus_joint_pour_critere_corpus(self):
+        payload = construire_eval_input(
+            {"nom": "CNEWS", "domaine": "cnews.fr", "type_media": "audiovisuel"},
+            "C2",
+            [],
+            run_id="r",
+            date_reference=date(2026, 8, 1),
+            version_methodo="v1.3",
+            bareme_verbatim="x",
+            contrat_commun="c",
+            version_prompt_sha="sha",
+            pre_flags=[],
+            corpus_articles=[{"url": "https://cnews.fr/a1"}],
+        )
+        assert payload["corpus_articles"] == [{"url": "https://cnews.fr/a1"}]
+
+    def test_pas_de_corpus_pour_critere_hors_corpus(self):
+        payload = construire_eval_input(
+            {"nom": "CNEWS", "domaine": "cnews.fr", "type_media": "audiovisuel"},
+            "C1",
+            [],
+            run_id="r",
+            date_reference=date(2026, 8, 1),
+            version_methodo="v1.3",
+            bareme_verbatim="x",
+            contrat_commun="c",
+            version_prompt_sha="sha",
+            pre_flags=[],
+            corpus_articles=None,
+        )
+        assert "corpus_articles" not in payload
+
+
+class TestChargerCorpusArticles:
+    async def test_lecture_et_extrait_borne(self, db_session, media_cnews, run_test):
+        db_session.add_all(
+            [
+                MediaEvalCorpusArticle(
+                    media_id=media_cnews.id,
+                    run_id=run_test.run_id,
+                    url="https://cnews.fr/2026/07/a1",
+                    titre="Titre 1",
+                    date_pub=date(2026, 7, 1),
+                    rubrique="politique",
+                    texte="y" * (CORPUS_EXTRAIT_MAX + 500),
+                    mode_acquisition="http",
+                    pre_metriques={"a_signature_html": True},
+                ),
+                MediaEvalCorpusArticle(
+                    media_id=media_cnews.id,
+                    run_id=run_test.run_id,
+                    url="https://cnews.fr/2026/06/a2",
+                    titre="Titre 2",
+                    date_pub=date(2026, 6, 1),
+                    rubrique="international",
+                    texte="court",
+                ),
+            ]
+        )
+        await db_session.commit()
+        arts = await _charger_corpus_articles(
+            db_session, media_cnews.id, run_test.run_id
+        )
+        assert len(arts) == 2
+        # Tri par date décroissante : le plus récent d'abord.
+        assert arts[0]["url"].endswith("a1")
+        assert len(arts[0]["extrait"]) == CORPUS_EXTRAIT_MAX
+        assert arts[0]["pre_metriques"] == {"a_signature_html": True}
+
+
+class TestNbDebunkagesFraisDedupAffaire:
+    async def _debunkage(self, db_session, media, run, *, cle, url, publie):
+        signal = MediaEvalSignal(
+            media_id=media.id,
+            critere="C1",
+            type_signal="debunkage",
+            statut=StatutSignal.PRESENT,
+            valeur={"url": url, "cle_affaire": cle},
+            voie=VoieCollecte.AGENT,
+            collecteur="agent:x@v1",
+            source_urls=[url],
+            run_id=run.run_id,
+            dedupe_key=f"k-{url}",
+        )
+        db_session.add(signal)
+        await db_session.flush()
+        db_session.add(
+            MediaEvalDebunkage(
+                media_id=media.id,
+                signal_id=signal.id,
+                url_debunkage=url,
+                emetteur="les_decodeurs",
+                poids_emetteur=PoidsEmetteur.MOYEN,
+                gravite=GraviteDebunkage.SIGNIFICATIVE,
+                suite_donnee=SuiteDonnee.AUCUNE,
+                publie_at=publie,
+            )
+        )
+
+    async def test_dedup_par_affaire(self, db_session, media_cnews, run_test):
+        # 3 débunkages, dont 2 pour la même affaire → 2 litiges distincts.
+        await self._debunkage(
+            db_session, media_cnews, run_test,
+            cle="affaire_x", url="https://d1", publie=date(2026, 1, 1),
+        )
+        await self._debunkage(
+            db_session, media_cnews, run_test,
+            cle="affaire_x", url="https://d2", publie=date(2026, 2, 1),
+        )
+        await self._debunkage(
+            db_session, media_cnews, run_test,
+            cle="affaire_y", url="https://d3", publie=date(2026, 3, 1),
+        )
+        await db_session.commit()
+        n = await _nb_debunkages_frais(
+            db_session, media_cnews.id, run_test.run_id, date(2026, 7, 8), "v1.2"
+        )
+        assert n == 2

--- a/packages/api/tests/scripts/media_eval/test_collect_corpus_articles.py
+++ b/packages/api/tests/scripts/media_eval/test_collect_corpus_articles.py
@@ -1,0 +1,223 @@
+"""Tests du collecteur de corpus d'articles (collect_corpus_articles.py).
+
+Fonctions pures (str → structures) testées sur fixtures HTML, zéro réseau :
+détection d'URL d'article, rubrique, date, extraction de titre, pré-métriques
+mécaniques. Plus un bout-en-bout DB avec fetcher injecté (fixtures figées).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from sqlalchemy import select
+
+from app.models.media_eval import MediaEvalCorpusArticle, ModeAcces
+from scripts.media_eval.collect_common import FetchResult
+from scripts.media_eval.collect_corpus_articles import (
+    collecter_corpus,
+    date_depuis_html,
+    date_depuis_url,
+    est_url_article,
+    extraire_titre,
+    extraire_urls_articles,
+    pre_metriques_article,
+    rubrique_depuis_url,
+)
+
+
+class TestEstUrlArticle:
+    def test_url_datee_est_article(self):
+        assert est_url_article("https://cnews.fr/politique/2026-07-01/titre-123456")
+
+    def test_id_numerique_long(self):
+        assert est_url_article("https://cnews.fr/article/1234567")
+
+    def test_page_de_service_ecartee(self):
+        # Segment de service même avec un id → pas un article.
+        assert not est_url_article("https://cnews.fr/tag/2026/immigration")
+        assert not est_url_article("https://cnews.fr/video/2026/07/x-123456")
+
+    def test_sans_marqueur_date_rejete(self):
+        assert not est_url_article("https://cnews.fr/politique/dossier")
+
+
+class TestRubriqueEtDate:
+    def test_rubrique_premier_segment(self):
+        assert rubrique_depuis_url("https://cnews.fr/politique/2026/07/x") == "politique"
+
+    def test_rubrique_saute_annee(self):
+        # /2026/... → prendre le segment parlant suivant.
+        assert (
+            rubrique_depuis_url("https://cnews.fr/2026/07/01/international-x")
+            == "international-x"
+        )
+
+    def test_date_depuis_url_complete(self):
+        assert date_depuis_url("https://cnews.fr/a/2026/07/01/x") == date(2026, 7, 1)
+
+    def test_date_depuis_url_tirets(self):
+        # Pattern CNEWS : /AAAA-MM-JJ/.
+        assert (
+            date_depuis_url("https://cnews.fr/france/2026-07-18/x-123456")
+            == date(2026, 7, 18)
+        )
+
+    def test_date_depuis_url_annee_seule(self):
+        assert date_depuis_url("https://cnews.fr/a/2026/x-123456") == date(2026, 1, 1)
+
+    def test_date_absente(self):
+        assert date_depuis_url("https://cnews.fr/a/x-123456") is None
+
+
+class TestExtractionHtml:
+    def test_titre_h1_prioritaire(self):
+        html = "<html><head><title>Titre onglet</title></head><body><h1>Le vrai titre</h1></body></html>"
+        assert extraire_titre(html) == "Le vrai titre"
+
+    def test_titre_repli_title(self):
+        assert extraire_titre("<html><head><title>Onglet</title></head></html>") == "Onglet"
+
+    def test_date_html_meta(self):
+        html = '<meta property="article:published_time" content="2026-05-04T10:00:00Z">'
+        assert date_depuis_html(html) == date(2026, 5, 4)
+
+    def test_date_html_time(self):
+        assert date_depuis_html('<time datetime="2026-05-04">4 mai</time>') == date(2026, 5, 4)
+
+
+class TestPreMetriques:
+    def test_signature_et_label_opinion(self):
+        html = (
+            '<article><meta name="author" content="Jean Dupont">'
+            '<a href="https://ext.com/source">source</a>'
+            "<p>corps</p></article>"
+        )
+        m = pre_metriques_article(
+            "https://cnews.fr/tribune/2026/07/x-123456", html, "corps de l'article"
+        )
+        assert m["a_signature_html"] is True
+        assert m["label_opinion"] == "tribune"
+        assert m["liens_sortants"] == 1
+        assert m["longueur_texte"] == len("corps de l'article")
+
+    def test_liens_sortants_ignore_liens_internes_absolus(self):
+        # Un lien interne absolu (même domaine, www. toléré) n'est pas « sortant ».
+        html = (
+            "<article>"
+            '<a href="https://www.cnews.fr/france/2026-07-01/autre-111111">interne</a>'
+            '<a href="https://ext.com/source">externe</a>'
+            "<p>corps</p></article>"
+        )
+        m = pre_metriques_article(
+            "https://cnews.fr/actu/2026/07/x-123456", html, "corps"
+        )
+        assert m["liens_sortants"] == 1
+
+    def test_mention_redaction_sans_label(self):
+        html = "<article><p>texte</p></article>"
+        m = pre_metriques_article(
+            "https://cnews.fr/actu/2026/07/x-123456",
+            html,
+            "Article rédigé par La Rédaction avec AFP.",
+        )
+        assert m["mention_redaction_ou_agence"] is True
+        assert m["label_opinion"] is None
+
+
+class TestExtraireUrlsArticles:
+    def test_home_puis_sitemap_dedup(self):
+        base = "https://cnews.fr"
+        home = (
+            "<html><body>"
+            '<a href="/politique/2026/07/a-111111">A</a>'
+            '<a href="/tag/immigration">tag</a>'
+            '<a href="https://autre.fr/2026/07/x-999999">externe</a>'
+            "</body></html>"
+        )
+        sitemap = [
+            "https://cnews.fr/politique/2026/07/a-111111",  # doublon home
+            "https://cnews.fr/eco/2026/07/b-222222",
+        ]
+        urls = extraire_urls_articles(base, home, sitemap)
+        assert urls == [
+            "https://cnews.fr/politique/2026/07/a-111111",
+            "https://cnews.fr/eco/2026/07/b-222222",
+        ]
+
+    def test_www_tolere_et_sitemap_filtre_domaine(self):
+        # Site canonique www. : les liens absolus www.cnews.fr sont retenus
+        # (media.domaine en DB est sans www) ; une URL étrangère du sitemap est
+        # écartée par le même filtre domaine que la home.
+        base = "https://cnews.fr"
+        home = (
+            "<html><body>"
+            '<a href="https://www.cnews.fr/france/2026-07-18/a-111111">A</a>'
+            "</body></html>"
+        )
+        sitemap = ["https://autre.fr/2026/07/x-999999"]
+        assert extraire_urls_articles(base, home, sitemap) == [
+            "https://www.cnews.fr/france/2026-07-18/a-111111",
+        ]
+
+
+# --------------------------------------------------------------------------- #
+# Bout-en-bout DB — fetcher injecté (aucun réseau).
+# --------------------------------------------------------------------------- #
+def _article_html(titre: str) -> str:
+    return (
+        f"<html><head><title>{titre}</title></head><body><main>"
+        f"<h1>{titre}</h1><p>{'contenu ' * 60}</p>"
+        '<a href="https://source.example/x">src</a></main></body></html>'
+    )
+
+
+class TestCollecterCorpusDB:
+    async def test_snapshot_et_dedup(self, db_session, media_cnews, run_test):
+        pages = {
+            "https://cnews.fr/": (
+                "<html><body>"
+                '<a href="/politique/2026/07/a-111111">A</a>'
+                '<a href="/eco/2026/07/b-222222">B</a>'
+                "</body></html>"
+            ),
+            "https://cnews.fr/sitemap.xml": "",  # pas de sitemap
+            "https://cnews.fr/politique/2026/07/a-111111": _article_html("Titre A"),
+            "https://cnews.fr/eco/2026/07/b-222222": _article_html("Titre B"),
+        }
+
+        async def fake_fetch(url: str) -> FetchResult:
+            if url == "https://cnews.fr/sitemap.xml":
+                return FetchResult(url, 404, "", ModeAcces.LIBRE, "HTTP 404")
+            return FetchResult(url, 200, pages.get(url, ""), ModeAcces.LIBRE)
+
+        stats = await collecter_corpus(
+            db_session, media_cnews, run_test, fake_fetch, max_articles=40
+        )
+        assert stats.inseres == 2
+        await db_session.commit()
+
+        # Ré-exécution : idempotence (déjà présents → doublons, pas de ré-insert).
+        stats2 = await collecter_corpus(
+            db_session, media_cnews, run_test, fake_fetch, max_articles=40
+        )
+        assert stats2.inseres == 0
+        assert stats2.doublons == 2
+
+        rows = (
+            await db_session.execute(
+                select(MediaEvalCorpusArticle).where(
+                    MediaEvalCorpusArticle.media_id == media_cnews.id
+                )
+            )
+        ).scalars().all()
+        assert {a.rubrique for a in rows} == {"politique", "eco"}
+        assert all(a.texte and a.pre_metriques is not None for a in rows)
+
+    async def test_home_bloquee_corpus_vide(self, db_session, media_cnews, run_test):
+        async def fake_fetch(url: str) -> FetchResult:
+            return FetchResult(url, 403, "", ModeAcces.BLOQUE, "HTTP 403")
+
+        stats = await collecter_corpus(
+            db_session, media_cnews, run_test, fake_fetch, max_articles=40
+        )
+        assert stats.inseres == 0

--- a/packages/api/tests/scripts/media_eval/test_evaluate_golden_agreement.py
+++ b/packages/api/tests/scripts/media_eval/test_evaluate_golden_agreement.py
@@ -8,8 +8,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from scripts.media_eval.evaluate_golden_agreement import evaluate, render_md
-from scripts.media_eval.schemas import GoldenSet
+from scripts.media_eval.evaluate_golden_agreement import (
+    _paire_accord,
+    evaluate,
+    render_md,
+)
+from scripts.media_eval.export_evaluations import accord_inter_evaluateurs
+from scripts.media_eval.schemas import GoldenEntry, GoldenSet
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "media_eval"
 
@@ -64,3 +69,71 @@ class TestEvaluate:
         md = render_md(evaluate(gold, generated))
         assert "na_vs_score" in md
         assert "reporterre.net" in md
+
+
+def _ev(critere, evaluateur, *, statut="evaluee", score=None, niveau=None):
+    return {
+        "media_domaine": "cnews.fr",
+        "critere": critere,
+        "statut": statut,
+        "score": score,
+        "niveau": niveau,
+        "evaluateur": evaluateur,
+    }
+
+
+class TestAccordInterEvaluateurs:
+    def test_accord_et_desaccord(self):
+        evals = [
+            # C9 : deux évaluateurs, accord (niveau 1).
+            _ev("C9", "agent:e@v1-a", score=5, niveau=1),
+            _ev("C9", "agent:e@v1-b", score=5, niveau=1),
+            # C5 : deux évaluateurs, désaccord (niveau 2 vs 1).
+            _ev("C5", "agent:e@v1-a", score=10, niveau=2),
+            _ev("C5", "agent:e@v1-b", score=5, niveau=1),
+            # C6 : un seul évaluateur → hors du décompte inter-évaluateurs.
+            _ev("C6", "agent:e@v1", score=4, niveau=2),
+        ]
+        rep = accord_inter_evaluateurs(evals)
+        assert rep["n"] == 2  # C9 + C5 seulement
+        assert rep["accords"] == 1
+        assert rep["accord_inter"] == 0.5
+        assert [d["critere"] for d in rep["desaccords"]] == ["C5"]
+        assert rep["desaccords"][0]["verdicts"] == {
+            "agent:e@v1-a": "niveau 2",
+            "agent:e@v1-b": "niveau 1",
+        }
+
+    def test_aucune_double_eval(self):
+        rep = accord_inter_evaluateurs([_ev("C9", "agent:e@v1", score=5, niveau=1)])
+        assert rep["n"] == 0
+        assert rep["accord_inter"] is None
+
+
+class TestVersionV13:
+    def _pair(self, gold_niv, gen_niv):
+        g = GoldenEntry(
+            media_domaine="cnews.fr",
+            critere="C2",
+            version_methodo="v1.3",
+            statut="evaluee",
+            score=float(gold_niv),
+            niveau=gold_niv,
+        )
+        gen = GoldenEntry(
+            media_domaine="cnews.fr",
+            critere="C2",
+            version_methodo="v1.3",
+            statut="evaluee",
+            score=float(gen_niv),
+            niveau=gen_niv,
+        )
+        return _paire_accord(g, gen)
+
+    def test_c2_v13_est_a_niveaux(self):
+        # C2 est continu en v1.2 mais à niveaux en v1.3 : l'accord est exact
+        # sur le niveau, pas une tolérance de 20 %.
+        assert self._pair(2, 2)["accord"] is True
+        r = self._pair(2, 3)
+        assert r["accord"] is False
+        assert r["type_desaccord"] == "niveau"

--- a/packages/api/tests/scripts/media_eval/test_export_evaluations.py
+++ b/packages/api/tests/scripts/media_eval/test_export_evaluations.py
@@ -1,15 +1,16 @@
 """Tests de l'export d'évaluations (export_evaluations.py).
 
 Couvre : transformation en GoldenSet ; inclusion du raccourci code:jti_shortcut
-et exclusion des préfixes non demandés ; erreur explicite sur (média, critère)
-dupliqué.
+et exclusion des préfixes non demandés ; **consensus double évaluation**
+(accord conservé, désaccord → revue_requise documentée).
 """
 
 from __future__ import annotations
 
-import pytest
-
-from scripts.media_eval.export_evaluations import evaluations_to_goldenset
+from scripts.media_eval.export_evaluations import (
+    evaluateurs_accordent,
+    evaluations_to_goldenset,
+)
 
 
 def _ev(
@@ -51,13 +52,40 @@ class TestEvaluationsToGoldenset:
         assert len(gs.entries) == 1
         assert gs.entries[0].critere == "C5"
 
-    def test_doublon_media_critere_leve(self):
+    def test_consensus_accord_conserve(self):
+        # Deux évaluateurs indépendants convergent (même niveau) → 1 entrée gardée.
         evals = [
-            _ev("cnews.fr", "C5", score=10),
-            _ev("cnews.fr", "C5", score=5, evaluateur="code:autre"),
+            _ev("cnews.fr", "C9", score=5, niveau=1, evaluateur="agent:eval@v1-a"),
+            _ev("cnews.fr", "C9", score=5, niveau=1, evaluateur="agent:eval@v1-b"),
         ]
-        with pytest.raises(ValueError, match="deux évaluations"):
-            evaluations_to_goldenset(evals)
+        gs = evaluations_to_goldenset(evals)
+        assert len(gs.entries) == 1
+        e = gs.entries[0]
+        assert e.statut == "evaluee"
+        assert e.niveau == 1
+        assert "consensus" in (e.commentaire or "")
+
+    def test_consensus_desaccord_revue_requise(self):
+        # Désaccord → revue_requise, les deux verdicts documentés (jamais moyenné).
+        evals = [
+            _ev("cnews.fr", "C9", score=10, niveau=2, evaluateur="agent:eval@v1-a"),
+            _ev("cnews.fr", "C9", score=5, niveau=1, evaluateur="agent:eval@v1-b"),
+        ]
+        gs = evaluations_to_goldenset(evals)
+        assert len(gs.entries) == 1
+        e = gs.entries[0]
+        assert e.statut == "revue_requise"
+        assert e.score is None and e.niveau is None
+        assert "niveau 2" in e.commentaire and "niveau 1" in e.commentaire
+
+    def test_evaluateurs_accordent_predicat(self):
+        base = _ev("cnews.fr", "C5", score=10, niveau=2)
+        assert evaluateurs_accordent([base, dict(base)])
+        autre = _ev("cnews.fr", "C5", score=5, niveau=1)
+        assert not evaluateurs_accordent([base, autre])
+        # Statuts différents = désaccord.
+        na = _ev("cnews.fr", "C5", statut="non_applicable")
+        assert not evaluateurs_accordent([base, na])
 
     def test_na_score_null(self):
         gs = evaluations_to_goldenset(

--- a/packages/api/tests/scripts/media_eval/test_ingest_artifacts.py
+++ b/packages/api/tests/scripts/media_eval/test_ingest_artifacts.py
@@ -117,6 +117,8 @@ class TestInsererDebunkages:
         assert signal.critere == "C1"
         assert signal.type_signal == "sanction_arcom"
         assert signal.valeur["poids_emetteur"] == "fort"
+        # cle_affaire non qualifiée dans la fixture → repli sur l'URL (dédup §5.2.1).
+        assert signal.valeur["cle_affaire"] == arcom.url_debunkage
 
     async def test_idempotence(self, db_session, media_cnews):
         await inserer_debunkages(db_session, _debunkages_batch())

--- a/packages/api/tests/scripts/media_eval/test_schemas.py
+++ b/packages/api/tests/scripts/media_eval/test_schemas.py
@@ -200,9 +200,22 @@ class TestGrilleV13:
         assert set(GRILLES) == {"v1.2", "v1.3"}
         g = grille("v1.3")
         assert sum(g.baremes.values()) == 100
-        assert g.criteres_vague_1 == ("C1", "C6", "C8", "C9", "C10")
+        # Batch 2 : les 10 critères sont actifs (corpus C2/C3/C4/C5/C7 inclus).
+        assert g.criteres_vague_1 == (
+            "C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10",
+        )
+        assert g.criteres_corpus == ("C2", "C3", "C4", "C5", "C7")
+        assert grille("v1.2").criteres_corpus == ()
         assert g.fraicheur_max_jours == 1095
         assert g.criteres_double_eval == ("C5", "C9", "C10")
+
+    def test_registre_type_signaux_corpus(self):
+        g = grille("v1.3")
+        for critere in g.criteres_corpus:
+            assert "articles" in g.type_signaux[critere]
+        # C3 mixte : structurels + bloc corpus.
+        assert "page_corrections" in g.type_signaux["C3"]
+        assert "canal_signalement" in g.type_signaux["C3"]
 
     def test_version_inconnue_leve(self):
         with pytest.raises(ValueError, match="version methodo inconnue"):
@@ -245,19 +258,20 @@ class TestGrilleV13:
         )
         assert ev.score_derive() == (15.0, 3)
 
-    def test_evaluation_output_v13_hors_vague_1(self):
-        # C2 (sourçage) est sur corpus : hors vague 1 v1.3 (batch 2).
-        with pytest.raises(ValidationError, match="hors vague 1"):
-            EvaluationOutput.model_validate(
-                {
-                    "media_domaine": "cnews.fr",
-                    "critere": "C2",
-                    "version_methodo": "v1.3",
-                    "determinations": {"niveau": 2},
-                    "justification": "x [signal:a].",
-                    "signal_ids_cites": [_UUID],
-                }
-            )
+    def test_evaluation_output_v13_corpus_actif(self):
+        # Batch 2 : C2 (sourçage, sur corpus) est désormais dans la vague 1 v1.3
+        # et produit une évaluation valide (score dérivé du niveau).
+        ev = EvaluationOutput.model_validate(
+            {
+                "media_domaine": "cnews.fr",
+                "critere": "C2",
+                "version_methodo": "v1.3",
+                "determinations": {"niveau": 2},
+                "justification": "x [signal:a].",
+                "signal_ids_cites": [_UUID],
+            }
+        )
+        assert ev.score_derive() == (7.0, 2)
 
     def test_signal_artifact_v13_fusion_c9(self):
         # Le C9 fusionné hérite des signaux ex-C8 (engagement) ET ex-C11 (position).


### PR DESCRIPTION
**PR C** de la trajectoire media-eval (base `main`). Outillage du batch 2 CNEWS,
**avant** toute collecte. Aucune migration (additif / expand-safe, 1 head).

## Ce que ça livre

**1. Corpus d'articles (C2/C3/C4/C5/C7)**
- `schemas.py` : vague-1 v1.3 étendue aux **10 critères** ; registre `articles`
  (+ structurels C3 `page_corrections`/`canal_signalement`/`reponse_evaluation_externe`) ;
  `Grille.criteres_corpus` (v1.3 = C2/C3/C4/C5/C7 ; v1.2 = ∅).
- **`collect_corpus_articles.py`** (nouveau, voie A) : échantillonne + snapshote
  des articles récents (home + sitemap) dans `media_eval_corpus_articles` +
  pré-métriques mécaniques (signature ? label d'opinion ? liens sortants ?).
  N'émet **aucun signal** (la qualification est voie B). Idempotent.
- `build_eval_input.py` : joint un bloc `corpus_articles` (contexte non citable,
  borné) aux eval_inputs des critères sur corpus.
- Agent **`media-eval-collecteur-corpus`** (nouveau, voie B) : qualifie le corpus
  → un signal `articles` agrégé par critère.

**2. Double évaluation C5/C9/C10 (décision PO 18/07)**
- `export_evaluations.py` : le `raise` sur doublon (média, critère) devient un
  **consensus** — accord conservé ; désaccord → `revue_requise` documenté (jamais
  moyenné). Rendu **version-aware** (chaque entrée porte `version_methodo`).
  Héberge aussi la métrique **accord inter-évaluateurs** (même règle d'accord).
- `evaluate_golden_agreement.py` : `_paire_accord` compare C2..C7 à niveaux en
  v1.3 (pas en tolérance continue), grille résolue depuis la version du gold.
- `/media-eval-run` §6 : deux évaluateurs indépendants `…@v1-a` / `…@v1-b`.

**3. Débunkages C1 — recall + dédup par affaire**
- `DebunkageArtifact.cle_affaire` → écrit dans le `valeur` du signal C1 (repli
  sur l'URL) ; `_nb_debunkages_frais` compte des **affaires distinctes** (fallback
  C1 correct : un événement très couvert = un litige).
- Agent débunkages : requêtes élargies (Les Surligneurs, ARCOM, CDJM), fenêtre
  **36 mois** (v1.3), `cle_affaire` par litige.

**4. Pappers** : inchangé (repli gratuit). Recharger les crédits = action Laurin.

## Hors périmètre (suivi séparé)
- Threading de la synthèse sur la version (`synthese_fiche`/`rapport_pilote`/
  `ingest_artifacts.rapport_couverture`) — **Phase 6**, avant la fiche publiable.
- Re-mapping des codes de critère **voie A** pour un run v1.3 (les collecteurs
  structurels posent encore C5/C7/C8/C11 v1.2) — signalé WARNING dans
  `/media-eval-run` §3, à traiter avant la collecte batch 2 hors CNEWS.

## Correctifs de revue (harness)
`collect_corpus_articles.py` : filtre same-domain tolérant `www.` (appliqué aussi
aux URLs sitemap — sinon corpus quasi vide pour un site canonique `www.` comme
CNEWS) ; `liens_sortants` ne compte que les liens vers un **autre** domaine
(pré-métrique C2 sinon gonflée par les liens internes absolus) ;
`date_depuis_url` lit le format `/AAAA-MM-JJ/` (pattern CNEWS).

## Simplify
`accord_inter_evaluateurs` déplacé dans `export_evaluations.py` (supprime le
cycle d'import différé + `_verdict` dupliqué) ; `collect_corpus_articles` porté
sur le harnais CLI commun `collect_common._run` (garde `--apply`, dry-run,
rollback — plus de copie) + helpers partagés (`meme_domaine`, `_RE_HREF_ARTICLE`,
`FetchResult` en test) ; `cle_affaire_signal` rangé dans `schemas.py` à côté du
contrat d'écriture ; paramètre mort `version_methodo` retiré de
`evaluations_to_goldenset`.

## Tests
`tests/scripts/media_eval/` : **260 passent** (en série ; fixture `create_tables`
DROP le schéma). 1 head Alembic. `ruff check` OK. Aucune migration.

Doc : `docs/maintenance/maintenance-media-eval-harness-batch2.md`.
Pas d'entrée changelog (outillage interne).
