### PR TITLE
fix(sources): couverture résiliente aux articles non classés + pastille thème rétablie

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Fiche source",
+      "summary": "La couverture d'une source reflète à nouveau ses vrais thèmes : les articles pas encore rangés ne gonflent plus la part « Autres », et son volume d'articles publiés reste affiché tel quel. Les cartes retrouvent aussi leur pastille de thème."
+    },
+    {
       "tag": "Essentiel",
       "summary": "L'Essentiel devient une surface vivante : tu y reviens toujours, et au fil de la journée il s'enrichit de contenu frais de tes sources et thèmes préférés. Une pastille « N nouveaux depuis ce matin » signale ce qui est arrivé depuis ta lettre du jour."
     },

--- a/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
@@ -575,6 +575,17 @@ class _Footer extends StatelessWidget {
             ),
           ),
         ],
+        // Pastille de thème (macro-thème ML granulaire, sinon thème source en
+        // fallback via `progressionTopic`) : rétablie après son retrait
+        // temporaire en Story 10.1. Le VM la calcule toujours ; masquée si vide.
+        if (vm.themeLabel != null && vm.themeLabel!.trim().isNotEmpty) ...[
+          const SizedBox(width: 6),
+          _ThemePill(
+            key: const Key('flux-theme-pill'),
+            label: vm.themeLabel!,
+            colors: colors,
+          ),
+        ],
         const SizedBox(width: 6),
         separator,
         const SizedBox(width: 6),
@@ -741,6 +752,36 @@ class _PressReviewChip extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// Pastille de thème compacte affichée dans le footer de carte (source ·
+/// thème · heure). Style discret : fond très léger, texte secondaire.
+class _ThemePill extends StatelessWidget {
+  final String label;
+  final FacteurColors colors;
+
+  const _ThemePill({super.key, required this.label, required this.colors});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
+      decoration: BoxDecoration(
+        color: colors.textPrimary.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        label,
+        style: GoogleFonts.dmSans(
+          fontSize: 10,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.2,
+          height: 1.4,
+          color: colors.textSecondary,
+        ),
+      ),
     );
   }
 }

--- a/apps/mobile/lib/features/sources/models/source_profile.dart
+++ b/apps/mobile/lib/features/sources/models/source_profile.dart
@@ -5,8 +5,9 @@ import 'source_model.dart';
 /// (`GET /sources/{id}/profile`).
 ///
 /// `theme` reste une clé brute backend (mapping label/couleur côté front, kit
-/// Flux continu). `share` ∈ [0, 1] = `count / total` : le mobile en dérive le
-/// pourcentage affiché.
+/// Flux continu). `share` ∈ [0, 1] = `count / articles classés` (les non
+/// classés `theme NULL` sont exclus du dénominateur) : les parts totalisent
+/// 100 % et le mobile en dérive le pourcentage affiché.
 class ThemeShare {
   final String theme;
   final int count;

--- a/apps/mobile/lib/features/sources/utils/publication_frequency.dart
+++ b/apps/mobile/lib/features/sources/utils/publication_frequency.dart
@@ -3,8 +3,11 @@
 /// Fonction **pure** : le chip horloge du header en dérive un libellé naturel
 /// (« 70 articles par jour en moyenne », « quelques articles par semaine »…).
 ///
-/// - [articles30d] : nombre d'articles publiés sur les 30 derniers jours
-///   (= `articles_30d` du profil = somme des `theme_distribution`).
+/// - [articles30d] : nombre d'articles **publiés** sur les 30 derniers jours
+///   (= `articles_30d` du profil, tous thèmes confondus, y compris les non
+///   classés). Peut donc dépasser la somme des `theme_distribution`, qui ne
+///   couvre que les articles classés (frais non encore classé exclu des barres,
+///   mais bien compté dans le volume/fréquence ici).
 /// - [oldestContentAt] : date du plus ancien contenu connu (tout l'historique).
 ///   Clampe la fenêtre pour ne pas **sous-estimer** une source fraîche :
 ///   6 articles publiés en 3 jours → « quelques-uns/jour », pas « /mois ».

--- a/apps/mobile/test/features/flux_continu/widgets/flux_continu_article_card_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/flux_continu_article_card_test.dart
@@ -12,7 +12,7 @@ import 'package:facteur/features/sources/models/source_model.dart';
 import 'package:facteur/widgets/design/facteur_thumbnail.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
-Content _content() => Content(
+Content _content({String? sourceTheme}) => Content(
       id: 'c-1',
       title: 'Titre article Flux',
       url: 'https://example.com/1',
@@ -21,7 +21,14 @@ Content _content() => Content(
       description: 'Un chapô pour l\'aperçu.',
       contentType: ContentType.article,
       publishedAt: DateTime(2026, 7, 10),
-      source: Source(id: 's-1', name: 'Le Monde', type: SourceType.article),
+      // Pas de topics ML → `progressionTopic` retombe sur le thème source, le
+      // fallback qui garde une pastille utile quand la classif est en retard.
+      source: Source(
+        id: 's-1',
+        name: 'Le Monde',
+        type: SourceType.article,
+        theme: sourceTheme,
+      ),
     );
 
 Widget _wrap(Widget child) => ProviderScope(
@@ -68,5 +75,27 @@ void main() {
     await gesture.up();
     await tester.pumpAndSettle();
     expect(find.byType(FacteurThumbnail), findsNothing);
+  });
+
+  testWidgets(
+      'footer renders the theme pill from the source-theme fallback when '
+      'ML topics are empty (mitigation « tout en Autres »)', (tester) async {
+    await tester.pumpWidget(_wrap(
+      FluxContinuArticleCard(article: _content(sourceTheme: 'tech')),
+    ));
+
+    expect(find.byKey(const Key('flux-theme-pill')), findsOneWidget);
+    // Le libellé affiché est le thème source mappé (fallback pré-ML), pas le
+    // slug brut : la pastille reste lisible même worker de classif mort.
+    expect(find.text('Tech & Innovation'), findsOneWidget);
+  });
+
+  testWidgets('no theme pill when neither ML topic nor source theme resolves',
+      (tester) async {
+    await tester.pumpWidget(_wrap(
+      FluxContinuArticleCard(article: _content()),
+    ));
+
+    expect(find.byKey(const Key('flux-theme-pill')), findsNothing);
   });
 }

--- a/docs/bugs/bug-classification-articles-autres.md
+++ b/docs/bugs/bug-classification-articles-autres.md
@@ -1,0 +1,64 @@
+# Bug — « tout en Autres » : la couverture source et les cartes tombent en « Autres » quand la classif est en retard
+
+Type : **Bug prod (mitigation d'affichage)**. Statut : correctif d'affichage
+livré. La **cause racine** (worker de classification ML mort depuis le 30/06)
+est traitée séparément — cf. [`bug-classification-worker-stopped.md`](bug-classification-worker-stopped.md)
+et le plan de redéploiement worker (`.context/handoff_worker_classif_asap.md`).
+
+## Symptôme
+
+Le worker de classification étant à l'arrêt, `content.theme` est **NULL à ~100 %
+sur le frais**. Deux surfaces le rendaient visible de façon dégradée :
+
+1. **Fiche source — barres de couverture** (`GET /sources/{id}/coverage`,
+   `/profile`) : les articles non classés (`theme IS NULL`) étaient repliés dans
+   la ligne agrégée `autres` **et** comptés dans le dénominateur des `pct`. Une
+   source dont le frais n'était pas classé s'affichait donc massivement « Autres »,
+   écrasant sa vraie couverture historique.
+2. **Cartes Flux continu** : la pastille de thème (retirée temporairement en
+   Story 10.1) ne montrait plus rien alors que le VM sait retomber sur le
+   **thème source** quand le thème ML est absent.
+
+## Correctif (affichage uniquement, zéro migration)
+
+### Backend — `packages/api/app/routers/sources.py`
+
+`_aggregate_source_themes` renvoie désormais `(rows, total_published,
+total_classified)` :
+
+- **`total_published`** = tous les articles publiés sur la fenêtre, **NULL
+  compris**. Reste la légende « N articles publiés » et le signal de
+  volume/fréquence — il ne doit **pas** chuter pendant un backlog de classif.
+- **`total_classified`** = articles au `theme` non NULL. C'est le **dénominateur
+  des `pct`/`share`** → les barres totalisent 100 % des articles *classés*.
+- Les **non classés sont exclus** des barres : ils ne rejoignent plus `autres`
+  (qui ne replie plus que la longue traîne des thèmes **nommés** au-delà du
+  top-N) ni le dénominateur.
+- Tout non classé → `rows` vide (section masquée côté mobile), mais
+  `total_count`/`articles_30d` gardent le volume réel.
+
+### Mobile
+
+- `flux_continu_article_card.dart` : la **pastille de thème** est rétablie dans
+  le footer, alimentée par `vm.themeLabel` (macro-thème ML granulaire, sinon
+  **thème source** en fallback via `Content.progressionTopic`). Masquée si vide.
+- `source_profile.dart` / `publication_frequency.dart` : commentaires alignés —
+  `share` porte sur les classés, `articles_30d` reste le volume publié (peut
+  dépasser la somme de la distribution pendant un backlog).
+
+## Tests
+
+- `tests/test_source_coverage.py` : NULL exclus des barres et des `pct` mais
+  comptés dans `total_count` ; tout-NULL → `rows: []` + volume gardé ;
+  longue traîne nommée → `autres`.
+- `tests/test_source_profile.py` : NULL exclus de `theme_distribution`
+  (`share` sur les classés, somme = 1.0) mais comptés dans `articles_30d` ;
+  tout-NULL → distribution vide.
+- `flux_continu_article_card_test.dart` : pastille rendue via le fallback
+  thème source quand les topics ML sont vides ; absente quand rien ne se résout.
+
+## Portée / non-régression
+
+Additif, sans DDL. La correction est purement d'affichage : dès que le worker
+reprend et que `theme` se repeuple, les barres se re-remplissent naturellement
+(le dénominateur `total_classified` remonte), sans autre changement.

--- a/packages/api/app/routers/sources.py
+++ b/packages/api/app/routers/sources.py
@@ -858,7 +858,9 @@ async def detect_source(
 # Nombre maximum de thèmes affichés individuellement ; la longue traîne au-delà
 # est regroupée dans une ligne unique `theme="autres"`.
 COVERAGE_TOP_N = 6
-# Clé brute utilisée pour la ligne agrégée (longue traîne + thèmes NULL).
+# Clé brute utilisée pour la ligne agrégée de la longue traîne (thèmes nommés
+# au-delà du top-N). Les contenus non classés (`theme IS NULL`) n'y sont PAS
+# repliés : ils sont exclus de la couverture (cf. `_aggregate_source_themes`).
 COVERAGE_OTHER_THEME = "autres"
 # Espace fine insécable (U+202F) — séparateur des milliers en typographie FR.
 _NARROW_NBSP = " "
@@ -874,18 +876,25 @@ async def _aggregate_source_themes(
     source_id: UUID,
     *,
     days: int,
-) -> tuple[list[tuple[str, int]], int]:
+) -> tuple[list[tuple[str, int]], int, int]:
     """Agrège les contenus d'une source par thème sur une fenêtre glissante.
 
     Helper partagé par `/coverage` et `/profile` (zéro duplication).
 
-    Renvoie `(rows, total)` :
-    - `total` = nombre d'articles publiés sur la fenêtre, tous thèmes confondus
-      (avant troncature top-N) ;
+    Renvoie `(rows, total_published, total_classified)` :
+    - `total_published` = nombre d'articles publiés sur la fenêtre, **tous
+      thèmes confondus, y compris les non classés** (`theme IS NULL`). C'est le
+      signal de volume/fréquence et la légende « N articles publiés » : il ne
+      doit PAS chuter quand la classification prend du retard (backlog worker).
+    - `total_classified` = nombre d'articles au thème **non NULL**. C'est le
+      dénominateur des parts/pourcentages : la barre de couverture représente
+      100 % des articles *classés*, les non classés n'y figurent pas.
     - `rows` = liste `(theme, count)` triée par volume décroissant : les
-      `COVERAGE_TOP_N` thèmes nommés les plus volumineux, suivis d'une ligne
-      `COVERAGE_OTHER_THEME` repliant la longue traîne **et** les thèmes NULL
-      (présente seulement si non vide). Liste vide quand `total == 0`.
+      `COVERAGE_TOP_N` thèmes **nommés** les plus volumineux, suivis d'une
+      ligne `COVERAGE_OTHER_THEME` repliant la longue traîne des thèmes nommés
+      au-delà du top-N (présente seulement si non vide). Ne contient **jamais**
+      les non classés. Liste vide quand `total_classified == 0` (rien à
+      afficher, même si des articles non classés ont été publiés).
     """
     cutoff = datetime.now(UTC) - timedelta(days=days)
 
@@ -897,32 +906,33 @@ async def _aggregate_source_themes(
     )
     aggregates = result.all()
 
-    # total = somme sur TOUS les thèmes de la fenêtre (avant troncature top-N).
-    total = sum(int(count) for _theme, count in aggregates)
-    if total == 0:
-        return [], 0
+    # Volume publié = somme sur TOUS les thèmes, NULL compris (frais non classé).
+    total_published = sum(int(count) for _theme, count in aggregates)
+    if total_published == 0:
+        return [], 0, 0
 
-    # Sépare les thèmes nommés (non-NULL) de la part NULL, qui ira dans « autres ».
-    named: list[tuple[str, int]] = []
-    other_count = 0
-    for theme, count in aggregates:
-        count = int(count)
-        if theme is None:
-            other_count += count
-        else:
-            named.append((theme, count))
+    # On ne garde que les thèmes nommés : les non classés (theme NULL) sont
+    # exclus de la couverture (ni bucket « autres », ni dénominateur des parts).
+    named: list[tuple[str, int]] = [
+        (theme, int(count)) for theme, count in aggregates if theme is not None
+    ]
+    total_classified = sum(count for _theme, count in named)
+    if total_classified == 0:
+        # Des articles existent mais aucun n'est classé → pas de couverture à
+        # afficher (section masquée côté mobile), mais le volume reste connu.
+        return [], total_published, 0
 
     named.sort(key=lambda item: item[1], reverse=True)
 
-    # Top N affichés individuellement ; le reste rejoint « autres ».
+    # Top N affichés individuellement ; la traîne des thèmes nommés → « autres ».
     head = named[:COVERAGE_TOP_N]
     tail = named[COVERAGE_TOP_N:]
-    other_count += sum(count for _theme, count in tail)
+    tail_count = sum(count for _theme, count in tail)
 
     rows: list[tuple[str, int]] = list(head)
-    if other_count > 0:
-        rows.append((COVERAGE_OTHER_THEME, other_count))
-    return rows, total
+    if tail_count > 0:
+        rows.append((COVERAGE_OTHER_THEME, tail_count))
+    return rows, total_published, total_classified
 
 
 @router.get("/{source_id}/coverage", response_model=CoverageResponse)
@@ -935,14 +945,18 @@ async def get_source_coverage(
     """Couverture par thèmes d'une source sur une fenêtre glissante.
 
     Agrège `contents` par `theme` sur les `days` derniers jours. Trie par
-    volume décroissant, conserve le top N et regroupe la longue traîne (ainsi
-    que les thèmes NULL) dans une ligne unique `autres`. La clé `theme` reste
-    brute : le mapping label/couleur est fait côté front.
+    volume décroissant, conserve le top N et regroupe la longue traîne des
+    thèmes nommés dans une ligne unique `autres`. Les articles **non classés**
+    (`theme IS NULL`) sont exclus des barres et du dénominateur des `pct`, mais
+    restent comptés dans `total_count` (volume réellement publié). La clé
+    `theme` reste brute : le mapping label/couleur est fait côté front.
     """
     period_label = f"{days} derniers jours"
-    rows, total_count = await _aggregate_source_themes(db, source_id, days=days)
+    rows, total_published, total_classified = await _aggregate_source_themes(
+        db, source_id, days=days
+    )
 
-    if total_count == 0:
+    if total_published == 0:
         return CoverageResponse(
             period_label=period_label,
             total_count=0,
@@ -950,17 +964,20 @@ async def get_source_coverage(
             rows=[],
         )
 
+    # `pct` est calculé sur les articles classés → les barres totalisent 100 %.
+    # `rows` est vide si rien n'est classé (total_classified == 0) : pas de
+    # division ici, et la section se masque côté mobile.
     coverage_rows = [
-        CoverageRow(theme=theme, count=count, pct=round(count / total_count * 100))
+        CoverageRow(theme=theme, count=count, pct=round(count / total_classified * 100))
         for theme, count in rows
     ]
 
-    noun = "article publié" if total_count == 1 else "articles publiés"
-    caption = f"{_format_fr_thousands(total_count)} {noun} sur la période"
+    noun = "article publié" if total_published == 1 else "articles publiés"
+    caption = f"{_format_fr_thousands(total_published)} {noun} sur la période"
 
     return CoverageResponse(
         period_label=period_label,
-        total_count=total_count,
+        total_count=total_published,
         caption=caption,
         rows=coverage_rows,
     )
@@ -1020,9 +1037,19 @@ async def get_source_profile(
         follower_count=follower_count,
     )
 
-    rows, total = await _aggregate_source_themes(db, source_id, days=30)
+    rows, total_published, total_classified = await _aggregate_source_themes(
+        db, source_id, days=30
+    )
+    # `share` est calculé sur les articles classés (les non classés sont exclus
+    # de la distribution) ; `articles_30d` reste le volume publié réel, qui peut
+    # donc dépasser la somme des `count` de la distribution pendant un backlog
+    # de classification (frais non encore classé).
     theme_distribution = [
-        ThemeShare(theme=theme, count=count, share=count / total if total else 0.0)
+        ThemeShare(
+            theme=theme,
+            count=count,
+            share=count / total_classified if total_classified else 0.0,
+        )
         for theme, count in rows
     ]
 
@@ -1052,7 +1079,7 @@ async def get_source_profile(
         source=source_response,
         recent_articles=recent_articles,
         theme_distribution=theme_distribution,
-        articles_30d=total,
+        articles_30d=total_published,
         oldest_content_at=oldest_content_at,
     )
 

--- a/packages/api/tests/test_source_coverage.py
+++ b/packages/api/tests/test_source_coverage.py
@@ -5,7 +5,9 @@ Story 7.8 — Refonte fiche source v2 (WS-A backend).
 Couvre :
 - agrégation par thème (counts, pct, tri décroissant) ;
 - exclusion de la fenêtre temporelle (articles plus vieux que `days`) ;
-- regroupement de la longue traîne (>top N) + thèmes NULL dans « autres » ;
+- regroupement de la longue traîne des thèmes nommés (>top N) dans « autres » ;
+- exclusion des non classés (`theme IS NULL`) des barres et du dénominateur
+  des `pct`, tout en les gardant dans `total_count` (volume publié réel) ;
 - source vide → rows: [], total 0 ;
 - `recent-items` renvoie désormais `theme` (et None si content.theme est NULL).
 """
@@ -123,7 +125,11 @@ async def test_coverage_excludes_articles_outside_window(coverage_client):
 
 @pytest.mark.asyncio
 async def test_coverage_long_tail_grouped_into_autres(coverage_client):
-    """Au-delà du top 6, la traîne et les thèmes NULL vont dans « autres »."""
+    """Au-delà du top 6, la traîne des thèmes NOMMÉS va dans « autres ».
+
+    Les non classés (theme NULL) restent comptés dans `total_count` (volume
+    publié) mais ne rejoignent PAS « autres » et ne pèsent pas dans les `pct`.
+    """
     ac, source, db = coverage_client
     # 8 thèmes nommés à volumes décroissants : t1=8 ... t8=1, + 4 NULL.
     for idx, count in enumerate(range(8, 0, -1), start=1):
@@ -137,7 +143,7 @@ async def test_coverage_long_tail_grouped_into_autres(coverage_client):
     assert resp.status_code == 200
     body = resp.json()
 
-    # total = sum(8..1) + 4 NULL = 36 + 4 = 40
+    # total_count = volume publié = sum(8..1) + 4 NULL = 36 + 4 = 40
     assert body["total_count"] == 40
 
     rows = body["rows"]
@@ -146,11 +152,59 @@ async def test_coverage_long_tail_grouped_into_autres(coverage_client):
     assert [r["theme"] for r in rows[:6]] == ["t1", "t2", "t3", "t4", "t5", "t6"]
     autres = rows[-1]
     assert autres["theme"] == "autres"
-    # « autres » = t7(2) + t8(1) + 4 NULL = 7
-    assert autres["count"] == 7
+    # « autres » = t7(2) + t8(1) = 3 (les 4 NULL sont EXCLUS, plus repliés ici).
+    assert autres["count"] == 3
+    # Dénominateur des pct = articles classés (36), pas le volume publié (40).
+    assert sum(r["count"] for r in rows) == 36
+    assert sum(r["pct"] for r in rows) == pytest.approx(100, abs=1)
     # Tri décroissant strict en tête
     counts = [r["count"] for r in rows[:6]]
     assert counts == sorted(counts, reverse=True)
+
+
+@pytest.mark.asyncio
+async def test_coverage_null_excluded_from_bars_and_pct(coverage_client):
+    """Thèmes NULL : hors barres et hors dénominateur des pct, mais dans total."""
+    ac, source, db = coverage_client
+    # politics x3, tech x1 classés + 6 non classés (NULL).
+    for _ in range(3):
+        db.add(_content(source.id, theme="politics", days_ago=1))
+    db.add(_content(source.id, theme="tech", days_ago=1))
+    for _ in range(6):
+        db.add(_content(source.id, theme=None, days_ago=1))
+    await db.commit()
+
+    resp = await ac.get(f"/api/sources/{source.id}/coverage?days=30")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    # total_count = volume publié réel = 3 + 1 + 6 = 10 (les NULL comptent ici).
+    assert body["total_count"] == 10
+    assert body["caption"] == "10 articles publiés sur la période"
+
+    rows = body["rows"]
+    # Aucune ligne « autres » : les NULL ne sont pas repliés.
+    assert [r["theme"] for r in rows] == ["politics", "tech"]
+    # pct calculés sur les 4 classés → 75 / 25, totalisent 100.
+    assert [r["pct"] for r in rows] == [75, 25]
+
+
+@pytest.mark.asyncio
+async def test_coverage_all_null_hides_bars_but_counts_published(coverage_client):
+    """Tout non classé : rows vide (section masquée) mais volume publié gardé."""
+    ac, source, db = coverage_client
+    for _ in range(5):
+        db.add(_content(source.id, theme=None, days_ago=1))
+    await db.commit()
+
+    resp = await ac.get(f"/api/sources/{source.id}/coverage?days=30")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    # 5 articles publiés mais aucun classé → pas de barres, volume renseigné.
+    assert body["rows"] == []
+    assert body["total_count"] == 5
+    assert body["caption"] == "5 articles publiés sur la période"
 
 
 @pytest.mark.asyncio

--- a/packages/api/tests/test_source_profile.py
+++ b/packages/api/tests/test_source_profile.py
@@ -170,6 +170,54 @@ async def test_profile_window_excludes_old_but_oldest_reflects_it(profile_client
 
 
 @pytest.mark.asyncio
+async def test_profile_null_theme_excluded_from_distribution(profile_client):
+    """Non classés (theme NULL) : hors distribution, mais comptés dans articles_30d.
+
+    `articles_30d` reste le volume publié réel (frais non classé compris) pour
+    ne pas fausser la fréquence ; la distribution ne porte que sur les classés,
+    dont les `share` totalisent 1.0.
+    """
+    ac, source, db = profile_client
+    for i in range(3):
+        db.add(_content(source.id, theme="politics", days_ago=i, title=f"Pol {i}"))
+    for i in range(2):
+        db.add(_content(source.id, theme=None, days_ago=i, title=f"NULL {i}"))
+    await db.commit()
+
+    resp = await ac.get(f"/api/sources/{source.id}/profile")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    # Volume = tous les articles publiés (3 classés + 2 non classés).
+    assert body["articles_30d"] == 5
+
+    dist = body["theme_distribution"]
+    assert [d["theme"] for d in dist] == ["politics"]
+    assert dist[0]["count"] == 3
+    # share sur les classés (3/3), pas sur le volume publié (3/5).
+    assert dist[0]["share"] == pytest.approx(1.0)
+    # La somme des counts de la distribution (3) est < articles_30d (5) : les
+    # non classés sont exclus de la couverture mais présents dans le volume.
+    assert sum(d["count"] for d in dist) < body["articles_30d"]
+
+
+@pytest.mark.asyncio
+async def test_profile_all_null_hides_distribution(profile_client):
+    """Tout non classé → distribution vide (section masquée), volume gardé."""
+    ac, source, db = profile_client
+    for i in range(4):
+        db.add(_content(source.id, theme=None, days_ago=i, title=f"NULL {i}"))
+    await db.commit()
+
+    resp = await ac.get(f"/api/sources/{source.id}/profile")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["theme_distribution"] == []
+    assert body["articles_30d"] == 4
+
+
+@pytest.mark.asyncio
 async def test_profile_unknown_source_returns_404(profile_client):
     """Source inconnue → 404."""
     ac, _source, _db = profile_client


### PR DESCRIPTION
## Contexte

Le worker de classification ML est à l'arrêt depuis le 30/06 → `content.theme` NULL à ~100 % sur le frais. Côté affichage, cela faisait basculer les fiches source en **« Autres »** et masquait la pastille de thème des cartes Flux continu. **PR d'affichage uniquement (zéro migration)** ; la cause racine (redéploiement du worker) est traitée séparément.

## Changements

**Backend — `sources.py`**
- `_aggregate_source_themes` renvoie désormais `(rows, total_published, total_classified)`.
- Les articles **non classés** (`theme IS NULL`) sont **exclus** des barres et du **dénominateur** des `pct`/`share` → les barres totalisent 100 % des articles *classés*.
- Ils restent **comptés** dans `total_count` / `articles_30d` (volume publié réel, insensible au backlog worker).
- `autres` ne replie plus que la longue traîne des thèmes **nommés** au-delà du top-N. Tout-NULL → `rows: []` (section masquée mobile) mais volume gardé.

**Mobile**
- `flux_continu_article_card.dart` : pastille de thème **rétablie** dans le footer, via le fallback thème source (`Content.progressionTopic`) quand le thème ML est absent. Masquée si vide.
- `source_profile.dart` / `publication_frequency.dart` : commentaires alignés (`share` sur les classés, `articles_30d` = volume publié).

## Tests
- Backend : `test_source_coverage.py` + `test_source_profile.py` (NULL hors barres/pct, comptés dans le volume ; tout-NULL → vide ; traîne nommée → `autres`). **18 passent.**
- Widget : `flux_continu_article_card_test.dart` (pastille via fallback source ; absente si rien ne se résout). **3 passent.**
- `flutter analyze` clean ; suite `test/features/sources/` verte (140).

## Notes
- Additif, sans DDL. Dès que le worker reprend et que `theme` se repeuple, les barres se re-remplissent naturellement.
- Doc : `docs/bugs/bug-classification-articles-autres.md`. Entrée changelog ajoutée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)