### PR TITLE
feat(api): observabilité worker classif — /api/health/classification + logs stderr + force-drive

### DIFF
--- a/docs/maintenance/maintenance-worker-observability-hardening.md
+++ b/docs/maintenance/maintenance-worker-observability-hardening.md
@@ -1,0 +1,81 @@
+# Maintenance — Durcissement observabilité du worker de classification
+
+Type : **Maintenance (observabilité / durcissement)**. Prérequis du
+redéploiement worker prod (cf. plan `.context/handoff_worker_classif_asap.md`).
+Sert à **voir en minutes** l'état du worker post-deploy et à **débugger** s'il
+refuse encore de tourner, sans dépendre des logs.
+
+## Contexte
+
+Le worker de classification ML (task asyncio du lifespan) est mort
+silencieusement le 30/06 (CancelledError) et **personne ne l'a vu pendant ~3
+semaines** : aucun endpoint d'état, et les logs `structlog` (worker, sondes
+pool) n'atteignaient pas Railway. `main` porte déjà la remédiation #948
+(superviseur `_on_task_done` + loop BaseException-safe + alerte 12 h). Il
+manquait les **yeux** : c'est l'objet de cette PR (aucun nouveau code worker,
+uniquement de l'observabilité).
+
+## Changements
+
+### 1. `GET /api/health/classification` (`app/main.py`)
+
+Endpoint `tags=["Health"]`, unauth (diagnostic, aucune donnée user), pattern
+`Depends(get_db)` + `JSONResponse`. Expose :
+
+- `worker_running` (`get_worker().running`) ;
+- `pending` / `oldest_pending_age_s` (`ClassificationQueueService.get_pending_stats()`) ;
+- `last_completed_at` / `last_completed_age_s` (`MAX(processed_at)`).
+
+Codes : **503** si `ML_ENABLED=true` mais worker down (état actionnable /
+alertable par simple code HTTP + `logger.critical`) ; **200** `ok` si le worker
+tourne ; **200** `disabled` si `ML_ENABLED=false` (service sans worker).
+
+### 2. Visibilité des logs
+
+- `app/main.py` : structlog routé vers **stderr**
+  (`PrintLoggerFactory(file=sys.stderr)`). Railway ne remonte de façon fiable
+  que stderr ; le stdout du process est block-buffered en conteneur → les logs
+  applicatifs étaient avalés.
+- `packages/api/Dockerfile` : `ENV PYTHONUNBUFFERED=1` (flush immédiat).
+
+Combinés : plus aucun log worker/pool invisible côté Railway.
+
+### 3. Force-drive admin (`app/routers/internal.py`)
+
+`POST /api/internal/admin/classification/drive` (gaté `require_admin_token`) :
+déclenche `ClassificationWorker.drive_once()` hors run-loop. Utile si le worker
+refuse de démarrer après deploy : force un batch pour capturer l'exception
+exacte (via stderr/Sentry) ou prouver que le pipeline tourne. Sûr en parallèle
+du worker vivant (`dequeue_batch` = `FOR UPDATE SKIP LOCKED`, aucun
+double-traitement).
+
+## Bug latent corrigé au passage — robustesse fuseau
+
+`get_pending_stats()` (et le nouveau calcul `last_completed_age_s`) faisaient
+`datetime.utcnow() - <colonne>`. Les colonnes reviennent **naïves en prod**
+(`timestamp`, d'où l'absence de crash historique) mais **tz-aware sous le
+harness de test** (`create_all` → `timestamptz`) : la soustraction levait
+`can't subtract offset-naive and offset-aware datetimes`. Normalisé en UTC
+(`replace(tzinfo=UTC)` + `datetime.now(UTC)`) → correct et identique en prod,
+et enfin testable. Sans ce fix, l'endpoint aurait **500** dès qu'un
+`processed_at` existe si prod migrait un jour vers `timestamptz`.
+
+## Tests
+
+- `tests/test_health_classification.py` : 503 worker_down / 200 ok+age /
+  200 disabled ; robustesse fuseau prouvée (200 sur `processed_at` aware).
+- `tests/routers/test_internal_classification_drive.py` : 401 sans token ;
+  200 + `dequeued` avec token.
+- `tests/workers/test_classification_worker_drive.py` : `drive_once` délègue à
+  `_process_batch` et renvoie son compte.
+- `tests/test_logging_stderr.py` : `logger_factory._file is sys.stderr`.
+
+Suite complète backend : **2452 passed**. Smoke uvicorn local :
+`GET /api/health/classification` → 200 `disabled` (worker off).
+
+## Suite (ops, hors PR)
+
+Une fois mergé et entré dans la release : réconcilier le drift Alembic, puis
+Weekly Release, puis vérifier `/api/health/classification` (`worker_running=true`,
+`pending` qui chute) et le SQL de monitoring. Cf.
+`.context/handoff_worker_classif_asap.md`.

--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -4,6 +4,13 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
+# Logs non bufferisés : sans ça, le stdout/stderr Python est block-buffered en
+# conteneur et les logs applicatifs (worker classif, sondes pool) n'atteignent
+# Railway qu'au flush du buffer (souvent jamais avant un crash). Combiné au
+# routage structlog vers stderr (app/main.py), garantit des logs temps réel.
+# Cf. incident worker 2026-06-30 : 3 semaines de silence, zéro log worker.
+ENV PYTHONUNBUFFERED=1
+
 # Install dependencies
 COPY packages/api/requirements.txt .
 RUN pip install --no-cache-dir --timeout 300 --retries 5 -r requirements.txt

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import os
 import socket
+import sys
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
@@ -45,7 +46,13 @@ structlog.configure(
         structlog.processors.TimeStamper(fmt="iso"),
         structlog.processors.JSONRenderer(),
     ],
-    logger_factory=structlog.PrintLoggerFactory(),
+    # Route les logs structlog vers stderr (et non le stdout par défaut).
+    # Railway ne capture de façon fiable que stderr (uvicorn/alembic y écrivent) ;
+    # le stdout du process app est block-buffered en conteneur → les logs
+    # structlog (worker classif, sondes pool) restaient invisibles côté Railway
+    # pendant l'incident worker 30/06. stderr est line-buffered et remonté.
+    # Combiné à PYTHONUNBUFFERED=1 (Dockerfile) : plus aucun log avalé.
+    logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
 )
 logger = structlog.get_logger()
 # Boot probe : confirme en prod que les warnings structlog atteignent stdout
@@ -689,6 +696,98 @@ async def pool_metrics() -> dict[str, Any]:
 
     logger.info("pool_metrics_probed", **metrics)
     return metrics
+
+
+@app.get("/api/health/classification", tags=["Health"])
+async def classification_health(
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """État du worker de classification ML — visible SANS dépendre des logs.
+
+    Incident 2026-06-30 : le worker (task asyncio du lifespan) est mort
+    silencieusement (CancelledError) et personne ne l'a vu pendant ~3 semaines,
+    faute d'observabilité. Cet endpoint expose l'état vivant du worker et de la
+    file pour vérifier en quelques minutes post-deploy que la loop tourne et
+    que le backlog se draine :
+
+    - `worker_running` : la task du worker in-process est-elle vivante
+      (`get_worker().running`) ;
+    - `pending` / `oldest_pending_age_s` : profondeur de file + âge du plus vieux
+      pending (un âge qui grimpe alors que `worker_running=true` = loop coincée) ;
+    - `last_completed_at` / `last_completed_age_s` : dernier `processed_at` écrit
+      (avance = le pipeline tourne réellement).
+
+    Renvoie **503** quand `ML_ENABLED=true` mais que le worker ne tourne pas
+    (état actionnable, alertable via le simple code HTTP). Un service où le
+    worker est légitimement désactivé (`ML_ENABLED=false`) répond 200/`disabled`.
+    Unauth exprès : diagnostic, aucune donnée utilisateur.
+    """
+    from datetime import UTC, datetime
+
+    from sqlalchemy import func as sa_func
+    from sqlalchemy import select as sa_select
+
+    from app.models.classification_queue import ClassificationQueue
+    from app.services.classification_queue_service import ClassificationQueueService
+    from app.workers.classification_worker import get_worker
+
+    worker_running = get_worker().running
+    ml_enabled = settings.ml_enabled
+
+    pending, oldest_pending_age_s = await ClassificationQueueService(
+        db
+    ).get_pending_stats()
+
+    last_completed_at = (
+        await db.execute(sa_select(sa_func.max(ClassificationQueue.processed_at)))
+    ).scalar_one_or_none()
+    # `processed_at` revient naïf en prod (`timestamp`) mais tz-aware sous le
+    # harness de test (`timestamptz`) : normaliser en UTC évite le TypeError
+    # naive/aware sur la soustraction.
+    if last_completed_at is not None:
+        _completed = (
+            last_completed_at
+            if last_completed_at.tzinfo is not None
+            else last_completed_at.replace(tzinfo=UTC)
+        )
+        last_completed_age_s = (datetime.now(UTC) - _completed).total_seconds()
+    else:
+        last_completed_age_s = None
+
+    if not ml_enabled:
+        status = "disabled"
+    elif worker_running:
+        status = "ok"
+    else:
+        status = "worker_down"
+
+    payload: dict[str, Any] = {
+        "status": status,
+        "worker_running": worker_running,
+        "ml_enabled": ml_enabled,
+        "pending": pending,
+        "oldest_pending_age_s": oldest_pending_age_s,
+        "last_completed_at": (
+            last_completed_at.isoformat() if last_completed_at is not None else None
+        ),
+        "last_completed_age_s": last_completed_age_s,
+        "environment": settings.environment,
+        "probe": "classification",
+    }
+
+    if status == "worker_down":
+        from fastapi.responses import JSONResponse
+
+        logger.critical(
+            "classification_worker_down",
+            pending=pending,
+            oldest_pending_age_s=oldest_pending_age_s,
+            last_completed_age_s=last_completed_age_s,
+            hint="ML_ENABLED=true but worker not running — dead loop or never started.",
+        )
+        return JSONResponse(status_code=503, content=payload)
+
+    return payload
 
 
 if __name__ == "__main__":

--- a/packages/api/app/routers/internal.py
+++ b/packages/api/app/routers/internal.py
@@ -63,6 +63,29 @@ async def backfill_serene(
     return {"message": "Backfill serene queued", "articles_queued": count}
 
 
+@router.post("/admin/classification/drive", status_code=status.HTTP_200_OK)
+async def force_drive_classification(
+    session: AsyncSession = Depends(get_db),
+):
+    """Force le traitement d'UN lot de classification à la demande (diagnostic).
+
+    Déclenche `ClassificationWorker.drive_once()` hors run-loop. Sert à vérifier
+    post-deploy que le pipeline tourne, ou à capturer l'exception exacte si le
+    worker refuse de démarrer (loop morte). Sûr même en parallèle du worker
+    vivant : `dequeue_batch` pose `FOR UPDATE SKIP LOCKED`, aucun double-traitement.
+    Peut durer jusqu'à ~3 min (appels Mistral batch).
+    """
+    from app.workers.classification_worker import get_worker
+
+    pending_before, _ = await ClassificationQueueService(session).get_pending_stats()
+    dequeued = await get_worker().drive_once()
+    return {
+        "message": "Classification batch driven",
+        "dequeued": dequeued,
+        "pending_before": pending_before,
+    }
+
+
 @router.get("/admin/ner-health", status_code=status.HTTP_200_OK)
 async def get_ner_health(
     sample_title: str = Query(

--- a/packages/api/app/services/classification_queue_service.py
+++ b/packages/api/app/services/classification_queue_service.py
@@ -1,6 +1,6 @@
 """Service pour gérer la file de classification."""
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 from sqlalchemy import func, select, update
@@ -298,7 +298,13 @@ class ClassificationQueueService:
         count, oldest = result.one()
         if not count or oldest is None:
             return 0, None
-        return int(count), (datetime.utcnow() - oldest).total_seconds()
+        # `oldest` (created_at) revient naïf en prod (colonne `timestamp`) mais
+        # tz-aware sous le harness de test (`create_all` → `timestamptz`). On
+        # normalise en UTC avant la soustraction pour ne jamais lever
+        # "can't subtract offset-naive and offset-aware datetimes".
+        if oldest.tzinfo is None:
+            oldest = oldest.replace(tzinfo=UTC)
+        return int(count), (datetime.now(UTC) - oldest).total_seconds()
 
     async def requeue_failed(self, max_retries: int = 3) -> int:
         """Remet en file d'attente les articles échoués avec retry_count < max_retries.

--- a/packages/api/app/workers/classification_worker.py
+++ b/packages/api/app/workers/classification_worker.py
@@ -314,8 +314,13 @@ class ClassificationWorker:
         except Exception as e:
             logger.error("classification_worker.reset_stale_failed", error=str(e))
 
-    async def _process_batch(self):
+    async def _process_batch(self) -> int:
         """Process one batch of pending items using batch API call.
+
+        Renvoie le nombre d'items dequeués sur ce lot (0 si la file était vide).
+        La run-loop ignore la valeur ; elle sert au pilotage manuel via
+        `drive_once()` (endpoint admin force-drive) pour observer un batch à la
+        demande post-deploy.
 
         3 phases pour ne jamais tenir une transaction DB pendant les appels
         Mistral (90-180 s au pire) : le timeout serveur
@@ -334,7 +339,7 @@ class ClassificationWorker:
             items = await service.dequeue_batch(batch_size=self.batch_size)
 
             if not items:
-                return
+                return 0
 
             logger.info("classification_worker.processing_batch", count=len(items))
 
@@ -549,6 +554,21 @@ class ClassificationWorker:
 
                 except Exception as e:
                     await service.mark_failed(rec["queue_id"], str(e)[:500])
+
+        return len(items)
+
+    async def drive_once(self) -> int:
+        """Traite un lot à la demande, hors run-loop, et renvoie le nb dequeué.
+
+        Pilotage manuel (endpoint admin force-drive) : permet, si le worker
+        refuse de tourner après deploy, de déclencher un batch pour capturer
+        l'exception exacte (via Sentry/logs stderr) ou prouver que le pipeline
+        fonctionne. Sûr même en parallèle de la run-loop vivante : `dequeue_batch`
+        pose `FOR UPDATE SKIP LOCKED` → aucun double-traitement. Le classifier
+        est chargé paresseusement, donc l'appel marche même si `start()` n'a
+        jamais été invoqué sur ce process.
+        """
+        return await self._process_batch()
 
 
 # Global worker instance (singleton)

--- a/packages/api/tests/routers/test_internal_classification_drive.py
+++ b/packages/api/tests/routers/test_internal_classification_drive.py
@@ -1,0 +1,64 @@
+"""Tests pour /api/internal/admin/classification/drive (force-drive).
+
+Endpoint de pilotage manuel ajouté avec l'observabilité worker (incident
+2026-06-30) : déclenche `ClassificationWorker.drive_once()` hors run-loop pour
+vérifier/débugger le pipeline post-deploy si le worker refuse de tourner.
+Gaté `require_admin_token`.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.database import get_db
+from app.main import app
+
+ADMIN_TOKEN = "s3cr3t"
+ADMIN_HEADERS = {"X-Admin-Token": ADMIN_TOKEN}
+
+
+@pytest_asyncio.fixture
+async def client(db_session):
+    async def _fake_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _fake_db
+    transport = ASGITransport(app=app)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+async def test_drive_without_admin_token_returns_401(client):
+    with patch("app.routers.admin_cohorts.get_settings") as mock_settings:
+        mock_settings.return_value.admin_api_token = ADMIN_TOKEN
+        resp = await client.post("/api/internal/admin/classification/drive")
+    assert resp.status_code == 401
+
+
+async def test_drive_with_admin_token_runs_one_batch(client):
+    fake_worker = MagicMock()
+    fake_worker.drive_once = AsyncMock(return_value=5)
+
+    with (
+        patch("app.routers.admin_cohorts.get_settings") as mock_settings,
+        patch(
+            "app.workers.classification_worker.get_worker",
+            return_value=fake_worker,
+        ),
+    ):
+        mock_settings.return_value.admin_api_token = ADMIN_TOKEN
+        resp = await client.post(
+            "/api/internal/admin/classification/drive",
+            headers=ADMIN_HEADERS,
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["dequeued"] == 5
+    # File vide dans le harness → pending_before == 0, remonté sans erreur.
+    assert body["pending_before"] == 0
+    fake_worker.drive_once.assert_awaited_once()

--- a/packages/api/tests/test_health_classification.py
+++ b/packages/api/tests/test_health_classification.py
@@ -1,0 +1,178 @@
+"""Tests pour /api/health/classification — observabilité du worker ML.
+
+Incident 2026-06-30 : le worker de classification (task asyncio du lifespan)
+est mort silencieusement (CancelledError) et personne ne l'a vu pendant ~3
+semaines, faute d'endpoint d'état. Ce health check expose l'état vivant du
+worker + de la file SANS dépendre des logs, et renvoie 503 (actionnable /
+alertable) quand `ML_ENABLED=true` mais que le worker ne tourne pas.
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+import app.main as main_module
+from app.database import get_db
+from app.main import app
+from app.models.classification_queue import ClassificationQueue
+from app.models.content import Content
+from app.models.enums import ContentType, SourceType
+from app.models.source import Source
+
+
+def _source() -> Source:
+    slug = uuid4()
+    return Source(
+        id=uuid4(),
+        name="Classif Health",
+        url=f"https://ch-{slug}.example.com",
+        feed_url=f"https://ch-{slug}.example.com/feed.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_active=True,
+        is_curated=False,
+    )
+
+
+def _content(source_id) -> Content:
+    return Content(
+        id=uuid4(),
+        source_id=source_id,
+        title="Article",
+        url=f"https://ch.example.com/{uuid4()}",
+        guid=str(uuid4()),
+        published_at=datetime.now(UTC),
+        content_type=ContentType.ARTICLE,
+        theme=None,
+    )
+
+
+def _worker(running: bool) -> MagicMock:
+    worker = MagicMock()
+    worker.running = running
+    return worker
+
+
+@pytest_asyncio.fixture
+async def health_client(db_session):
+    async def _fake_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _fake_db
+    transport = ASGITransport(app=app)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac, db_session
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.mark.asyncio
+async def test_worker_down_returns_503_with_full_payload(health_client):
+    """ML_ENABLED=true mais worker mort → 503 actionnable + file remontée."""
+    ac, db = health_client
+    src = _source()
+    db.add(src)
+    await db.flush()
+    for _ in range(2):
+        c = _content(src.id)
+        db.add(c)
+        await db.flush()
+        db.add(
+            ClassificationQueue(
+                id=uuid4(),
+                content_id=c.id,
+                status="pending",
+                created_at=datetime.now(UTC) - timedelta(minutes=5),
+            )
+        )
+    await db.commit()
+
+    with (
+        patch(
+            "app.workers.classification_worker.get_worker",
+            return_value=_worker(False),
+        ),
+        patch.object(main_module.settings, "ml_enabled", True),
+    ):
+        resp = await ac.get("/api/health/classification")
+
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["status"] == "worker_down"
+    assert body["worker_running"] is False
+    assert body["ml_enabled"] is True
+    assert body["pending"] == 2
+    assert body["oldest_pending_age_s"] is not None
+    assert body["oldest_pending_age_s"] >= 0
+    # Aucun completed → dernier thème inconnu (le symptôme exact du 30/06).
+    assert body["last_completed_at"] is None
+    assert body["last_completed_age_s"] is None
+    assert body["probe"] == "classification"
+
+
+@pytest.mark.asyncio
+async def test_worker_running_returns_ok_with_last_completed(health_client):
+    """Worker vivant + un `processed_at` récent → 200 `ok`, âge calculé (no 500).
+
+    Valide au passage la robustesse fuseau : `processed_at` revient tz-aware
+    sous le harness (`timestamptz`) ; la soustraction ne doit pas lever.
+    """
+    ac, db = health_client
+    src = _source()
+    db.add(src)
+    await db.flush()
+    c = _content(src.id)
+    db.add(c)
+    await db.flush()
+    db.add(
+        ClassificationQueue(
+            id=uuid4(),
+            content_id=c.id,
+            status="completed",
+            processed_at=datetime.now(UTC) - timedelta(minutes=2),
+        )
+    )
+    await db.commit()
+
+    with (
+        patch(
+            "app.workers.classification_worker.get_worker",
+            return_value=_worker(True),
+        ),
+        patch.object(main_module.settings, "ml_enabled", True),
+    ):
+        resp = await ac.get("/api/health/classification")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["worker_running"] is True
+    assert body["pending"] == 0
+    assert body["last_completed_at"] is not None
+    assert body["last_completed_age_s"] is not None
+    assert body["last_completed_age_s"] >= 60
+
+
+@pytest.mark.asyncio
+async def test_ml_disabled_returns_200_disabled(health_client):
+    """Service où le worker est légitimement off (ML_ENABLED=false) → 200/disabled."""
+    ac, _db = health_client
+    with (
+        patch(
+            "app.workers.classification_worker.get_worker",
+            return_value=_worker(False),
+        ),
+        patch.object(main_module.settings, "ml_enabled", False),
+    ):
+        resp = await ac.get("/api/health/classification")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "disabled"
+    assert body["worker_running"] is False
+    assert body["ml_enabled"] is False

--- a/packages/api/tests/test_logging_stderr.py
+++ b/packages/api/tests/test_logging_stderr.py
@@ -1,0 +1,22 @@
+"""Garde-fou : structlog écrit sur stderr, pas stdout.
+
+Incident worker 2026-06-30 : ~3 semaines de silence côté Railway. Cause du
+trou d'observabilité : structlog écrivait sur le stdout par défaut, block-buffered
+en conteneur, tandis que Railway ne remonte de façon fiable que stderr
+(uvicorn/alembic). Ce test verrouille le routage stderr (couplé à
+`PYTHONUNBUFFERED=1` dans le Dockerfile) pour éviter une régression silencieuse.
+"""
+
+import sys
+
+import structlog
+
+import app.main  # noqa: F401  — applique structlog.configure() au import
+
+
+def test_structlog_logger_factory_targets_stderr():
+    factory = structlog.get_config()["logger_factory"]
+    assert isinstance(factory, structlog.PrintLoggerFactory)
+    # Le fix concret : cible stderr (et surtout PAS le stdout par défaut).
+    assert factory._file is not sys.stdout
+    assert factory._file is sys.stderr

--- a/packages/api/tests/workers/test_classification_worker_drive.py
+++ b/packages/api/tests/workers/test_classification_worker_drive.py
@@ -1,0 +1,24 @@
+"""Tests pour le pilotage manuel du worker de classification (`drive_once`).
+
+`drive_once()` traite un lot hors run-loop pour le diagnostic post-deploy et
+renvoie le nombre d'items dequeués (contrat consommé par l'endpoint admin
+force-drive). Ici on vérifie la délégation ; l'exécution réelle du batch est
+couverte par les tests d'intégration du worker.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.workers.classification_worker import ClassificationWorker
+
+
+@pytest.mark.asyncio
+async def test_drive_once_delegates_to_process_batch_and_returns_count():
+    worker = ClassificationWorker()
+    worker._process_batch = AsyncMock(return_value=3)
+
+    result = await worker.drive_once()
+
+    assert result == 3
+    worker._process_batch.assert_awaited_once()


### PR DESCRIPTION
## Contexte

Prérequis du **redéploiement du worker de classification prod** (mort silencieusement le 30/06, ~3 semaines de silence *faute d'observabilité*). `main` porte déjà la remédiation #948 (superviseur + loop BaseException-safe + alerte 12 h) : **aucun nouveau code worker ici**, uniquement les **yeux** pour vérifier/débugger en minutes post-deploy. Backend-only, **zéro migration**.

## Changements

**1. `GET /api/health/classification`** (`main.py`, unauth, `Depends(get_db)`)
- `worker_running` (`get_worker().running`), `pending` + `oldest_pending_age_s`, `last_completed_at` + `last_completed_age_s` (`MAX(processed_at)`).
- **503** actionnable (+ `logger.critical`) si `ML_ENABLED=true` mais worker down ; **200** `ok` si vivant ; **200** `disabled` si `ML_ENABLED=false`.

**2. Visibilité des logs** — LE levier concret
- structlog routé vers **stderr** (`PrintLoggerFactory(file=sys.stderr)`) ; le stdout du process est block-buffered en conteneur → Railway l'avalait.
- `ENV PYTHONUNBUFFERED=1` dans le `Dockerfile`.

**3. Force-drive admin** — `POST /api/internal/admin/classification/drive` (`require_admin_token`)
- Déclenche `ClassificationWorker.drive_once()` hors run-loop : force un batch pour capturer l'exception exacte si le worker refuse de démarrer, ou prouver que le pipeline tourne. Sûr en parallèle du worker vivant (`FOR UPDATE SKIP LOCKED`).

## Bug latent corrigé au passage

`get_pending_stats()` (et le calcul d'âge) faisaient `datetime.utcnow() - <colonne timestamp>`. **Naïf en prod** (d'où l'absence de crash historique) mais **tz-aware sous le harness** (`create_all` → `timestamptz`) → `TypeError` naive/aware. Normalisé en UTC (`replace(tzinfo=UTC)` + `datetime.now(UTC)`) : identique en prod, et enfin testable. Sans ce fix, l'endpoint aurait 500 dès qu'un `processed_at` existe si prod passait un jour à `timestamptz`.

## Tests
- `test_health_classification.py` : 503 worker_down / 200 ok+age / 200 disabled + robustesse fuseau.
- `test_internal_classification_drive.py` : 401 sans token / 200 + `dequeued`.
- `test_classification_worker_drive.py` : `drive_once` délègue à `_process_batch`.
- `test_logging_stderr.py` : `logger_factory._file is sys.stderr`.
- **Suite complète backend : 2452 passed, 0 failed.** `ruff` clean, 1 head Alembic. Smoke uvicorn local : `GET /api/health/classification` → `200 {"status":"disabled","worker_running":false,...}`.

## Suite (ops, hors PR)
Une fois mergé : réconcilier le drift Alembic → Weekly Release → vérifier `/api/health/classification` (`worker_running=true`, `pending` qui chute) + SQL de monitoring. Cf. `docs/maintenance/maintenance-worker-observability-hardening.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)