### PR TITLE
fix(essentiel): fenêtre de grâce anti-éviction pour la coche de lecture

### DIFF
--- a/docs/bugs/bug-essentiel-coche-lecture.md
+++ b/docs/bugs/bug-essentiel-coche-lecture.md
@@ -1,0 +1,81 @@
+# Bug: coche de lecture non fonctionnelle sur "Ton Essentiel"
+
+## Statut
+- [x] En cours de correction
+- [x] Corrigé (date: 2026-07-22)
+
+## Sévérité
+🟠 Majeur — UX cassée sur la surface la plus vue de l'app (carte "Ton Essentiel"), sans perte
+de données (le statut lu est bien persisté côté backend, seul l'affichage/la persistance
+visuelle échoue).
+
+## Description
+
+La coche de lecture (checkmark vert, `_ReadCheckBadge`) ne s'active pas — ou disparaît quasi
+immédiatement — pour les articles ouverts depuis la carte "Ton Essentiel", alors que le même
+indicateur fonctionne correctement sur les autres sections du flux (Tournée, Actus du jour).
+
+## Étapes de reproduction
+
+1. Ouvrir l'app, lire un article depuis la carte "Ton Essentiel" (rester > 1s pour déclencher
+   le marquage lu).
+2. Revenir au flux — la coche s'affiche correctement en mémoire (comportement attendu, non cassé).
+3. Fermer l'app (ou la laisser en arrière-plan assez longtemps pour que l'OS tue le process —
+   très courant sur mobile) puis la rouvrir.
+4. **Constat** : l'article lu n'est plus visible du tout dans la carte "Ton Essentiel" — il a
+   été remplacé par un autre article, non lu, sans coche. L'utilisateur a l'impression que la
+   lecture n'a jamais été enregistrée.
+
+## Cause racine
+
+Deux mécanismes se combinent :
+
+1. **Éviction systématique des articles lus côté backend.** `build_essentiel_response_with_supplements`
+   (`packages/api/app/services/essentiel_service.py:906-979`, feature "Essentiel vivant", story 9.8)
+   évince de la réponse tout article `is_read=True` à **chaque** appel `GET /api/essentiel`
+   (`non_read = [a for a in response.articles if not a.is_read]`, ligne 933) et le remplace par
+   du contenu frais. Contrairement au digest classique (Tournée/Actus, généré une fois/nuit,
+   liste stable, seul le flag `is_read` bascule), Essentiel fait disparaître l'article de la
+   réponse dès qu'il est lu.
+
+2. **Ce refetch se produit bien plus souvent que prévu par le design.**
+   `fluxContinuProvider.build()` (`apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart:340-386`)
+   appelle **inconditionnellement** `_fetchAll()` (ligne 382) après avoir peint le cache du
+   jour — donc à **chaque cold start** de l'app (relance après fermeture ou kill OS en
+   arrière-plan), **sans aucun cooldown**. Ce chemin contredit l'intention documentée du
+   cooldown existant `essentielForegroundRefreshCooldown` (2 min,
+   `apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart:104-117` : *"un
+   aller-retour éclair ... ne DOIT pas recharger le feed et coûter à l'utilisateur le fil de sa
+   progression"*) — ce cooldown ne protège que le chemin `didChangeAppLifecycleState`
+   (foreground-resume en process vivant), jamais le cold-start SWR de `build()`.
+
+Résultat : dans l'usage réel (app fermée/tuée entre deux sessions, extrêmement fréquent sur
+mobile), le premier `GET /api/essentiel` qui suit une lecture évince quasi systématiquement
+l'article lu avant que l'utilisateur n'ait l'occasion de revoir sa coche persister.
+
+Le pipeline générique de marquage lu (`ContentDetailScreen` → `ReadSyncService.markConsumed` →
+`fluxContinuProvider.markArticleRead()` → `POST /contents/{id}/status` →
+`UserContentStatus`) a été vérifié et fonctionne correctement — aucun bug de déclenchement ou
+de persistance dans ce pipeline. Un refetch immédiat post-lecture (au retour du reader) a
+également été envisagé puis infirmé par le code (`markArticleRead` est une mutation d'état pure
+sans effet réseau, aucun provider ne `watch` l'état de lecture pour se relancer).
+
+## Solution
+
+Fenêtre de grâce backend : un article marqué lu il y a moins de
+`ESSENTIEL_READ_EVICTION_GRACE` (30 min) reste traité comme non-évictable dans
+`build_essentiel_response_with_supplements`, même si `is_read=True` — sa coche reste donc
+visible sur les refetch qui suivent une lecture récente (cold start, pull-to-refresh, retour
+foreground). Passé ce délai, le comportement actuel (éviction + remplacement par du contenu
+frais) reprend, préservant l'intention originale de "Essentiel vivant au retour" pour les
+retours après une vraie absence.
+
+Le timestamp `UserContentStatus.seen_at` (déjà posé de façon idempotente à la première
+transition vers `CONSUMED`) est remonté jusqu'à `EssentielArticle.read_at` via
+`_get_batch_action_states` → `DigestTopicArticle.read_at` → `EssentielArticle.read_at`. Aucune
+migration Alembic requise (aucun changement de schéma DB). Aucune modification Flutter requise
+(le rendu de la coche fonctionne déjà dès que `is_read=true` est présent dans la réponse).
+
+Détail d'implémentation : voir plan associé (fichiers modifiés : `digest_service.py`,
+`schemas/digest.py`, `schemas/essentiel.py`, `essentiel_service.py`, tests dans
+`test_essentiel_supplements.py` et `test_digest_service.py`).

--- a/packages/api/app/schemas/digest.py
+++ b/packages/api/app/schemas/digest.py
@@ -73,6 +73,7 @@ class DigestTopicArticle(BaseModel):
     is_saved: bool = False
     is_liked: bool = False
     is_dismissed: bool = False
+    read_at: datetime | None = None
     # Langue détectée du titre (forward-compat — label éventuel mobile).
     language: str | None = None
 

--- a/packages/api/app/schemas/essentiel.py
+++ b/packages/api/app/schemas/essentiel.py
@@ -59,6 +59,7 @@ class EssentielArticle(BaseModel):
     is_saved: bool = False
     is_liked: bool = False
     is_dismissed: bool = False
+    read_at: datetime | None = None
     # Signaux user-aware pour affichage mobile (badges "Tu suis", pastille "Actu du jour").
     is_followed_source: bool = False
     is_followed_topic: bool = False

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -383,6 +383,16 @@ _EDITORIAL_FORMATS: tuple[str, ...] = (
 _READABLE_FORMATS: tuple[str, ...] = (*_EDITORIAL_FORMATS, "topics_v1")
 _HOTPATH_FALLBACK_DAYS = 7
 
+# Action state for a content_id absent from `_get_batch_action_states`'
+# result (no `UserContentStatus` row yet — never read/saved/liked/dismissed).
+_DEFAULT_ACTION_STATE: dict[str, bool | datetime | None] = {
+    "is_read": False,
+    "is_saved": False,
+    "is_liked": False,
+    "is_dismissed": False,
+    "read_at": None,
+}
+
 
 async def read_digest_or_fallback(
     session: AsyncSession,
@@ -2311,15 +2321,7 @@ class DigestService:
                     )
                     continue
 
-                action_state = action_states_map.get(
-                    content_id,
-                    {
-                        "is_read": False,
-                        "is_saved": False,
-                        "is_liked": False,
-                        "is_dismissed": False,
-                    },
-                )
+                action_state = action_states_map.get(content_id, _DEFAULT_ACTION_STATE)
 
                 reason = art_data.get("match_reason") or subject.get(
                     "selection_reason", ""
@@ -2348,6 +2350,7 @@ class DigestService:
                     is_saved=action_state["is_saved"],
                     is_liked=action_state["is_liked"],
                     is_dismissed=action_state["is_dismissed"],
+                    read_at=action_state.get("read_at"),
                 )
                 topic_articles.append(topic_article)
 
@@ -2552,15 +2555,7 @@ class DigestService:
                 if not content or not content.source:
                     continue
 
-                action_state = action_states_map.get(
-                    content_id,
-                    {
-                        "is_read": False,
-                        "is_saved": False,
-                        "is_liked": False,
-                        "is_dismissed": False,
-                    },
-                )
+                action_state = action_states_map.get(content_id, _DEFAULT_ACTION_STATE)
 
                 # Rebuild breakdown
                 breakdown_raw = art_data.get("breakdown") or []
@@ -2605,6 +2600,7 @@ class DigestService:
                     is_saved=action_state["is_saved"],
                     is_liked=action_state["is_liked"],
                     is_dismissed=action_state["is_dismissed"],
+                    read_at=action_state.get("read_at"),
                 )
                 topic_articles.append(topic_article)
 
@@ -2707,7 +2703,7 @@ class DigestService:
 
     async def _get_batch_action_states(
         self, user_id: UUID, content_ids: list[UUID]
-    ) -> dict[UUID, dict[str, bool]]:
+    ) -> dict[UUID, dict[str, bool | datetime | None]]:
         """Batch-fetch action states for multiple content items in one query.
 
         Optimized replacement for calling _get_item_action_state per item.
@@ -2731,6 +2727,7 @@ class DigestService:
                 "is_saved": status.is_saved,
                 "is_liked": status.is_liked,
                 "is_dismissed": status.is_hidden,
+                "read_at": status.seen_at,
             }
             for status in statuses
         }

--- a/packages/api/app/services/essentiel_service.py
+++ b/packages/api/app/services/essentiel_service.py
@@ -80,6 +80,14 @@ _ESSENTIEL_DELTA_CAP = 9
 # suivies sont prioritaires, puis le pool éditorial global frais complète.
 ESSENTIEL_TOURNEE_WINDOW = timedelta(hours=24)
 
+# Fenêtre de grâce après lecture : "Essentiel vivant" (story 9.8) évince
+# activement tout article lu de la réponse `GET /api/essentiel` pour laisser
+# la place à du contenu frais. Mais l'app relance `_fetchAll()` sans cooldown
+# à chaque cold start, ce qui évince quasi systématiquement l'article qu'on
+# vient de lire avant que l'utilisateur n'ait pu voir la coche persister.
+# On protège donc un article tout juste lu de l'éviction pendant cette durée.
+ESSENTIEL_READ_EVICTION_GRACE = timedelta(minutes=30)
+
 # Valeur de `DigestTopicArticle.badge` qui marque l'article comme "Actu du jour".
 _BADGE_ACTU = "actu"
 
@@ -673,6 +681,7 @@ def _to_essentiel_article(
         is_saved=article.is_saved,
         is_liked=article.is_liked,
         is_dismissed=article.is_dismissed,
+        read_at=article.read_at,
         is_followed_source=_is_followed_source(article, ctx),
         is_followed_topic=_is_followed_topic(topic, ctx),
         is_actu_du_jour=_is_actu_du_jour(topic, article),
@@ -903,6 +912,21 @@ async def _fetch_live_supplements(
     return supplements, new_since_morning
 
 
+def _is_within_read_grace(article: EssentielArticle, now: datetime | None) -> bool:
+    """True si l'article a été lu il y a moins de `ESSENTIEL_READ_EVICTION_GRACE`.
+
+    Protège un article tout juste lu de l'éviction "Essentiel vivant" le temps
+    que l'utilisateur voie la coche persister sur un cold-start proche.
+    """
+    if not article.is_read or article.read_at is None:
+        return False
+    reference = now or datetime.now(UTC)
+    read_at = article.read_at
+    if read_at.tzinfo is None:
+        read_at = read_at.replace(tzinfo=UTC)
+    return reference - read_at < ESSENTIEL_READ_EVICTION_GRACE
+
+
 async def build_essentiel_response_with_supplements(
     db: AsyncSession,
     user_id: UUID,
@@ -919,8 +943,8 @@ async def build_essentiel_response_with_supplements(
     journée, tout en préservant l'ancre éditoriale et le cap 5 :
 
     1. Projection digest → jusqu'à 5 articles rankés + read-pénalisés.
-    2. Partition en **non-lus** (ancre stable, ordre digest) et **lus**
-       (évictables).
+    2. Partition en **non-lus** (ancre stable, ordre digest ; inclut les lus
+       tout juste marqués, en grâce) et **lus** (évictables, hors grâce).
     3. Pool live frais (sources suivies ∪ thèmes appréciés riches), scoré, pour
        remplir les slots libérés à mesure que l'utilisateur lit.
     4. Ordre final ≤ 5 : non-lus → live (score desc) → lus en dernier recours.
@@ -930,8 +954,13 @@ async def build_essentiel_response_with_supplements(
     """
     response = build_essentiel_response(digest, user_context=user_context, now=now)
 
-    non_read = [a for a in response.articles if not a.is_read]
-    read = [a for a in response.articles if a.is_read]
+    non_read: list[EssentielArticle] = []
+    read: list[EssentielArticle] = []
+    for article in response.articles:
+        if not article.is_read or _is_within_read_grace(article, now):
+            non_read.append(article)
+        else:
+            read.append(article)
     digest_content_ids = {a.content_id for a in response.articles}
     morning_anchor = _morning_anchor(now)
 

--- a/packages/api/tests/test_digest_service.py
+++ b/packages/api/tests/test_digest_service.py
@@ -1251,3 +1251,119 @@ async def test_editorial_label_falls_back_to_actu_title(
 
     assert len(response.topics) == 1
     assert response.topics[0].label == expected_label
+
+
+# ─── Tests: propagation de `read_at` (fix coche Essentiel) ────────────────────
+
+
+def _make_digest_mock(*, format_version, items):
+    """Mock DailyDigest minimal, commun aux deux formats de réponse."""
+    digest = Mock()
+    digest.id = uuid4()
+    digest.user_id = uuid4()
+    digest.target_date = date(2026, 6, 1)
+    digest.generated_at = datetime(2026, 6, 1, 7, 30, 0)
+    digest.mode = "pour_vous"
+    digest.is_serene = False
+    digest.format_version = format_version
+    digest.items = items
+    return digest
+
+
+def _read_action_state(read_at):
+    return {
+        "is_read": True,
+        "is_saved": False,
+        "is_liked": False,
+        "is_dismissed": False,
+        "read_at": read_at,
+    }
+
+
+@pytest.mark.asyncio
+async def test_editorial_response_propagates_read_at(service, mock_session):
+    """`_get_batch_action_states["read_at"]` remonte jusqu'à `DigestTopicArticle`."""
+    cid = uuid4()
+    content = _make_editorial_content(content_id=cid, title="Conflit au Liban")
+    read_at = datetime(2026, 6, 1, 7, 0, 0)
+
+    digest = _make_digest_mock(
+        format_version="editorial_v1",
+        items={
+            "subjects": [
+                {
+                    "topic_id": "t1",
+                    "label": "À la une : Liban",
+                    "rank": 1,
+                    "actu_article": {
+                        "content_id": str(cid),
+                        "title": "Conflit au Liban",
+                    },
+                }
+            ]
+        },
+    )
+
+    followed_result = Mock()
+    followed_result.scalars.return_value.all.return_value = []
+    content_result = Mock()
+    content_result.scalars.return_value.all.return_value = [content]
+    mock_session.execute.side_effect = [followed_result, content_result]
+
+    with (
+        patch.object(
+            service,
+            "_get_batch_action_states",
+            new=AsyncMock(return_value={cid: _read_action_state(read_at)}),
+        ),
+        patch.object(service, "_compute_target_size", new=AsyncMock(return_value=5)),
+    ):
+        response = await service._build_editorial_response(digest, digest.user_id)
+
+    assert response.topics[0].articles[0].is_read is True
+    assert response.topics[0].articles[0].read_at == read_at
+
+
+@pytest.mark.asyncio
+async def test_topics_response_propagates_read_at(service, mock_session):
+    """Même propagation de `read_at` sur le chemin `_build_topics_response`."""
+    cid = uuid4()
+    content = _make_editorial_content(content_id=cid, title="Conflit au Liban")
+    read_at = datetime(2026, 6, 1, 7, 0, 0)
+
+    digest = _make_digest_mock(
+        format_version="topics_v1",
+        items={
+            "topics": [
+                {
+                    "topic_id": "t1",
+                    "label": "Politique",
+                    "rank": 1,
+                    "articles": [{"content_id": str(cid), "rank": 1, "reason": "Test"}],
+                }
+            ]
+        },
+    )
+
+    followed_result = Mock()
+    followed_result.scalars.return_value.all.return_value = []
+    mock_session.execute.return_value = followed_result
+    mock_session.scalar = AsyncMock(return_value=None)
+
+    with (
+        patch.object(
+            service,
+            "_get_cached_digest_contents",
+            new=AsyncMock(return_value={cid: content}),
+        ),
+        patch.object(
+            service,
+            "_get_batch_action_states",
+            new=AsyncMock(return_value={cid: _read_action_state(read_at)}),
+        ),
+    ):
+        response = await service._build_topics_response(digest, digest.user_id)
+
+    assert len(response.topics) == 1
+    assert response.topics[0].articles[0].is_read is True
+    assert response.topics[0].articles[0].read_at == read_at

--- a/packages/api/tests/test_essentiel_supplements.py
+++ b/packages/api/tests/test_essentiel_supplements.py
@@ -18,6 +18,7 @@ from app.models.source import Source
 from app.schemas.digest import DigestResponse
 from app.services.essentiel_service import (
     ESSENTIEL_MIN_ARTICLES,
+    ESSENTIEL_READ_EVICTION_GRACE,
     EssentielUserContext,
     build_essentiel_response_with_supplements,
 )
@@ -39,7 +40,9 @@ def _empty_digest() -> DigestResponse:
 
 @pytest_asyncio.fixture
 async def make_source(db_session):
-    async def _make(name: str, *, coverage_themes=None, theme: str = "politics") -> Source:
+    async def _make(
+        name: str, *, coverage_themes=None, theme: str = "politics"
+    ) -> Source:
         source = Source(
             id=uuid4(),
             name=name,
@@ -73,7 +76,8 @@ async def _add_content(
         source_id=source.id,
         title=title,
         url=f"https://example.com/{uuid4()}",
-        published_at=published_at or (datetime.now(UTC) - timedelta(minutes=minutes_ago)),
+        published_at=published_at
+        or (datetime.now(UTC) - timedelta(minutes=minutes_ago)),
         content_type=content_type,
         guid=str(uuid4()),
         is_serene=is_serene,
@@ -423,3 +427,173 @@ async def test_rich_theme_source_contributes_without_being_followed(
     ids = {a.content_id for a in response.articles}
     assert rich_article.id in ids, "source riche sur thème apprécié doit alimenter"
     assert thin_article.id not in ids, "coverage_themes NULL exclut la source"
+
+
+def _digest_with_topics(topics: list) -> DigestResponse:
+    return DigestResponse(
+        digest_id=uuid4(),
+        user_id=uuid4(),
+        target_date=datetime.now(UTC).date(),
+        generated_at=datetime.now(UTC),
+        format_version="topics_v1",
+        items=[],
+        topics=topics,
+        is_stale_fallback=False,
+    )
+
+
+def _topic_with_article(
+    label: str, *, is_read: bool = False, read_at: datetime | None = None
+):
+    """Un topic à article unique — permet de contrôler is_read/read_at par cas."""
+    from app.schemas.content import SourceMini
+    from app.schemas.digest import DigestTopic, DigestTopicArticle
+
+    return DigestTopic(
+        topic_id=uuid4().hex,
+        label=label,
+        rank=1,
+        reason="Test",
+        theme=label.lower(),
+        perspective_count=2,
+        articles=[
+            DigestTopicArticle(
+                content_id=uuid4(),
+                title=label,
+                url=f"https://example.com/{label.lower()}",
+                published_at=datetime.now(UTC),
+                source=SourceMini(
+                    id=uuid4(), name="Le Monde", logo_url=None, type="rss", theme=None
+                ),
+                rank=1,
+                reason="Test",
+                is_read=is_read,
+                read_at=read_at,
+            )
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_recently_read_article_stays_within_grace_window(db_session, make_source):
+    """Un article lu il y a 5 min reste dans la réponse (coche visible au cold-start)."""
+    user_id = uuid4()
+    now = datetime.now(UTC)
+    source = await make_source("Mediapart")
+    live_extra = await _add_content(db_session, source, title="Frais du jour")
+
+    digest = _digest_with_topics(
+        [
+            _topic_with_article(
+                "Politique", is_read=True, read_at=now - timedelta(minutes=5)
+            ),
+            _topic_with_article("Sciences"),
+            _topic_with_article("Cuisine"),
+        ]
+    )
+    ctx = EssentielUserContext(followed_source_ids=frozenset({source.id}))
+
+    response = await build_essentiel_response_with_supplements(
+        db_session,
+        user_id,
+        digest,
+        user_context=ctx,
+        is_serene=False,
+        now=now,
+    )
+
+    politique = next(a for a in response.articles if a.section_label == "Politique")
+    assert politique.is_read is True
+    assert politique.read_at is not None
+    # 3 articles digest (dont l'article en grâce, compté comme non-lu) + 1 slot
+    # live libre = 4 ; le blend live ne comble qu'un seul slot, pas deux.
+    assert len(response.articles) == 4
+    assert live_extra.id in {a.content_id for a in response.articles}
+
+
+@pytest.mark.asyncio
+async def test_stale_read_article_still_evicted_after_grace(db_session, make_source):
+    """Passé la fenêtre de grâce, l'article lu est évincé comme avant (Essentiel vivant)."""
+    user_id = uuid4()
+    now = datetime.now(UTC)
+    source = await make_source("Mediapart")
+    live_extra = await _add_content(db_session, source, title="Frais du jour")
+
+    digest = _digest_with_topics(
+        [
+            _topic_with_article(
+                "Politique",
+                is_read=True,
+                read_at=now - ESSENTIEL_READ_EVICTION_GRACE - timedelta(minutes=1),
+            ),
+            _topic_with_article("Sciences"),
+            _topic_with_article("Cuisine"),
+        ]
+    )
+    ctx = EssentielUserContext(followed_source_ids=frozenset({source.id}))
+
+    response = await build_essentiel_response_with_supplements(
+        db_session,
+        user_id,
+        digest,
+        user_context=ctx,
+        is_serene=False,
+        now=now,
+    )
+
+    labels = [a.section_label for a in response.articles]
+    # L'article lu (hors grâce) est repoussé en dernier recours, derrière le
+    # frais des sources suivies — comportement "Essentiel vivant" inchangé.
+    assert labels[-1] == "Politique" or "Politique" not in labels[:-1]
+    assert live_extra.id in {a.content_id for a in response.articles}
+
+
+@pytest.mark.asyncio
+async def test_never_read_article_has_no_read_at(db_session, make_source):
+    """Un article jamais lu n'a pas de `read_at`."""
+    user_id = uuid4()
+    digest = _digest_with_topics([_topic_with_article("Politique")])
+    ctx = EssentielUserContext()
+
+    response = await build_essentiel_response_with_supplements(
+        db_session,
+        user_id,
+        digest,
+        user_context=ctx,
+        is_serene=False,
+    )
+
+    assert len(response.articles) == 1
+    assert response.articles[0].is_read is False
+    assert response.articles[0].read_at is None
+
+
+@pytest.mark.asyncio
+async def test_read_at_exactly_at_grace_boundary_is_evicted(db_session, make_source):
+    """`read_at` exactement à `now - GRACE` est évincé (comparaison stricte `<`)."""
+    user_id = uuid4()
+    now = datetime.now(UTC)
+    source = await make_source("Mediapart")
+    live_extra = await _add_content(db_session, source, title="Frais du jour")
+
+    digest = _digest_with_topics(
+        [
+            _topic_with_article(
+                "Politique", is_read=True, read_at=now - ESSENTIEL_READ_EVICTION_GRACE
+            ),
+            _topic_with_article("Sciences"),
+            _topic_with_article("Cuisine"),
+        ]
+    )
+    ctx = EssentielUserContext(followed_source_ids=frozenset({source.id}))
+
+    response = await build_essentiel_response_with_supplements(
+        db_session,
+        user_id,
+        digest,
+        user_context=ctx,
+        is_serene=False,
+        now=now,
+    )
+
+    assert live_extra.id in {a.content_id for a in response.articles}


### PR DESCRIPTION
## Quoi

Corrige la coche de lecture non fonctionnelle sur "Ton Essentiel" : un article
tout juste lu était évincé de la réponse `GET /api/essentiel` avant que
l'utilisateur ne revoie sa coche persister au retour dans l'app.

## Pourquoi

`build_essentiel_response_with_supplements` (feature "Essentiel vivant",
story 9.8) évince activement tout article `is_read=True` à **chaque** appel
pour laisser place à du contenu frais — comportement voulu pour les vrais
retours après absence. Mais `fluxContinuProvider.build()` relance
inconditionnellement `_fetchAll()` à **chaque cold start** de l'app (kill OS
en arrière-plan, très fréquent sur mobile), sans cooldown. Résultat : le
premier refetch qui suit une lecture évince quasi systématiquement l'article
qu'on vient de lire.

Fix backend uniquement : le timestamp `UserContentStatus.seen_at` (déjà posé
de façon idempotente) est remonté jusqu'à `EssentielArticle.read_at`, et un
article lu depuis moins de 30 min (`ESSENTIEL_READ_EVICTION_GRACE`) est
protégé de l'éviction — il se comporte comme un non-lu (occupe un slot,
réduit le blend live) mais reste visible avec `is_read=true`. Passé la
grâce, le comportement "Essentiel vivant" reprend inchangé. Aucune
modification Flutter nécessaire (le client ignore les champs JSON inconnus,
le rendu de la coche réagit déjà à `is_read=true`).

Aucune migration Alembic (pas de changement de schéma DB, seulement des
schémas Pydantic + logique service).

## Comment ça a été vérifié

- [x] pytest (2462 passed, 18 skipped, 2 xfailed — suite complète)
- [x] Nouveaux tests ciblés : grâce active (5 min), grâce expirée (31 min,
      non-régression "Essentiel vivant"), pas de `read_at` sur un article
      jamais lu, frontière stricte `now - GRACE` évincée
      (`test_essentiel_supplements.py`), propagation de `read_at` sur les
      deux chemins de construction `DigestTopicArticle`
      (`test_digest_service.py`)
- [x] `alembic heads` — 1 seul head, inchangé
- [x] `/simplify` passé (4 agents de revue en parallèle — reuse,
      simplification, efficiency, altitude)
- Backend uniquement, pas de changement Flutter → pas de session
  `/validate-feature`

## Zones à risque

- `essentiel_service.py::build_essentiel_response_with_supplements` — logique
  de blend live/éviction partagée par tous les utilisateurs de "Ton
  Essentiel"
- Schémas Pydantic `DigestTopicArticle`/`EssentielArticle` — champ optionnel
  non-breaking, mais traverse plusieurs points de construction dans
  `digest_service.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)