### PR TITLE
feat(flaner): diversité source stricte + dédup cluster du scroll + durcissement Essentiel

### DIFF
--- a/docs/maintenance/maintenance-flaner-source-diversity-cluster-dedup.md
+++ b/docs/maintenance/maintenance-flaner-source-diversity-cluster-dedup.md
@@ -1,0 +1,81 @@
+# Maintenance — Diversité source + dédup cluster dans Flâner (et durcissement Essentiel)
+
+> Type : Maintenance (tuning curation, backend-only, 100 % runtime, aucune
+> migration Alembic). Plan de référence : `.context/attachments/3zHeEv/plan.md`.
+
+## Problème
+
+Dans « Flâner » (`GET /api/feed/`, mode par défaut / chronologique) :
+
+1. **Répétition de source** — le pipeline n'espaçait que les runs de **3+
+   consécutifs** (`_apply_source_interleaving` testait `i-1` ET `i-2`). On peut
+   donc voir 2 articles de la même source **collés**.
+2. **Doublons de cluster** — le scroll linéaire ne dédupliquait pas par sujet.
+   Le même événement couvert par plusieurs sources apparaissait plusieurs fois
+   (les regroupements entité/mot-clé ratent les doublons narratifs à titres
+   proches mais entités différentes). `Content.cluster_id` persisté est dormant
+   (~1,3 % des articles récents) → inutilisable.
+3. **Essentiel** — cap **2 articles/source** jugé trop permissif par le PO.
+
+## Décisions PO
+
+1. Espacement local : jamais 2 articles même source collés (réordonne
+   seulement, ne retire aucun article ; best-effort si la fin est mono-source).
+2. Masquer les doublons de cluster dans le flux (garder le 1er = plus récent),
+   **sans casser le carrousel « Actu chaude »** qui doit toujours voir la
+   couverture multi-sources complète.
+3. Durcir l'Essentiel : cap source **2 → 1**, avec fallback anti-régression.
+
+## Changements
+
+### 1. `recommendation_service.py :: _apply_source_interleaving`
+Resserré : boucle `range(1, n)`, teste uniquement `result[i] == result[i-1]`,
+swap avec le prochain article d'une **autre** source. Best-effort (aucune
+exception, aucun retrait si la queue est mono-source). Le safety-net
+3-consécutifs (`_apply_source_safety_net`) reste en place, désormais rarement
+déclenché.
+
+### 2. `recommendation_service.py :: _apply_cluster_dedup` (nouveau)
+Appelé dans `get_feed()` (chemin chronologique) **juste après** le snapshot
+`pre_regroup_map` et **avant** l'entity regroupement. Recalcule les clusters à
+la volée via `ImportanceDetector().build_topic_clusters` (Jaccard 0.4, même algo
+qu'« Actu chaude »), puis `diversify(max_per_key=1, fallback_ok=False)` garde le
+1er article par cluster.
+
+> **Invariant clé** : `_apply_cluster_dedup` ne **mute pas** sa liste d'entrée.
+> `pre_regroup_map` étant capturé AVANT l'appel, le carrousel « Actu chaude »
+> (`_build_carousels` → `find_hot_cluster`, qui consomme `pre_regroup_map`)
+> conserve la couverture complète. Le sujet apparaît une fois dans le flux +
+> éventuellement comme carrousel de couverture. Le buffer `phase1_limit =
+> limit * 3` garantit assez d'articles après masquage.
+
+### 3. `essentiel_service.py :: ESSENTIEL_MAX_PER_SOURCE 2 → 1` + fallback
+- Constante `ESSENTIEL_MAX_PER_SOURCE = 1`, nouveau `_MAX_PER_SOURCE_FALLBACK = 2`.
+- `_pick_transversal_articles` (digest anchor) : cap porté par une variable
+  `max_per_source` lue par `_try_pick`. Après la 1re passe cap 1, si les 5 slots
+  ne sont pas remplis (trop peu de sources distinctes), 2e passe à cap 2.
+- `_fetch_live_supplements` (blend live) : sélection refactorée en `_fill(cap)`
+  ré-exécutée à cap 2 si le pool cap 1 n'atteint pas `limit`.
+- Rationale : cap 1 maximise la diversité source ; le fallback cap 2 évite une
+  carte pauvre / un `202 preparing` sous `ESSENTIEL_MIN_ARTICLES`. Même logique
+  que `DigestSelector._select_with_diversity` (fallback source si trop peu de
+  sources). La 2e passe est idempotente (articles déjà pris re-rejetés) et ne
+  relâche QUE la diversité source — la diversité de **sujet** reste garantie par
+  `_is_duplicate_subject`/`used_topics`.
+
+## Réutilisation (aucun nouveau code de clustering/dédup)
+`ImportanceDetector.build_topic_clusters`, `diversify`, pattern fallback de
+`digest_selector`.
+
+## Tests
+- `tests/test_feed_diversity_dedup.py` (nouveau) — interleaving (zéro paire
+  adjacente + best-effort mono-source), dédup cluster (masquage + **non-mutation
+  de l'entrée** = couverture carrousel préservée).
+- `tests/test_essentiel_endpoint.py` — cap 1/source respecté (≥5 sources) ;
+  fallback cap 2 quand sources rares (pas de régression `202`).
+- `tests/test_essentiel_supplements.py` — cap 1 dans le blend live (pool
+  diversifié) ; l'ancien `test_max_two_articles_per_source` reste vert (plafond
+  dur 2 via fallback).
+
+## Alembic
+Aucune migration. `alembic heads` reste à 1 head (inchangé).

--- a/packages/api/app/services/essentiel_service.py
+++ b/packages/api/app/services/essentiel_service.py
@@ -60,7 +60,12 @@ from app.utils.time import PARIS_TZ
 logger = logging.getLogger(__name__)
 
 ESSENTIEL_MAX_ARTICLES = 5
-ESSENTIEL_MAX_PER_SOURCE = 2  # Diversité dure : max 2 articles d'une même source.
+# Diversité dure : au plus 1 article par source. Relâché à 2 (``_MAX_PER_SOURCE_FALLBACK``)
+# en 2e passe quand le pool de sources distinctes ne suffit pas à remplir les 5
+# slots — évite une carte pauvre / un ``202 preparing``. Même logique que
+# ``DigestSelector._select_with_diversity`` (fallback source si trop peu de sources).
+ESSENTIEL_MAX_PER_SOURCE = 1
+_MAX_PER_SOURCE_FALLBACK = 2
 
 # Plancher de qualité : en-dessous de ce nombre d'articles issus du digest, on
 # complète depuis les sources suivies/favorites de l'utilisateur ; si le total
@@ -531,6 +536,10 @@ def _pick_transversal_articles(
     picked_title_tokens: list[set[str]] = []
     dedup_rejections = 0
     sport_rejections = 0
+    # Cap source courant : 1 en 1re passe (diversité dure), relâché à 2 si le
+    # pool de sources distinctes ne suffit pas à remplir les 5 slots (cf. plus
+    # bas). Lu comme variable libre par `_try_pick`.
+    max_per_source = ESSENTIEL_MAX_PER_SOURCE
 
     def _is_duplicate_subject(topic: DigestTopic, article: DigestTopicArticle) -> bool:
         """Un même sujet ne doit jamais occuper deux slots de l'Essentiel.
@@ -566,7 +575,7 @@ def _pick_transversal_articles(
         if article.content_id in seen_content_ids:
             dedup_rejections += 1
             return False
-        if source_count.get(article.source.id, 0) >= ESSENTIEL_MAX_PER_SOURCE:
+        if source_count.get(article.source.id, 0) >= max_per_source:
             return False
         if _is_duplicate_subject(topic, article):
             dedup_rejections += 1
@@ -630,6 +639,17 @@ def _pick_transversal_articles(
     followed_pick_count = len(picked)
     if len(picked) < ESSENTIEL_MAX_ARTICLES:
         _fill_from_tier(fresh_topics)
+
+    # Fallback diversité : le cap 1/source n'a pas rempli les 5 slots (trop peu
+    # de sources distinctes dans le pool). On relâche à 2/source et on complète.
+    # Les articles déjà retenus restent (idempotent : ils sont re-rejetés par
+    # `seen_content_ids`/`used_topics`), seuls des 2es articles d'un NOUVEAU
+    # sujet peuvent entrer — la diversité de sujet reste garantie.
+    if len(picked) < ESSENTIEL_MAX_ARTICLES and max_per_source < _MAX_PER_SOURCE_FALLBACK:
+        max_per_source = _MAX_PER_SOURCE_FALLBACK
+        _fill_from_tier(followed_topics)
+        if len(picked) < ESSENTIEL_MAX_ARTICLES:
+            _fill_from_tier(fresh_topics)
 
     # `picked` only grows after `followed_pick_count` is captured, so the
     # supplement count is always non-negative.
@@ -871,34 +891,44 @@ async def _fetch_live_supplements(
 
     supplements: list[EssentielArticle] = []
     rank = len(existing) + 1
-    for content in candidates:
-        if len(supplements) >= limit:
-            break
-        if content.id in seen_content_ids:
-            continue
-        source = content.source
-        if (source.type or "").lower() in _EXCLUDED_SOURCE_TYPES:
-            continue
-        if is_news_bulletin_title(content.title):
-            continue
-        if ctx.muted_topic_slugs and ctx.muted_topic_slugs.intersection(
-            content.topics or ()
-        ):
-            continue
-        if source_count.get(source.id, 0) >= ESSENTIEL_MAX_PER_SOURCE:
-            continue
-        tokens = normalize_title(content.title)
-        if tokens and any(
-            jaccard_similarity(tokens, prev) >= ScoringWeights.TOPIC_CLUSTER_THRESHOLD
-            for prev in picked_title_tokens
-            if prev
-        ):
-            continue
-        supplements.append(_content_to_essentiel_article(content, rank, ctx))
-        seen_content_ids.add(content.id)
-        source_count[source.id] = source_count.get(source.id, 0) + 1
-        picked_title_tokens.append(tokens)
-        rank += 1
+
+    def _fill(cap: int) -> None:
+        nonlocal rank
+        for content in candidates:
+            if len(supplements) >= limit:
+                return
+            if content.id in seen_content_ids:
+                continue
+            source = content.source
+            if (source.type or "").lower() in _EXCLUDED_SOURCE_TYPES:
+                continue
+            if is_news_bulletin_title(content.title):
+                continue
+            if ctx.muted_topic_slugs and ctx.muted_topic_slugs.intersection(
+                content.topics or ()
+            ):
+                continue
+            if source_count.get(source.id, 0) >= cap:
+                continue
+            tokens = normalize_title(content.title)
+            if tokens and any(
+                jaccard_similarity(tokens, prev)
+                >= ScoringWeights.TOPIC_CLUSTER_THRESHOLD
+                for prev in picked_title_tokens
+                if prev
+            ):
+                continue
+            supplements.append(_content_to_essentiel_article(content, rank, ctx))
+            seen_content_ids.add(content.id)
+            source_count[source.id] = source_count.get(source.id, 0) + 1
+            picked_title_tokens.append(tokens)
+            rank += 1
+
+    # 1re passe cap 1/source (diversité) ; fallback cap 2 pour compléter les
+    # slots libres si le pool de sources distinctes est trop pauvre.
+    _fill(ESSENTIEL_MAX_PER_SOURCE)
+    if len(supplements) < limit and ESSENTIEL_MAX_PER_SOURCE < _MAX_PER_SOURCE_FALLBACK:
+        _fill(_MAX_PER_SOURCE_FALLBACK)
 
     return supplements, new_since_morning
 

--- a/packages/api/app/services/essentiel_service.py
+++ b/packages/api/app/services/essentiel_service.py
@@ -645,7 +645,10 @@ def _pick_transversal_articles(
     # Les articles déjà retenus restent (idempotent : ils sont re-rejetés par
     # `seen_content_ids`/`used_topics`), seuls des 2es articles d'un NOUVEAU
     # sujet peuvent entrer — la diversité de sujet reste garantie.
-    if len(picked) < ESSENTIEL_MAX_ARTICLES and max_per_source < _MAX_PER_SOURCE_FALLBACK:
+    if (
+        len(picked) < ESSENTIEL_MAX_ARTICLES
+        and max_per_source < _MAX_PER_SOURCE_FALLBACK
+    ):
         max_per_source = _MAX_PER_SOURCE_FALLBACK
         _fill_from_tier(followed_topics)
         if len(picked) < ESSENTIEL_MAX_ARTICLES:

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -729,8 +729,20 @@ class RecommendationService:
             # Source interleaving: avoid consecutive articles from same source
             result = self._apply_source_interleaving(result)
 
-            # Snapshot all articles before regroupement removes hidden ones
+            # Snapshot all articles before regroupement removes hidden ones.
+            # Captured BEFORE cluster dedup so carousels (« Actu chaude ») keep
+            # the full multi-source coverage of a topic.
             pre_regroup_map = {a.id: a for a in result}
+
+            # Hide narrative duplicates (same subject covered by several sources)
+            # from the linear scroll of the default « Flâner » view. Skipped when
+            # a filter is active: entity/keyword views *want* the multi-source
+            # coverage of one subject, and `saved_only` must never hide an
+            # article the user explicitly saved. The carousel still surfaces the
+            # coverage via pre_regroup_map above.
+            has_filter = any([theme, topic, source_id, entity, keyword, saved_only])
+            if not has_filter:
+                result = self._apply_cluster_dedup(result)
 
             # Phase 1.5: Entity regroupement (highest thematic priority)
             result, entity_overflow, assigned_ids, entity_ctas = (
@@ -751,8 +763,8 @@ class RecommendationService:
             self.keyword_overflow = keyword_overflow
             self.topic_overflow = topic_overflow
 
-            # Phase 2.5: Promote overflow groups to carousels
-            has_filter = any([theme, topic, source_id, entity, keyword, saved_only])
+            # Phase 2.5: Promote overflow groups to carousels (same gate as the
+            # cluster dedup above — `has_filter` computed there).
             if not has_filter:
                 result, carousel_data = await self._build_carousels(
                     result, pre_regroup_map, user_id=user_id, serein=serein
@@ -1150,25 +1162,58 @@ class RecommendationService:
     @staticmethod
     def _apply_source_interleaving(articles: list[Content]) -> list[Content]:
         """
-        Prevent more than 2 consecutive articles from the same source.
+        Avoid two adjacent articles from the same source (soft, best-effort).
 
-        For each position i (starting at 2), if article[i] shares the same
-        source as article[i-1] and article[i-2], swap with the nearest
-        following article from a different source.
+        For each position i (starting at 1), if article[i] shares the same
+        source as its left neighbour article[i-1], swap it with the nearest
+        following article from a different source. If the tail is mono-source
+        (no such article exists), leave it as-is — we only reorder, never drop.
+        The swapped-in duplicate at position j is revisited as i advances.
         """
         result = list(articles)
         n = len(result)
-        for i in range(2, n):
-            if (
-                result[i].source_id == result[i - 1].source_id
-                and result[i].source_id == result[i - 2].source_id
-            ):
-                # Find the nearest different source to swap with
+        for i in range(1, n):
+            if result[i].source_id == result[i - 1].source_id:
+                # Find the nearest article from a different source to swap in
                 for j in range(i + 1, n):
-                    if result[j].source_id != result[i].source_id:
+                    if result[j].source_id != result[i - 1].source_id:
                         result[i], result[j] = result[j], result[i]
                         break
         return result
+
+    @staticmethod
+    def _apply_cluster_dedup(articles: list[Content]) -> list[Content]:
+        """Masque les doublons de cluster du scroll linéaire de Flâner.
+
+        Recalcule les clusters de sujets à la volée (Jaccard des titres, même
+        algo que « Actu chaude » via ``ImportanceDetector.build_topic_clusters``)
+        car ``Content.cluster_id`` persisté est dormant. On garde le 1er article
+        de chaque cluster (= plus récent/prioritaire, l'ordre étant déjà
+        chronologique diversifié) et on écarte les autres.
+
+        Réutilise le helper générique ``diversify`` (``max_per_key=1``,
+        ``fallback_ok=False`` pour ne PAS ré-injecter les doublons). Les
+        singletons ont chacun leur propre clé → tous conservés ; un titre sans
+        token (absent d'un cluster) tombe sur ``None`` → conservé.
+        """
+        if len(articles) < 2:
+            return articles
+
+        from app.services.briefing.importance_detector import ImportanceDetector
+        from app.services.recommendation.helpers.diversification import diversify
+
+        clusters = ImportanceDetector().build_topic_clusters(articles)
+        cluster_key: dict[UUID, int] = {}
+        for idx, cluster in enumerate(clusters):
+            for content in cluster.contents:
+                cluster_key[content.id] = idx
+
+        return diversify(
+            articles,
+            key_fn=lambda a: cluster_key.get(a.id),
+            max_per_key=1,
+            fallback_ok=False,
+        )
 
     @staticmethod
     def _apply_entity_regroupement(

--- a/packages/api/tests/test_essentiel_endpoint.py
+++ b/packages/api/tests/test_essentiel_endpoint.py
@@ -26,6 +26,7 @@ from app.services.essentiel_service import (
     _W_TRENDING,
     _W_UNE,
     ESSENTIEL_MAX_ARTICLES,
+    ESSENTIEL_MIN_ARTICLES,
     EssentielUserContext,
     _perspective_score,
     _score_article,
@@ -134,6 +135,96 @@ def test_build_essentiel_picks_one_article_per_topic():
     for i, article in enumerate(response.articles):
         assert article.rank == i + 1
         assert article.section_label == f"T{i + 1}"
+
+
+def _topic_from_articles(
+    *, rank: int, label: str, articles: list[DigestTopicArticle]
+) -> DigestTopic:
+    return DigestTopic(
+        topic_id=f"topic-{label}",
+        label=label,
+        rank=rank,
+        reason="Test",
+        theme="technologie",
+        perspective_count=1,
+        articles=articles,
+    )
+
+
+def test_build_essentiel_caps_one_article_per_source():
+    """Cap 1/source : avec ≥5 sources distinctes, aucune source n'apparaît 2×.
+
+    SourceA couvre 2 sujets distincts, mais 4 autres sources suffisent à remplir
+    les 5 slots → le 2e article de A est écarté (le fallback cap 2 ne se
+    déclenche pas puisqu'on atteint déjà le cap 5 en 1re passe).
+    """
+    src_a = _make_source("SourceA")
+    others = [_make_source(f"Src{i}") for i in range(4)]
+    # Titres à tokens distincts → aucune fausse dédup par similarité.
+    other_titles = ["Climat", "Culture", "Sciences", "Sante"]
+    topics = [
+        _topic_from_articles(
+            rank=1,
+            label="Politique",
+            articles=[_make_article(rank=1, title="Politique", source=src_a)],
+        ),
+        _topic_from_articles(
+            rank=2,
+            label="Economie",
+            articles=[_make_article(rank=1, title="Economie", source=src_a)],
+        ),
+    ] + [
+        _topic_from_articles(
+            rank=3 + i,
+            label=other_titles[i],
+            articles=[_make_article(rank=1, title=other_titles[i], source=others[i])],
+        )
+        for i in range(4)
+    ]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(digest)
+
+    assert len(response.articles) == ESSENTIEL_MAX_ARTICLES
+    source_ids = [a.source.id for a in response.articles]
+    assert len(source_ids) == len(set(source_ids)), "cap 1/source respecté"
+
+
+def test_build_essentiel_falls_back_to_two_per_source_when_scarce():
+    """Fallback : trop peu de sources distinctes → relâche à 2/source.
+
+    2 sources sur 5 sujets distincts : le cap 1 ne remplit que 2 slots (sous le
+    plancher `ESSENTIEL_MIN_ARTICLES`). Le 2e passage à cap 2 complète à 4 (2 par
+    source) → pas de régression `202 preparing` par excès de diversité.
+    """
+    src_a = _make_source("SourceA")
+    src_b = _make_source("SourceB")
+    layout = [
+        ("Alpha", src_a),
+        ("Bravo", src_b),
+        ("Charlie", src_a),
+        ("Delta", src_b),
+        ("Echo", src_a),
+    ]
+    topics = [
+        _topic_from_articles(
+            rank=i + 1,
+            label=title,
+            articles=[_make_article(rank=1, title=title, source=src)],
+        )
+        for i, (title, src) in enumerate(layout)
+    ]
+    digest = _make_digest(topics)
+
+    response = build_essentiel_response(digest)
+
+    assert len(response.articles) >= ESSENTIEL_MIN_ARTICLES, "pas de 202 preparing"
+    per_source: dict[UUID, int] = {}
+    for a in response.articles:
+        per_source[a.source.id] = per_source.get(a.source.id, 0) + 1
+    assert max(per_source.values()) <= 2, "fallback plafonne à 2 articles/source"
+    # 2 sources × cap 2 = 4 slots ; le 5e est impossible sans 3e source.
+    assert len(response.articles) == 4
 
 
 def test_build_essentiel_one_subject_per_topic_no_backfill():

--- a/packages/api/tests/test_essentiel_supplements.py
+++ b/packages/api/tests/test_essentiel_supplements.py
@@ -235,8 +235,44 @@ async def test_max_two_articles_per_source(db_session, make_source):
         is_serene=False,
     )
 
-    # 4 articles distincts d'une seule source → cap dur à 2.
-    assert len(response.articles) == 2, "cap de 2 articles par source"
+    # 4 articles distincts d'une seule source → cap 1 en 1re passe, puis
+    # fallback cap 2 (pool mono-source, sous le plancher) → plafond dur à 2.
+    assert len(response.articles) == 2, "cap de 2 articles par source (fallback)"
+
+
+@pytest.mark.asyncio
+async def test_live_blend_caps_one_per_source_when_pool_diverse(
+    db_session, make_source
+):
+    """Cap 1/source respecté : 5 sources suivies (2 articles chacune) → 5
+    articles au total, jamais 2× la même source (le fallback ne se déclenche
+    pas puisque le cap 1 remplit déjà les 5 slots)."""
+    user_id = uuid4()
+    sources = [await make_source(f"Src{i}") for i in range(5)]
+    titles = [
+        ["Politique", "Justice"],
+        ["Economie", "Emploi"],
+        ["Climat", "Energie"],
+        ["Culture", "Cinema"],
+        ["Sciences", "Espace"],
+    ]
+    for src, pair in zip(sources, titles, strict=True):
+        for title in pair:
+            await _add_content(db_session, src, title=title)
+
+    ctx = EssentielUserContext(followed_source_ids=frozenset(s.id for s in sources))
+
+    response = await build_essentiel_response_with_supplements(
+        db_session,
+        user_id,
+        _empty_digest(),
+        user_context=ctx,
+        is_serene=False,
+    )
+
+    assert len(response.articles) == 5
+    source_ids = [a.source.id for a in response.articles]
+    assert len(source_ids) == len(set(source_ids)), "cap 1/source respecté"
 
 
 @pytest.mark.asyncio

--- a/packages/api/tests/test_feed_diversity_dedup.py
+++ b/packages/api/tests/test_feed_diversity_dedup.py
@@ -1,0 +1,103 @@
+"""Diversité source + dédup cluster du scroll « Flâner » (GET /api/feed/).
+
+Deux garde-fous runtime, additifs et sans schéma DB :
+- `_apply_source_interleaving` : jamais 2 articles de la même source collés
+  (réordonne, ne retire rien ; best-effort si la fin est mono-source).
+- `_apply_cluster_dedup` : un même sujet (cluster de titres, Jaccard 0.4)
+  n'apparaît qu'une fois dans le flux, en gardant le 1er (plus récent). La
+  liste d'entrée n'est PAS mutée → le snapshot `pre_regroup_map` conserve la
+  couverture complète pour le carrousel « Actu chaude ».
+"""
+
+from uuid import uuid4
+
+from app.models.content import Content
+from app.services.recommendation_service import RecommendationService
+
+
+def _content(source_id, title: str, *, theme: str | None = None) -> Content:
+    """Content transient (sans session) : suffisant pour les fonctions pures."""
+    return Content(
+        id=uuid4(),
+        source_id=source_id,
+        title=title,
+        url=f"https://example.com/{uuid4()}",
+        theme=theme,
+    )
+
+
+# ─── _apply_source_interleaving ──────────────────────────────────────────────
+
+
+def test_interleaving_breaks_adjacent_same_source():
+    """3×A + 2×B → réordonné en A B A B A, zéro paire adjacente."""
+    a, b = uuid4(), uuid4()
+    items = [
+        _content(a, "A1"),
+        _content(a, "A2"),
+        _content(a, "A3"),
+        _content(b, "B1"),
+        _content(b, "B2"),
+    ]
+
+    out = RecommendationService._apply_source_interleaving(items)
+
+    # Aucune source identique en position adjacente (arrangement possible ici).
+    assert all(
+        out[i].source_id != out[i - 1].source_id for i in range(1, len(out))
+    ), "aucune paire de sources adjacentes ne doit subsister"
+    # On ne retire aucun article : même multiset d'ids.
+    assert {c.id for c in out} == {c.id for c in items}
+
+
+def test_interleaving_is_best_effort_on_mono_source_tail():
+    """Fin mono-source impossible à casser → on laisse tel quel, sans crash."""
+    a, b = uuid4(), uuid4()
+    items = [_content(a, "A1"), _content(b, "B1"), _content(a, "A2"), _content(a, "A3")]
+
+    out = RecommendationService._apply_source_interleaving(items)
+
+    # Rien n'est retiré ; l'unique adjacence de queue (A2,A3) est tolérée.
+    assert {c.id for c in out} == {c.id for c in items}
+    adjacent = sum(
+        1 for i in range(1, len(out)) if out[i].source_id == out[i - 1].source_id
+    )
+    assert adjacent <= 1
+
+
+# ─── _apply_cluster_dedup ────────────────────────────────────────────────────
+
+
+def test_cluster_dedup_hides_narrative_duplicates():
+    """Deux titres quasi-identiques (sources différentes) → un seul survit."""
+    src_x, src_y, src_z = uuid4(), uuid4(), uuid4()
+    dup_first = _content(src_x, "Réforme des retraites adoptée par le Parlement")
+    dup_second = _content(src_y, "Réforme des retraites adoptée au Parlement")
+    singleton = _content(src_z, "Tempête Ciaran frappe la côte atlantique bretonne")
+    articles = [dup_first, dup_second, singleton]
+
+    out = RecommendationService._apply_cluster_dedup(articles)
+
+    out_ids = [c.id for c in out]
+    # Le doublon narratif est masqué, le singleton conservé.
+    assert dup_first.id in out_ids, "on garde le 1er (plus récent) du cluster"
+    assert dup_second.id not in out_ids, "le doublon de cluster est masqué"
+    assert singleton.id in out_ids
+    assert len(out) == 2
+
+
+def test_cluster_dedup_does_not_mutate_input():
+    """La liste d'entrée (future `pre_regroup_map`) garde la couverture complète."""
+    src_x, src_y = uuid4(), uuid4()
+    articles = [
+        _content(src_x, "Le président annonce une réforme fiscale ambitieuse"),
+        _content(src_y, "Le président annonce une réforme fiscale majeure"),
+    ]
+    snapshot_ids = [c.id for c in articles]
+
+    out = RecommendationService._apply_cluster_dedup(articles)
+
+    # L'entrée reste intacte : le carrousel « Actu chaude » voit toujours tout.
+    assert [c.id for c in articles] == snapshot_ids
+    # Le scroll linéaire, lui, est dédupliqué.
+    assert len(out) == 1


### PR DESCRIPTION
## Quoi
Tuning curation backend-only (100 % runtime, aucune migration) sur le scroll « Flâner » et l'Essentiel :

- **`_apply_source_interleaving`** resserré : jamais 2 articles de la même source *collés* (avant : seulement 3+ consécutifs). Réordonne uniquement — ne retire aucun article ; best-effort si la fin est mono-source.
- **`_apply_cluster_dedup`** (nouveau) : masque les doublons de sujet du scroll linéaire (même événement couvert par plusieurs sources) en réutilisant `ImportanceDetector.build_topic_clusters` (Jaccard 0.4) + `diversify(max_per_key=1)`. Gaté hors filtre (entité/mot-clé/`saved_only` veulent la couverture multi-sources). **N'altère pas** `pre_regroup_map` → le carrousel « Actu chaude » garde la couverture complète.
- **Essentiel** : cap source **2 → 1** (diversité dure), avec fallback cap 2 anti-régression quand le pool de sources est trop pauvre (évite carte pauvre / `202 preparing`), dans `_pick_transversal_articles` et `_fetch_live_supplements`.

## Pourquoi
Décisions PO (cf. `docs/maintenance/maintenance-flaner-source-diversity-cluster-dedup.md`) : trop de répétition de source et de doublons narratifs dans Flâner ; cap 2/source jugé trop permissif dans l'Essentiel. `Content.cluster_id` persisté est dormant (~1,3 %) → clusters recalculés à la volée.

## Comment ça a été vérifié
- [x] `pytest` suite complète : **2463 passed, 18 skipped, 2 xfailed, 0 échec**
- [x] Tests ciblés (66) : interleaving, dédup cluster (masquage + non-mutation de l'entrée), cap 1/source + fallback cap 2 (Essentiel anchor & blend live)
- [x] API boot OK : `/api/health` 200, `/api/feed/` sans auth → 403 (edge case)
- [x] Alembic : 1 head, aucune migration dans cette branche
- [x] `/simplify` passé (code déjà propre ; voir suivi ci-dessous)
- [ ] Pas de changement UI → pas de Playwright

## Zones à risque
- `RecommendationService.get_feed` (chemin chronologique, hot path) — le carrousel « Actu chaude » dépend de `pre_regroup_map` capturé **avant** la dédup ; invariant testé (non-mutation de l'entrée).
- `essentiel_service` sélection transversale + blend live.

## Suivi (hors périmètre)
`_apply_cluster_dedup` et `find_hot_cluster` (carrousel) appellent tous deux `build_topic_clusters` sur le même jeu d'articles → 2 passes O(n²) par requête feed par défaut (~60 articles, borné). Optimisation possible : clusteriser une fois et partager la map — touche `_build_carousels`/`article_clustering_service` (hors diff), reporté.