### PR TITLE
perf(reader): isole le raster des cartes carrousel + chrome vertical (RepaintBoundary natif)

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,67 +1,46 @@
-# feat(media-eval): harness batch 2 — critères sur corpus + double évaluation + recall C1 (Phase 4)
+## perf(reader) — isolation raster : cartes carrousel + chrome vertical (RepaintBoundary natif)
 
-**PR C** de la trajectoire media-eval (base `main`). Outillage du batch 2 CNEWS,
-**avant** toute collecte. Aucune migration (additif / expand-safe, 1 head).
+Regroupe **PR 1 + PR 2** du plan fluidité scroll (`.context/attachments/97Nbws/plan.md`) en une
+seule PR, à la demande du PO. 100 % Dart mobile — aucun backend, aucune migration.
 
-## Ce que ça livre
+### Problème
 
-**1. Corpus d'articles (C2/C3/C4/C5/C7)**
-- `schemas.py` : vague-1 v1.3 étendue aux **10 critères** ; registre `articles`
-  (+ structurels C3 `page_corrections`/`canal_signalement`/`reponse_evaluation_externe`) ;
-  `Grille.criteres_corpus` (v1.3 = C2/C3/C4/C5/C7 ; v1.2 = ∅).
-- **`collect_corpus_articles.py`** (nouveau, voie A) : échantillonne + snapshote
-  des articles récents (home + sitemap) dans `media_eval_corpus_articles` +
-  pré-métriques mécaniques (signature ? label d'opinion ? liens sortants ?).
-  N'émet **aucun signal** (la qualification est voie B). Idempotent.
-- `build_eval_input.py` : joint un bloc `corpus_articles` (contexte non citable,
-  borné) aux eval_inputs des critères sur corpus.
-- Agent **`media-eval-collecteur-corpus`** (nouveau, voie B) : qualifie le corpus
-  → un signal `articles` agrégé par critère.
+`FacteurCard` n'isole ses cartes que via `webRepaintBoundary` (`core/web/web_perf.dart:52`),
+**no-op hors web**. Sur natif, aucune carte du carrousel « comparaison de points de vue » n'était
+donc isolée : tout le `Row` (≤ 8 cartes, chacune ombre `blurRadius: 6` + `DiffTitle` multi-span +
+favicon) pouvait se re-rastériser à chaque frame de translation.
 
-**2. Double évaluation C5/C9/C10 (décision PO 18/07)**
-- `export_evaluations.py` : le `raise` sur doublon (média, critère) devient un
-  **consensus** — accord conservé ; désaccord → `revue_requise` documenté (jamais
-  moyenné). Rendu **version-aware** (chaque entrée porte `version_methodo`).
-  Héberge aussi la métrique **accord inter-évaluateurs** (même règle d'accord).
-- `evaluate_golden_agreement.py` : `_paire_accord` compare C2..C7 à niveaux en
-  v1.3 (pas en tolérance continue), grille résolue depuis la version du gold.
-- `/media-eval-run` §6 : deux évaluateurs indépendants `…@v1-a` / `…@v1-b`.
+### Changements
 
-**3. Débunkages C1 — recall + dédup par affaire**
-- `DebunkageArtifact.cle_affaire` → écrit dans le `valeur` du signal C1 (repli
-  sur l'URL) ; `_nb_debunkages_frais` compte des **affaires distinctes** (fallback
-  C1 correct : un événement très couvert = un litige).
-- Agent débunkages : requêtes élargies (Les Surligneurs, ARCOM, CDJM), fenêtre
-  **36 mois** (v1.3), `cle_affaire` par litige.
+**PR 1 — carrousel + nettoyage**
+- `RepaintBoundary` explicite par carte + par CTA dans `_buildCarousel` (le vrai boundary, pas le
+  helper web-only) → chaque carte = son layer, composité tel quel au scroll. Invisible.
+- `RepaintBoundary` par squelette dans `_buildLoadingSkeleton` (isole le shimmer).
+- `RepaintBoundary` autour des 2 `PerspectivesInlineSection` (N2) → isole les animations d'intro de
+  la bande du corps vertical.
+- Suppression de `_FadeScrollRow` (code mort, jamais instancié). −82 lignes.
+- **Choix H1 (Row + RepaintBoundary) plutôt que H2 (ListView virtualisée)** : pour ≤ 8 cartes, la
+  virtualisation rendrait `maxScrollExtent` estimé (casse le tap-to-scroll de la barre de biais) et
+  introduirait des hitches de build en cours de scroll. H1 délivre le gain cœur sans ces risques.
+  Détail dans `docs/maintenance/maintenance-reader-scroll-carrousel-repaint.md`.
 
-**4. Pappers** : inchangé (repli gratuit). Recharger les crédits = action Laurin.
+**PR 2 — audit V1 + micro-fix**
+- `RepaintBoundary` autour du `Transform.scale` du `_ctaPulseController` (N3). NB : pulse one-shot
+  280 ms, pas une animation répétée.
+- `PivotWashTitle` : key laissée telle quelle (rekey intentionnel qui pilote l'animation « wash » ;
+  la toucher casserait l'anim sans gain mesuré).
 
-## Hors périmètre (suivi séparé)
-- Threading de la synthèse sur la version (`synthese_fiche`/`rapport_pilote`/
-  `ingest_artifacts.rapport_couverture`) — **Phase 6**, avant la fiche publiable.
-- Re-mapping des codes de critère **voie A** pour un run v1.3 (les collecteurs
-  structurels posent encore C5/C7/C8/C11 v1.2) — signalé WARNING dans
-  `/media-eval-run` §3, à traiter avant la collecte batch 2 hors CNEWS.
+### Vérification
 
-## Correctifs de revue (harness)
-`collect_corpus_articles.py` : filtre same-domain tolérant `www.` (appliqué aussi
-aux URLs sitemap — sinon corpus quasi vide pour un site canonique `www.` comme
-CNEWS) ; `liens_sortants` ne compte que les liens vers un **autre** domaine
-(pré-métrique C2 sinon gonflée par les liens internes absolus) ;
-`date_depuis_url` lit le format `/AAAA-MM-JJ/` (pattern CNEWS).
+- `flutter analyze` (fichiers touchés) : 0 nouvelle issue (warnings restants pré-existants).
+- `flutter test` (perspectives `feed/widgets` + `detail`) : 0 nouvel échec. Les échecs restants
+  (badge `scale: 1.6` vs test `1.0` ; phrase d'intro ; 4 stubs `notification_test`) sont
+  **confirmés pré-existants via baseline HEAD**.
+- ⚠️ **Profiling < 16 ms/frame = étape PO device** : le gain ne se mesure pas sur web (CanvasKit).
+  À vérifier en `flutter run --profile` (long article + carrousel).
 
-## Simplify
-`accord_inter_evaluateurs` déplacé dans `export_evaluations.py` (supprime le
-cycle d'import différé + `_verdict` dupliqué) ; `collect_corpus_articles` porté
-sur le harnais CLI commun `collect_common._run` (garde `--apply`, dry-run,
-rollback — plus de copie) + helpers partagés (`meme_domaine`, `_RE_HREF_ARTICLE`,
-`FetchResult` en test) ; `cle_affaire_signal` rangé dans `schemas.py` à côté du
-contrat d'écriture ; paramètre mort `version_methodo` retiré de
-`evaluations_to_goldenset`.
+### Hors scope
 
-## Tests
-`tests/scripts/media_eval/` : **260 passent** (en série ; fixture `create_tables`
-DROP le schéma). 1 head Alembic. `ruff check` OK. Aucune migration.
-
-Doc : `docs/maintenance/maintenance-media-eval-harness-batch2.md`.
-Pas d'entrée changelog (outillage interne).
+PR 3 / V2 (virtualisation du corps `flutter_html`) — **le** levier pour le jank du corps des
+articles sans carrousel — non inclus (risque plus élevé, casse `_measureArticleExtent`). À ouvrir si
+le profiling montre encore > 16 ms/frame sur longs articles après ce lot.

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -2398,9 +2398,15 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                 final t = _ctaPulseController.value;
                                 final scale =
                                     1.0 + 0.04 * math.sin(t * math.pi);
-                                return Transform.scale(
-                                  scale: scale,
-                                  child: child,
+                                // RepaintBoundary : confine le raster du pop
+                                // (Transform.scale animé, one-shot 280 ms) au
+                                // bouton — un pulse concomitant d'un scroll ne
+                                // salit pas la peinture du footer autour.
+                                return RepaintBoundary(
+                                  child: Transform.scale(
+                                    scale: scale,
+                                    child: child,
+                                  ),
                                 );
                               },
                               child: FilledButton(
@@ -3165,27 +3171,34 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                           const SizedBox(height: FacteurSpacing.space8),
                           Container(
                             color: colors.backgroundPrimary,
-                            child: PerspectivesInlineSection(
-                              key: _perspectivesKey,
-                              status: _perspectivesStatus,
-                              perspectives: _inlinePerspectives,
-                              biasDistribution:
-                                  _perspectivesResponse?.biasDistribution ??
-                                      const {},
-                              keywords:
-                                  _perspectivesResponse?.keywords ?? const [],
-                              sourceBiasStance:
-                                  _perspectivesResponse?.sourceBiasStance ??
-                                      'unknown',
-                              sourceName: _content?.source.name ?? '',
-                              contentId: widget.contentId,
-                              comparisonQuality:
-                                  _perspectivesResponse?.comparisonQuality ??
-                                      'low',
-                              divergenceLevel:
-                                  _perspectivesResponse?.divergenceLevel,
-                              partial: _perspectivesResponse?.partial ?? false,
-                              onOpenAnalysis: _openPerspectivesAnalysis,
+                            // RepaintBoundary : isole les animations d'intro de
+                            // la bande perspectives (AnimatedOpacity/AnimatedSize,
+                            // fondu du carrousel) du corps vertical au-dessus, pour
+                            // qu'elles n'invalident pas la peinture du texte.
+                            child: RepaintBoundary(
+                              child: PerspectivesInlineSection(
+                                key: _perspectivesKey,
+                                status: _perspectivesStatus,
+                                perspectives: _inlinePerspectives,
+                                biasDistribution:
+                                    _perspectivesResponse?.biasDistribution ??
+                                        const {},
+                                keywords:
+                                    _perspectivesResponse?.keywords ?? const [],
+                                sourceBiasStance:
+                                    _perspectivesResponse?.sourceBiasStance ??
+                                        'unknown',
+                                sourceName: _content?.source.name ?? '',
+                                contentId: widget.contentId,
+                                comparisonQuality:
+                                    _perspectivesResponse?.comparisonQuality ??
+                                        'low',
+                                divergenceLevel:
+                                    _perspectivesResponse?.divergenceLevel,
+                                partial:
+                                    _perspectivesResponse?.partial ?? false,
+                                onOpenAnalysis: _openPerspectivesAnalysis,
+                              ),
                             ),
                           ),
                           SizedBox(
@@ -3769,22 +3782,26 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                 // invisible) ; large respiration au-dessus pour la détacher.
                 if (_showPerspectivesBand) ...[
                   const SizedBox(height: FacteurSpacing.space8),
-                  PerspectivesInlineSection(
-                    key: _perspectivesKey,
-                    status: _perspectivesStatus,
-                    perspectives: _inlinePerspectives,
-                    biasDistribution:
-                        _perspectivesResponse?.biasDistribution ?? const {},
-                    keywords: _perspectivesResponse?.keywords ?? const [],
-                    sourceBiasStance:
-                        _perspectivesResponse?.sourceBiasStance ?? 'unknown',
-                    sourceName: _content?.source.name ?? '',
-                    contentId: widget.contentId,
-                    comparisonQuality:
-                        _perspectivesResponse?.comparisonQuality ?? 'low',
-                    divergenceLevel: _perspectivesResponse?.divergenceLevel,
-                    partial: _perspectivesResponse?.partial ?? false,
-                    onOpenAnalysis: _openPerspectivesAnalysis,
+                  RepaintBoundary(
+                    // Isole les animations d'intro de la bande perspectives du
+                    // corps vertical au-dessus (même motif que le reader natif).
+                    child: PerspectivesInlineSection(
+                      key: _perspectivesKey,
+                      status: _perspectivesStatus,
+                      perspectives: _inlinePerspectives,
+                      biasDistribution:
+                          _perspectivesResponse?.biasDistribution ?? const {},
+                      keywords: _perspectivesResponse?.keywords ?? const [],
+                      sourceBiasStance:
+                          _perspectivesResponse?.sourceBiasStance ?? 'unknown',
+                      sourceName: _content?.source.name ?? '',
+                      contentId: widget.contentId,
+                      comparisonQuality:
+                          _perspectivesResponse?.comparisonQuality ?? 'low',
+                      divergenceLevel: _perspectivesResponse?.divergenceLevel,
+                      partial: _perspectivesResponse?.partial ?? false,
+                      onOpenAnalysis: _openPerspectivesAnalysis,
+                    ),
                   ),
                 ],
 
@@ -4269,85 +4286,6 @@ class _ShimmerSkeletonState extends State<_ShimmerSkeleton>
         crossAxisAlignment: CrossAxisAlignment.stretch,
         mainAxisSize: MainAxisSize.min,
         children: widget.children,
-      ),
-    );
-  }
-}
-
-class _FadeScrollRow extends StatefulWidget {
-  final List<Widget> children;
-
-  const _FadeScrollRow({required this.children});
-
-  @override
-  State<_FadeScrollRow> createState() => _FadeScrollRowState();
-}
-
-class _FadeScrollRowState extends State<_FadeScrollRow> {
-  final _controller = ScrollController();
-  bool _atStart = true;
-  bool _atEnd = false;
-  bool _pointerDown = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _controller.addListener(_onScroll);
-    WidgetsBinding.instance.addPostFrameCallback((_) => _onScroll());
-  }
-
-  void _onScroll() {
-    if (!_controller.hasClients) return;
-    final pos = _controller.position;
-    final atStart = pos.pixels <= 0;
-    final atEnd = pos.pixels >= pos.maxScrollExtent;
-    if (atStart != _atStart || atEnd != _atEnd) {
-      setState(() {
-        _atStart = atStart;
-        _atEnd = atEnd;
-      });
-    }
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: double.infinity,
-      child: PopScope(
-        canPop: _atStart || !_pointerDown,
-        child: Listener(
-          onPointerDown: (_) => setState(() => _pointerDown = true),
-          onPointerUp: (_) => setState(() => _pointerDown = false),
-          onPointerCancel: (_) => setState(() => _pointerDown = false),
-          child: ShaderMask(
-            shaderCallback: (bounds) => LinearGradient(
-              begin: Alignment.centerLeft,
-              end: Alignment.centerRight,
-              colors: [
-                _atStart ? Colors.white : Colors.transparent,
-                Colors.white,
-                Colors.white,
-                _atEnd ? Colors.white : Colors.transparent,
-              ],
-              stops: const [0.0, 0.12, 0.82, 1.0],
-            ).createShader(bounds),
-            blendMode: BlendMode.dstIn,
-            child: NotificationListener<ScrollNotification>(
-              onNotification: (_) => true,
-              child: SingleChildScrollView(
-                controller: _controller,
-                scrollDirection: Axis.horizontal,
-                child: Row(spacing: 6, children: widget.children),
-              ),
-            ),
-          ),
-        ),
       ),
     );
   }

--- a/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
+++ b/apps/mobile/lib/features/feed/widgets/perspectives_bottom_sheet.dart
@@ -2011,6 +2011,16 @@ class _PerspectivesInlineSectionState
   Widget _buildCarousel(List<Perspective> variants) {
     // Sources suivies → résolution par domaine pour rendre la pastille cliquable.
     final sources = ref.watch(userSourcesProvider).valueOrNull;
+    // RepaintBoundary explicite par carte (et par CTA). `FacteurCard` n'isole
+    // ses cartes que via `webRepaintBoundary`, un no-op hors web
+    // (cf. core/web/web_perf.dart) : sur natif, sans ce boundary, tout le Row se
+    // re-rastérisait à chaque frame de translation (ombre blurRadius 6 +
+    // DiffTitle multi-span + favicon par carte). Ces boundaries confinent le
+    // raster de chaque carte à son propre layer, réutilisé tel quel pendant le
+    // scroll. On garde SingleChildScrollView+Row (carrousel court, ≤8 cartes) :
+    // build eager → `maxScrollExtent` exact pour le tap-to-scroll de la barre de
+    // biais (`_onSpectrumSegmentTap`) et zéro hitch de construction paresseuse
+    // en cours de défilement (ce qu'introduirait une ListView virtualisée ici).
     return SizedBox(
       height: _kCarouselViewportHeight,
       child: SingleChildScrollView(
@@ -2027,21 +2037,25 @@ class _PerspectivesInlineSectionState
           children: [
             // Carte CTA « Analyse Facteur » en tête du carrousel (avant les
             // cartes sources) : toujours rendue, le tap déclenche un fetch lazy.
-            _AnalysisCtaCard(
-              onTap: widget.onOpenAnalysis,
-              count: _displayedPerspectives.length,
+            RepaintBoundary(
+              child: _AnalysisCtaCard(
+                onTap: widget.onOpenAnalysis,
+                count: _displayedPerspectives.length,
+              ),
             ),
             if (variants.isNotEmpty) const SizedBox(width: _kCoverageCardGap),
             for (var i = 0; i < variants.length; i++) ...[
               if (i > 0) const SizedBox(width: _kCoverageCardGap),
-              CoverageComparisonCard(
-                key: ValueKey('coverage_${_animationGeneration}_$i'),
-                perspective: variants[i],
-                firstCardKey: i == 0 ? widget.firstCardKey : null,
-                onSourceTap: _sourceTapFor(
-                  context,
-                  sources,
-                  variants[i].sourceDomain,
+              RepaintBoundary(
+                child: CoverageComparisonCard(
+                  key: ValueKey('coverage_${_animationGeneration}_$i'),
+                  perspective: variants[i],
+                  firstCardKey: i == 0 ? widget.firstCardKey : null,
+                  onSourceTap: _sourceTapFor(
+                    context,
+                    sources,
+                    variants[i].sourceDomain,
+                  ),
                 ),
               ),
             ],
@@ -2061,12 +2075,15 @@ class _PerspectivesInlineSectionState
         scrollDirection: Axis.horizontal,
         physics: NeverScrollableScrollPhysics(),
         padding: EdgeInsets.fromLTRB(18, 15, 18, 16),
+        // RepaintBoundary par squelette : isole le shimmer (animation continue)
+        // de son voisin. Row conservé (2 items fixes, non défilants) plutôt
+        // qu'une ListView non scrollable qui n'apporterait rien ici.
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            _CoverageCardSkeleton(),
+            RepaintBoundary(child: _CoverageCardSkeleton()),
             SizedBox(width: 13),
-            _CoverageCardSkeleton(),
+            RepaintBoundary(child: _CoverageCardSkeleton()),
           ],
         ),
       ),

--- a/docs/maintenance/maintenance-reader-scroll-carrousel-repaint.md
+++ b/docs/maintenance/maintenance-reader-scroll-carrousel-repaint.md
@@ -1,0 +1,97 @@
+# Maintenance — Fluidité scroll readers : isolation raster (carrousel + chrome vertical)
+
+> Type : Maintenance (perf). Surface : 100 % Dart mobile. Branche : `boujonlaurin-dotcom/reader-scroll-fluidity`.
+> Regroupe **PR 1** (carrousel horizontal + nettoyage) **et PR 2** (audit V1 + micro-fix) du plan
+> `.context/attachments/97Nbws/plan.md` en une seule PR, à la demande du PO.
+
+## Contexte
+
+Léger jank au scroll dans les readers, sous la barre de qualité :
+- **Horizontal** — carrousel « comparaison de points de vue » (symptôme le plus aigu).
+- **Vertical** — corps d'article + chrome (le PO confirme le jank sur des articles **sans** carrousel).
+
+Acquis antérieurs : PR #962/#963 (blur au repos, cache offsets, dédup progression, barre sans
+TweenAnimationBuilder, déferral WebView), PR #970 (BackdropFilter retiré). Le chrome vertical est
+déjà propre en steady-state (header à hauteur constante, footer composité en `Transform.translate`,
+progression via `ValueNotifier`+`RepaintBoundary`, pas de `setState` par frame).
+
+## Insight central (vérifié dans le code)
+
+`FacteurCard` n'isole ses cartes que via `webRepaintBoundary` /`webShadows`
+(`core/web/web_perf.dart:52,37`), **no-op hors web** (`if (!kWebPerf) return child;`). Donc sur
+iOS/Android natif **aucune** carte du carrousel n'était isolée : tout le `Row` (jusqu'à 8
+`CoverageComparisonCard`, chacune avec ombre `blurRadius: 6` + `DiffTitle` multi-span + favicon)
+pouvait se re-rastériser ensemble à chaque frame de translation. Le code *croyait* isoler les cartes,
+mais seulement sur web.
+
+## Changements
+
+### PR 1 — Carrousel + nettoyage (`perspectives_bottom_sheet.dart`, `content_detail_screen.dart`)
+
+1. **`RepaintBoundary` explicite par carte + par CTA** dans `_buildCarousel` (le vrai
+   `RepaintBoundary`, pas le helper web-only). Chaque carte devient son propre layer, composité tel
+   quel pendant le scroll → plus de re-raster du Row entier. `RepaintBoundary` est invisible → zéro
+   impact visuel.
+2. **`RepaintBoundary` par squelette** dans `_buildLoadingSkeleton` pour isoler le shimmer (animation
+   continue) de son voisin.
+3. **N2** — `RepaintBoundary` autour des deux `PerspectivesInlineSection` du reader
+   (`content_detail_screen.dart`, chemin natif + chemin WebView) pour isoler les animations d'intro
+   de la bande (`AnimatedOpacity`/`AnimatedSize`, fondu carrousel) du corps vertical au-dessus.
+4. **Nettoyage** — suppression de `_FadeScrollRow` (code mort : classe définie, jamais instanciée ;
+   le `ShaderMask`+`setState` par scroll qu'un agent avait pris pour une source de jank ne tournait
+   pas). −82 lignes.
+
+#### Décision : H1 (Row + RepaintBoundary) plutôt que H2 (ListView virtualisée)
+
+Le plan proposait de remplacer `SingleChildScrollView`+`Row` par une `ListView.builder` horizontale
+(H2, « superset » de H1). L'implémentation H2 a été écrite puis **écartée** après analyse : pour un
+carrousel court (≤ 8 cartes), la virtualisation introduit deux régressions que H1 évite :
+
+- **`maxScrollExtent` devient une *estimation*** tant que la liste n'a pas été défilée jusqu'au bout
+  → `_onSpectrumSegmentTap` (tap sur la barre de biais) sous-scrollerait le segment le plus à droite.
+  Le `Row` est layouté en entier → extent **exact** aujourd'hui.
+- **Hitch de construction paresseuse** : une `ListView` construit/peint chaque carte quand elle entre
+  dans le viewport → drop de frame *pendant* le scroll qu'on cherche justement à lisser.
+
+H1 délivre le gain cœur (isolation par carte sur natif) avec **zéro risque comportemental et zéro
+churn de test** (le `CrossAxisAlignment.stretch` du Row continue de borner la hauteur des cartes,
+l'extent reste exact). Le culling lazy ne vaut ~rien pour 8 cartes et les layers `RepaintBoundary`
+sont de toute façon réutilisés à la translation.
+
+### PR 2 — Audit V1 + micro-fix (`content_detail_screen.dart`)
+
+- **N3** — `RepaintBoundary` autour du `Transform.scale` animé par `_ctaPulseController`. NB : ce pulse
+  est un **one-shot 280 ms** (`forward(from: 0)` au passage `_footerPermanent` → orange), **pas** une
+  animation répétée pendant la lecture comme le supposait le plan. Le boundary confine son raster au
+  bouton si le pulse coïncide avec un scroll.
+- **`PivotWashTitle` : key laissée telle quelle.** Sa key (`ValueKey('article-title-wash-$_showPivot-
+  ...pivot.start-...end')`) est rekeyée **intentionnellement** à l'arrivée de `_perspectivesResponse`
+  pour relancer l'animation de « wash ». C'est une mutation **async** (one-time), pas du jank par
+  frame de scroll. La « stabiliser » (suggestion conditionnelle du plan) casserait le déclencheur
+  d'animation sans bénéfice mesuré → écarté.
+
+## Vérification
+
+- **`flutter analyze`** (fichiers touchés) : **0 nouvelle issue**. Les warnings/infos restants
+  (`_maybeRequestReadOnSiteNudge` non référencé, 7 `unawaited_futures`) sont **pré-existants**, sur
+  des lignes non modifiées.
+- **`flutter test`** (suites `feed/widgets` perspectives + `detail`) : **0 nouvel échec**.
+  Échecs restants tous **confirmés pré-existants via baseline HEAD** (worktree) :
+  - `perspectives_inline_intro_test.dart` « badge à l'échelle 1.0 » : source hardcode `scale: 1.6`
+    (`perspectives_bottom_sheet.dart:1985`), test attend `1.0` — non touché par ce diff.
+  - `perspectives_bottom_sheet_intro_test.dart` « phrase d'intro présente » : échoue déjà sur HEAD.
+  - `notification_test.dart` : 4 stubs `fail(...)` pré-existants (−4 constant).
+- **Profiling (preuve du gain) : étape PO device.** Le gain perf **ne se mesure pas sur web**
+  (CanvasKit). À faire en `flutter run --profile` overlay perf, viser **< 16 ms/frame**, sur un long
+  article (The Conversation / Le Grand Continent) + le carrousel « comparaison de points de vue ».
+
+## Hors scope (non inclus dans cette PR)
+
+- **PR 3 / V2 — virtualisation du corps `flutter_html`.** C'est **le** levier pour le jank du *corps*
+  des articles sans carrousel (rasterisation d'un seul arbre `flutter_html` très haut). Non engagé
+  ici (risque plus élevé : casse `_measureArticleExtent` + le marqueur `_articleEndKey`, cf. N4 du
+  plan). À ouvrir si le profiling on-device montre encore > 16 ms/frame sur longs articles après ce
+  lot.
+- **V3** (renderer maison / `flutter_widget_from_html_core`) — dernier recours.
+- Activer `webRepaintBoundary`/`webShadows` sur mobile globalement (N1) — blast radius trop large ;
+  on se limite au point chaud (carrousel).


### PR DESCRIPTION
## perf(reader) — isolation raster : cartes carrousel + chrome vertical (RepaintBoundary natif)

Regroupe **PR 1 + PR 2** du plan fluidité scroll (`.context/attachments/97Nbws/plan.md`) en une
seule PR, à la demande du PO. 100 % Dart mobile — aucun backend, aucune migration.

### Problème

`FacteurCard` n'isole ses cartes que via `webRepaintBoundary` (`core/web/web_perf.dart:52`),
**no-op hors web**. Sur natif, aucune carte du carrousel « comparaison de points de vue » n'était
donc isolée : tout le `Row` (≤ 8 cartes, chacune ombre `blurRadius: 6` + `DiffTitle` multi-span +
favicon) pouvait se re-rastériser à chaque frame de translation.

### Changements

**PR 1 — carrousel + nettoyage**
- `RepaintBoundary` explicite par carte + par CTA dans `_buildCarousel` (le vrai boundary, pas le
  helper web-only) → chaque carte = son layer, composité tel quel au scroll. Invisible.
- `RepaintBoundary` par squelette dans `_buildLoadingSkeleton` (isole le shimmer).
- `RepaintBoundary` autour des 2 `PerspectivesInlineSection` (N2) → isole les animations d'intro de
  la bande du corps vertical.
- Suppression de `_FadeScrollRow` (code mort, jamais instancié). −82 lignes.
- **Choix H1 (Row + RepaintBoundary) plutôt que H2 (ListView virtualisée)** : pour ≤ 8 cartes, la
  virtualisation rendrait `maxScrollExtent` estimé (casse le tap-to-scroll de la barre de biais) et
  introduirait des hitches de build en cours de scroll. H1 délivre le gain cœur sans ces risques.
  Détail dans `docs/maintenance/maintenance-reader-scroll-carrousel-repaint.md`.

**PR 2 — audit V1 + micro-fix**
- `RepaintBoundary` autour du `Transform.scale` du `_ctaPulseController` (N3). NB : pulse one-shot
  280 ms, pas une animation répétée.
- `PivotWashTitle` : key laissée telle quelle (rekey intentionnel qui pilote l'animation « wash » ;
  la toucher casserait l'anim sans gain mesuré).

### Vérification

- `flutter analyze` (fichiers touchés) : 0 nouvelle issue (warnings restants pré-existants).
- `flutter test` (perspectives `feed/widgets` + `detail`) : 0 nouvel échec. Les échecs restants
  (badge `scale: 1.6` vs test `1.0` ; phrase d'intro ; 4 stubs `notification_test`) sont
  **confirmés pré-existants via baseline HEAD**.
- ⚠️ **Profiling < 16 ms/frame = étape PO device** : le gain ne se mesure pas sur web (CanvasKit).
  À vérifier en `flutter run --profile` (long article + carrousel).

### Hors scope

PR 3 / V2 (virtualisation du corps `flutter_html`) — **le** levier pour le jank du corps des
articles sans carrousel — non inclus (risque plus élevé, casse `_measureArticleExtent`). À ouvrir si
le profiling montre encore > 16 ms/frame sur longs articles après ce lot.
