### PR TITLE
fix(sources): débloque la promotion catalogue + garde-fou marque (WS1)

### DIFF
--- a/docs/maintenance/maintenance-source-promotion-pipeline.md
+++ b/docs/maintenance/maintenance-source-promotion-pipeline.md
@@ -1,0 +1,84 @@
+# Maintenance — Débloquer le pipeline de promotion des sources (WS1)
+
+> PR A du plan « Enrichir le pool de sources par thème ». Débloque le backlog de
+> sources évaluées bloquées en Tier 3 et empêche le backlog de se reformer.
+
+## Contexte
+
+Le footer « Étoffer [thème] » ne pousse que des sources `is_curated=true`. La
+promotion vers ce catalogue passe par `scripts/retag_and_promote_sources.py`,
+mais ce script ne tournait **qu'au lancement manuel** → un backlog de ~160
+sources actives + évaluées (biais connu, fiabilité medium/high) restait
+invisible à la reco. Diagnostic complet : plan `sources-theme-coverage`.
+
+## Décision PO (2026-07-22) — garde-fou image de marque
+
+La promotion automatique ne peut pas juger la valeur éditoriale d'une source ;
+on a donc resserré le gate **avant** de vider le backlog :
+
+1. **Exclusion `alternative`** — le gate de promotion n'excluait que `unknown`,
+   alors que le gate de recommandation (`source_recommendation_gate`) exclut
+   `alternative` ET `unknown`. Une source `alternative` pouvait donc être
+   stampée `is_curated=true` (catalogue, admin, CSV master) sans jamais remonter
+   dans « Étoffer ». Corrigé : `PROMO_EXCLUDED_BIAS = {unknown, alternative}`,
+   miroir de `QUALITY_CATALOG_EXCLUDED_BIAS` (test de garde `test_excluded_bias_
+   mirrors_reco_gate`). Sort **Élucid** automatiquement. `specialized`
+   (sport/tech/science) reste promouvable : c'est un biais thématique.
+
+2. **Denylist éditoriale** (`PROMO_DENYLIST`, 12 URLs) — sources qui passent le
+   gate automatique mais dont la promotion se discute : blogs corpo/vendor
+   (Hugging Face, The Stack/Humanloop), newsletters/agrégateurs (TLDR, Lenny's,
+   Latent Space, Towards Data Science, Korben), hyper-niche (Reggae.fr,
+   H2-mobile, Vertige Media), data aggregator (Statista), ONG militante
+   (Amnesty). Réversible : retirer la ligne du dict.
+
+**Résultat : 51 sources promues** (64 candidates au seuil ≥20 art/30j − 1
+`alternative` − 12 denylist). Liste gelée : `.context/promotion-confirmed-list.md`.
+
+## Changements
+
+- `scripts/retag_and_promote_sources.py`
+  - `PROMO_EXCLUDED_BIAS`, `PROMO_DENYLIST[_RAW]`, `_norm_url` remonté.
+  - `is_promotable` / `compute_plan` : exclusion biais + denylist (paramétrables).
+  - `write_promotions` extrait de `write_plan` (promotions seules, réutilisable).
+- `app/jobs/promote_sources_job.py` — `promote_evaluated_sources()` : read →
+  `compute_plan` → `write_promotions`. **Promotions seules** (ne touche pas
+  `granular_topics`, réservé au run manuel + revue CSV). Idempotent, best-effort.
+- `app/workers/scheduler.py` — job hebdo dimanche 04h00 Paris (après le recalcul
+  de couverture 03h45). Empêche le backlog de se reformer.
+
+## Sécurité migrations / DB partagée
+
+Aucun DDL → pas de migration Alembic. La promotion est **additive**
+(`is_curated` false→true), sûre pour le backend prod (ancien code) qui lit la
+même colonne via son propre gate de reco. Le job n'est planifié que dans `main` ;
+`production` l'obtiendra à la prochaine release hebdo, déjà avec le gate corrigé.
+
+## Vérification
+
+- `pytest tests/scripts/test_retag_and_promote_sources.py` (29 tests, dont
+  `alternative` exclu, `specialized` gardé, denylist, garde miroir reco-gate).
+- Import scheduler + job OK.
+- Liste finale des 51 produite en lecture seule contre la DB prod.
+
+## Appliquer le backlog en prod (post-merge)
+
+Le job hebdo videra le backlog dimanche ; pour l'appliquer immédiatement :
+
+```bash
+cd packages/api
+DATABASE_URL=<prod> python3 scripts/retag_and_promote_sources.py            # dry-run
+DATABASE_URL=<prod> python3 scripts/retag_and_promote_sources.py --apply --allow-prod
+```
+
+Backup JSON écrit dans `.context/` avant mutation (rollback : `is_curated=false`
+sur les IDs listés).
+
+## Suivi (hors périmètre PR A)
+
+- **WS1b — seuil adaptatif thèmes maigres** (science/sport/politics, ~22
+  spécialistes 5–19 art/30j) : reporté, **exige une revue de liste PO** (promeut
+  des sources non revues).
+- **WS2** — colonne pondérée `coverage_theme_weights` + tri des suggestions.
+- Corriger le `theme` mal étiqueté de plusieurs sources (L'Humanité→tech,
+  Basket USA→tech, Science & Vie→tech…) pour le tri par thème de WS2.

--- a/packages/api/app/jobs/promote_sources_job.py
+++ b/packages/api/app/jobs/promote_sources_job.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import structlog
 
 from app.database import safe_async_session
-from scripts.retag_and_promote_sources import (
+from app.services.source_promotion import (
     compute_promotions,
     load_metas,
     write_promotions,
@@ -47,9 +47,7 @@ async def promote_evaluated_sources() -> None:
             promotions = compute_promotions(metas)
 
             if not promotions:
-                logger.info(
-                    "source_promotion_no_candidates", active_sources=len(metas)
-                )
+                logger.info("source_promotion_no_candidates", active_sources=len(metas))
                 return
 
             await write_promotions(session, promotions)

--- a/packages/api/app/jobs/promote_sources_job.py
+++ b/packages/api/app/jobs/promote_sources_job.py
@@ -1,0 +1,68 @@
+"""Job hebdo : promotion catalogue (`is_curated`) du backlog évalué.
+
+Cause racine du sous-fonctionnement (cf. plan sources-theme-coverage) : la
+promotion des sources évaluées vers le catalogue curé ne tournait qu'au
+lancement **manuel** de `scripts/retag_and_promote_sources.py`, donc un backlog
+de sources qualité restait invisible à la reco « Étoffer [thème] ». On planifie
+ici la même promotion, en réutilisant la **logique pure + la couche DB** du
+script (une seule source de vérité pour le gate).
+
+Ce job **ne promeut que** (`is_curated=false -> true`) — il ne touche jamais
+`granular_topics` (re-tag réservé au run manuel avec revue du CSV master par le
+PO). Gate strict, aligné sur le gate de recommandation : biais connu **et non
+`alternative`**, fiabilité medium/high, volume >= seuil, et URL hors denylist
+éditoriale (`PROMO_DENYLIST`). Idempotent : `NOT is_curated` filtre les sources
+déjà promues, donc un 2e passage (ou le double run staging+prod sur la DB
+partagée) est un no-op.
+
+⚠️ Additif uniquement (expand-contract, DB partagée staging/prod) : flipper
+`is_curated` à true est sûr pour le backend prod (ancien code) qui lit la même
+colonne via son propre gate de reco.
+"""
+
+from __future__ import annotations
+
+import structlog
+
+from app.database import safe_async_session
+from scripts.retag_and_promote_sources import (
+    compute_promotions,
+    load_metas,
+    write_promotions,
+)
+
+logger = structlog.get_logger()
+
+
+async def promote_evaluated_sources() -> None:
+    """Promeut le backlog de sources évaluées franchissant le gate de promotion.
+
+    Read → `compute_promotions` (gate strict + denylist, sans re-tag ni audit) →
+    apply promotions only. Logue les noms promus (audit Railway/Sentry) ; aucune
+    exception ne remonte au scheduler (best-effort, comme les autres jobs
+    hebdo). `safe_async_session` garantit le rollback en sortie."""
+    try:
+        async with safe_async_session() as session:
+            metas = await load_metas(session)
+            promotions = compute_promotions(metas)
+
+            if not promotions:
+                logger.info(
+                    "source_promotion_no_candidates", active_sources=len(metas)
+                )
+                return
+
+            await write_promotions(session, promotions)
+            await session.commit()
+            logger.info(
+                "source_promotion_applied",
+                count=len(promotions),
+                names=[p.name for p in promotions],
+            )
+    except Exception as exc:
+        logger.error(
+            "source_promotion_failed",
+            error=str(exc),
+            error_type=type(exc).__name__,
+            exc_info=True,
+        )

--- a/packages/api/app/services/source_promotion.py
+++ b/packages/api/app/services/source_promotion.py
@@ -1,0 +1,222 @@
+"""Cœur de la promotion catalogue (`is_curated`) — logique pure + couche DB.
+
+Extrait de `scripts/retag_and_promote_sources.py` pour être importable depuis
+l'app (le job hebdo `app/jobs/promote_sources_job.py`) sans dépendre du package
+`scripts/` — celui-ci n'est pas embarqué dans l'image Docker, donc un
+`from scripts...` au boot plante le conteneur. Le script CLI importe désormais
+d'ici (dépendance script -> app, le bon sens).
+
+Contenu : le gate de promotion (biais/fiabilité/volume/denylist), les
+dataclasses `SourceMeta`/`Promotion`, le sous-plan léger `compute_promotions`
+(promotions seules, sans re-tag ni audit) et les helpers DB `load_metas` /
+`write_promotions`. Le re-tag `granular_topics`, l'audit de couverture et la
+régénération CSV restent dans le script (usage manuel + revue PO).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy import text
+
+from app.services.source_recommendation_gate import QUALITY_CATALOG_EXCLUDED_BIAS
+
+PROMO_WINDOW_DAYS = 30  # fenêtre du volume pour la promotion
+PROMO_MIN_VOLUME = 20  # articles_30d mini pour promouvoir
+PROMO_RELIABILITY = {"medium", "high"}
+# Biais exclus de la promotion. **Dérivé** (pas copié) du gate de RECOMMANDATION
+# `source_recommendation_gate.QUALITY_CATALOG_EXCLUDED_BIAS` -> une seule source
+# de vérité : une source `alternative`/`unknown` ne doit JAMAIS être stampée
+# `is_curated=true` (elle entrerait au catalogue curé sans jamais remonter dans
+# « Étoffer »). `specialized` reste promouvable (biais thématique, pas idéologique).
+PROMO_EXCLUDED_BIAS = frozenset(b.value for b in QUALITY_CATALOG_EXCLUDED_BIAS)
+
+
+def _norm_url(u: str | None) -> str:
+    return (u or "").strip().rstrip("/").lower()
+
+
+# Denylist ÉDITORIALE (décision PO 2026-07-22) : sources qui passent le gate
+# automatique (biais connu + fiabilité medium/high + volume) mais dont la
+# promotion au « catalogue qualité Facteur » se discute — l'auto-promotion ne
+# peut pas juger la valeur éditoriale. On les exclut par URL (normalisée) tant
+# qu'un choix PO explicite ne les réintègre pas. Réversible : retirer la ligne.
+PROMO_DENYLIST_RAW: dict[str, str] = {
+    # Blogs corpo / vendor (contenu promotionnel par nature)
+    "https://huggingface.co/blog": "Blog de Hugging Face (corpo)",
+    "https://thestack.technology/": "The Stack by Humanloop (vendor)",
+    # Newsletters / agrégateurs (pas du reportage primaire)
+    "https://tldr.tech/rss": "TLDR (agrégateur newsletter)",
+    "https://www.lennysnewsletter.com/": "Lenny's Newsletter",
+    "https://www.latent.space/": "Latent Space (newsletter)",
+    "https://towardsdatascience.com": "Towards Data Science (Medium UGC)",
+    "https://korben.info/feed": "Korben (blog perso)",
+    # Hyper-niche / hors ligne éditoriale
+    "https://www.reggae.fr/dev/rss/news.php": "Reggae.fr (niche musique)",
+    "https://www.h2-mobile.fr/feed/": "H2-mobile.fr (niche hydrogène)",
+    "https://www.vertigemedia.fr/blog-feed.xml": "Vertige Media (niche)",
+    # Data aggregator
+    "https://www.statista.com": "Statista (agrégateur data)",
+    # ONG militante (pas un média d'information)
+    "https://www.amnesty.org/": "Amnesty International (ONG)",
+}
+PROMO_DENYLIST = frozenset(_norm_url(u) for u in PROMO_DENYLIST_RAW)
+
+
+@dataclass
+class SourceMeta:
+    source_id: str
+    name: str
+    url: str
+    theme: str | None
+    type: str
+    is_curated: bool
+    bias_stance: str
+    reliability_score: str
+    description: str | None
+    score_independence: float | None
+    score_rigor: float | None
+    score_ux: float | None
+    source_tier: str
+    granular_topics: list[str] | None
+    articles_30d: int
+
+
+@dataclass
+class Promotion:
+    source_id: str
+    name: str
+    url: str
+    theme: str | None
+    type: str
+    bias_stance: str
+    reliability_score: str
+    description: str | None
+    score_independence: float | None
+    score_rigor: float | None
+    score_ux: float | None
+    source_tier: str
+    granular_topics: list[str] | None
+    articles_30d: int
+
+
+def is_promotable(
+    m: SourceMeta,
+    *,
+    min_volume: int = PROMO_MIN_VOLUME,
+    reliability_set: set[str] = PROMO_RELIABILITY,
+    excluded_bias: frozenset[str] = PROMO_EXCLUDED_BIAS,
+    denylist: frozenset[str] = PROMO_DENYLIST,
+) -> bool:
+    """Source évaluée + productive, non curée, non denylistée : candidate.
+
+    Biais **connu et non alternatif** (aligné sur le gate de recommandation),
+    fiabilité medium/high, volume suffisant, et pas dans la denylist éditoriale.
+    """
+    return (
+        not m.is_curated
+        and m.bias_stance not in excluded_bias
+        and m.reliability_score in reliability_set
+        and m.articles_30d >= min_volume
+        and _norm_url(m.url) not in denylist
+    )
+
+
+def _to_promotion(m: SourceMeta, granular_topics: list[str] | None) -> Promotion:
+    """Projette une source promue en `Promotion` (report / CSV / DB)."""
+    return Promotion(
+        source_id=m.source_id,
+        name=m.name,
+        url=m.url,
+        theme=m.theme,
+        type=m.type,
+        bias_stance=m.bias_stance,
+        reliability_score=m.reliability_score,
+        description=m.description,
+        score_independence=m.score_independence,
+        score_rigor=m.score_rigor,
+        score_ux=m.score_ux,
+        source_tier=m.source_tier,
+        granular_topics=granular_topics,
+        articles_30d=m.articles_30d,
+    )
+
+
+def compute_promotions(
+    metas: list[SourceMeta],
+    *,
+    min_volume: int = PROMO_MIN_VOLUME,
+    reliability_set: set[str] = PROMO_RELIABILITY,
+    excluded_bias: frozenset[str] = PROMO_EXCLUDED_BIAS,
+    denylist: frozenset[str] = PROMO_DENYLIST,
+) -> list[Promotion]:
+    """Sous-plan léger « promotions seules » — sans dériver `granular_topics`
+    ni auditer la couverture. Utilisé par le job hebdo (qui ne réécrit que
+    `is_curated`) ; conserve `granular_topics` tel quel (jamais écrit)."""
+    return [
+        _to_promotion(m, m.granular_topics)
+        for m in metas
+        if is_promotable(
+            m,
+            min_volume=min_volume,
+            reliability_set=reliability_set,
+            excluded_bias=excluded_bias,
+            denylist=denylist,
+        )
+    ]
+
+
+async def load_metas(session) -> list[SourceMeta]:
+    sql = text(
+        f"""
+        SELECT s.id, s.name, s.url, s.theme, s.type, s.is_curated,
+               s.bias_stance, s.reliability_score, s.description,
+               s.score_independence, s.score_rigor, s.score_ux,
+               s.source_tier, s.granular_topics,
+               COALESCE(a30.n, 0) AS articles_30d
+        FROM sources s
+        LEFT JOIN (
+            SELECT source_id, COUNT(*) AS n
+            FROM contents
+            WHERE published_at >= now() - interval '{PROMO_WINDOW_DAYS} days'
+            GROUP BY source_id
+        ) a30 ON a30.source_id = s.id
+        WHERE s.is_active
+        """
+    )
+    result = await session.execute(sql)
+    metas: list[SourceMeta] = []
+    for r in result.mappings():
+        metas.append(
+            SourceMeta(
+                source_id=str(r["id"]),
+                name=r["name"],
+                url=r["url"],
+                theme=r["theme"],
+                type=str(r["type"]),
+                is_curated=bool(r["is_curated"]),
+                bias_stance=str(r["bias_stance"]),
+                reliability_score=str(r["reliability_score"]),
+                description=r["description"],
+                score_independence=r["score_independence"],
+                score_rigor=r["score_rigor"],
+                score_ux=r["score_ux"],
+                source_tier=r["source_tier"] or "mainstream",
+                granular_topics=list(r["granular_topics"])
+                if r["granular_topics"]
+                else None,
+                articles_30d=int(r["articles_30d"]),
+            )
+        )
+    return metas
+
+
+async def write_promotions(session, promotions: list[Promotion]) -> None:
+    """Applique UNIQUEMENT les promotions `is_curated=true` (idempotent).
+
+    Isolé de `write_plan` pour que le job hebdo puisse promouvoir sans toucher
+    `granular_topics` (le re-tag reste réservé au run manuel + revue CSV PO)."""
+    promote_stmt = text("UPDATE sources SET is_curated = true WHERE id = :id")
+    for p in promotions:
+        await session.execute(promote_stmt, {"id": UUID(p.source_id)})

--- a/packages/api/app/workers/scheduler.py
+++ b/packages/api/app/workers/scheduler.py
@@ -12,6 +12,7 @@ from app.jobs.digest_generation_job import (
     compute_digest_coverage,
     run_digest_generation,
 )
+from app.jobs.promote_sources_job import promote_evaluated_sources
 from app.jobs.purge_deleted_users import purge_deleted_users
 from app.jobs.recompute_source_coverage_themes import (
     recompute_source_coverage_themes,
@@ -560,6 +561,22 @@ def start_scheduler() -> None:
         max_instances=1,
     )
 
+    # Promotion catalogue hebdo (is_curated) — dimanche 04h00 Paris, juste après
+    # le recalcul de couverture (03h45). Vide le backlog de sources évaluées
+    # (biais connu non alternatif, fiabilité medium/high, volume >= seuil, hors
+    # denylist éditoriale) vers le catalogue curé de la reco « Étoffer ». Avant,
+    # la promotion ne tournait qu'au lancement manuel du script → backlog
+    # invisible. Idempotent (NOT is_curated), additif (DB partagée staging/prod).
+    scheduler.add_job(
+        promote_evaluated_sources,
+        trigger=CronTrigger(day_of_week="sun", hour=4, minute=0, timezone=_PARIS_TZ),
+        id="promote_evaluated_sources",
+        name="Weekly catalogue promotion (is_curated backlog)",
+        replace_existing=True,
+        coalesce=True,
+        max_instances=1,
+    )
+
     # Projection budget coût API externes (évidence G3 scaling) : conso du mois
     # courant par provider/call_site + projection ×2.25 (89→200 users), loguée
     # une fois par jour. Read-only, ne change aucun comportement.
@@ -649,6 +666,7 @@ def start_scheduler() -> None:
             "recompute_source_language",
             "rescue_failed_sources",
             "recompute_source_coverage_themes",
+            "promote_evaluated_sources",
             "zombie_session_sweeper",
             "pool_health_probe",
             "daily_essentiel_push_dispatch",

--- a/packages/api/scripts/retag_and_promote_sources.py
+++ b/packages/api/scripts/retag_and_promote_sources.py
@@ -17,8 +17,10 @@ Deux composants, un seul rapport :
       l'ancien vocab — jamais de wipe d'un vrai spécialiste mince.
 
   A2. **Promotion catalogue** — `is_active AND NOT is_curated` avec
-      `bias_stance <> 'unknown'` **et** `reliability_score IN {medium,high}`
-      **et** `articles_30d >= MIN_VOLUME` -> `is_curated = true`.
+      `bias_stance NOT IN {unknown, alternative}` (aligné sur le gate de
+      recommandation) **et** `reliability_score IN {medium,high}` **et**
+      `articles_30d >= MIN_VOLUME` **et** URL hors `PROMO_DENYLIST` (exclusions
+      éditoriales PO) -> `is_curated = true`.
 
 Sorties : (a) mutation DB gatée + backup JSON ; (b) `--write-csv` régénère les
 colonnes `granular_topics`/`Status` de `sources/sources_master.csv` (relisible
@@ -55,6 +57,7 @@ from sqlalchemy import text
 from app.config import get_settings
 from app.database import async_session_maker, engine
 from app.services.ml.classification_service import VALID_TOPIC_SLUGS
+from app.services.source_recommendation_gate import QUALITY_CATALOG_EXCLUDED_BIAS
 from scripts.cleanup_orphan_sources import _is_test_db
 
 # --------------------------------------------------------------------------- #
@@ -68,6 +71,43 @@ TOP_K = 6  # nb max de spécialités gardées (par share desc)
 PROMO_WINDOW_DAYS = 30  # fenêtre du volume pour la promotion
 PROMO_MIN_VOLUME = 20  # articles_30d mini pour promouvoir
 PROMO_RELIABILITY = {"medium", "high"}
+# Biais exclus de la promotion. **Dérivé** (pas copié) du gate de RECOMMANDATION
+# `source_recommendation_gate.QUALITY_CATALOG_EXCLUDED_BIAS` -> une seule source
+# de vérité : une source `alternative`/`unknown` ne doit JAMAIS être stampée
+# `is_curated=true` (elle entrerait au catalogue curé sans jamais remonter dans
+# « Étoffer »). `specialized` reste promouvable (biais thématique, pas idéologique).
+PROMO_EXCLUDED_BIAS = frozenset(b.value for b in QUALITY_CATALOG_EXCLUDED_BIAS)
+
+
+def _norm_url(u: str | None) -> str:
+    return (u or "").strip().rstrip("/").lower()
+
+
+# Denylist ÉDITORIALE (décision PO 2026-07-22) : sources qui passent le gate
+# automatique (biais connu + fiabilité medium/high + volume) mais dont la
+# promotion au « catalogue qualité Facteur » se discute — l'auto-promotion ne
+# peut pas juger la valeur éditoriale. On les exclut par URL (normalisée) tant
+# qu'un choix PO explicite ne les réintègre pas. Réversible : retirer la ligne.
+PROMO_DENYLIST_RAW: dict[str, str] = {
+    # Blogs corpo / vendor (contenu promotionnel par nature)
+    "https://huggingface.co/blog": "Blog de Hugging Face (corpo)",
+    "https://thestack.technology/": "The Stack by Humanloop (vendor)",
+    # Newsletters / agrégateurs (pas du reportage primaire)
+    "https://tldr.tech/rss": "TLDR (agrégateur newsletter)",
+    "https://www.lennysnewsletter.com/": "Lenny's Newsletter",
+    "https://www.latent.space/": "Latent Space (newsletter)",
+    "https://towardsdatascience.com": "Towards Data Science (Medium UGC)",
+    "https://korben.info/feed": "Korben (blog perso)",
+    # Hyper-niche / hors ligne éditoriale
+    "https://www.reggae.fr/dev/rss/news.php": "Reggae.fr (niche musique)",
+    "https://www.h2-mobile.fr/feed/": "H2-mobile.fr (niche hydrogène)",
+    "https://www.vertigemedia.fr/blog-feed.xml": "Vertige Media (niche)",
+    # Data aggregator
+    "https://www.statista.com": "Statista (agrégateur data)",
+    # ONG militante (pas un média d'information)
+    "https://www.amnesty.org/": "Amnesty International (ONG)",
+}
+PROMO_DENYLIST = frozenset(_norm_url(u) for u in PROMO_DENYLIST_RAW)
 
 # Vocab hérité (sources.granular_topics) -> 51-slugs valides. Appliqué AVANT le
 # purge dans `resolve_new_topics` : sans cette map, une source à faible activité
@@ -246,14 +286,65 @@ def is_promotable(
     *,
     min_volume: int = PROMO_MIN_VOLUME,
     reliability_set: set[str] = PROMO_RELIABILITY,
+    excluded_bias: frozenset[str] = PROMO_EXCLUDED_BIAS,
+    denylist: frozenset[str] = PROMO_DENYLIST,
 ) -> bool:
-    """Source évaluée + productive, non encore curée : candidate à la promotion."""
+    """Source évaluée + productive, non curée, non denylistée : candidate.
+
+    Biais **connu et non alternatif** (aligné sur le gate de recommandation),
+    fiabilité medium/high, volume suffisant, et pas dans la denylist éditoriale.
+    """
     return (
         not m.is_curated
-        and m.bias_stance != "unknown"
+        and m.bias_stance not in excluded_bias
         and m.reliability_score in reliability_set
         and m.articles_30d >= min_volume
+        and _norm_url(m.url) not in denylist
     )
+
+
+def _to_promotion(m: SourceMeta, granular_topics: list[str] | None) -> Promotion:
+    """Projette une source promue en `Promotion` (report / CSV / DB)."""
+    return Promotion(
+        source_id=m.source_id,
+        name=m.name,
+        url=m.url,
+        theme=m.theme,
+        type=m.type,
+        bias_stance=m.bias_stance,
+        reliability_score=m.reliability_score,
+        description=m.description,
+        score_independence=m.score_independence,
+        score_rigor=m.score_rigor,
+        score_ux=m.score_ux,
+        source_tier=m.source_tier,
+        granular_topics=granular_topics,
+        articles_30d=m.articles_30d,
+    )
+
+
+def compute_promotions(
+    metas: list[SourceMeta],
+    *,
+    min_volume: int = PROMO_MIN_VOLUME,
+    reliability_set: set[str] = PROMO_RELIABILITY,
+    excluded_bias: frozenset[str] = PROMO_EXCLUDED_BIAS,
+    denylist: frozenset[str] = PROMO_DENYLIST,
+) -> list[Promotion]:
+    """Sous-plan léger « promotions seules » — sans dériver `granular_topics`
+    ni auditer la couverture. Utilisé par le job hebdo (qui ne réécrit que
+    `is_curated`) ; conserve `granular_topics` tel quel (jamais écrit)."""
+    return [
+        _to_promotion(m, m.granular_topics)
+        for m in metas
+        if is_promotable(
+            m,
+            min_volume=min_volume,
+            reliability_set=reliability_set,
+            excluded_bias=excluded_bias,
+            denylist=denylist,
+        )
+    ]
 
 
 def compute_plan(
@@ -266,6 +357,8 @@ def compute_plan(
     top_k: int = TOP_K,
     min_volume: int = PROMO_MIN_VOLUME,
     reliability_set: set[str] = PROMO_RELIABILITY,
+    excluded_bias: frozenset[str] = PROMO_EXCLUDED_BIAS,
+    denylist: frozenset[str] = PROMO_DENYLIST,
     valid_slugs: set[str] = VALID_TOPIC_SLUGS,
 ) -> RetagPlan:
     """Construit le plan complet (changes + promotions + audit) sans I/O."""
@@ -299,28 +392,15 @@ def compute_plan(
             )
 
         promote = is_promotable(
-            m, min_volume=min_volume, reliability_set=reliability_set
+            m,
+            min_volume=min_volume,
+            reliability_set=reliability_set,
+            excluded_bias=excluded_bias,
+            denylist=denylist,
         )
         curated_after[m.source_id] = m.is_curated or promote
         if promote:
-            promotions.append(
-                Promotion(
-                    source_id=m.source_id,
-                    name=m.name,
-                    url=m.url,
-                    theme=m.theme,
-                    type=m.type,
-                    bias_stance=m.bias_stance,
-                    reliability_score=m.reliability_score,
-                    description=m.description,
-                    score_independence=m.score_independence,
-                    score_rigor=m.score_rigor,
-                    score_ux=m.score_ux,
-                    source_tier=m.source_tier,
-                    granular_topics=new_topics,
-                    articles_30d=m.articles_30d,
-                )
-            )
+            promotions.append(_to_promotion(m, new_topics))
 
     coverage_contains, coverage_dominant = _coverage_audit(
         metas, granular_after, curated_after, valid_slugs
@@ -366,10 +446,6 @@ def _coverage_audit(
 # --------------------------------------------------------------------------- #
 # Régénération CSV (pure — testable avec des lignes synthétiques)
 # --------------------------------------------------------------------------- #
-def _norm_url(u: str | None) -> str:
-    return (u or "").strip().rstrip("/").lower()
-
-
 def _is_source_row(row: dict) -> bool:
     name = (row.get("Name") or "").strip()
     url = (row.get("URL") or "").strip()
@@ -548,13 +624,21 @@ async def load_topic_stats(
     return topic_stats, totals
 
 
+async def write_promotions(session, promotions: list[Promotion]) -> None:
+    """Applique UNIQUEMENT les promotions `is_curated=true` (idempotent).
+
+    Isolé de `write_plan` pour que le job hebdo puisse promouvoir sans toucher
+    `granular_topics` (le re-tag reste réservé au run manuel + revue CSV PO)."""
+    promote_stmt = text("UPDATE sources SET is_curated = true WHERE id = :id")
+    for p in promotions:
+        await session.execute(promote_stmt, {"id": UUID(p.source_id)})
+
+
 async def write_plan(session, plan: RetagPlan) -> None:
     topic_stmt = text("UPDATE sources SET granular_topics = :gt WHERE id = :id")
     for c in plan.topic_changes:
         await session.execute(topic_stmt, {"gt": c.new, "id": UUID(c.source_id)})
-    promote_stmt = text("UPDATE sources SET is_curated = true WHERE id = :id")
-    for p in plan.promotions:
-        await session.execute(promote_stmt, {"id": UUID(p.source_id)})
+    await write_promotions(session, plan.promotions)
 
 
 # --------------------------------------------------------------------------- #

--- a/packages/api/scripts/retag_and_promote_sources.py
+++ b/packages/api/scripts/retag_and_promote_sources.py
@@ -57,7 +57,26 @@ from sqlalchemy import text
 from app.config import get_settings
 from app.database import async_session_maker, engine
 from app.services.ml.classification_service import VALID_TOPIC_SLUGS
-from app.services.source_recommendation_gate import QUALITY_CATALOG_EXCLUDED_BIAS
+
+# Cœur de la promotion (gate, dataclasses, DB) extrait dans app/ pour rester
+# importable sans le package `scripts/` (pas embarqué dans l'image Docker).
+# Ré-exporté ici pour l'usage CLI + la compat des imports existants.
+from app.services.source_promotion import (  # noqa: F401
+    PROMO_DENYLIST,
+    PROMO_DENYLIST_RAW,
+    PROMO_EXCLUDED_BIAS,
+    PROMO_MIN_VOLUME,
+    PROMO_RELIABILITY,
+    PROMO_WINDOW_DAYS,
+    Promotion,
+    SourceMeta,
+    _norm_url,
+    _to_promotion,
+    compute_promotions,
+    is_promotable,
+    load_metas,
+    write_promotions,
+)
 from scripts.cleanup_orphan_sources import _is_test_db
 
 # --------------------------------------------------------------------------- #
@@ -67,47 +86,6 @@ WINDOW_DAYS = 90  # fenêtre d'agrégation des articles classés
 MIN_COUNT = 4  # nb mini d'articles taggés d'un topic pour le retenir
 MIN_SHARE = 0.10  # part mini de la production de la source sur ce topic
 TOP_K = 6  # nb max de spécialités gardées (par share desc)
-
-PROMO_WINDOW_DAYS = 30  # fenêtre du volume pour la promotion
-PROMO_MIN_VOLUME = 20  # articles_30d mini pour promouvoir
-PROMO_RELIABILITY = {"medium", "high"}
-# Biais exclus de la promotion. **Dérivé** (pas copié) du gate de RECOMMANDATION
-# `source_recommendation_gate.QUALITY_CATALOG_EXCLUDED_BIAS` -> une seule source
-# de vérité : une source `alternative`/`unknown` ne doit JAMAIS être stampée
-# `is_curated=true` (elle entrerait au catalogue curé sans jamais remonter dans
-# « Étoffer »). `specialized` reste promouvable (biais thématique, pas idéologique).
-PROMO_EXCLUDED_BIAS = frozenset(b.value for b in QUALITY_CATALOG_EXCLUDED_BIAS)
-
-
-def _norm_url(u: str | None) -> str:
-    return (u or "").strip().rstrip("/").lower()
-
-
-# Denylist ÉDITORIALE (décision PO 2026-07-22) : sources qui passent le gate
-# automatique (biais connu + fiabilité medium/high + volume) mais dont la
-# promotion au « catalogue qualité Facteur » se discute — l'auto-promotion ne
-# peut pas juger la valeur éditoriale. On les exclut par URL (normalisée) tant
-# qu'un choix PO explicite ne les réintègre pas. Réversible : retirer la ligne.
-PROMO_DENYLIST_RAW: dict[str, str] = {
-    # Blogs corpo / vendor (contenu promotionnel par nature)
-    "https://huggingface.co/blog": "Blog de Hugging Face (corpo)",
-    "https://thestack.technology/": "The Stack by Humanloop (vendor)",
-    # Newsletters / agrégateurs (pas du reportage primaire)
-    "https://tldr.tech/rss": "TLDR (agrégateur newsletter)",
-    "https://www.lennysnewsletter.com/": "Lenny's Newsletter",
-    "https://www.latent.space/": "Latent Space (newsletter)",
-    "https://towardsdatascience.com": "Towards Data Science (Medium UGC)",
-    "https://korben.info/feed": "Korben (blog perso)",
-    # Hyper-niche / hors ligne éditoriale
-    "https://www.reggae.fr/dev/rss/news.php": "Reggae.fr (niche musique)",
-    "https://www.h2-mobile.fr/feed/": "H2-mobile.fr (niche hydrogène)",
-    "https://www.vertigemedia.fr/blog-feed.xml": "Vertige Media (niche)",
-    # Data aggregator
-    "https://www.statista.com": "Statista (agrégateur data)",
-    # ONG militante (pas un média d'information)
-    "https://www.amnesty.org/": "Amnesty International (ONG)",
-}
-PROMO_DENYLIST = frozenset(_norm_url(u) for u in PROMO_DENYLIST_RAW)
 
 # Vocab hérité (sources.granular_topics) -> 51-slugs valides. Appliqué AVANT le
 # purge dans `resolve_new_topics` : sans cette map, une source à faible activité
@@ -166,27 +144,9 @@ _TYPE_TO_CSV = {
 
 
 # --------------------------------------------------------------------------- #
-# Données chargées (thin DB layer)
+# Données chargées (thin DB layer). `SourceMeta`/`Promotion` sont importés depuis
+# `app.services.source_promotion` (ré-exportés en tête de module).
 # --------------------------------------------------------------------------- #
-@dataclass
-class SourceMeta:
-    source_id: str
-    name: str
-    url: str
-    theme: str | None
-    type: str
-    is_curated: bool
-    bias_stance: str
-    reliability_score: str
-    description: str | None
-    score_independence: float | None
-    score_rigor: float | None
-    score_ux: float | None
-    source_tier: str
-    granular_topics: list[str] | None
-    articles_30d: int
-
-
 @dataclass
 class TopicChange:
     source_id: str
@@ -194,24 +154,6 @@ class TopicChange:
     url: str
     old: list[str] | None
     new: list[str] | None
-
-
-@dataclass
-class Promotion:
-    source_id: str
-    name: str
-    url: str
-    theme: str | None
-    type: str
-    bias_stance: str
-    reliability_score: str
-    description: str | None
-    score_independence: float | None
-    score_rigor: float | None
-    score_ux: float | None
-    source_tier: str
-    granular_topics: list[str] | None
-    articles_30d: int
 
 
 @dataclass
@@ -279,72 +221,6 @@ def resolve_new_topics(
     # dict.fromkeys = dédup en conservant l'ordre de 1re occurrence (idiome maison).
     cleaned = list(dict.fromkeys(t for t in remapped if t in valid_slugs))
     return cleaned or None
-
-
-def is_promotable(
-    m: SourceMeta,
-    *,
-    min_volume: int = PROMO_MIN_VOLUME,
-    reliability_set: set[str] = PROMO_RELIABILITY,
-    excluded_bias: frozenset[str] = PROMO_EXCLUDED_BIAS,
-    denylist: frozenset[str] = PROMO_DENYLIST,
-) -> bool:
-    """Source évaluée + productive, non curée, non denylistée : candidate.
-
-    Biais **connu et non alternatif** (aligné sur le gate de recommandation),
-    fiabilité medium/high, volume suffisant, et pas dans la denylist éditoriale.
-    """
-    return (
-        not m.is_curated
-        and m.bias_stance not in excluded_bias
-        and m.reliability_score in reliability_set
-        and m.articles_30d >= min_volume
-        and _norm_url(m.url) not in denylist
-    )
-
-
-def _to_promotion(m: SourceMeta, granular_topics: list[str] | None) -> Promotion:
-    """Projette une source promue en `Promotion` (report / CSV / DB)."""
-    return Promotion(
-        source_id=m.source_id,
-        name=m.name,
-        url=m.url,
-        theme=m.theme,
-        type=m.type,
-        bias_stance=m.bias_stance,
-        reliability_score=m.reliability_score,
-        description=m.description,
-        score_independence=m.score_independence,
-        score_rigor=m.score_rigor,
-        score_ux=m.score_ux,
-        source_tier=m.source_tier,
-        granular_topics=granular_topics,
-        articles_30d=m.articles_30d,
-    )
-
-
-def compute_promotions(
-    metas: list[SourceMeta],
-    *,
-    min_volume: int = PROMO_MIN_VOLUME,
-    reliability_set: set[str] = PROMO_RELIABILITY,
-    excluded_bias: frozenset[str] = PROMO_EXCLUDED_BIAS,
-    denylist: frozenset[str] = PROMO_DENYLIST,
-) -> list[Promotion]:
-    """Sous-plan léger « promotions seules » — sans dériver `granular_topics`
-    ni auditer la couverture. Utilisé par le job hebdo (qui ne réécrit que
-    `is_curated`) ; conserve `granular_topics` tel quel (jamais écrit)."""
-    return [
-        _to_promotion(m, m.granular_topics)
-        for m in metas
-        if is_promotable(
-            m,
-            min_volume=min_volume,
-            reliability_set=reliability_set,
-            excluded_bias=excluded_bias,
-            denylist=denylist,
-        )
-    ]
 
 
 def compute_plan(
@@ -542,53 +418,9 @@ def write_csv(path: Path, plan: RetagPlan, metas: list[SourceMeta]) -> int:
 
 
 # --------------------------------------------------------------------------- #
-# DB layer (thin)
+# DB layer (thin). `load_metas` / `write_promotions` sont dans
+# `app.services.source_promotion` (ré-exportés en tête de module).
 # --------------------------------------------------------------------------- #
-async def load_metas(session) -> list[SourceMeta]:
-    sql = text(
-        f"""
-        SELECT s.id, s.name, s.url, s.theme, s.type, s.is_curated,
-               s.bias_stance, s.reliability_score, s.description,
-               s.score_independence, s.score_rigor, s.score_ux,
-               s.source_tier, s.granular_topics,
-               COALESCE(a30.n, 0) AS articles_30d
-        FROM sources s
-        LEFT JOIN (
-            SELECT source_id, COUNT(*) AS n
-            FROM contents
-            WHERE published_at >= now() - interval '{PROMO_WINDOW_DAYS} days'
-            GROUP BY source_id
-        ) a30 ON a30.source_id = s.id
-        WHERE s.is_active
-        """
-    )
-    result = await session.execute(sql)
-    metas: list[SourceMeta] = []
-    for r in result.mappings():
-        metas.append(
-            SourceMeta(
-                source_id=str(r["id"]),
-                name=r["name"],
-                url=r["url"],
-                theme=r["theme"],
-                type=str(r["type"]),
-                is_curated=bool(r["is_curated"]),
-                bias_stance=str(r["bias_stance"]),
-                reliability_score=str(r["reliability_score"]),
-                description=r["description"],
-                score_independence=r["score_independence"],
-                score_rigor=r["score_rigor"],
-                score_ux=r["score_ux"],
-                source_tier=r["source_tier"] or "mainstream",
-                granular_topics=list(r["granular_topics"])
-                if r["granular_topics"]
-                else None,
-                articles_30d=int(r["articles_30d"]),
-            )
-        )
-    return metas
-
-
 async def load_topic_stats(
     session,
 ) -> tuple[dict[str, dict[str, int]], dict[str, int]]:
@@ -622,16 +454,6 @@ async def load_topic_stats(
         for r in (await session.execute(totals_sql)).mappings()
     }
     return topic_stats, totals
-
-
-async def write_promotions(session, promotions: list[Promotion]) -> None:
-    """Applique UNIQUEMENT les promotions `is_curated=true` (idempotent).
-
-    Isolé de `write_plan` pour que le job hebdo puisse promouvoir sans toucher
-    `granular_topics` (le re-tag reste réservé au run manuel + revue CSV PO)."""
-    promote_stmt = text("UPDATE sources SET is_curated = true WHERE id = :id")
-    for p in promotions:
-        await session.execute(promote_stmt, {"id": UUID(p.source_id)})
 
 
 async def write_plan(session, plan: RetagPlan) -> None:

--- a/packages/api/tests/scripts/test_retag_and_promote_sources.py
+++ b/packages/api/tests/scripts/test_retag_and_promote_sources.py
@@ -11,9 +11,12 @@ from __future__ import annotations
 from app.services.ml.classification_service import VALID_TOPIC_SLUGS
 from scripts.retag_and_promote_sources import (
     EXTENDED_MIGRATION_MAP,
+    PROMO_DENYLIST_RAW,
+    PROMO_EXCLUDED_BIAS,
     Promotion,
     SourceMeta,
     compute_plan,
+    compute_promotions,
     derive_granular_topics,
     is_promotable,
     regenerate_csv_rows,
@@ -167,6 +170,63 @@ def test_not_promotable_low_reliability():
 
 def test_not_promotable_low_volume():
     assert is_promotable(_meta("a", articles_30d=5)) is False
+
+
+def test_not_promotable_alternative_bias():
+    # Aligné sur le gate de reco : une source `alternative` n'entre jamais au
+    # catalogue curé, même évaluée + productive (image de marque Facteur).
+    assert is_promotable(_meta("a", bias_stance="alternative")) is False
+
+
+def test_promotable_specialized_bias():
+    # `specialized` (sport/tech/science) = biais thématique, pas idéologique :
+    # reste promouvable (ne pas sur-filtrer les spécialistes).
+    assert is_promotable(_meta("a", bias_stance="specialized")) is True
+
+
+def test_not_promotable_denylisted_url():
+    # URL dans la denylist éditoriale -> jamais promue, malgré un gate passant.
+    denied = next(iter(PROMO_DENYLIST_RAW))
+    assert is_promotable(_meta("a", url=denied)) is False
+
+
+def test_denylist_url_match_ignores_trailing_slash_and_case():
+    denied = next(iter(PROMO_DENYLIST_RAW)).rstrip("/")
+    assert is_promotable(_meta("a", url=f"{denied.upper()}/")) is False
+
+
+def test_excluded_bias_is_alternative_and_unknown():
+    # PROMO_EXCLUDED_BIAS est dérivé de QUALITY_CATALOG_EXCLUDED_BIAS ; on pin la
+    # policy attendue pour alerter si la source de vérité change par accident.
+    assert frozenset({"unknown", "alternative"}) == PROMO_EXCLUDED_BIAS
+
+
+def test_compute_promotions_filters_gate_and_denylist():
+    # Le sous-plan léger du job hebdo : même gate que compute_plan, promotions
+    # seules, granular_topics conservé tel quel (jamais dérivé).
+    metas = [
+        _meta("ok", granular_topics=["politics"]),
+        _meta("alt", bias_stance="alternative"),
+        _meta("deny", url=next(iter(PROMO_DENYLIST_RAW))),
+        _meta("curated", is_curated=True),
+        _meta("thin", articles_30d=5),
+    ]
+    promos = compute_promotions(metas)
+    assert {p.source_id for p in promos} == {"ok"}
+    assert promos[0].granular_topics == ["politics"]  # conservé, pas dérivé
+
+
+def test_compute_plan_skips_denylisted_and_alternative():
+    metas = [
+        _meta("ok", url="https://legit.test/"),
+        _meta("alt", bias_stance="alternative"),
+        _meta("deny", url=next(iter(PROMO_DENYLIST_RAW))),
+    ]
+    plan = compute_plan(metas, {}, {})
+    promoted = {p.source_id for p in plan.promotions}
+    assert promoted == {"ok"}
+    assert plan.curated_after["alt"] is False
+    assert plan.curated_after["deny"] is False
 
 
 # --------------------------------------------------------------------------- #

--- a/packages/api/tests/services/test_source_promotion.py
+++ b/packages/api/tests/services/test_source_promotion.py
@@ -1,0 +1,74 @@
+"""Tests du cœur de promotion `app.services.source_promotion`.
+
+La logique est aussi couverte via le script CLI (qui la ré-exporte) dans
+`tests/scripts/test_retag_and_promote_sources.py` ; ici on la teste en
+first-class depuis l'app + un garde-fou anti-régression sur l'import (le job ne
+doit JAMAIS réimporter `scripts`, sinon le conteneur Docker plante au boot —
+`scripts/` n'est pas embarqué dans l'image).
+"""
+
+from __future__ import annotations
+
+from app.services.source_promotion import (
+    PROMO_DENYLIST_RAW,
+    PROMO_EXCLUDED_BIAS,
+    SourceMeta,
+    compute_promotions,
+    is_promotable,
+)
+
+
+def _meta(sid: str, **kw) -> SourceMeta:
+    base = {
+        "source_id": sid,
+        "name": f"Source {sid}",
+        "url": f"https://{sid}.test/",
+        "theme": "society",
+        "type": "article",
+        "is_curated": False,
+        "bias_stance": "center",
+        "reliability_score": "high",
+        "description": "Desc.",
+        "score_independence": 0.7,
+        "score_rigor": 0.7,
+        "score_ux": 0.7,
+        "source_tier": "mainstream",
+        "granular_topics": None,
+        "articles_30d": 50,
+    }
+    base.update(kw)
+    return SourceMeta(**base)
+
+
+def test_excluded_bias_derived_from_reco_gate():
+    assert frozenset({"unknown", "alternative"}) == PROMO_EXCLUDED_BIAS
+
+
+def test_gate_excludes_alternative_and_denylist_keeps_specialized():
+    assert is_promotable(_meta("ok")) is True
+    assert is_promotable(_meta("spec", bias_stance="specialized")) is True
+    assert is_promotable(_meta("alt", bias_stance="alternative")) is False
+    assert is_promotable(_meta("deny", url=next(iter(PROMO_DENYLIST_RAW)))) is False
+
+
+def test_compute_promotions_filters_and_keeps_granular_topics():
+    metas = [
+        _meta("ok", granular_topics=["politics"]),
+        _meta("alt", bias_stance="alternative"),
+        _meta("thin", articles_30d=5),
+    ]
+    promos = compute_promotions(metas)
+    assert {p.source_id for p in promos} == {"ok"}
+    assert promos[0].granular_topics == ["politics"]  # conservé, jamais dérivé
+
+
+def test_promotion_job_does_not_import_scripts_package():
+    # Garde-fou anti-régression du crash boot Docker (ModuleNotFoundError:
+    # No module named 'scripts') : le job passe par app.services, pas scripts.
+    import inspect
+
+    import app.jobs.promote_sources_job as job
+
+    src = inspect.getsource(job)
+    assert "import scripts" not in src
+    assert "from scripts" not in src

--- a/packages/api/tests/workers/test_scheduler.py
+++ b/packages/api/tests/workers/test_scheduler.py
@@ -65,6 +65,37 @@ class TestScheduler:
             assert job["max_instances"] == 1
             assert job["coalesce"] is True
 
+    def test_scheduler_has_promotion_job_weekly_sunday(self):
+        """WS1 : promote_evaluated_sources hebdo dim. 04:00 Paris (après 03:45)."""
+        with patch("app.workers.scheduler.AsyncIOScheduler") as mock_scheduler_class:
+            mock_scheduler = Mock()
+            mock_scheduler_class.return_value = mock_scheduler
+
+            captured = {}
+
+            def capture_add_job(*args, **kwargs):
+                job_id = kwargs.get("id")
+                if job_id:
+                    captured[job_id] = {
+                        "func": args[0] if args else kwargs.get("func"),
+                        **kwargs,
+                    }
+
+            mock_scheduler.add_job = capture_add_job
+            start_scheduler()
+
+            assert "promote_evaluated_sources" in captured
+            job = captured["promote_evaluated_sources"]
+            assert job["func"].__name__ == "promote_evaluated_sources"
+            assert isinstance(job["trigger"], CronTrigger)
+            assert "Europe/Paris" in str(job["trigger"].timezone)
+            fields = {f.name: str(f) for f in job["trigger"].fields}
+            assert fields.get("day_of_week") == "sun"
+            assert fields.get("hour") == "4"
+            assert fields.get("minute") == "0"
+            assert job["max_instances"] == 1
+            assert job["coalesce"] is True
+
     def test_scheduler_has_daily_digest_job(self):
         """TEST-01: Verify daily digest job is scheduled at 07:30 Paris time."""
         with patch("app.workers.scheduler.AsyncIOScheduler") as mock_scheduler_class:


### PR DESCRIPTION
# fix(sources): débloquer la promotion catalogue + garde-fou marque (WS1)

Débloque le backlog de sources évaluées bloquées en Tier 3 (invisibles à
« Étoffer [thème] ») et empêche le backlog de se reformer, **avec un garde-fou
image de marque validé PO** sur ce qui entre au catalogue curé. Base `main`.
Aucune migration (additif).

## Contexte
La promotion vers `is_curated=true` passe par `retag_and_promote_sources.py`,
qui ne tournait qu'au **lancement manuel** → ~160 sources actives + évaluées
restaient hors reco. Diagnostic : plan `sources-theme-coverage`.

## Garde-fou marque (décision PO 2026-07-22)
1. **Exclusion `alternative`** — le gate de promotion n'excluait que `unknown`,
   pas `alternative` (contrairement au gate de reco). Une source `alternative`
   pouvait donc être stampée `is_curated`. Corrigé : `PROMO_EXCLUDED_BIAS =
   {unknown, alternative}`, miroir de `QUALITY_CATALOG_EXCLUDED_BIAS` (test de
   garde). Sort **Élucid**. `specialized` reste promouvable.
2. **Denylist éditoriale** (`PROMO_DENYLIST`, 12 URLs) — blogs corpo (Hugging
   Face, Humanloop), newsletters/agrégateurs (TLDR, Lenny's, Latent Space,
   Towards Data Science, Korben), niche (Reggae.fr, H2-mobile, Vertige Media),
   Statista, Amnesty. Réversible (retirer la ligne).

→ **51 sources promues** (64 − 1 alternative − 12 denylist). Liste gelée :
`.context/promotion-confirmed-list.md`.

## Changements
- `scripts/retag_and_promote_sources.py` : `PROMO_EXCLUDED_BIAS`,
  `PROMO_DENYLIST`, gate `is_promotable`/`compute_plan` mis à jour,
  `write_promotions` extrait (promotions seules).
- `app/jobs/promote_sources_job.py` : job `promote_evaluated_sources`
  (promotions seules, idempotent, best-effort, logue les noms).
- `app/workers/scheduler.py` : cron hebdo dimanche 04h00 Paris (après 03h45).
- Tests : +9 (alternative exclu, specialized gardé, denylist, miroir reco-gate,
  cron promotion). Suite scripts+scheduler verte (57).

## Sécurité DB
Aucun DDL (pas de migration). Promotion **additive** (`is_curated` false→true),
sûre pour le backend prod (ancien code, même colonne). Job planifié dans `main`
seulement ; `production` l'aura à la release hebdo, gate déjà corrigé.

## Appliquer le backlog en prod (post-merge)
`python3 scripts/retag_and_promote_sources.py --apply --allow-prod` (dry-run
d'abord). Sinon le job hebdo le fera dimanche.

## Suivi (hors PR A)
WS1b seuil adaptatif thèmes maigres (**revue de liste PO requise**), WS2 colonne
pondérée `coverage_theme_weights` + tri des suggestions, correction des `theme`
mal étiquetés (L'Humanité→tech, Basket USA→tech, Science & Vie→tech…).

Doc : `docs/maintenance/maintenance-source-promotion-pipeline.md`.
