### PR TITLE
fix(essentiel): stoppe l'éviction des sources de l'Essentiel (divergence DB/local)

### DIFF
--- a/apps/mobile/lib/features/flux_continu/providers/essentiel_placement_sync.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/essentiel_placement_sync.dart
@@ -142,6 +142,24 @@ Future<void> reconcileEssentielPlacement(Ref ref) async {
         // Essentiel : présent dans tournee, absent de Flâner (modèle exclusif).
         if (!nextTournee.contains(tKey)) nextTournee.add(tKey);
         nextTab.remove(bKey);
+      } else if (nextTournee.contains(tKey)) {
+        // Self-heal : la DB dit Flâner, mais la clé Essentiel est présente
+        // localement. Les clés ne s'ajoutent que par action utilisateur
+        // explicite sur ce device ⇒ ce `false` est une divergence (écriture DB
+        // ratée). Le local gagne : on ne retire PAS la clé (pas d'éviction), on
+        // ne l'ajoute PAS à Flâner, et on RE-pousse `essentiel_mode=true` en DB
+        // (best-effort : retenté au prochain cold boot si l'échec persiste).
+        // Répare rétroactivement tout user déjà divergé, sans UI ni backfill.
+        try {
+          await ref.read(userSourcesStateProvider.notifier).setSourceState(
+                s.sourceId,
+                InterestState.favorite,
+                essentielMode: true,
+              );
+        } catch (e) {
+          debugPrint(
+              '[essentiel-sync] self-heal source ${s.sourceId} failed: $e');
+        }
       } else {
         // Flâner : retiré de l'Essentiel, présent dans les onglets.
         nextTournee.remove(tKey);
@@ -157,6 +175,21 @@ Future<void> reconcileEssentielPlacement(Ref ref) async {
       if (mode) {
         // Essentiel = défaut du thème : il suffit de le retirer de Flâner.
         nextTab.remove(bKey);
+      } else if (nextTournee.contains(tKey)) {
+        // Self-heal miroir (thème) : la clé Essentiel explicite (posée par
+        // `_moveTheme` / `_onAddTheme` dans `tournee_order_v1`) est
+        // présente localement alors que la DB porte un `false` incohérent. On
+        // garde le placement local et re-pousse `essentiel_mode=true`.
+        try {
+          await ref.read(userInterestsProvider.notifier).setInterestState(
+                ThemeFavoriteRef(slug: t.interestSlug),
+                InterestState.favorite,
+                essentielMode: true,
+              );
+        } catch (e) {
+          debugPrint(
+              '[essentiel-sync] self-heal theme ${t.interestSlug} failed: $e');
+        }
       } else {
         // Flâner : présent dans les onglets, retiré de l'Essentiel explicite.
         nextTournee.remove(tKey);

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -2162,7 +2162,13 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
         await _appendTourneeOrder(tourneeThemeKey(section.themeSlug!));
       }
     } catch (e) {
+      // Ne plus avaler l'échec : `setSourceState`/`setInterestState` ont
+      // rollback leur état optimiste, l'ordre local n'a pas été touché ; on
+      // propage pour que l'écran affiche une erreur au lieu d'un faux succès
+      // (qui laissait une source « ajoutée » côté UI mais false en DB → évincée
+      // au prochain cold boot).
       debugPrint('FluxContinu: promoteSuggestion failed: $e');
+      rethrow;
     }
   }
 

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -911,8 +911,17 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
       sectionTitle: section.label,
       reason: section.reason,
       onKeep: () async {
-        await notifier.promoteSuggestion(section);
-        NotificationService.showSuccess('Ajoutée à tes favoris');
+        // N'annonce le succès que si la promotion a réellement persisté en DB.
+        // Un faux « Ajoutée » sur échec réseau laissait une divergence local/DB
+        // que le cold boot rejouait en éviction.
+        try {
+          await notifier.promoteSuggestion(section);
+          NotificationService.showSuccess('Ajoutée à tes favoris');
+        } catch (_) {
+          NotificationService.showError(
+            'Impossible d\'ajouter à tes favoris pour le moment.',
+          );
+        }
       },
       onDismiss: () async {
         await notifier.dismissSuggestion(section);

--- a/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
@@ -243,69 +243,64 @@ class _ManageFavoritesContentState
     await _appendTournee(key);
   }
 
-  // ── Déplacement de mode (sources uniquement) ───────────────────────────────
+  // ── Déplacement de mode (sources & thèmes) ─────────────────────────────────
 
-  Future<void> _moveSourceToFlaner(String sourceId) async {
-    await ref.read(tourneeOrderPrefsProvider.notifier).markCustomized();
-    await _removeTournee(tourneeSourceKey(sourceId));
-    await _appendTab(tabOrderSourceKey(sourceId));
-    // Persiste le placement Flâner en DB (la source reste favorite, seul le mode
-    // change) — durable au-delà des prefs locales, resync sur chaque device.
-    await _persistSourceMode(sourceId, essentiel: false);
-    NotificationService.showSuccess('Déplacé vers Flâner');
+  // DB d'abord, local ensuite (même pattern que `_onAddSource`) : `setSourceState`
+  // /`setInterestState` sont optimistic + rollback + rethrow, donc en cas d'échec
+  // réseau on n'écrit AUCUNE pref locale → plus de divergence « clé locale
+  // présente + DB false » que la réconciliation cold-boot rejouerait en éviction.
+  // La clé (`source:<id>` / `theme:<slug>`) est partagée entre `tournee_order_v1`
+  // (Essentiel) et `pinned_tabs_order_v1` (Flâner) ; seul le mode bascule (la
+  // favorite reste intacte : `SourceFavoriteRef` / `ThemeFavoriteRef`).
+  Future<void> _moveSource(String sourceId, {required bool toEssentiel}) async {
+    await _moveMode(
+      persist: () => ref.read(userSourcesStateProvider.notifier).setSourceState(
+            sourceId,
+            InterestState.favorite,
+            essentielMode: toEssentiel,
+          ),
+      tourneeKey: tourneeSourceKey(sourceId),
+      tabKey: tabOrderSourceKey(sourceId),
+      toEssentiel: toEssentiel,
+    );
   }
 
-  Future<void> _moveSourceToEssentiel(String sourceId) async {
-    await ref.read(tourneeOrderPrefsProvider.notifier).markCustomized();
-    await _removeTab(tabOrderSourceKey(sourceId));
-    await _appendTournee(tourneeSourceKey(sourceId));
-    await _persistSourceMode(sourceId, essentiel: true);
-    NotificationService.showSuccess('Déplacé vers l\'Essentiel');
+  Future<void> _moveTheme(String slug, {required bool toEssentiel}) async {
+    await _moveMode(
+      persist: () =>
+          ref.read(userInterestsProvider.notifier).setInterestState(
+                ThemeFavoriteRef(slug: slug),
+                InterestState.favorite,
+                essentielMode: toEssentiel,
+              ),
+      tourneeKey: tourneeThemeKey(slug),
+      tabKey: tabOrderThemeKey(slug),
+      toEssentiel: toEssentiel,
+    );
   }
 
-  /// Écrit le mode Essentiel/Flâner d'une source favorite en DB (best-effort :
-  /// l'échec réseau ne doit pas casser le déplacement local déjà appliqué).
-  Future<void> _persistSourceMode(String sourceId,
-      {required bool essentiel}) async {
+  /// Bascule une favorite entre Essentiel et Flâner : DB d'abord (via [persist]),
+  /// puis les prefs locales seulement si la DB a réussi ; échec réseau → toast,
+  /// aucune écriture locale, donc aucune divergence.
+  Future<void> _moveMode({
+    required Future<void> Function() persist,
+    required String tourneeKey,
+    required String tabKey,
+    required bool toEssentiel,
+  }) async {
+    await ref.read(tourneeOrderPrefsProvider.notifier).markCustomized();
     try {
-      await ref
-          .read(userSourcesStateProvider.notifier)
-          .setSourceState(sourceId, InterestState.favorite,
-              essentielMode: essentiel);
-    } catch (e) {
-      NotificationService.showError('Erreur : $e');
-    }
-  }
-
-  // Thèmes : même modèle exclusif que les sources. La clé `theme:<slug>` est
-  // partagée entre `tournee_order_v1` (Essentiel) et `pinned_tabs_order_v1`
-  // (Flâner) ; la favorite reste un `ThemeFavoriteRef` (on ne touche pas à
-  // `setInterestState`).
-  Future<void> _moveThemeToFlaner(String slug) async {
-    await ref.read(tourneeOrderPrefsProvider.notifier).markCustomized();
-    await _removeTournee(tourneeThemeKey(slug));
-    await _appendTab(tabOrderThemeKey(slug));
-    // Persiste le placement Flâner en DB (le thème reste favorite, seul le mode
-    // change) — durable au-delà des prefs locales, resync sur chaque device.
-    await _persistThemeMode(slug, essentiel: false);
-    NotificationService.showSuccess('Déplacé vers Flâner');
-  }
-
-  Future<void> _moveThemeToEssentiel(String slug) async {
-    await ref.read(tourneeOrderPrefsProvider.notifier).markCustomized();
-    await _removeTab(tabOrderThemeKey(slug));
-    await _appendTournee(tourneeThemeKey(slug));
-    await _persistThemeMode(slug, essentiel: true);
-    NotificationService.showSuccess('Déplacé vers l\'Essentiel');
-  }
-
-  /// Écrit le mode Essentiel/Flâner d'un thème favori en DB (best-effort).
-  Future<void> _persistThemeMode(String slug, {required bool essentiel}) async {
-    try {
-      await ref
-          .read(userInterestsProvider.notifier)
-          .setInterestState(ThemeFavoriteRef(slug: slug), InterestState.favorite,
-              essentielMode: essentiel);
+      await persist();
+      if (toEssentiel) {
+        await _removeTab(tabKey);
+        await _appendTournee(tourneeKey);
+      } else {
+        await _removeTournee(tourneeKey);
+        await _appendTab(tabKey);
+      }
+      NotificationService.showSuccess(
+        toEssentiel ? 'Déplacé vers l\'Essentiel' : 'Déplacé vers Flâner',
+      );
     } catch (e) {
       NotificationService.showError('Erreur : $e');
     }
@@ -801,8 +796,8 @@ class _ManageFavoritesContentState
                     moveTooltip: 'Déplacer vers Flâner',
                     moveLabel: 'Flâner',
                     onMove: (item) => item.kind == _FavKind.theme
-                        ? _moveThemeToFlaner(item.id)
-                        : _moveSourceToFlaner(item.id),
+                        ? _moveTheme(item.id, toEssentiel: false)
+                        : _moveSource(item.id, toEssentiel: false),
                   ),
                 const SizedBox(height: FacteurSpacing.space4),
 
@@ -847,8 +842,8 @@ class _ManageFavoritesContentState
                     moveTooltip: 'Déplacer vers l\'Essentiel',
                     moveLabel: 'Essentiel',
                     onMove: (item) => item.kind == _FavKind.theme
-                        ? _moveThemeToEssentiel(item.id)
-                        : _moveSourceToEssentiel(item.id),
+                        ? _moveTheme(item.id, toEssentiel: true)
+                        : _moveSource(item.id, toEssentiel: true),
                     onSubjectVeille: (item) => _openVeilleConfig(),
                   ),
                 const SizedBox(height: FacteurSpacing.space4),

--- a/apps/mobile/test/features/flux_continu/providers/essentiel_placement_sync_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/essentiel_placement_sync_test.dart
@@ -28,6 +28,10 @@ class _FakeRepo implements UserInterestsRepository {
   final List<({String sourceId, bool? mode})> sourcePatches = [];
   final List<({String slug, bool? mode})> themePatches = [];
 
+  /// Simule un échec réseau sur `setSourceState` (test du re-push self-heal
+  /// best-effort : la clé locale doit survivre, pas de crash).
+  bool throwOnSetSource = false;
+
   _FakeRepo({required this.sources, required this.interests});
 
   @override
@@ -43,6 +47,7 @@ class _FakeRepo implements UserInterestsRepository {
     int? position,
     bool? essentielMode,
   }) async {
+    if (throwOnSetSource) throw Exception('network down');
     sourcePatches.add((sourceId: sourceId, mode: essentielMode));
     return sources;
   }
@@ -224,8 +229,50 @@ void main() {
   });
 
   test(
-      'hydrate: source backend essentiel=false → clé retirée de tournee, '
-      'ajoutée à pinned_tabs', () async {
+      'self-heal: source backend essentiel=false MAIS clé Essentiel locale '
+      'présente → clé conservée + re-push essentiel=true (le local gagne)',
+      () async {
+    final repo = _FakeRepo(
+      sources: _sourcesWith(const [
+        SourceInterest(
+          sourceId: s1,
+          state: InterestState.favorite,
+          priorityMultiplier: 1.0,
+          essentielMode: false, // `false` incohérent (écriture DB ratée).
+        ),
+      ]),
+      interests: _interestsWith(const []),
+    );
+    // Divergence : la clé Essentiel est présente localement (action utilisateur
+    // explicite) alors que la DB porte un `false`. Flag posé → on isole le
+    // chemin d'hydratation/self-heal du backfill.
+    final container = await _boot(repo, {
+      'tournee_order_v1': <String>['source:$s1'],
+      'essentiel_placement_reconciled_v1': true,
+    });
+    addTearDown(container.dispose);
+
+    await container.read(_reconcileProbe.future);
+
+    // Le local gagne : la clé reste dans l'Essentiel, absente de Flâner (plus
+    // d'éviction au cold boot).
+    expect(
+      container.read(tourneeOrderPrefsProvider).order,
+      contains('source:$s1'),
+    );
+    expect(
+      container.read(tabOrderPrefsProvider),
+      isNot(contains('source:$s1')),
+    );
+    // Et la DB est réparée : re-push essentiel=true.
+    expect(repo.sourcePatches, hasLength(1));
+    expect(repo.sourcePatches.single.sourceId, s1);
+    expect(repo.sourcePatches.single.mode, isTrue);
+  });
+
+  test(
+      'hydrate: source backend essentiel=false SANS clé locale → Flâner (clé '
+      'absente de tournee, présente dans pinned, aucun re-push)', () async {
     final repo = _FakeRepo(
       sources: _sourcesWith(const [
         SourceInterest(
@@ -237,9 +284,10 @@ void main() {
       ]),
       interests: _interestsWith(const []),
     );
-    // Localement (à tort) placé dans l'Essentiel : l'hydratation doit corriger.
+    // Aucune clé locale (ex. réinstallation) → la DB fait foi : Flâner. Le
+    // self-heal ne se déclenche PAS (pas d'action utilisateur locale à préserver).
     final container = await _boot(repo, {
-      'tournee_order_v1': <String>['source:$s1'],
+      'essentiel_placement_reconciled_v1': true,
     });
     addTearDown(container.dispose);
 
@@ -251,6 +299,69 @@ void main() {
     );
     expect(
       container.read(tabOrderPrefsProvider),
+      contains('source:$s1'),
+    );
+    expect(repo.sourcePatches, isEmpty);
+  });
+
+  test(
+      'self-heal miroir (thème): backend essentiel=false MAIS clé theme:<slug> '
+      'locale présente → conservée + re-push essentiel=true', () async {
+    final repo = _FakeRepo(
+      sources: _sourcesWith(const []),
+      interests: _interestsWith(const [
+        ThemeInterest(
+          interestSlug: 'tech',
+          weight: 1.0,
+          state: InterestState.favorite,
+          essentielMode: false,
+        ),
+      ]),
+    );
+    // Le thème a été explicitement placé en Essentiel (clé dans tournee_order_v1)
+    // mais la DB porte un `false` incohérent.
+    final container = await _boot(repo, {
+      'tournee_order_v1': <String>['theme:tech'],
+      'essentiel_placement_reconciled_v1': true,
+    });
+    addTearDown(container.dispose);
+
+    await container.read(_reconcileProbe.future);
+
+    expect(
+      container.read(tourneeOrderPrefsProvider).order,
+      contains('theme:tech'),
+    );
+    expect(repo.themePatches, hasLength(1));
+    expect(repo.themePatches.single.slug, 'tech');
+    expect(repo.themePatches.single.mode, isTrue);
+  });
+
+  test(
+      'self-heal best-effort: le re-push DB échoue → clé locale conservée, pas '
+      'de crash (retenté au boot suivant)', () async {
+    final repo = _FakeRepo(
+      sources: _sourcesWith(const [
+        SourceInterest(
+          sourceId: s1,
+          state: InterestState.favorite,
+          priorityMultiplier: 1.0,
+          essentielMode: false,
+        ),
+      ]),
+      interests: _interestsWith(const []),
+    )..throwOnSetSource = true;
+    final container = await _boot(repo, {
+      'tournee_order_v1': <String>['source:$s1'],
+      'essentiel_placement_reconciled_v1': true,
+    });
+    addTearDown(container.dispose);
+
+    // Ne doit pas lever : la réconciliation est best-effort.
+    await container.read(_reconcileProbe.future);
+
+    expect(
+      container.read(tourneeOrderPrefsProvider).order,
       contains('source:$s1'),
     );
   });

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
@@ -11,6 +11,7 @@ import 'package:facteur/features/feed/providers/feed_provider.dart';
 import 'package:facteur/features/feed/repositories/feed_repository.dart';
 import 'package:facteur/features/flux_continu/models/flux_continu_models.dart';
 import 'package:facteur/features/flux_continu/providers/flux_continu_provider.dart';
+import 'package:facteur/features/flux_continu/providers/tournee_order_prefs_provider.dart';
 import 'package:facteur/features/flux_continu/repositories/essentiel_repository.dart';
 import 'package:facteur/features/flux_continu/repositories/flux_continu_repository.dart';
 import 'package:facteur/features/flux_continu/services/flux_continu_cache_service.dart';
@@ -100,6 +101,22 @@ class _StubUserInterestsNotifier extends UserInterestsNotifier {
   void setState(UserInterestsState next) {
     _initial = next;
     state = AsyncValue.data(next);
+  }
+}
+
+/// Comme [_StubUserInterestsNotifier] mais `setInterestState` lève (le vrai
+/// notifier fait rollback + rethrow sur échec réseau) : sert à vérifier que
+/// `promoteSuggestion` propage l'erreur au lieu de l'avaler.
+class _ThrowingInterestsNotifier extends _StubUserInterestsNotifier {
+  _ThrowingInterestsNotifier(super.initial);
+
+  @override
+  Future<void> setInterestState(
+    FavoriteRef ref,
+    InterestState s, {
+    bool? essentielMode,
+  }) async {
+    throw Exception('network down');
   }
 }
 
@@ -1578,6 +1595,44 @@ void main() {
       expect(capped.coreVisibleCount, 1);
       expect(capped.themeSlug, 'tech');
       expect(capped.currentPage, 2);
+    });
+  });
+
+  group('FluxContinuNotifier — promoteSuggestion', () {
+    test(
+        'échec DB → exception propagée + ordre Tournée non pollué (plus de '
+        'faux succès)', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final container = makeContainer(
+        interestsNotifier: _ThrowingInterestsNotifier(_interestsState()),
+      );
+      addTearDown(container.dispose);
+      await settle(container);
+
+      final notifier = container.read(fluxContinuProvider.notifier);
+      const section = FeedThemeSection(
+        kind: SectionKind.theme,
+        label: 'Tech',
+        accent: Color(0xFF000000),
+        coreVisibleCount: 0,
+        items: <Content>[],
+        themeSlug: 'tech',
+        origin: SectionOrigin.suggested,
+      );
+
+      // L'erreur DB remonte (l'écran l'attrape pour montrer un message d'échec
+      // au lieu d'un faux « Ajoutée à tes favoris »).
+      await expectLater(
+        notifier.promoteSuggestion(section),
+        throwsA(isA<Exception>()),
+      );
+
+      // L'ordre local n'a PAS reçu d'append fantôme `theme:tech` : pas de
+      // divergence « clé locale + DB non persistée » à évincer au cold boot.
+      expect(
+        container.read(tourneeOrderPrefsProvider).order,
+        isNot(contains('theme:tech')),
+      );
     });
   });
 }

--- a/apps/mobile/test/features/flux_continu/widgets/manage_favorites_sheet_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/manage_favorites_sheet_test.dart
@@ -31,6 +31,9 @@ class _SpyInterestsNotifier extends UserInterestsNotifier {
   final List<(FavoriteRef, InterestState)> stateCalls = [];
   final List<bool?> modeCalls = [];
 
+  /// Simule un échec réseau du setter DB (le vrai fait rollback + rethrow).
+  bool throwOnSet = false;
+
   @override
   Future<UserInterestsState> build() async => _initial;
 
@@ -42,6 +45,7 @@ class _SpyInterestsNotifier extends UserInterestsNotifier {
   }) async {
     stateCalls.add((ref, s));
     modeCalls.add(essentielMode);
+    if (throwOnSet) throw Exception('network down');
   }
 
   @override
@@ -54,6 +58,9 @@ class _SpySourcesNotifier extends UserSourcesStateNotifier {
   final List<(String, InterestState)> stateCalls = [];
   final List<bool?> modeCalls = [];
 
+  /// Simule un échec réseau du setter DB (le vrai fait rollback + rethrow).
+  bool throwOnSet = false;
+
   @override
   Future<UserSourcesState> build() async => _initial;
 
@@ -65,6 +72,7 @@ class _SpySourcesNotifier extends UserSourcesStateNotifier {
   }) async {
     stateCalls.add((sourceId, s));
     modeCalls.add(essentielMode);
+    if (throwOnSet) throw Exception('network down');
   }
 
   @override
@@ -173,9 +181,13 @@ Future<({_SpyInterestsNotifier interests, _SpySourcesNotifier sources})>
   required UserSourcesState sources,
   List<Source> catalog = const [],
   ManageFavoritesEntry entry = ManageFavoritesEntry.essentiel,
+  bool throwOnSourceSet = false,
+  bool throwOnInterestSet = false,
 }) async {
-  final spyInterests = _SpyInterestsNotifier(interests);
-  final spySources = _SpySourcesNotifier(sources);
+  final spyInterests = _SpyInterestsNotifier(interests)
+    ..throwOnSet = throwOnInterestSet;
+  final spySources = _SpySourcesNotifier(sources)
+    ..throwOnSet = throwOnSourceSet;
 
   await tester.pumpWidget(
     ProviderScope(
@@ -335,6 +347,96 @@ void main() {
     expect(
       prefs.getStringList('pinned_tabs_order_v1') ?? const <String>[],
       isNot(contains('source:s1')),
+    );
+  });
+
+  testWidgets(
+      'déplacer une source Flâner → Essentiel (DB OK) persiste '
+      'essentielMode=true APRÈS la DB', (tester) async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      'pinned_tabs_order_v1': ['source:s1'],
+    });
+    final spies = await _openSheet(
+      tester,
+      interests: _interests(),
+      sources: _sources(
+        favorites: const [SourceFavoriteRef(sourceId: 's1', position: 0)],
+      ),
+      catalog: [_source('s1', 'Le Monde')],
+    );
+
+    await tester.tap(
+      find.byIcon(PhosphorIcons.arrowLineUp(PhosphorIconsStyle.bold)),
+    );
+    await tester.pumpAndSettle();
+
+    // Le mode Essentiel est persisté en DB (DB d'abord).
+    expect(spies.sources.stateCalls, isNotEmpty);
+    expect(spies.sources.modeCalls.last, isTrue);
+    // Puis le local est mis à jour.
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getStringList('tournee_order_v1'), contains('source:s1'));
+  });
+
+  testWidgets(
+      'déplacer une source Flâner → Essentiel quand la DB échoue ne modifie '
+      'AUCUNE pref locale (DB-first, pas de divergence)', (tester) async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      'pinned_tabs_order_v1': ['source:s1'],
+    });
+    final spies = await _openSheet(
+      tester,
+      interests: _interests(),
+      sources: _sources(
+        favorites: const [SourceFavoriteRef(sourceId: 's1', position: 0)],
+      ),
+      catalog: [_source('s1', 'Le Monde')],
+      throwOnSourceSet: true,
+    );
+
+    await tester.tap(
+      find.byIcon(PhosphorIcons.arrowLineUp(PhosphorIconsStyle.bold)),
+    );
+    await tester.pumpAndSettle();
+
+    // La DB a bien été tentée EN PREMIER avec le bon mode…
+    expect(spies.sources.modeCalls, contains(true));
+    // …mais son échec laisse les prefs locales intactes : aucune clé Essentiel
+    // fantôme, la source reste en Flâner (plus de « clé locale + DB false »
+    // rejouée en éviction au cold boot).
+    final prefs = await SharedPreferences.getInstance();
+    expect(
+      prefs.getStringList('tournee_order_v1') ?? const <String>[],
+      isNot(contains('source:s1')),
+    );
+    expect(prefs.getStringList('pinned_tabs_order_v1'), contains('source:s1'));
+  });
+
+  testWidgets(
+      'déplacer un thème Essentiel → Flâner quand la DB échoue ne modifie '
+      'AUCUNE pref locale', (tester) async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      'tournee_order_v1': ['theme:tech'],
+    });
+    final spies = await _openSheet(
+      tester,
+      interests: _interests(favorites: const [ThemeFavoriteRef(slug: 'tech')]),
+      sources: _sources(),
+      throwOnInterestSet: true,
+    );
+
+    await tester.tap(
+      find.byIcon(PhosphorIcons.arrowLineDown(PhosphorIconsStyle.bold)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(spies.interests.modeCalls, contains(false));
+    final prefs = await SharedPreferences.getInstance();
+    // Le thème reste dans l'Essentiel, jamais poussé en Flâner.
+    expect(prefs.getStringList('tournee_order_v1'), contains('theme:tech'));
+    expect(
+      prefs.getStringList('pinned_tabs_order_v1') ?? const <String>[],
+      isNot(contains('theme:tech')),
     );
   });
 

--- a/docs/bugs/bug-essentiel-mode-divergence-eviction.md
+++ b/docs/bugs/bug-essentiel-mode-divergence-eviction.md
@@ -1,0 +1,124 @@
+# Bug — Divergence `essentiel_mode` DB/local : sources évincées de l'Essentiel à chaque cold-boot
+
+## Symptôme (PO, 22/07/2026)
+
+> « Les sources ajoutées à l'Essentiel ne s'enregistrent toujours pas correctement
+> dans la Tournée du jour ! Constamment retirées de mon Essentiel ! »
+
+Persiste malgré les deux fixes précédents : réordre non destructeur
+(`mergeVisibleReorder`, [bug-tournee-sources-not-saving](bug-tournee-sources-not-saving.md))
+et colonne DB `essentiel_mode`
+([bug-essentiel-placement-persistence](bug-essentiel-placement-persistence.md), es01).
+
+## Cause racine — divergence créée localement, puis rejouée à chaque boot
+
+Trois maillons, tous vérifiés dans le code :
+
+1. **Écritures local-first « best-effort » dans les déplacements.**
+   `manage_favorites_sheet.dart` — `_moveSourceToEssentiel` (l.258-264),
+   `_moveSourceToFlaner`, `_moveThemeToEssentiel`, `_moveThemeToFlaner` :
+   les prefs locales (`tournee_order_v1` / `pinned_tabs_order_v1`) sont écrites
+   **avant** la DB, puis `_persistSourceMode`/`_persistThemeMode` est explicitement
+   best-effort (l.266-278 : `catch` → toast d'erreur, le déplacement local reste
+   appliqué). Un échec réseau crée l'état : **clé locale présente + DB
+   `essentiel_mode=false`** (ou `false` hérité d'un placement Flâner antérieur).
+   NB : `_onAddSource` (l.208-230) fait déjà l'inverse (DB d'abord) — c'est le bon
+   pattern.
+
+2. **`promoteSuggestion` avale l'échec et l'UI confirme quand même.**
+   `flux_continu_provider.dart:2145-2167` : `catch (e) { debugPrint(...) }` ;
+   l'appelant (`flux_continu_screen.dart:913-916`) affiche « Ajoutée à tes
+   favoris » inconditionnellement. Même divergence possible, avec en plus un faux
+   feedback de succès.
+
+3. **La réconciliation cold-boot rejoue la divergence en éviction.**
+   `essentiel_placement_sync.dart:145-148` : pour une source favorite avec
+   `essentiel_mode == false` en DB, `reconcileEssentielPlacement` **retire** la clé
+   de `tournee_order_v1` et la remet en Flâner, silencieusement, **à chaque cold
+   boot**. Le backfill one-shot local→DB ne répare que `essentiel_mode == NULL`
+   (l.82-98), jamais un `false` incohérent. D'où le « constamment retirées » : une
+   seule écriture DB ratée suffit, l'éviction se répète ensuite indéfiniment.
+
+## Fix (mobile-only, 0 migration, 0 backend)
+
+### 1. DB d'abord, local ensuite (alignement sur le pattern `_onAddSource`)
+
+Dans `manage_favorites_sheet.dart`, réordonner les 4 `_move*` : d'abord
+`setSourceState`/`setInterestState` (qui rollback + rethrow déjà), et seulement en
+cas de succès appliquer les écritures locales (`_removeTab`/`_appendTournee`, etc.)
+et le toast de succès. En cas d'échec : toast d'erreur, **aucun** changement local,
+pas de divergence possible. Supprimer les helpers `_persistSourceMode`/
+`_persistThemeMode` best-effort (inlinés dans le nouveau flux).
+
+Dans `flux_continu_provider.dart::promoteSuggestion` : ne plus avaler l'erreur
+(rethrow après le debugPrint) ; DB d'abord, `_appendTourneeOrder` +
+`markCustomized` après succès. Côté écran, `onKeep` n'affiche le succès que si la
+promotion a réussi, sinon un message d'erreur.
+
+### 2. Réconciliation self-heal : le local gagne en cas de conflit
+
+Dans `reconcileEssentielPlacement`, branche `mode == false` d'une source : si la
+clé `source:<id>` est **déjà présente** dans `tournee_order_v1` local, ne plus la
+retirer. Cette présence témoigne d'une action utilisateur explicite sur ce device
+(les clés ne s'ajoutent que par action) : on **re-pousse** `essentiel_mode=true`
+en DB (best-effort, retenté au boot suivant si échec) au lieu de détruire le
+placement. Même logique en miroir pour les thèmes (`mode == false` avec clé
+`theme:<slug>` présente dans l'ordre Tournée).
+
+- La restauration après réinstallation reste inchangée : local vide → aucune clé
+  présente → la DB hydrate normalement (`mode == true` → ajout).
+- **Auto-réparation rétroactive** : tous les utilisateurs déjà divergés sont
+  réparés au premier cold boot, sans UI ni backfill.
+- Trade-off assumé (documenté ici) : un retrait de l'Essentiel effectué sur un
+  **autre device** peut être annulé par un device dont le cache local est plus
+  ancien. Cas rare (usage mono-device dominant) et le pire cas devient additif
+  (source qui reste dans l'Essentiel) au lieu de destructeur (config perdue).
+
+## Tests (lock de régression)
+
+`apps/mobile/test/features/flux_continu/`
+
+1. `manage_favorites_sheet_test.dart` : `_moveSourceToEssentiel` avec repo qui
+   échoue → `tournee_order_v1` et `pinned_tabs_order_v1` inchangés, erreur
+   affichée ; avec repo OK → local mis à jour après la DB.
+2. `essentiel_placement_sync` : conflit (clé locale présente + DB `false`) → clé
+   conservée + `setSourceState(essentielMode: true)` appelé ; local vide + DB
+   `true` → hydratation inchangée (réinstall) ; DB `false` sans clé locale →
+   comportement inchangé (Flâner).
+3. `promoteSuggestion` : échec repo → pas d'append à l'ordre, erreur propagée ;
+   pas de toast succès (test widget écran).
+
+## Vérification
+
+```bash
+cd apps/mobile
+flutter test test/features/flux_continu/
+flutter test && flutter analyze
+```
+
+QA manuelle : ajouter une source à l'Essentiel, kill app, relancer ×2 → la source
+reste. Simuler mode avion pendant le déplacement → erreur visible, état local
+intact, pas d'éviction aux boots suivants.
+
+## Statut — implémenté
+
+Mobile-only, 0 migration, 0 backend. Fichiers touchés :
+
+- `manage_favorites_sheet.dart` — déplacements réordonnés DB-first (DB via
+  `setSourceState`/`setInterestState`, écritures locales seulement en cas de
+  succès) ; helpers best-effort `_persistSourceMode`/`_persistThemeMode` supprimés.
+  Les 4 `_move*ToFlaner`/`_move*ToEssentiel` sont consolidés en `_moveSource`/
+  `_moveTheme` (`{required bool toEssentiel}`) déléguant à un helper `_moveMode`
+  qui porte le try/catch DB-first commun.
+- `flux_continu_provider.dart::promoteSuggestion` — `rethrow` après le `debugPrint`.
+- `flux_continu_screen.dart::onKeep` — `try/catch` : succès seulement si la
+  promotion a persisté, sinon message d'erreur.
+- `essentiel_placement_sync.dart` — branche self-heal (source + miroir thème) : clé
+  Essentiel locale présente + DB `false` → clé conservée + re-push
+  `essentiel_mode=true` (best-effort).
+
+Tests (verts) : `essentiel_placement_sync_test.dart` (self-heal source/thème,
+Flâner sans clé locale inchangé, re-push best-effort sur échec),
+`manage_favorites_sheet_test.dart` (DB-first : échec DB → prefs locales intactes),
+`flux_continu_provider_test.dart` (`promoteSuggestion` échec → exception propagée +
+ordre non pollué). `flutter analyze` : 0 issue.


### PR DESCRIPTION
## Quoi

Les sources/thèmes ajoutés à l'Essentiel étaient retirés à **chaque cold boot**
(« Constamment retirées de mon Essentiel ! », PO 22/07). Ce fix ferme la
divergence local/DB à la source et auto-répare les utilisateurs déjà touchés.

## Pourquoi

Cause racine (3 maillons) :
1. **Déplacements local-first best-effort** (`manage_favorites_sheet`) : les prefs
   locales étaient écrites *avant* la DB, la persistance DB étant best-effort. Un
   échec réseau laissait « clé locale présente + DB `essentiel_mode=false` ».
2. **`promoteSuggestion` avalait l'échec** et l'UI affichait « Ajoutée » quand
   même → même divergence + faux succès.
3. **La réconciliation cold-boot rejouait cette divergence en éviction**, à chaque
   boot (le backfill one-shot ne réparait que `NULL`, jamais un `false` incohérent).

## Comment

- `manage_favorites_sheet` : déplacements **DB-first** (`setSourceState`/
  `setInterestState` d'abord, prefs locales seulement en cas de succès, sinon toast
  d'erreur et **aucune** écriture locale). Helpers best-effort
  `_persistSourceMode`/`_persistThemeMode` supprimés ; les 4 `_move*` consolidés en
  `_moveSource`/`_moveTheme` (`{required bool toEssentiel}`) déléguant au helper
  commun `_moveMode` (issu de `/simplify`).
- `promoteSuggestion` : `rethrow` au lieu d'avaler ; `onKeep` ne confirme le succès
  que si la promotion a persisté, sinon message d'erreur.
- `essentiel_placement_sync` : branche **self-heal** (source + miroir thème) : clé
  Essentiel locale présente + DB `false` → clé conservée (plus d'éviction) +
  re-push `essentiel_mode=true` (best-effort, retenté au boot suivant). Répare
  rétroactivement les users déjà divergés, sans UI ni backfill. Trade-off assumé
  et documenté (`docs/bugs/bug-essentiel-mode-divergence-eviction.md`) : un retrait
  fait sur un autre device peut être annulé par un cache local plus ancien (pire cas
  additif, plus destructeur).

## Comment ça a été vérifié

- [x] `flutter test test/features/flux_continu/` → **451 tests OK** (dont les
  nouveaux locks de régression : DB-first échec → prefs intactes ; self-heal
  source/thème ; Flâner sans clé locale inchangé ; `promoteSuggestion` échec →
  exception propagée + ordre non pollué)
- [x] `flutter analyze` → 0 issue
- [x] `/simplify` passé (consolidation 4 `_move*` → 2 + `_moveMode`)
- Mobile-only : **0 migration, 0 backend**

## Zones à risque

- `essentiel_placement_sync.dart` (réconciliation cold-boot, `unawaited` hors
  chemin critique) et le placement Essentiel/Flâner des favoris. Couvert par les
  tests de régression ci-dessus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
