### PR TITLE
feat(tournee): suggestions garanties + quota visible + CTA carte + instrumentation (story 22.6)

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,46 +1,47 @@
-## perf(reader) — isolation raster : cartes carrousel + chrome vertical (RepaintBoundary natif)
+# feat(tournee): suggestions garanties + quota visible + CTA carte + instrumentation (story 22.6)
 
-Regroupe **PR 1 + PR 2** du plan fluidité scroll (`.context/attachments/97Nbws/plan.md`) en une
-seule PR, à la demande du PO. 100 % Dart mobile — aucun backend, aucune migration.
+Story 22.6 (PR 2), base `main`. Rend la Tournée « vivante » : un accent quotidien
+de 4-5 sections « Choisie pour vous » **garanti pour tous** (même 8+ favoris), un
+quota de 3 suggestions visibles sous le cap pour les comptes personnalisés, un CTA
+direct sur la carte, et l'instrumentation PostHog. **Aucune migration** (additif,
+expand-safe, 1 head Alembic). Invariant 22.3 conservé (jamais hors univers suivi).
 
-### Problème
+> PR 1 (`promoteSuggestion` fiabilisé) vit dans un autre workspace ; cette PR
+> suppose la même signature `promoteSuggestion(section)` et ajoute seulement un
+> `origin` **optionnel** (défaut `card`) → rebase non cassante.
 
-`FacteurCard` n'isole ses cartes que via `webRepaintBoundary` (`core/web/web_perf.dart:52`),
-**no-op hors web**. Sur natif, aucune carte du carrousel « comparaison de points de vue » n'était
-donc isolée : tout le `Row` (≤ 8 cartes, chacune ombre `blurRadius: 6` + `DiffTitle` multi-span +
-favicon) pouvait se re-rastériser à chaque frame de translation.
+## A. Backend — plancher de suggestions
 
-### Changements
+- `scoring_config.py` : `TOURNEE_SUGGEST_FLOOR = 4` ; `TOURNEE_SUGGEST_SUBCAP` 8 → 5.
+- `routers/users.py` `_arrange_tournee` : `sub_cap = min(SUBCAP, max(remaining, FLOOR))` ;
+  suppression de l'early-return `remaining <= 0` (gate `_smart_arrangement_enabled` conservé).
+  Effet : 0 favori → 5, 7 favoris → 4, 8+ favoris → 4. Pool pauvre → sert moins, jamais d'invention.
 
-**PR 1 — carrousel + nettoyage**
-- `RepaintBoundary` explicite par carte + par CTA dans `_buildCarousel` (le vrai boundary, pas le
-  helper web-only) → chaque carte = son layer, composité tel quel au scroll. Invisible.
-- `RepaintBoundary` par squelette dans `_buildLoadingSkeleton` (isole le shimmer).
-- `RepaintBoundary` autour des 2 `PerspectivesInlineSection` (N2) → isole les animations d'intro de
-  la bande du corps vertical.
-- Suppression de `_FadeScrollRow` (code mort, jamais instancié). −82 lignes.
-- **Choix H1 (Row + RepaintBoundary) plutôt que H2 (ListView virtualisée)** : pour ≤ 8 cartes, la
-  virtualisation rendrait `maxScrollExtent` estimé (casse le tap-to-scroll de la barre de biais) et
-  introduirait des hitches de build en cours de scroll. H1 délivre le gain cœur sans ces risques.
-  Détail dans `docs/maintenance/maintenance-reader-scroll-carrousel-repaint.md`.
+## B. Mobile — quota visible ≥3 sous le cap
 
-**PR 2 — audit V1 + micro-fix**
-- `RepaintBoundary` autour du `Transform.scale` du `_ctaPulseController` (N3). NB : pulse one-shot
-  280 ms, pas une animation répétée.
-- `PivotWashTitle` : key laissée telle quelle (rekey intentionnel qui pilote l'animation « wash » ;
-  la toucher casserait l'anim sans gain mesuré).
+- `flux_continu_provider.dart` `_orderedTourneeKeys` : insertion additive à la frontière du cap ;
+  `quota = min(kTourneeSuggestQuota=3, suggestions visibles)`, favoris tronqués à `cap - quota`
+  **sans permutation**, puis les `quota` premières suggestions en queue. No-op non-personnalisé.
 
-### Vérification
+## C. Mobile — CTA « Ajouter à mon Essentiel »
 
-- `flutter analyze` (fichiers touchés) : 0 nouvelle issue (warnings restants pré-existants).
-- `flutter test` (perspectives `feed/widgets` + `detail`) : 0 nouvel échec. Les échecs restants
-  (badge `scale: 1.6` vs test `1.0` ; phrase d'intro ; 4 stubs `notification_test`) sont
-  **confirmés pré-existants via baseline HEAD**.
-- ⚠️ **Profiling < 16 ms/frame = étape PO device** : le gain ne se mesure pas sur web (CanvasKit).
-  À vérifier en `flutter run --profile` (long article + carrousel).
+- `section_block.dart` : `onPromoteSuggestion` + `_PromoteSuggestionButton` (spinner, anti
+  double-tap, SnackBar « Ajouté à ton Essentiel »). Banner (badge + info-tap → sheet) inchangé.
+- `flux_continu_screen.dart` : câble `promoteSuggestion(section, origin: 'card')` ; la sheet
+  passe `origin: 'sheet'`.
 
-### Hors scope
+## D. Instrumentation PostHog
 
-PR 3 / V2 (virtualisation du corps `flutter_html`) — **le** levier pour le jank du corps des
-articles sans carrousel — non inclus (risque plus élevé, casse `_measureArticleExtent`). À ouvrir si
-le profiling montre encore > 16 ms/frame sur longs articles après ce lot.
+- `analytics_service.dart` : `trackSuggestionImpression` / `Promoted` / `Dismissed`.
+- Impressions dédupliquées **1/section/jour, persistées** (SharedPreferences `suggestion_impressions_v1`,
+  purge des jours passés). Émission au premier build de la section suggérée.
+
+## Vérification
+
+- Backend : `pytest` — 37 tests top-themes/suggester/users OK ; 1 head Alembic (`181c618da382`).
+- Mobile : `flutter test` — 453 tests flux_continu OK, 29 section_block, 14 analytics ;
+  `flutter analyze` 0 erreur (5 warnings pré-existants `dio.post` hors périmètre).
+- Changelog in-app : entrée « Ma Tournée » ajoutée (impact visible).
+
+Story : `docs/stories/core/22.6.tournee-suggestions-garanties-cta.md`.
+QA handoff : `.context/qa-handoff.md`.

--- a/.context/qa-handoff.md
+++ b/.context/qa-handoff.md
@@ -1,79 +1,77 @@
-# QA Handoff — « Rattraper » : nudge éphémère + point rouge « pas à jour »
+# QA Handoff — Tournée vivante : suggestions garanties + CTA (Story 22.6)
 
-> Rempli par l'agent dev. Input de /validate-feature. Story : `docs/stories/core/9.7.essentiel-rattraper-signal.md`.
-> (Handoff précédent « Lettres passées à parité visuelle » archivé dans
-> `.context/qa-handoff-lettres-parite.md`.)
+> Rempli par l'agent dev. Input de /validate-feature. Story :
+> `docs/stories/core/22.6.tournee-suggestions-garanties-cta.md`.
 
 ## Feature développée
 
-L'en-tête de la carte « Ton Essentiel » n'affiche plus « Rattraper » en
-permanence. En today à jour → icône ⏪ seule. Si l'édition d'hier (J-1) n'a pas
-été ouverte → point rouge persistant sur ⏪ + le texte « Rattraper ? » qui
-apparaît en fondu (~1 s), tient 2 s, disparaît en fondu, au plus 1×/jour. Sur
-une lettre passée → « Revenir » fixe (inchangé).
+La Tournée du jour garantit désormais un accent quotidien de 4-5 sections
+« Choisie pour vous » **pour tous les comptes** (même 8+ favoris), avec un quota
+de 3 suggestions visibles sous le cap d'affichage pour les comptes personnalisés,
+et un CTA direct « Ajouter à mon Essentiel » sur chaque carte suggérée.
 
 ## PR associée
 
-_(à compléter à l'ouverture de la PR)_
+À créer via `/go` (base `main`).
 
 ## Écrans impactés
 
 | Écran | Route | Modifié / Nouveau |
 |-------|-------|-------------------|
-| Flux Continu — carte « Ton Essentiel » (en-tête, déclencheur rewind) | onglet Essentiel | Modifié |
+| Tournée du jour / Flux Continu | `/flux-continu` | Modifié |
+| Sheet « Pourquoi cette section ? » | overlay | Inchangé (toujours fonctionnel) |
 
 ## Scénarios de test
 
-> ⚠️ L'état « en retard » dépend des streaks (J-1 `opened == false`), difficile
-> à forcer sur le build web sans backend/streaks peuplés. **La preuve principale
-> = les widget tests** (`essentiel_hi_fi_card_test.dart`,
-> `ephemeral_rattraper_label_test.dart`, `edition_read_status_provider_test.dart`).
-> Playwright couvre surtout le rendu « à jour » et le tap ⏪ → timeline.
-
-### Scénario 1 : à jour (happy path) — header épuré
+### Scénario 1 : Happy path — CTA sur la carte suggérée
 **Parcours** :
-1. Ouvrir l'app, onglet Essentiel (today), utilisateur à jour.
-2. Observer l'en-tête à droite du titre « Ton Essentiel ».
-**Résultat attendu** : icône ⏪ **seule**, aucun texte « Rattraper », aucun point
-rouge. Tap sur ⏪ → la timeline « Remonter le temps » s'ouvre.
+1. Ouvrir la Tournée du jour avec un compte qui reçoit des suggestions.
+2. Repérer une section badgée « Choisie pour vous ».
+3. Taper le bouton « Ajouter à mon Essentiel » en pied de carte.
+**Résultat attendu** : spinner bref, SnackBar « Ajouté à ton Essentiel », la
+section devient favorite (badge « Choisie pour vous » disparaît), l'ordre des
+autres favoris n'est **pas** permuté.
 
-### Scénario 2 : en retard — point rouge + nudge éphémère
+### Scénario 2 : Quota visible (compte personnalisé)
 **Parcours** :
-1. Utilisateur ayant manqué l'édition d'hier (J-1 non ouverte).
-2. Ouvrir l'onglet Essentiel (today).
-**Résultat attendu** : **point rouge** vif sur ⏪ (persistant) ; **~1 s** après,
-« Rattraper ? » apparaît en fondu, **tient 2 s**, disparaît en fondu. Ne se
-rejoue **pas** dans la journée (gate 1×/jour). Le point rouge, lui, reste.
+1. Compte avec un ordre de Tournée personnalisé et beaucoup de favoris (proche
+   du cap 13).
+2. Ouvrir la Tournée.
+**Résultat attendu** : exactement 3 sections « Choisie pour vous » restent
+visibles en queue, sous le cap — elles ne sont plus toutes coupées.
 
-### Scénario 3 : lettre passée — « Revenir » fixe
+### Scénario 3 : Dismiss d'une suggestion
 **Parcours** :
-1. Ouvrir la timeline, sélectionner « Hier ».
-**Résultat attendu** : l'en-tête montre « Revenir » **fixe** (sans point rouge,
-sans animation).
+1. Sur une section suggérée, ouvrir le « i » du badge → sheet.
+2. Choisir « Retirer » (dismiss).
+**Résultat attendu** : la section disparaît (retrait local réversible) ; une
+autre suggestion coupée par le cap peut remonter à sa place.
 
-### Scénario 4 : reduce-motion / accessibilité
+### Scénario 4 : Anti double-tap
 **Parcours** :
-1. Activer « Réduire les animations » (OS), état « en retard ».
-**Résultat attendu** : le point rouge reste (signal immobile) ; le texte animé
-« Rattraper ? » **n'est pas joué**.
+1. Taper rapidement 2× le bouton « Ajouter à mon Essentiel ».
+**Résultat attendu** : une seule promotion (bouton désactivé pendant l'attente),
+une seule SnackBar.
 
 ## Critères d'acceptation
 
-- [ ] À jour → icône ⏪ seule (ni libellé fixe, ni point, ni nudge).
-- [ ] En retard → point rouge persistant + « Rattraper ? » fondu-in ~1 s / tient
-  2 s / fondu-out, au plus 1×/jour.
-- [ ] Lettre passée → « Revenir » fixe, sans point.
-- [ ] ⏪ toujours tappable (ouvre la timeline) dans tous les états ; cible ≥ 24 px.
-- [ ] Reduce-motion → pas d'animation de texte.
-- [ ] Aucun faux positif au cold-boot / nouvel utilisateur (streaks indispo).
+- [ ] 4-5 suggestions/jour garanties, y compris pour un compte 8+ favoris.
+- [ ] ≥3 suggestions visibles sous le cap pour un compte personnalisé, ordre des
+  favoris préservé.
+- [ ] CTA « Ajouter à mon Essentiel » rendu uniquement sur les sections suggérées.
+- [ ] La sheet « Pourquoi cette section ? » (garder/retirer) reste fonctionnelle.
+- [ ] Pas d'em-dash dans la copy visible.
 
 ## Zones de risque
 
-- Frontière de jour 07h30 Paris vs off-by-one streaks (déjà assumé par la
-  timeline existante ; cf. `.context/streaks-health-handoff.md`).
-- Gate 1×/jour persisté au moment du fondu-in (prefs
-  `essentiel_rattraper_nudge_last_shown_v1`).
+- Ordre des favoris jamais permuté par l'insertion du quota (vérifier visuellement).
+- Sections éditoriales (Actus, Bonnes, Grille) : sur un compte très chargé elles
+  peuvent être repoussées hors cap (comportement pré-existant, non aggravé).
+- Instrumentation PostHog : impression dédupliquée 1×/section/jour (persistée) —
+  non visible à l'écran mais à ne pas casser.
 
 ## Dépendances
 
-- Aucun endpoint / migration. Réutilise `editionReadStatusProvider` (streaks).
+- Backend `GET /api/users/top-themes` (plancher de suggestions, aucune migration).
+- Events PostHog : `suggestion_impression`, `suggestion_promoted`,
+  `suggestion_dismissed`.

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Ma Tournée",
+      "summary": "Chaque jour, ta tournée te propose quelques sections « Choisie pour vous » puisées dans tes thèmes et sources préférés, même si tu as déjà beaucoup configuré. Un bouton « Ajouter à mon Essentiel » sur la carte les garde en un tap, et celles que tu personnalises restent toujours visibles."
+    },
+    {
       "tag": "Fiche source",
       "summary": "La couverture d'une source reflète à nouveau ses vrais thèmes : les articles pas encore rangés ne gonflent plus la part « Autres », et son volume d'articles publiés reste affiché tel quel. Les cartes retrouvent aussi leur pastille de thème."
     },

--- a/apps/mobile/lib/core/services/analytics_service.dart
+++ b/apps/mobile/lib/core/services/analytics_service.dart
@@ -820,6 +820,73 @@ class AnalyticsService {
   }
 
   // ──────────────────────────────────────────────────────────────
+  // Tournée — suggestions « Choisie pour vous » (Story 22.6)
+  // ──────────────────────────────────────────────────────────────
+
+  /// Clé SharedPreferences de dédup des impressions de suggestions. Une entrée
+  /// `'$dayKey|$sectionKey'` par section suggérée déjà comptée aujourd'hui ;
+  /// purgée des jours passés à chaque émission (1 impression/section/jour).
+  static const _kSuggestionImpressionsKey = 'suggestion_impressions_v1';
+
+  /// Impression d'une section suggérée, **dédupliquée 1×/section/jour** et
+  /// persistée (survit aux rebuilds et relances). Émise au premier build de la
+  /// section ; les appels suivants du même jour sont des no-op silencieux.
+  Future<void> trackSuggestionImpression({
+    required String sectionKey,
+    required String kind,
+    required String dayKey,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    final entry = '$dayKey|$sectionKey';
+    // Purge des jours passés : on ne conserve que les entrées du jour courant.
+    final kept = (prefs.getStringList(_kSuggestionImpressionsKey) ?? const [])
+        .where((e) => e.startsWith('$dayKey|'))
+        .toList();
+    if (kept.contains(entry)) return; // déjà comptée aujourd'hui
+    kept.add(entry);
+    await prefs.setStringList(_kSuggestionImpressionsKey, kept);
+    final props = {
+      'session_id': _sessionId,
+      'section_key': sectionKey,
+      'kind': kind,
+      'day_key': dayKey,
+    };
+    await _logEvent('suggestion_impression', props);
+    await _capturePostHog('suggestion_impression', props);
+  }
+
+  /// Promotion d'une suggestion en favori. [origin] = `card` (CTA de la carte)
+  /// ou `sheet` (« Garder dans mes favoris »).
+  Future<void> trackSuggestionPromoted({
+    required String sectionKey,
+    required String kind,
+    required String origin,
+  }) async {
+    final props = {
+      'session_id': _sessionId,
+      'section_key': sectionKey,
+      'kind': kind,
+      'origin': origin,
+    };
+    await _logEvent('suggestion_promoted', props);
+    await _capturePostHog('suggestion_promoted', props);
+  }
+
+  /// Dismiss d'une suggestion (retrait local réversible).
+  Future<void> trackSuggestionDismissed({
+    required String sectionKey,
+    required String kind,
+  }) async {
+    final props = {
+      'session_id': _sessionId,
+      'section_key': sectionKey,
+      'kind': kind,
+    };
+    await _logEvent('suggestion_dismissed', props);
+    await _capturePostHog('suggestion_dismissed', props);
+  }
+
+  // ──────────────────────────────────────────────────────────────
   // La Grille du jour (Story 24.2)
   // ──────────────────────────────────────────────────────────────
 

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -7,6 +7,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/auth/auth_state.dart' show authStateProvider;
+import '../../../core/providers/analytics_provider.dart'
+    show analyticsServiceProvider;
 import '../../digest/models/digest_models.dart';
 import '../../digest/models/dual_digest_response.dart';
 import '../../digest/providers/digest_provider.dart'
@@ -2135,14 +2137,31 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   /// avait été coupée par le cap) remonte gratuitement.
   Future<void> dismissSuggestion(FeedThemeSection section) async {
     final key = sectionKey(section);
+    unawaited(
+      ref.read(analyticsServiceProvider).trackSuggestionDismissed(
+            sectionKey: key,
+            kind: section.kind.name,
+          ),
+    );
     await ref.read(tourneeOrderPrefsProvider.notifier).setHidden(key, true);
   }
 
   /// Promeut une suggestion en favori dédié (réutilise le chemin favori
   /// existant). La section repassera `origin="validated"` au prochain load et
   /// sortira du pool suggéré. Les listeners `userInterests`/`userSources`
-  /// recomposent la Tournée.
-  Future<void> promoteSuggestion(FeedThemeSection section) async {
+  /// recomposent la Tournée. [origin] (`card`/`sheet`, Story 22.6) trace le
+  /// point d'entrée de la promotion pour l'analytics.
+  Future<void> promoteSuggestion(
+    FeedThemeSection section, {
+    String origin = 'card',
+  }) async {
+    unawaited(
+      ref.read(analyticsServiceProvider).trackSuggestionPromoted(
+            sectionKey: sectionKey(section),
+            kind: section.kind.name,
+            origin: origin,
+          ),
+    );
     await ref.read(tourneeOrderPrefsProvider.notifier).markCustomized();
     try {
       if (section.kind == SectionKind.source && section.sourceId != null) {
@@ -2298,9 +2317,37 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       ordered.insert(actusIndex >= 0 ? actusIndex + 1 : 0, kTourneeGrilleKey);
     }
 
-    return cap == null
-        ? ordered.toList(growable: false)
-        : ordered.take(cap).toList(growable: false);
+    if (cap == null) return ordered.toList(growable: false);
+
+    // Story 22.6 — quota de suggestions garanti sous le cap. Un ordre
+    // personnalisé (`applyOrder` sticky) relègue les sections « Choisie pour
+    // vous » en fin de liste, où `take(cap)` les coupait toutes (« plus tu
+    // configures, moins tu vois de suggestions »). On réserve jusqu'à
+    // `kTourneeSuggestQuota` slots en queue du cap aux premières suggestions
+    // disponibles, **sans jamais permuter l'ordre relatif des favoris**. No-op
+    // quand `take(cap)` en contient déjà assez (cas non-personnalisé) ou
+    // qu'aucune suggestion ne survit aux `hiddenKeys` (quota 0 rend tous les
+    // slots aux favoris).
+    final suggestedKeySet = suggestedKeys.toSet();
+    final orderedSuggested = [
+      for (final key in ordered)
+        if (suggestedKeySet.contains(key)) key,
+    ];
+    final quota = math.min(orderedSuggested.length, kTourneeSuggestQuota);
+    final capped = ordered.take(cap).toList(growable: false);
+    final visibleSuggested = capped.where(suggestedKeySet.contains).length;
+    // Couvre aussi `quota == 0` (aucune suggestion) : `0 >= 0` rend tous les
+    // slots aux favoris sans branche dédiée.
+    if (visibleSuggested >= quota) return capped;
+
+    // Rééquilibrage : favoris/éditorial dans l'ordre appliqué, tronqués à
+    // `cap - quota` (ordre préservé), puis les `quota` premières suggestions.
+    final favSlots = math.max(0, cap - quota);
+    final head = [
+      for (final key in ordered)
+        if (!suggestedKeySet.contains(key)) key,
+    ].take(favSlots);
+    return [...head, ...orderedSuggested.take(quota)].toList(growable: false);
   }
 
   /// Renvoie [themeKeys] avec, en tête, la clé du thème auquel l'utilisateur a

--- a/apps/mobile/lib/features/flux_continu/providers/tournee_order_prefs_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/tournee_order_prefs_provider.dart
@@ -39,6 +39,13 @@ const _kTourneeCustomizedKey = 'tournee_customized_v1';
 /// 8 thématiques + Actus + Bonnes + Grille = 11, + marge.
 const int kTourneeVisibleCap = 13;
 
+/// Quota de sections « Choisie pour vous » garanti **sous le cap** (Story 22.6).
+/// Un ordre personnalisé relègue les suggestions en fin de liste où le cap les
+/// coupait ; `_orderedTourneeKeys` réserve jusqu'à ce nombre de slots en queue
+/// du cap aux premières suggestions disponibles, sans permuter les favoris. Le
+/// quota effectif est `min(kTourneeSuggestQuota, suggestions visibles)`.
+const int kTourneeSuggestQuota = 3;
+
 /// Seuils de cohérence d'affichage des sections favorites (thème/source) après
 /// la dédup inter-sections. Une section **maigre** (≤ [kThinSectionMaxItems]
 /// survivants) est dépriorisée sous les **riches** (≥ [kRichSectionMinItems])

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -56,6 +56,8 @@ import '../providers/selected_edition_date_provider.dart';
 import '../providers/tournee_order_prefs_provider.dart'
     show tourneeOrderPrefsProvider;
 import '../services/auto_grow_nudge_scheduler.dart';
+import '../services/tournee_progress_service.dart'
+    show TourneeProgressService;
 import '../utils/morning_ritual_format.dart' show formatFrenchLongDate;
 import '../utils/section_fit.dart' show kMinPlausibleUsableHeight;
 import '../utils/section_snap.dart';
@@ -293,6 +295,12 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
   final Set<String> _pendingFeedback = <String>{};
   bool _gestureNudgeRequested = false;
   bool _showSwipeHint = false;
+
+  /// Story 22.6 — garde-fou mémoire : sections suggérées déjà comptées en
+  /// impression durant la vie de cet écran. Évite de relire SharedPreferences à
+  /// chaque rebuild ; la dédup **persistée** (1×/section/jour) reste dans
+  /// `AnalyticsService.trackSuggestionImpression`.
+  final Set<String> _impressedSuggestionKeys = <String>{};
 
   /// Mutable, stable holder of the section-start anchors (absolute scroll
   /// pixels). Passed *by reference* to the immutable [_SectionSnapPhysics],
@@ -911,7 +919,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
       sectionTitle: section.label,
       reason: section.reason,
       onKeep: () async {
-        await notifier.promoteSuggestion(section);
+        await notifier.promoteSuggestion(section, origin: 'sheet');
         NotificationService.showSuccess('Ajoutée à tes favoris');
       },
       onDismiss: () async {
@@ -1665,6 +1673,21 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
       // (elle se gère via son badge « Choisie pour vous » + sheet), pour ne pas
       // confondre les deux affordances.
       final isSuggested = section is FeedThemeSection && section.isSuggested;
+      // Story 22.6 — impression au premier build d'une section suggérée
+      // affichée (dédup persistée 1×/section/jour côté AnalyticsService ;
+      // garde-fou mémoire pour ne pas relire SharedPreferences à chaque frame).
+      if (isSuggested) {
+        final key = sectionKey(section);
+        if (_impressedSuggestionKeys.add(key)) {
+          unawaited(
+            ref.read(analyticsServiceProvider).trackSuggestionImpression(
+                  sectionKey: key,
+                  kind: section.kind.name,
+                  dayKey: TourneeProgressService.dayKey(DateTime.now()),
+                ),
+          );
+        }
+      }
       // Mode personnalisé : préfixe l'inline « Gérer / Tes N favoris » au-dessus
       // du `SectionBlock`, à l'intérieur du subtree mesuré → l'inline fait
       // partie du bloc de snap de cette section (cf. [inlineTargetIndex]).
@@ -1713,6 +1736,14 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
                       onTapSuggestionInfo: isSuggested
                           ? () =>
                               _openSuggestionSheet(context, section, notifier)
+                          : null,
+                      // Story 22.6 — CTA direct « Ajouter à mon Essentiel » sur
+                      // la carte suggérée (origin=card pour l'analytics).
+                      onPromoteSuggestion: isSuggested
+                          ? () => notifier.promoteSuggestion(
+                                section,
+                                origin: 'card',
+                              )
                           : null,
                       // Story 23.4 — bouton réglages (tune) sur la section veille →
                       // ouvre la config en édition. Réutilisé par le CTA d'état vide.

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -63,6 +63,13 @@ class SectionBlock extends StatelessWidget {
   /// pour les sections `origin == suggested` (cf. flux_continu_screen).
   final VoidCallback? onTapSuggestionInfo;
 
+  /// Story 22.6 — CTA direct « Ajouter à mon Essentiel » en pied d'une section
+  /// suggérée : promeut la section en favorite sans passer par la sheet. Câblé
+  /// uniquement pour les sections `origin == suggested` (non-null ⇒ bouton
+  /// rendu). Le future résout après la promotion (le bouton gère spinner +
+  /// anti double-tap localement).
+  final Future<void> Function()? onPromoteSuggestion;
+
   const SectionBlock({
     super.key,
     required this.section,
@@ -82,6 +89,7 @@ class SectionBlock extends StatelessWidget {
     this.onAddSources,
     this.onSeeAll,
     this.onTapSuggestionInfo,
+    this.onPromoteSuggestion,
   });
 
   @override
@@ -146,6 +154,12 @@ class SectionBlock extends StatelessWidget {
           onTapInfo: onTapSuggestionInfo,
         ),
         ...cards,
+        // Story 22.6 — CTA direct sur la carte suggérée (le badge/info-tap du
+        // banner reste, lui, la voie « Pourquoi cette section ? »).
+        if (section is FeedThemeSection &&
+            section.isSuggested &&
+            onPromoteSuggestion != null)
+          _PromoteSuggestionButton(onPromote: onPromoteSuggestion!),
         const SizedBox(height: 16),
       ],
     );
@@ -630,3 +644,56 @@ class SectionSkeletonCard extends StatelessWidget {
 List<Widget> sectionSkeletonCards(int count) => [
   for (var i = 0; i < count; i++) const SectionSkeletonCard(),
 ];
+
+/// Story 22.6 — bouton « Ajouter à mon Essentiel » en pied d'une section
+/// suggérée. Gère localement le spinner d'attente + l'anti double-tap ; la
+/// SnackBar de succès est émise via le `ScaffoldMessenger` capturé avant l'await
+/// (le bouton peut être démonté quand la section devient favorite).
+class _PromoteSuggestionButton extends StatefulWidget {
+  const _PromoteSuggestionButton({required this.onPromote});
+
+  final Future<void> Function() onPromote;
+
+  @override
+  State<_PromoteSuggestionButton> createState() =>
+      _PromoteSuggestionButtonState();
+}
+
+class _PromoteSuggestionButtonState extends State<_PromoteSuggestionButton> {
+  bool _pending = false;
+
+  Future<void> _handlePromote() async {
+    if (_pending) return;
+    final messenger = ScaffoldMessenger.of(context);
+    setState(() => _pending = true);
+    try {
+      await widget.onPromote();
+      // Succès uniquement : un throw saute directement au `finally`.
+      messenger.showSnackBar(
+        const SnackBar(content: Text('Ajouté à ton Essentiel')),
+      );
+    } finally {
+      if (mounted) setState(() => _pending = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 0, 12, 4),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: FilledButton.tonal(
+          onPressed: _pending ? null : _handlePromote,
+          child: _pending
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('Ajouter à mon Essentiel'),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/test/core/services/analytics_service_dual_track_test.dart
+++ b/apps/mobile/test/core/services/analytics_service_dual_track_test.dart
@@ -223,4 +223,78 @@ void main() {
     // PostHog still fired (independent of backend).
     expect(posthog.captured.map((e) => e.event), contains('source_added'));
   });
+
+  // ── Suggestions « Choisie pour vous » (Story 22.6) ──────────────────────
+
+  test('trackSuggestionPromoted fires suggestion_promoted with origin/kind',
+      () async {
+    final service = AnalyticsService(api, posthog: posthog);
+    await service.trackSuggestionPromoted(
+      sectionKey: 'theme:tech',
+      kind: 'theme',
+      origin: 'card',
+    );
+    final entry =
+        posthog.captured.firstWhere((e) => e.event == 'suggestion_promoted');
+    expect(entry.properties?['section_key'], 'theme:tech');
+    expect(entry.properties?['kind'], 'theme');
+    expect(entry.properties?['origin'], 'card');
+  });
+
+  test('trackSuggestionDismissed fires suggestion_dismissed', () async {
+    final service = AnalyticsService(api, posthog: posthog);
+    await service.trackSuggestionDismissed(
+      sectionKey: 'source:s1',
+      kind: 'source',
+    );
+    final entry =
+        posthog.captured.firstWhere((e) => e.event == 'suggestion_dismissed');
+    expect(entry.properties?['section_key'], 'source:s1');
+    expect(entry.properties?['kind'], 'source');
+  });
+
+  test('trackSuggestionImpression dédupe 1×/section/jour et purge les jours '
+      'passés', () async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    final service = AnalyticsService(api, posthog: posthog);
+
+    Iterable<dynamic> impressions() =>
+        posthog.captured.where((e) => e.event == 'suggestion_impression');
+
+    // Même section, même jour → une seule impression.
+    await service.trackSuggestionImpression(
+      sectionKey: 'theme:tech',
+      kind: 'theme',
+      dayKey: '2026-07-23',
+    );
+    await service.trackSuggestionImpression(
+      sectionKey: 'theme:tech',
+      kind: 'theme',
+      dayKey: '2026-07-23',
+    );
+    expect(impressions(), hasLength(1));
+
+    // Autre section le même jour → nouvelle impression.
+    await service.trackSuggestionImpression(
+      sectionKey: 'theme:science',
+      kind: 'theme',
+      dayKey: '2026-07-23',
+    );
+    expect(impressions(), hasLength(2));
+
+    // Jour suivant, même section → réémise (jour passé purgé).
+    await service.trackSuggestionImpression(
+      sectionKey: 'theme:tech',
+      kind: 'theme',
+      dayKey: '2026-07-24',
+    );
+    expect(impressions(), hasLength(3));
+
+    // La purge borne le set persisté au jour courant.
+    final prefs = await SharedPreferences.getInstance();
+    final stored =
+        prefs.getStringList('suggestion_impressions_v1') ?? const [];
+    expect(stored.every((e) => e.startsWith('2026-07-24|')), isTrue);
+    expect(stored, ['2026-07-24|theme:tech']);
+  });
 }

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_tournee_order_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_tournee_order_test.dart
@@ -1020,6 +1020,155 @@ void main() {
     });
   });
 
+  group('quota de suggestions sous le cap (Story 22.6)', () {
+    // 13 slugs thématiques favoris = cap plein, sans marge pour les
+    // suggestions reléguées en fin d'un ordre personnalisé.
+    const favSlugs = [
+      'society',
+      'culture',
+      'economy',
+      'politics',
+      'tech',
+      'science',
+      'environment',
+      'health',
+      'sport',
+      'international',
+      'media',
+      'justice',
+      'food',
+    ];
+
+    List<TopTheme> suggested(List<String> slugs) => [
+          for (final slug in slugs)
+            TopTheme(
+              interestSlug: slug,
+              weight: 1.0,
+              articleCount: 4,
+              origin: 'suggested',
+              reason: const SuggestionReason(label: 'Tu suis ce thème'),
+            ),
+        ];
+
+    Map<String, List<String>> feedFor(List<String> slugs) => {
+          for (final slug in slugs) slug: ['$slug-1', '$slug-2'],
+        };
+
+    Future<ProviderContainer> personalized({
+      required List<String> suggestedSlugs,
+      required List<String> hiddenKeys,
+    }) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'tournee_customized_v1': true,
+        'tournee_order_v1': [for (final s in favSlugs) 'theme:$s'],
+        if (hiddenKeys.isNotEmpty) 'tournee_hidden_keys_v1': hiddenKeys,
+      });
+      when(() => fluxRepo.getTopThemes())
+          .thenAnswer((_) async => suggested(suggestedSlugs));
+      stubFeed(themeIds: {...feedFor(favSlugs), ...feedFor(suggestedSlugs)});
+      final container = await buildContainer(
+        interests: _interestsState(
+          favorites: [for (final s in favSlugs) ThemeFavoriteRef(slug: s)],
+        ),
+        sourcesState: _sourcesState(),
+        catalog: const [],
+      );
+      addTearDown(container.dispose);
+      await settle(container);
+      return container;
+    }
+
+    test('personnalisé + 13 favoris ⇒ 3 suggestions en queue, favoris intacts',
+        () async {
+      final container = await personalized(
+        suggestedSlugs: const ['sugA', 'sugB', 'sugC', 'sugD'],
+        hiddenKeys: const [],
+      );
+      final sections = favoriteSections(container);
+      expect(sections, hasLength(kTourneeVisibleCap));
+
+      final suggestedVisible = sections.where((s) => s.isSuggested).toList();
+      expect(suggestedVisible, hasLength(3), reason: 'quota garanti sous le cap');
+      // Best-first (daily_rank backend) : les 3 premières, pas sugD.
+      expect(
+        suggestedVisible.map((s) => s.themeSlug).toList(),
+        ['sugA', 'sugB', 'sugC'],
+      );
+      // Suggestions en queue ; les 10 premiers slots = favoris, ordre manuel
+      // strictement préservé (jamais permuté).
+      final favVisible = sections.where((s) => !s.isSuggested).toList();
+      expect(favVisible.map((s) => s.themeSlug).toList(), favSlugs.take(10));
+      expect(sections.skip(10).every((s) => s.isSuggested), isTrue);
+    });
+
+    test('suggestion cachée non comptée dans le quota', () async {
+      // 3 suggestions, 1 dismissée → 2 disponibles → quota 2.
+      final container = await personalized(
+        suggestedSlugs: const ['sugA', 'sugB', 'sugC'],
+        hiddenKeys: const ['theme:sugB'],
+      );
+      final sections = favoriteSections(container);
+      final suggestedVisible = sections.where((s) => s.isSuggested).toList();
+      expect(suggestedVisible, hasLength(2));
+      expect(
+        suggestedVisible.map((s) => s.themeSlug).toList(),
+        ['sugA', 'sugC'],
+        reason: 'la suggestion cachée sort du quota, pas de re-comptage',
+      );
+      final favVisible = sections.where((s) => !s.isSuggested).toList();
+      expect(favVisible.map((s) => s.themeSlug).toList(), favSlugs.take(11));
+    });
+
+    test('1 seule suggestion dispo ⇒ quota 1', () async {
+      final container = await personalized(
+        suggestedSlugs: const ['sugA'],
+        hiddenKeys: const [],
+      );
+      final sections = favoriteSections(container);
+      final suggestedVisible = sections.where((s) => s.isSuggested).toList();
+      expect(suggestedVisible, hasLength(1));
+      expect(suggestedVisible.first.themeSlug, 'sugA');
+      final favVisible = sections.where((s) => !s.isSuggested).toList();
+      expect(favVisible.map((s) => s.themeSlug).toList(), favSlugs.take(12));
+    });
+
+    test('non-personnalisé sous le cap ⇒ ordre naturel inchangé', () async {
+      // 2 favoris + 2 suggestions tiennent largement sous le cap : pas de
+      // rééquilibrage, suggestions à leur position naturelle (après favoris).
+      when(() => fluxRepo.getTopThemes())
+          .thenAnswer((_) async => suggested(const ['sugA', 'sugB']));
+      stubFeed(
+        themeIds: {
+          ...feedFor(const ['society', 'culture']),
+          ...feedFor(const ['sugA', 'sugB']),
+        },
+      );
+      final container = await buildContainer(
+        interests: _interestsState(
+          favorites: const [
+            ThemeFavoriteRef(slug: 'society'),
+            ThemeFavoriteRef(slug: 'culture'),
+          ],
+        ),
+        sourcesState: _sourcesState(),
+        catalog: const [],
+      );
+      addTearDown(container.dispose);
+      await settle(container);
+
+      final sections = favoriteSections(container);
+      expect(
+        sections.map((s) => s.themeSlug).toList(),
+        ['society', 'culture', 'sugA', 'sugB'],
+        reason: 'favoris puis suggestions best-first, aucun rééquilibrage',
+      );
+      expect(
+        sections.where((s) => s.isSuggested).map((s) => s.themeSlug).toList(),
+        ['sugA', 'sugB'],
+      );
+    });
+  });
+
   test(
       'thème favori explicite à 1 item ⇒ section construite (jamais masquée, '
       'miroir source/veille)', () async {

--- a/apps/mobile/test/features/flux_continu/widgets/section_block_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/section_block_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -118,6 +120,20 @@ FeedThemeSection _sourceSection({
     items: List.generate(items, (i) => _content('c$i')),
     hasMore: false,
     noRecentSource: noRecentSource,
+  );
+}
+
+FeedThemeSection _suggestedThemeSection({int items = 3}) {
+  return FeedThemeSection(
+    kind: SectionKind.theme,
+    label: 'Science',
+    accent: const Color(0xFF16A085),
+    coreVisibleCount: 3,
+    themeSlug: 'science',
+    items: List.generate(items, (i) => _content('c$i')),
+    hasMore: false,
+    origin: SectionOrigin.suggested,
+    reason: const SuggestionReason(label: 'Tu suis ce thème'),
   );
 }
 
@@ -576,6 +592,97 @@ void main() {
       // hero sur une section thème → toute FacteurImage est une image de carte).
       expect(find.byType(FluxContinuArticleCard), findsNWidgets(3));
       expect(find.byType(FacteurImage), findsNWidgets(2));
+    });
+  });
+
+  group('SectionBlock — CTA « Ajouter à mon Essentiel » (Story 22.6)', () {
+    final ctaFinder =
+        find.widgetWithText(FilledButton, 'Ajouter à mon Essentiel');
+
+    testWidgets('rendu uniquement pour une suggérée avec callback',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        SectionBlock(
+          section: _suggestedThemeSection(),
+          onTapArticle: (_) {},
+          onPromoteSuggestion: () async {},
+        ),
+      ));
+      expect(ctaFinder, findsOneWidget);
+    });
+
+    testWidgets('absent sur une section validée', (tester) async {
+      await tester.pumpWidget(_wrap(
+        SectionBlock(
+          section: _themeSection(items: 3),
+          onTapArticle: (_) {},
+          onPromoteSuggestion: () async {},
+        ),
+      ));
+      expect(find.text('Ajouter à mon Essentiel'), findsNothing);
+    });
+
+    testWidgets('absent si onPromoteSuggestion est null', (tester) async {
+      await tester.pumpWidget(_wrap(
+        SectionBlock(
+          section: _suggestedThemeSection(),
+          onTapArticle: (_) {},
+        ),
+      ));
+      expect(find.text('Ajouter à mon Essentiel'), findsNothing);
+    });
+
+    testWidgets('tap déclenche le callback une fois + SnackBar succès',
+        (tester) async {
+      var calls = 0;
+      await tester.pumpWidget(_wrap(
+        SectionBlock(
+          section: _suggestedThemeSection(),
+          onTapArticle: (_) {},
+          onPromoteSuggestion: () async => calls++,
+        ),
+      ));
+      await tester.ensureVisible(ctaFinder);
+      await tester.tap(ctaFinder);
+      await tester.pumpAndSettle();
+      expect(calls, 1);
+      expect(find.text('Ajouté à ton Essentiel'), findsOneWidget);
+    });
+
+    testWidgets('désactivé pendant le pending (anti double-tap)',
+        (tester) async {
+      final completer = Completer<void>();
+      var calls = 0;
+      await tester.pumpWidget(_wrap(
+        SectionBlock(
+          section: _suggestedThemeSection(),
+          onTapArticle: (_) {},
+          onPromoteSuggestion: () {
+            calls++;
+            return completer.future;
+          },
+        ),
+      ));
+      await tester.ensureVisible(ctaFinder);
+      await tester.tap(ctaFinder);
+      await tester.pump(); // entre en état pending
+
+      // Spinner affiché, libellé remplacé, bouton désactivé.
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(ctaFinder, findsNothing);
+      final button = tester.widget<FilledButton>(find.byType(FilledButton));
+      expect(button.onPressed, isNull);
+
+      // Second tap pendant le pending : aucun nouvel appel.
+      await tester.tap(find.byType(FilledButton), warnIfMissed: false);
+      await tester.pump();
+      expect(calls, 1);
+
+      // Résolution → CTA revient, SnackBar de succès.
+      completer.complete();
+      await tester.pumpAndSettle();
+      expect(calls, 1);
+      expect(find.text('Ajouté à ton Essentiel'), findsOneWidget);
     });
   });
 }

--- a/docs/stories/core/22.6.tournee-suggestions-garanties-cta.md
+++ b/docs/stories/core/22.6.tournee-suggestions-garanties-cta.md
@@ -1,0 +1,112 @@
+# Story 22.6 — Tournée vivante : suggestions garanties + CTA (PR 2)
+
+> **Type** : Feature
+> **Statut** : En cours (VERIFY)
+> **Branche** : `boujonlaurin-dotcom/tournee-vivante-suggestions-cta` → `main`
+> **Épopée** : 22 — Tournée du jour / Essentiel
+
+---
+
+## Contexte
+
+Les suggestions « Choisie pour vous » (Story 22.3) ne faisaient que **compléter jusqu'à 8
+sections** (`TOURNEE_TARGET_SECTIONS`) : un compte bien configuré (8+ favoris) recevait **zéro
+suggestion**, et côté mobile un ordre personnalisé reléguait les suggestions en fin de liste où
+le cap d'affichage (13) les coupait — « plus tu configures, moins tu vois de suggestions ». Le
+CTA de promotion était enfoui dans la sheet « Pourquoi cette section ? ».
+
+**Objectif** : 4-5 suggestions/jour **garanties pour tous**, un **quota visible ≥3 sous le cap**
+côté mobile, un **CTA direct sur la carte**, et une **instrumentation PostHog** pour arbitrer les
+suites. Invariant 22.3 conservé : suggestions uniquement dans l'univers déjà suivi (+
+élargissement doux : sources curées sur thème suivi — validé PO).
+
+## Arbitrages PO (22/07/2026)
+
+- `TOURNEE_SUGGEST_SUBCAP` 8 → 5 ; plancher `TOURNEE_SUGGEST_FLOOR = 4`.
+- Élargissement doux OK pour remplir le plancher (déjà en place, Story 22.3).
+- Impressions dédupliquées **1/section/jour, persistées** (SharedPreferences).
+- **PR 1 (`promoteSuggestion` fiabilisé) est dans un autre workspace** — cette PR suppose la même
+  signature `promoteSuggestion(section)` et sera rebasée avant merge ; seul ajout ici : le
+  paramètre optionnel `origin` pour l'analytics (`card` défaut → rebase non cassante).
+
+---
+
+## Plan technique & tasks
+
+### A. Backend — plancher de suggestions ✓
+
+- [x] `scoring_config.py` : `TOURNEE_SUGGEST_FLOOR = 4` ; `TOURNEE_SUGGEST_SUBCAP` 8 → 5.
+- [x] `routers/users.py` `_arrange_tournee` : `sub_cap = min(SUBCAP, max(remaining, FLOOR))` ;
+  suppression de l'early-return `remaining <= 0` (le gate `_smart_arrangement_enabled` reste).
+  Effet : 0 favori → 5, 7 favoris → 4, 8+ favoris → 4. Docstring mise à jour.
+- [x] Pool insuffisant (comptes de niche) : `TourneeSuggester._build_pool` sert naturellement
+  moins que `FLOOR` — jamais d'invention hors invariant ; l'élargissement doux
+  (`soft_limit = max(sub_cap*2, 4)`) reste la seule réserve.
+- [x] Tests `tests/routers/test_top_themes_suggestions.py` : 7 favoris → 4 suggestions (pas 1) ;
+  pool riche + 0 favori → plafonné à SUBCAP (5). Tests suggester inchangés (arrange prend
+  `sub_cap` en paramètre ; le plancher vit dans le routeur).
+
+### B. Mobile — quota visible ≥3 sous le cap ✓
+
+- [x] `flux_continu_provider.dart` `_orderedTourneeKeys` : après `applyOrder`, insertion additive
+  à la frontière du cap. `quota = min(kTourneeSuggestQuota=3, suggestions visibles post-hidden)` ;
+  no-op si `take(cap)` en contient déjà assez (cas non-personnalisé) ; sinon favoris/éditorial
+  tronqués à `cap - quota` (ordre manuel **strictement préservé**) puis les `quota` premières
+  suggestions en queue. `kTourneeSuggestQuota` défini dans `tournee_order_prefs_provider.dart`.
+- [x] Tests `flux_continu_tournee_order_test.dart` : personnalisé + 13 favoris → exactement 3
+  suggestions en queue, favoris intacts ; suggestion cachée non comptée ; 1 seule dispo → quota
+  1 ; non-personnalisé sous le cap inchangé.
+
+### C. Mobile — CTA « Ajouter à mon Essentiel » sur la carte ✓
+
+- [x] `section_block.dart` : nouveau `Future<void> Function()? onPromoteSuggestion` (rendu ssi
+  `origin == suggested`) ; bouton footer `FilledButton.tonal` « Ajouter à mon Essentiel » via un
+  `_PromoteSuggestionButton` stateful (spinner pendant l'await, désactivé anti double-tap,
+  SnackBar succès « Ajouté à ton Essentiel »). Le banner garde badge « Choisie pour vous » +
+  info-tap → sheet. Pas d'em-dash dans la copy.
+- [x] `flux_continu_screen.dart` : `onPromoteSuggestion: () => notifier.promoteSuggestion(section,
+  origin: 'card')` ; la sheet (`suggestion_reason_sheet.dart`) passe `origin: 'sheet'`.
+- [x] Tests `section_block_test.dart` : CTA rendu ssi suggested + callback ; tap → callback 1× +
+  SnackBar ; désactivé pendant le pending.
+
+### D. Instrumentation PostHog ✓
+
+- [x] `analytics_service.dart` : `trackSuggestionImpression` / `trackSuggestionPromoted` (origin
+  `card|sheet`) / `trackSuggestionDismissed`, pattern `_logEvent` + `_capturePostHog`.
+- [x] Dédup impressions **persistée 1/section/jour** : SharedPreferences `suggestion_impressions_v1`,
+  set de `'$dayKey|$sectionKey'` purgé des jours passés à chaque émission. Émission au premier
+  build de la section suggérée (garde-fou mémoire `_impressedSuggestionKeys` côté écran).
+- [x] Appels dans `promoteSuggestion(origin)` et `dismissSuggestion` (`flux_continu_provider.dart`).
+- [x] Tests `analytics_service_dual_track_test.dart` : promoted/dismissed émettent les bons
+  events ; impression dédupe 1×/section/jour et purge les jours passés.
+
+## Hors scope (explicite)
+
+Carte « Ton Essentiel » (reste à 5) ; unification des libellés CTA de config (PR 3 éventuelle) ;
+onglets Flâner dynamiques (différé).
+
+---
+
+## Fichiers modifiés
+
+- `packages/api/app/services/recommendation/scoring_config.py`
+- `packages/api/app/routers/users.py`
+- `packages/api/tests/routers/test_top_themes_suggestions.py`
+- `apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart`
+- `apps/mobile/lib/features/flux_continu/providers/tournee_order_prefs_provider.dart`
+- `apps/mobile/lib/features/flux_continu/widgets/section_block.dart`
+- `apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart`
+- `apps/mobile/lib/core/services/analytics_service.dart`
+- `apps/mobile/test/features/flux_continu/providers/flux_continu_tournee_order_test.dart`
+- `apps/mobile/test/features/flux_continu/widgets/section_block_test.dart`
+- `apps/mobile/test/core/services/analytics_service_dual_track_test.dart`
+
+## Migrations
+
+Aucune (changements additifs, expand-safe, 1 head Alembic conservé).
+
+## Vérification
+
+1. Backend : `cd packages/api && pytest -v` (DB `facteur_test`, port 54322).
+2. Mobile : `cd apps/mobile && flutter test && flutter analyze`.
+3. QA handoff `.context/qa-handoff.md` (feature UI) puis `/go` → PR `--base main`.

--- a/packages/api/app/routers/users.py
+++ b/packages/api/app/routers/users.py
@@ -504,28 +504,33 @@ async def _arrange_tournee(
     user_uuid: UUID,
     validated: list[TopThemeResponse],
 ) -> list[TopThemeResponse]:
-    """Affecte les `daily_rank` aux validées et **complète** jusqu'à la cible
-    `TOURNEE_TARGET_SECTIONS` par des sections « Choisie pour vous » (Story 22.3).
+    """Affecte les `daily_rank` aux validées et **ajoute** un accent quotidien de
+    sections « Choisie pour vous » (Story 22.3 + plancher garanti 22.6).
 
     Les validées gardent leur ordre d'entrée (jamais réordonnées/masquées ici) ;
-    les suggérées **s'ajoutent** derrière elles jusqu'à atteindre la cible
-    (additif, pas un reliquat du plafond favoris), déjà triées best-first pour
-    aujourd'hui par `TourneeSuggester`. Un compte à 7 favoris reçoit donc 1
-    suggestion, un compte à 0 favori jusqu'à `TOURNEE_TARGET_SECTIONS`. No-op si
-    le toggle est off, si la cible est déjà atteinte, ou si le pool est vide.
+    les suggérées **s'ajoutent** derrière elles, déjà triées best-first pour
+    aujourd'hui par `TourneeSuggester`. Story 22.6 : le nombre visé n'est plus le
+    reliquat jusqu'à la cible mais `min(SUBCAP, max(remaining, FLOOR))`, donc
+    tout compte (même 8+ favoris) reçoit au moins `FLOOR` suggestions tant que le
+    pool le permet. Effet : 0 favori → 5, 7 favoris → 4, 8+ favoris → 4. No-op
+    seulement si le toggle est off ou si le pool est vide (jamais d'empty-state
+    suggéré : un pool pauvre sert simplement moins que `FLOOR`).
     """
     from app.services.recommendation.scoring_config import ScoringWeights
 
     for rank, item in enumerate(validated):
         item.daily_rank = rank
 
-    remaining = max(0, ScoringWeights.TOURNEE_TARGET_SECTIONS - len(validated))
-    if remaining <= 0 or not await _smart_arrangement_enabled(db, user_uuid):
+    if not await _smart_arrangement_enabled(db, user_uuid):
         return validated
 
     from app.services.recommendation.tournee_suggester import TourneeSuggester
 
-    sub_cap = min(ScoringWeights.TOURNEE_SUGGEST_SUBCAP, remaining)
+    remaining = max(0, ScoringWeights.TOURNEE_TARGET_SECTIONS - len(validated))
+    sub_cap = min(
+        ScoringWeights.TOURNEE_SUGGEST_SUBCAP,
+        max(remaining, ScoringWeights.TOURNEE_SUGGEST_FLOOR),
+    )
     validated_slugs = {item.interest_slug for item in validated if item.interest_slug}
     suggestions = await TourneeSuggester(db).arrange(
         user_uuid, validated_slugs, sub_cap

--- a/packages/api/app/services/recommendation/scoring_config.py
+++ b/packages/api/app/services/recommendation/scoring_config.py
@@ -506,12 +506,19 @@ class ScoringWeights:
     TOURNEE_TARGET_SECTIONS = 8
 
     # Plafond dur de sections « Choisie pour vous » (thèmes + sources confondus)
-    # par arrangement. Levier *distinct* de la cible : aligné sur
-    # `TOURNEE_TARGET_SECTIONS` (donc non contraignant tant qu'ils sont égaux —
-    # un compte neuf est complété jusqu'à la cible), mais permet de plafonner les
-    # suggestions *sous* la cible sans toucher au nombre de sections visé
-    # (ex. cible 10 mais au plus 8 suggérées).
-    TOURNEE_SUGGEST_SUBCAP = 8
+    # par arrangement. Levier *distinct* de la cible : borne le nombre de
+    # suggestions servies un jour donné, indépendamment du nombre de favoris.
+    # Story 22.6 : abaissé 8 → 5 pour que les suggestions restent un accent
+    # quotidien (4-5) et non le gros de la Tournée d'un compte peu configuré.
+    TOURNEE_SUGGEST_SUBCAP = 5
+
+    # Plancher de suggestions « Choisie pour vous » (Story 22.6). Garantit un
+    # accent quotidien même aux comptes qui ont déjà atteint (ou dépassé)
+    # `TOURNEE_TARGET_SECTIONS` de favoris : `_arrange_tournee` vise
+    # `min(SUBCAP, max(remaining, FLOOR))` suggestions. Effet : 0 favori → 5
+    # (borné par SUBCAP), 8+ favoris → 4. Le pool réel peut en servir moins un
+    # jour pauvre (jamais d'invention hors invariant 22.3).
+    TOURNEE_SUGGEST_FLOOR = 4
 
     # Fenêtre de récence (jours) du comptage d'articles par candidat (aligné
     # sur le filtre 14 j du fallback `get_top_themes`).

--- a/packages/api/tests/routers/test_top_themes_suggestions.py
+++ b/packages/api/tests/routers/test_top_themes_suggestions.py
@@ -140,12 +140,13 @@ async def test_disabled_via_preference(configured_user, db_session):
 
 
 @pytest.mark.asyncio
-async def test_seven_favorites_leaves_one_suggestion_slot(db_session):
-    """7 favoris validés → la cible additive (8) laisse 1 slot → 1 suggérée.
+async def test_seven_favorites_still_gets_floor_suggestions(db_session):
+    """7 favoris validés → plancher garanti `FLOOR` (4) suggestions (Story 22.6).
 
-    Sous le mécanisme additif (`TOURNEE_TARGET_SECTIONS=8`), un compte à 7
-    favoris (plafond `FAVORITE_CAP`) reçoit exactement 1 suggestion, au lieu de
-    plafonner à 7 comme avec l'ancien reliquat de plafond favoris.
+    L'ancien reliquat de cible (`TOURNEE_TARGET_SECTIONS - 7 = 1`) plafonnait un
+    compte chargé à 1 suggestion (« plus tu configures, moins tu vois »). Le
+    plancher 22.6 vise `min(SUBCAP, max(remaining=1, FLOOR=4)) = 4` : un pool de
+    5 sources suivies non épinglées sert donc 4 suggestions, pas 1.
     """
     user_id = uuid4()
     db_session.add(UserProfile(user_id=user_id, onboarding_completed=True))
@@ -162,20 +163,22 @@ async def test_seven_favorites_leaves_one_suggestion_slot(db_session):
                 state=InterestState.FOLLOWED,
             )
         )
-    # Une source suivie qui comble l'unique slot restant.
-    src = _source("Extra", "international")
-    db_session.add(src)
-    await db_session.flush()
-    for d in range(5):
-        db_session.add(_content(src.id, "international", days_ago=d))
-    db_session.add(
-        UserSource(
-            user_id=user_id,
-            source_id=src.id,
-            is_custom=False,
-            state=InterestState.FOLLOWED,
+    # 5 sources suivies non épinglées → pool de suggestions au-dessus du plancher.
+    src_themes = ["international", "environment", "health", "media", "justice"]
+    for name in src_themes:
+        src = _source(f"Src {name}", name)
+        db_session.add(src)
+        await db_session.flush()
+        for d in range(3):
+            db_session.add(_content(src.id, name, days_ago=d))
+        db_session.add(
+            UserSource(
+                user_id=user_id,
+                source_id=src.id,
+                is_custom=False,
+                state=InterestState.FOLLOWED,
+            )
         )
-    )
     await db_session.commit()
 
     async def _fake_user():
@@ -193,13 +196,71 @@ async def test_seven_favorites_leaves_one_suggestion_slot(db_session):
         body = resp.json()
         validated = [t for t in body if t["origin"] == "validated"]
         suggested = [t for t in body if t["origin"] == "suggested"]
-        # 7 validés (plafond favoris) + 1 suggéré (cible additive 8).
+        # 7 validés (plafond favoris) + plancher 4 suggérées (pas 1).
         assert len(validated) == 7
-        assert len(suggested) == 1
-        assert len(body) == 8
-        # Le slot restant est comblé par la source internationale suivie.
-        assert suggested[0]["kind"] == "source"
-        assert suggested[0]["source_id"] == str(src.id)
+        assert len(suggested) == 4
+        assert len(body) == 11
+        assert all(t["kind"] == "source" for t in suggested)
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.mark.asyncio
+async def test_suggestions_never_exceed_subcap(db_session):
+    """Pool riche + 0 favori → au plus `SUBCAP` (5) suggestions (Story 22.6).
+
+    0 favori valide → `min(SUBCAP=5, max(remaining=8, FLOOR=4)) = 5` : un pool de
+    8 sources suivies est plafonné à 5, jamais 8.
+    """
+    user_id = uuid4()
+    db_session.add(UserProfile(user_id=user_id, onboarding_completed=True))
+    # Un thème suivi SANS contenu récent : garde le fallback hors early-return
+    # `[]` mais reste hors des validées (aucun article 14j) et hors du pool
+    # suggéré (plancher contenu).
+    db_session.add(
+        UserInterest(
+            user_id=user_id,
+            interest_slug="tech",
+            weight=1.0,
+            state=InterestState.FOLLOWED,
+        )
+    )
+    # 8 sources suivies alimentées → pool > SUBCAP.
+    names = ["a", "b", "c", "d", "e", "f", "g", "h"]
+    for name in names:
+        src = _source(f"Src {name}", name)
+        db_session.add(src)
+        await db_session.flush()
+        for d in range(3):
+            db_session.add(_content(src.id, name, days_ago=d))
+        db_session.add(
+            UserSource(
+                user_id=user_id,
+                source_id=src.id,
+                is_custom=False,
+                state=InterestState.FOLLOWED,
+            )
+        )
+    await db_session.commit()
+
+    async def _fake_user():
+        return str(user_id)
+
+    async def _fake_db():
+        yield db_session
+
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/api/users/top-themes")
+        body = resp.json()
+        validated = [t for t in body if t["origin"] == "validated"]
+        suggested = [t for t in body if t["origin"] == "suggested"]
+        assert len(validated) == 0
+        assert len(suggested) == 5  # plafonné à SUBCAP, pas 8
     finally:
         app.dependency_overrides.pop(get_current_user_id, None)
         app.dependency_overrides.pop(get_db, None)


### PR DESCRIPTION
Story 22.6 (PR 2), base `main`. Rend la Tournée « vivante » : un accent quotidien
de 4-5 sections « Choisie pour vous » **garanti pour tous** (même 8+ favoris), un
quota de 3 suggestions visibles sous le cap pour les comptes personnalisés, un CTA
direct sur la carte, et l'instrumentation PostHog. **Aucune migration** (additif,
expand-safe, 1 head Alembic). Invariant 22.3 conservé (jamais hors univers suivi).

> PR 1 (`promoteSuggestion` fiabilisé) vit dans un autre workspace ; cette PR
> suppose la même signature `promoteSuggestion(section)` et ajoute seulement un
> `origin` **optionnel** (défaut `card`) → rebase non cassante.

## A. Backend — plancher de suggestions

- `scoring_config.py` : `TOURNEE_SUGGEST_FLOOR = 4` ; `TOURNEE_SUGGEST_SUBCAP` 8 → 5.
- `routers/users.py` `_arrange_tournee` : `sub_cap = min(SUBCAP, max(remaining, FLOOR))` ;
  suppression de l'early-return `remaining <= 0` (gate `_smart_arrangement_enabled` conservé).
  Effet : 0 favori → 5, 7 favoris → 4, 8+ favoris → 4. Pool pauvre → sert moins, jamais d'invention.

## B. Mobile — quota visible ≥3 sous le cap

- `flux_continu_provider.dart` `_orderedTourneeKeys` : insertion additive à la frontière du cap ;
  `quota = min(kTourneeSuggestQuota=3, suggestions visibles)`, favoris tronqués à `cap - quota`
  **sans permutation**, puis les `quota` premières suggestions en queue. No-op non-personnalisé.

## C. Mobile — CTA « Ajouter à mon Essentiel »

- `section_block.dart` : `onPromoteSuggestion` + `_PromoteSuggestionButton` (spinner, anti
  double-tap, SnackBar « Ajouté à ton Essentiel »). Banner (badge + info-tap → sheet) inchangé.
- `flux_continu_screen.dart` : câble `promoteSuggestion(section, origin: 'card')` ; la sheet
  passe `origin: 'sheet'`.

## D. Instrumentation PostHog

- `analytics_service.dart` : `trackSuggestionImpression` / `Promoted` / `Dismissed`.
- Impressions dédupliquées **1/section/jour, persistées** (SharedPreferences `suggestion_impressions_v1`,
  purge des jours passés). Émission au premier build de la section suggérée.

## Vérification

- Backend : `pytest` — 37 tests top-themes/suggester/users OK ; 1 head Alembic (`181c618da382`).
- Mobile : `flutter test` — 453 tests flux_continu OK, 29 section_block, 14 analytics ;
  `flutter analyze` 0 erreur (5 warnings pré-existants `dio.post` hors périmètre).
- Changelog in-app : entrée « Ma Tournée » ajoutée (impact visible).

Story : `docs/stories/core/22.6.tournee-suggestions-garanties-cta.md`.
QA handoff : `.context/qa-handoff.md`.

## Vérifié via /go

- **Backend** : `pytest` suite complète — **2470 passed, 18 skipped, 2 xfailed** ; `alembic heads` = 1 (`181c618da382`, aucune migration dans ce diff).
- **Mobile** : `flutter analyze` sur les fichiers touchés — 0 issue ; fichiers de test touchés (tournee_order + section_block + analytics) — **65 passed**. Le répertoire `flux_continu` a un test flaky pré-existant (timing `unawaited`/`Future.delayed(Duration.zero)`, test différent d'un run à l'autre, passe en isolation) — sans lien avec ce diff.
- **/simplify** passé : `math.min`/`math.max` dans `_orderedTourneeKeys`, garde `quota == 0` morte retirée, flag `ok` inutile retiré de `_PromoteSuggestionButton`.
- **QA web (Playwright)** : à lancer via `/validate-feature` (handoff prêt dans `.context/qa-handoff.md`) avant merge — feature UI.
