### PR TITLE
docs(maintenance): plan prompt v2 Analyse Facteur — établi vs en débat

### DIFF
--- a/docs/maintenance/maintenance-analyse-facteur-prompt-v2.md
+++ b/docs/maintenance/maintenance-analyse-facteur-prompt-v2.md
@@ -111,16 +111,45 @@ s'éteignent naturellement (digests quotidiens).
 
 Aucun fichier mobile modifié (contrat `analysis` / `divergence_level` inchangé).
 
-## Vérification prévue
+## Vérification effectuée
 
-1. `pytest tests/test_perspective_service.py -v` — invariants prompt + contrat.
-2. `pytest tests/editorial/ -v` — non-régression pipeline (mocks `analyze_divergences`).
-3. Suite backend complète `pytest -v`.
-4. Vérification manuelle du rendu : le premier `\n\n` doit toujours produire
-   deux sections non vides dans le bottom sheet (test widget existant
-   `perspectives_inline_states_test.dart` inchangé).
-5. Optionnel (nécessite `MISTRAL_API_KEY`) : script de comparaison v1/v2 sur
-   3-4 sujets réels, à archiver dans `docs/qa/scripts/`.
+1. `pytest tests/test_perspective_service.py -q` — **22 passed** (16 existants
+   + 6 nouveaux tests de garde).
+2. `pytest tests/editorial/ -q` — **147 passed, 3 skipped**. 3 erreurs de setup
+   `TestPersistContentClusterIds` : Postgres de test (port 54322) indisponible
+   dans le conteneur, pas de Docker — **pré-existant, sans lien avec le diff**.
+3. Suite backend complète — **1951 passed, 30 skipped, 1 failed, 525 errors**.
+   Les 525 erreurs sont toutes des `psycopg.OperationalError` (base de test
+   absente). L'unique `failed`
+   (`test_essentiel_endpoint.py::test_get_essentiel_uses_user_context_from_router`)
+   **échoue à l'identique sur l'arbre propre** (vérifié via `git stash`) →
+   pré-existant.
+4. `ruff check` sur les 2 fichiers touchés — **All checks passed**.
+   `ruff format --check` : `perspective_service.py` propre ; le fichier de test
+   est signalé, mais uniquement sur des lignes **pré-existantes** (l. 47-172,
+   diff identique sur l'arbre propre) — non reformatées pour garder le diff
+   lisible.
+5. Contrat de rendu vérifié par test : le premier `\n\n` produit toujours deux
+   sections non vides, la seconde commençant par `→`. Aucun fichier mobile
+   modifié, donc `perspectives_inline_states_test.dart` reste valide.
+6. Prompt final relu en sortie réelle (dump du `system` + `user_message`).
+
+### Tests de garde ajoutés
+
+| Test | Ce qu'il verrouille |
+|---|---|
+| `test_analyze_divergences_prompt_targets_substance` | présence des 4 directives v2, disparition des consignes de lexicométrie v1, lexique borné à un rôle de preuve, `d'après leurs titres` passé d'obligation à interdiction |
+| `test_analyze_divergences_preserves_two_section_contract` | séparateur `\n\n`, puces `→ `, valeurs de `divergence_level` |
+| `test_analyze_divergences_feeds_wider_context` | troncatures 450/900, `temperature` 0.3, `max_tokens` 900 |
+| `test_analyze_divergences_json_contract_unchanged` | dict `{analysis, divergence_level}`, `None` si `analysis` absent |
+| `test_analyze_divergences_no_perspectives_skips_llm` | zéro perspective → zéro appel Mistral (garde-fou de coût) |
+
+### Reste à faire (hors code, au déploiement)
+
+- Purge du cache : `DELETE FROM perspective_analyses;` via le SQL Editor
+  Supabase, sinon les articles déjà analysés continuent de servir du texte v1.
+- Optionnel (nécessite `MISTRAL_API_KEY`) : comparaison v1/v2 sur 3-4 sujets
+  réels, à archiver dans `docs/qa/scripts/`.
 
 ## Annexe — prompt v2 proposé (texte exact soumis à validation)
 
@@ -203,9 +232,9 @@ sur le volet santé. »
 
 ## Statut
 
-- [ ] Plan confirmé PO
-- [ ] Prompt v2 implémenté
-- [ ] Troncatures / paramètres d'appel ajustés
-- [ ] Tests de garde ajoutés
-- [ ] Suite backend verte
+- [x] Plan confirmé PO
+- [x] Prompt v2 implémenté
+- [x] Troncatures / paramètres d'appel ajustés
+- [x] Tests de garde ajoutés
+- [x] Suite backend verte (hors échecs pré-existants / base de test absente)
 - [ ] Purge cache `perspective_analyses` (Supabase SQL Editor, au déploiement)

--- a/docs/maintenance/maintenance-analyse-facteur-prompt-v2.md
+++ b/docs/maintenance/maintenance-analyse-facteur-prompt-v2.md
@@ -1,0 +1,211 @@
+# Maintenance — Analyse Facteur : prompt v2 (« établi » vs « en débat »)
+
+> Type : **Maintenance / prompt engineering**. Aucun changement de schéma API,
+> de modèle mobile, ni de migration Alembic. Base : `main` (`3d18e42b`).
+> Plan à confirmer PO.
+
+## Problème constaté (PO)
+
+L'« Analyse Facteur » (carrousel médiatique en bas d'article + bloc digest)
+commente **les variations de formulation des titres** au lieu de délivrer une
+position claire sur **ce que l'on sait** et **ce qui fait débat**.
+
+## Diagnostic — où ça se joue
+
+Un seul prompt alimente les deux surfaces :
+`PerspectiveService.analyze_divergences` — `packages/api/app/services/perspective_service.py:374-486`.
+
+| # | Cause dans le prompt actuel | Effet observé |
+|---|---|---|
+| 1 | Section « établi » plafonnée à **une phrase de 15-25 mots** (`perspective_service.py:426`) alors que l'UI lui consacre un titre de section entier (`1 · L'ESSENTIEL PARTAGÉ`) | Le « ce que l'on sait » est structurellement famélique ; tout le budget de texte part dans la section 2 |
+| 2 | La section 2 est **définie comme une analyse lexicale** : « la qualification des faits choisie (mots forts vs neutres) », « marqueur d'opinion (adjectifs chargés) », « mot précis cité entre guillemets », « emploient le terme «X» » (`:419-434`) | Le modèle fait de la lexicométrie de titres, pas de la restitution de désaccord |
+| 3 | L'**exemple one-shot** (`:450-459`) cite un terme entre guillemets sur **3 lignes sur 3** | L'exemple est le signal le plus fort du prompt : il verrouille le style « variations de titres » |
+| 4 | Regroupement imposé en « 2 à 4 clusters selon l'angle commun » (`:415`) → l'unité d'analyse est **le média**, pas **le point litigieux** | Constats du type « X et Y cadrent… » au lieu de « le désaccord porte sur… » |
+| 5 | `« d'après leurs titres »` à ajouter dès qu'un angle vient du titre (`:441`) | Prose méta, référentielle au titre, qui rappelle au lecteur qu'on n'analyse que des titres |
+| 6 | Sur les sujets **peu divergents**, la consigne demande quand même 2 à 4 constats de cadrage | Quand il n'y a pas de désaccord, la seule matière restante *est* la variation de titre → le prompt force le nitpicking |
+| 7 | Aucune règle n'oblige à nommer **l'objet** du désaccord (un fait, une cause, une ampleur, une responsabilité, une conséquence) | Rien ne pousse vers la substance |
+| 8 | Matière d'entrée volontairement rognée : `description[:300]` par perspective (`:406`), `article_description[:500]` (`:468`) | Moins de substance disponible → le modèle se rabat sur les titres |
+
+**Contrainte de format à préserver** (sinon régression UI) : le champ `analysis`
+reste une **string markdown** dont le **premier `\n\n` sépare les 2 sections**.
+C'est le contrat lu par `splitAnalysisSections` (`perspectives_bottom_sheet.dart:2506`)
+qui alimente `1 · L'ESSENTIEL PARTAGÉ` / `2 · LÀ OÙ LES MÉDIAS DIVERGENT`, et le
+bloc digest (`divergence_analysis_block.dart:167`) rend la string brute. La clé
+`divergence_level` (`low|medium|high`) reste inchangée — elle est consommée par
+`digest_selector.py:1272` (`polarization_bonus`) et par le badge mobile.
+
+→ **Le correctif est donc 100 % côté prompt + fenêtres de troncature.** Zéro
+changement de contrat, zéro migration, zéro modif mobile.
+
+## Changements proposés
+
+### 1. Rééquilibrer les deux sections (cœur du fix)
+
+| | v1 | v2 |
+|---|---|---|
+| Section 1 « établi » | 1 phrase, 15-25 mots | **2-3 phrases, 45-75 mots** : les faits sur lesquels les couvertures convergent (quoi, qui, quand, chiffres répétés d'une source à l'autre). Interdiction d'y nommer un média ou de commenter une formulation. |
+| Section 2 « en débat » | 2-4 constats de **cadrage média** | **2-3 constats de désaccord**, unité d'analyse = **le point litigieux**, pas le média. Chaque ligne : l'objet du désaccord en gras, puis position A (médias nommés) vs position B (médias nommés). |
+
+### 2. Test de recevabilité d'un constat
+
+Nouvelle règle bloquante : un constat n'est retenu que s'il peut se reformuler
+en **question** (« Qui est responsable ? », « Quelle ampleur ? », « Est-ce que
+ça marche ? », « Que se passe-t-il ensuite ? »). Une différence qui ne répond à
+aucune question de fond est une variation de style → **écartée**.
+
+### 3. Le lexique devient une preuve, plus un sujet
+
+Un terme cité entre guillemets est autorisé **en appui** d'un désaccord de fond,
+**une seule fois par ligne maximum**, et jamais comme sujet de la ligne.
+Suppression de la consigne « marqueur d'opinion » comme objectif en soi.
+
+### 4. Sortie honnête quand il n'y a pas de débat
+
+Si les couvertures convergent réellement (`divergence_level: "low"`) : section 2
+= **1 seule ligne** disant que les traitements concordent + **ce qui reste
+inconnu / non vérifié** dans le dossier. Ferme le trou #6 qui fabriquait du
+désaccord lexical par défaut.
+
+### 5. Nouvel exemple one-shot
+
+Réécrit intégralement dans le style cible (fait établi étoffé + désaccords de
+fond avec positions opposées attribuées). C'est le levier #1 du changement.
+
+### 6. Interdits mis à jour
+
+Conservation de la liste anti-jargon existante (« met en lumière », « soulève
+des questions », …), **plus** : pas de constat portant uniquement sur le choix
+d'un mot, pas de « d'après leurs titres » en boilerplate (hedging global via
+« semble » si une position est inférée d'un titre seul).
+
+### 7. Plus de matière en entrée
+
+- `description` par perspective : `[:300]` → `[:450]`
+- `article_description` : `[:500]` → `[:900]`
+- `max_tokens` : `700` → `900` (section 1 s'allonge)
+- `temperature` : `0.4` → `0.3` (ancrage factuel)
+
+Coût : ~+400 tokens d'entrée et ~+150 de sortie par sujet analysé, sur un appel
+déjà gated par `divergence_llm_min_perspectives` (`pipeline.py:789`).
+
+### 8. Rollout du cache (sans migration)
+
+`perspective_analyses` est un cache persistant sans version de prompt
+(`app/models/perspective_analysis.py`) : les articles déjà analysés
+continueraient de servir du texte v1, y compris via le L2 de
+`analyze_perspectives` (`contents.py:1672-1684`).
+
+Option retenue : **purge one-shot via Supabase SQL Editor** au déploiement
+(`DELETE FROM perspective_analyses;` — c'est un cache dérivable, aucune perte
+de donnée utilisateur), conformément à la règle « SQL via Supabase SQL Editor,
+jamais d'Alembic sur Railway ». Le cache L1 in-memory se vide au redéploiement.
+Les snapshots `divergence_analysis` des digests déjà générés restent en v1 et
+s'éteignent naturellement (digests quotidiens).
+
+## Fichiers touchés
+
+| Fichier | Changement |
+|---|---|
+| `packages/api/app/services/perspective_service.py` | Réécriture du `system` de `analyze_divergences`, troncatures, `max_tokens`/`temperature` |
+| `packages/api/tests/test_perspective_service.py` | Tests de garde sur les invariants du prompt + contrat JSON |
+
+Aucun fichier mobile modifié (contrat `analysis` / `divergence_level` inchangé).
+
+## Vérification prévue
+
+1. `pytest tests/test_perspective_service.py -v` — invariants prompt + contrat.
+2. `pytest tests/editorial/ -v` — non-régression pipeline (mocks `analyze_divergences`).
+3. Suite backend complète `pytest -v`.
+4. Vérification manuelle du rendu : le premier `\n\n` doit toujours produire
+   deux sections non vides dans le bottom sheet (test widget existant
+   `perspectives_inline_states_test.dart` inchangé).
+5. Optionnel (nécessite `MISTRAL_API_KEY`) : script de comparaison v1/v2 sur
+   3-4 sujets réels, à archiver dans `docs/qa/scripts/`.
+
+## Annexe — prompt v2 proposé (texte exact soumis à validation)
+
+```
+Analyste média français. À partir de la couverture d'un même sujet par
+plusieurs rédactions, tu produis deux choses : CE QUI EST ÉTABLI et CE QUI
+FAIT DÉBAT.
+
+Méthode obligatoire :
+1. Lis tous les titres + résumés.
+2. ÉTABLI : isole les faits que les couvertures partagent — l'événement, les
+   acteurs, les chiffres et les dates repris d'une source à l'autre.
+3. DÉBAT : identifie 2 à 3 POINTS LITIGIEUX. Un point litigieux est une
+   question de fond sur laquelle les couvertures ne répondent pas pareil : la
+   cause, la responsabilité, l'ampleur, l'efficacité, la légitimité, la suite
+   probable. Pour chacun, dis quelle position tient quel média.
+4. TEST DE RECEVABILITÉ : si un constat ne peut pas se reformuler en question
+   (« Qui est responsable ? », « Quelle ampleur ? », « Est-ce que ça marche ? »,
+   « Et après ? »), c'est une variation de style — écarte-le. Ne retiens jamais
+   un constat dont le seul contenu est le choix d'un mot.
+5. Si les couvertures convergent vraiment, ne fabrique pas de désaccord :
+   dis-le et nomme ce qui reste inconnu ou non vérifié (divergence_level: low).
+
+Réponds en JSON avec deux clés :
+- "analysis" : texte structuré ainsi :
+  1. CE QUI EST ÉTABLI : 2 à 3 phrases (45-75 mots), les faits partagés. Aucun
+     nom de média ici, aucun commentaire sur les formulations.
+  2. Saut de ligne double (\n\n).
+  3. CE QUI FAIT DÉBAT : 2 à 3 lignes préfixées "→ ", 35-55 mots chacune :
+     • l'objet du désaccord en **gras** (« **la responsabilité du déficit** »,
+       « **l'ampleur réelle des économies** »),
+     • la position A et les médias qui la tiennent (noms en **gras**),
+     • la position opposée et les médias qui la tiennent,
+     • au plus UN terme cité entre guillemets, en appui du désaccord, jamais
+       comme sujet de la ligne.
+  Si divergence_level = low : une seule ligne « → », qui constate la
+  convergence et nomme ce qui reste en suspens.
+  Max 5 segments en gras par ligne. Aucun titre de section (l'app les ajoute).
+- "divergence_level" : "low" (mêmes faits, mêmes conclusions), "medium"
+  (désaccords d'interprétation ou de priorité), "high" (conclusions
+  contradictoires sur un même fait).
+
+RÈGLES :
+- Uniquement les titres/résumés fournis. Zéro fait inventé, zéro intention
+  prêtée à un média sans appui textuel.
+- Position inférée d'un titre seul : nuance avec « semble » ou « laisse
+  entendre ». Pas de formule répétée en fin de ligne.
+- Verbes de position : attribue(nt) à, impute(nt) à, chiffre(nt) à, juge(nt),
+  conteste(nt), relativise(nt), tient/tiennent pour, avance(nt), doute(nt) de,
+  lie(nt) à.
+- Interdits : "met en lumière", "soulève des questions", "révèle la fragilité",
+  "fait écho", "interroge", "questionne", "d'après leurs titres".
+- Ton assertif, phrases denses, pas de précautions inutiles. Français
+  impeccable.
+
+EXEMPLE :
+« Bercy a présenté le 14 octobre un budget 2026 prévoyant 12 milliards d'euros
+d'économies, dont 4 sur l'assurance maladie et 2 sur les collectivités. Le
+texte arrive à l'Assemblée en novembre, sans majorité acquise. Toutes les
+rédactions donnent les mêmes montants et le même calendrier.
+
+→ **L'origine du déficit** : **Les Échos** et **Le Figaro** l'imputent à la
+dérive des dépenses sociales et chiffrent à 2 points de PIB le décrochage ;
+**Mediapart** et **Libération** l'attribuent aux baisses d'impôts consenties
+depuis 2017, jamais compensées.
+→ **L'ampleur réelle de l'effort** : **Le Monde** rappelle que les 12 milliards
+portent sur une hausse tendancielle, soit une quasi-stabilité en euros
+constants ; **Le Point** présente le même chiffre comme la coupe la plus forte
+depuis 2011.
+→ **Les chances d'adoption** : **Politico** et **L'Opinion** jugent le 49.3
+probable dès décembre ; **La Croix** croit à un compromis avec les socialistes
+sur le volet santé. »
+```
+
+### Ce que ça change concrètement pour le lecteur
+
+| v1 (constat type) | v2 (constat type) |
+|---|---|
+| « → **Le Figaro** et **Les Échos** **cadrent** la mesure comme un signal de sérieux budgétaire, mettant en avant le terme «redressement» dans leurs titres. » | « → **L'ampleur réelle de l'effort** : **Le Monde** rappelle que les 12 milliards portent sur une hausse tendancielle ; **Le Point** y voit la coupe la plus forte depuis 2011. » |
+
+## Statut
+
+- [ ] Plan confirmé PO
+- [ ] Prompt v2 implémenté
+- [ ] Troncatures / paramètres d'appel ajustés
+- [ ] Tests de garde ajoutés
+- [ ] Suite backend verte
+- [ ] Purge cache `perspective_analyses` (Supabase SQL Editor, au déploiement)

--- a/packages/api/app/services/perspective_service.py
+++ b/packages/api/app/services/perspective_service.py
@@ -43,6 +43,13 @@ PERSPECTIVE_FILTER_ENABLED = (
     os.environ.get("PERSPECTIVE_FILTER_ENABLED", "true").lower() == "true"
 )
 
+# --- Matière envoyée à l'Analyse Facteur (analyze_divergences) ---
+# Fenêtres élargies en prompt v2 : moins de résumé = le modèle se rabat sur les
+# variations de titres, ce qu'on cherche justement à éviter.
+# Cf. docs/maintenance/maintenance-analyse-facteur-prompt-v2.md
+PERSPECTIVE_DESC_CHARS = 450
+REFERENCE_DESC_CHARS = 900
+
 
 def _parse_entity_names(
     entities: list[str] | None, types: set[str] | None = None
@@ -381,8 +388,16 @@ class PerspectiveService:
     ) -> dict | None:
         """Generate a short LLM analysis of editorial divergences.
 
+        Prompt v2 : la sortie répond à « ce que l'on sait » puis « ce qui fait
+        débat » (points litigieux de fond), et non plus aux variations de
+        formulation entre titres. Cf.
+        docs/maintenance/maintenance-analyse-facteur-prompt-v2.md.
+
         Returns a dict with keys:
-        - "analysis": str — the editorial divergence text (~150 words)
+        - "analysis": str — texte markdown (~180 mots). Le **premier `\\n\\n`**
+          sépare la section « établi » de la section « en débat » : c'est le
+          contrat lu côté mobile par `splitAnalysisSections`
+          (perspectives_bottom_sheet.dart). Ne pas casser ce séparateur.
         - "divergence_level": str — "low", "medium", or "high"
         Or None on failure.
         """
@@ -403,60 +418,84 @@ class PerspectiveService:
             line = f'- "{p["title"]}" ({p["source_name"]}, {stance})'
             desc = p.get("description")
             if desc:
-                line += f" — {desc[:300]}"
+                line += f" — {desc[:PERSPECTIVE_DESC_CHARS]}"
             perspectives_lines.append(line)
         perspectives_text = "\n".join(perspectives_lines)
 
         system = (
-            "Analyste média français. Tu compares la couverture d'un même sujet "
-            "par plusieurs rédactions et tu fais ressortir CE QUI LES OPPOSE.\n\n"
+            "Analyste média français. À partir de la couverture d'un même sujet "
+            "par plusieurs rédactions, tu produis deux choses : CE QUI EST ÉTABLI "
+            "et CE QUI FAIT DÉBAT.\n\n"
             "Méthode obligatoire :\n"
             "1. Lis tous les titres + résumés.\n"
-            "2. REGROUPE les médias en 2 à 4 clusters selon l'angle commun qu'ils "
-            "adoptent — pas un constat par média, mais un constat par groupe partageant "
-            "un même cadrage. Si tous traitent le sujet de la même manière, dis-le "
-            "et explique pourquoi (divergence_level: low).\n"
-            "3. Pour chaque cluster, identifie : la qualification des faits choisie "
-            "(mots forts vs neutres), ce qui est mis en avant ou occulté, et tout "
-            "marqueur d'opinion (adjectifs chargés, attribution morale, lexique "
-            'révélateur — "dérapage" vs "incident", "renoncement" vs "ajustement", '
-            '"victoire" vs "concession").\n\n'
+            "2. ÉTABLI : isole les faits que les couvertures partagent — "
+            "l'événement, les acteurs, les chiffres et les dates repris d'une "
+            "source à l'autre.\n"
+            "3. DÉBAT : identifie 2 à 3 POINTS LITIGIEUX. Un point litigieux est "
+            "une question de fond sur laquelle les couvertures ne répondent pas "
+            "pareil : la cause, la responsabilité, l'ampleur, l'efficacité, la "
+            "légitimité, la suite probable. Pour chacun, dis quelle position tient "
+            "quel média.\n"
+            "4. TEST DE RECEVABILITÉ : si un constat ne peut pas se reformuler en "
+            "question (« Qui est responsable ? », « Quelle ampleur ? », « Est-ce "
+            "que ça marche ? », « Et après ? »), c'est une variation de style — "
+            "écarte-le. Ne retiens jamais un constat dont le seul contenu est le "
+            "choix d'un mot.\n"
+            "5. Si les couvertures convergent vraiment, ne fabrique pas de "
+            "désaccord : dis-le et nomme ce qui reste inconnu ou non vérifié "
+            "(divergence_level: low).\n\n"
             "Réponds en JSON avec deux clés :\n"
             '- "analysis": texte structuré ainsi :\n'
-            "  1. Phrase de contexte : le fait central que tous couvrent (15-25 mots).\n"
+            "  1. CE QUI EST ÉTABLI : 2 à 3 phrases (45-75 mots), les faits "
+            "partagés. Aucun nom de média ici, aucun commentaire sur les "
+            "formulations.\n"
             "  2. Saut de ligne double (\\n\\n).\n"
-            '  3. 2 à 4 constats, chacun préfixé "→ ", chacun 30-50 mots :\n'
-            '     • cluster de médias en **gras** ("**Le Monde** et **Libération**"),\n'
-            '     • verbe ou nom-clé d\'angle en **gras** ("**cadrent**", "**minimisent**"),\n'
-            "     • un élément concret tiré du titre/résumé (chiffre, acteur, "
-            "qualification, mot précis cité entre guillemets si possible),\n"
-            "     • si pertinent : marqueur d'opinion repéré "
-            '("emploient le terme «X»", "qualifient de Y", "présentent comme Z").\n'
-            "  Max 5 segments en gras par ligne. Aucun titre de section.\n"
-            '- "divergence_level": "low" (couvertures similaires), "medium" '
-            '(angles sensiblement différents), "high" (cadrages opposés ou contradictoires).\n\n'
+            '  3. CE QUI FAIT DÉBAT : 2 à 3 lignes préfixées "→ ", 35-55 mots '
+            "chacune :\n"
+            "     • l'objet du désaccord en **gras** "
+            "(« **la responsabilité du déficit** », "
+            "« **l'ampleur réelle des économies** »),\n"
+            "     • la position A et les médias qui la tiennent (noms en **gras**),\n"
+            "     • la position opposée et les médias qui la tiennent,\n"
+            "     • au plus UN terme cité entre guillemets, en appui du désaccord, "
+            "jamais comme sujet de la ligne.\n"
+            "  Si divergence_level = low : une seule ligne « → », qui constate la "
+            "convergence et nomme ce qui reste en suspens.\n"
+            "  Max 5 segments en gras par ligne. Aucun titre de section "
+            "(l'app les ajoute).\n"
+            '- "divergence_level": "low" (mêmes faits, mêmes conclusions), '
+            '"medium" (désaccords d\'interprétation ou de priorité), "high" '
+            "(conclusions contradictoires sur un même fait).\n\n"
             "RÈGLES :\n"
             "- Uniquement les titres/résumés fournis. Zéro fait inventé, zéro "
             "intention prêtée à un média sans appui textuel.\n"
-            "- Si l'angle d'un cluster repose uniquement sur le titre, ajouter "
-            '"d\'après leurs titres".\n'
-            "- Verbes concrets : insiste(nt) sur, minimise(nt), cadre(nt) comme, "
-            "ignore(nt), met(tent) en avant, oppose(nt), contextualise(nt), "
-            "relativise(nt), dramatise(nt), neutralise(nt), qualifie(nt) de, "
-            "dénonce(nt), salue(nt).\n"
+            "- Position inférée d'un titre seul : nuance avec « semble » ou "
+            "« laisse entendre ». Pas de formule répétée en fin de ligne.\n"
+            "- Verbes de position : attribue(nt) à, impute(nt) à, chiffre(nt) à, "
+            "juge(nt), conteste(nt), relativise(nt), tient/tiennent pour, "
+            "avance(nt), doute(nt) de, lie(nt) à.\n"
             '- Interdits : "met en lumière", "soulève des questions", '
-            '"révèle la fragilité", "fait écho", "interroge", "questionne".\n'
-            "- Ton factuel, phrases denses. Français impeccable.\n\n"
+            '"révèle la fragilité", "fait écho", "interroge", "questionne", '
+            '"d\'après leurs titres".\n'
+            "- Ton assertif, phrases denses, pas de précautions inutiles. "
+            "Français impeccable.\n\n"
             "EXEMPLE :\n"
-            "\"Tous reviennent sur l'annonce du plan budgétaire 2026 présenté par Bercy.\\n\\n"
-            "→ **Le Monde** et **Libération** **insistent** sur le volet social, "
-            "citant les arbitrages à venir sur les retraites et qualifiant la "
-            "trajectoire de «resserrement nécessaire mais douloureux».\\n"
-            "→ **Le Figaro** et **Les Échos** **cadrent** la mesure comme un signal "
-            "de sérieux budgétaire, mettant en avant les 12 milliards d'économies "
-            "et le terme «redressement» dans leurs titres.\\n"
-            "→ **Mediapart** **dénonce** un budget «d'austérité déguisée», marqueur "
-            "d'opinion explicite absent des autres couvertures.\""
+            "« Bercy a présenté le 14 octobre un budget 2026 prévoyant 12 milliards "
+            "d'euros d'économies, dont 4 sur l'assurance maladie et 2 sur les "
+            "collectivités. Le texte arrive à l'Assemblée en novembre, sans "
+            "majorité acquise. Toutes les rédactions donnent les mêmes montants et "
+            "le même calendrier.\\n\\n"
+            "→ **L'origine du déficit** : **Les Échos** et **Le Figaro** "
+            "l'imputent à la dérive des dépenses sociales et chiffrent à 2 points "
+            "de PIB le décrochage ; **Mediapart** et **Libération** l'attribuent "
+            "aux baisses d'impôts consenties depuis 2017, jamais compensées.\\n"
+            "→ **L'ampleur réelle de l'effort** : **Le Monde** rappelle que les "
+            "12 milliards portent sur une hausse tendancielle, soit une "
+            "quasi-stabilité en euros constants ; **Le Point** présente le même "
+            "chiffre comme la coupe la plus forte depuis 2011.\\n"
+            "→ **Les chances d'adoption** : **Politico** et **L'Opinion** jugent "
+            "le 49.3 probable dès décembre ; **La Croix** croit à un compromis "
+            "avec les socialistes sur le volet santé. »"
         )
 
         source_stance = STANCE_LABELS.get(source_bias, source_bias)
@@ -465,7 +504,7 @@ class PerspectiveService:
             f'Article de référence : "{article_title}" ({source_name}, {source_stance})'
         )
         if article_description:
-            user_message += f"\nRésumé : {article_description[:500]}"
+            user_message += f"\nRésumé : {article_description[:REFERENCE_DESC_CHARS]}"
         user_message += f"\n\nCouverture par d'autres médias :\n{perspectives_text}"
 
         try:
@@ -473,8 +512,8 @@ class PerspectiveService:
                 system=system,
                 user_message=user_message,
                 model="mistral-large-latest",
-                temperature=0.4,
-                max_tokens=700,
+                temperature=0.3,
+                max_tokens=900,
             )
             if isinstance(result, dict) and "analysis" in result:
                 return result

--- a/packages/api/tests/test_perspective_service.py
+++ b/packages/api/tests/test_perspective_service.py
@@ -469,3 +469,184 @@ def test_topical_signals_empty_seed_title():
     assert signals["title_jaccard"] == 0.0
     is_ok, reason = PerspectiveService._is_topically_coherent(signals)
     assert is_ok is False
+
+
+# ─── Analyse Facteur — prompt v2 (« établi » vs « en débat ») ─────────────────
+# Cf. docs/maintenance/maintenance-analyse-facteur-prompt-v2.md
+
+
+class _FakeLLMClient:
+    """Capture les arguments passés à `chat_json` sans appeler Mistral."""
+
+    calls: list[dict] = []
+    response: dict | None = {
+        "analysis": "Faits partagés.\n\n→ **Objet du désaccord** : A vs B.",
+        "divergence_level": "medium",
+    }
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    @property
+    def is_ready(self) -> bool:
+        return True
+
+    async def chat_json(self, **kwargs):
+        type(self).calls.append(kwargs)
+        return type(self).response
+
+    async def close(self):
+        return None
+
+
+@pytest.fixture
+def fake_llm(monkeypatch):
+    """Patch le client LLM importé dans `analyze_divergences` (import local)."""
+    import app.services.editorial.llm_client as llm_module
+
+    _FakeLLMClient.calls = []
+    _FakeLLMClient.response = {
+        "analysis": "Faits partagés.\n\n→ **Objet du désaccord** : A vs B.",
+        "divergence_level": "medium",
+    }
+    monkeypatch.setattr(llm_module, "EditorialLLMClient", _FakeLLMClient)
+    return _FakeLLMClient
+
+
+PERSPECTIVES_FIXTURE = [
+    {
+        "title": "Budget 2026 : 12 milliards d'économies annoncés",
+        "source_name": "Les Échos",
+        "bias_stance": "center-right",
+        "description": "D" * 800,
+    },
+    {
+        "title": "Budget 2026 : un tour de vis sur la santé",
+        "source_name": "Libération",
+        "bias_stance": "left",
+        "description": "Un résumé court.",
+    },
+]
+
+
+async def _run_analysis(**overrides):
+    service = PerspectiveService()
+    kwargs = {
+        "article_title": "Bercy présente le budget 2026",
+        "source_name": "Le Monde",
+        "source_bias": "center-left",
+        "perspectives": PERSPECTIVES_FIXTURE,
+        "article_description": "R" * 1500,
+    }
+    kwargs.update(overrides)
+    return await service.analyze_divergences(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_analyze_divergences_prompt_targets_substance(fake_llm):
+    """Le prompt doit demander « ce qu'on sait / ce qui fait débat », pas une
+    lexicométrie des titres (plainte PO : analyse trop centrée sur les
+    variations de formulation)."""
+    await _run_analysis()
+
+    assert len(fake_llm.calls) == 1
+    system = fake_llm.calls[0]["system"]
+
+    # Structure v2 attendue
+    for directive in (
+        "CE QUI EST ÉTABLI",
+        "CE QUI FAIT DÉBAT",
+        "POINTS LITIGIEUX",
+        "TEST DE RECEVABILITÉ",
+    ):
+        assert directive in system, f"directive manquante : {directive}"
+
+    # La section « établi » n'est plus une phrase unique famélique
+    assert "45-75 mots" in system
+    assert "15-25 mots" not in system
+
+    # Les consignes de lexicométrie v1 ont disparu comme OBJECTIF
+    for banned in (
+        "marqueur d'opinion",
+        "mots forts vs neutres",
+        "REGROUPE les médias",
+        "emploient le terme",
+    ):
+        assert banned not in system, f"consigne v1 encore présente : {banned}"
+
+    # Le lexique reste admis, mais borné à un rôle de preuve
+    assert "au plus UN terme cité entre guillemets" in system
+    assert "jamais comme sujet de la ligne" in system
+
+    # « d'après leurs titres » passe d'obligation à interdiction
+    assert "d'après leurs titres" in system
+    assert "Interdits :" in system
+    interdits_block = system.split("Interdits :", 1)[1]
+    assert "d'après leurs titres" in interdits_block
+
+
+@pytest.mark.asyncio
+async def test_analyze_divergences_preserves_two_section_contract(fake_llm):
+    """Le prompt doit continuer d'imposer le séparateur `\\n\\n` entre les deux
+    sections : c'est le contrat lu par `splitAnalysisSections` côté mobile."""
+    await _run_analysis()
+
+    system = fake_llm.calls[0]["system"]
+    assert "Saut de ligne double (\\n\\n)" in system
+    # Les puces de la section 2 restent préfixées "→ " (rendu markdown mobile)
+    assert '"→ "' in system
+    # divergence_level : mêmes valeurs, consommées par polarization_bonus()
+    for level in ('"low"', '"medium"', '"high"'):
+        assert level in system
+
+
+@pytest.mark.asyncio
+async def test_analyze_divergences_feeds_wider_context(fake_llm):
+    """Fenêtres de matière élargies : sans résumé, le modèle se rabat sur les
+    titres — exactement le biais qu'on corrige."""
+    from app.services.perspective_service import (
+        PERSPECTIVE_DESC_CHARS,
+        REFERENCE_DESC_CHARS,
+    )
+
+    await _run_analysis()
+
+    call = fake_llm.calls[0]
+    user_message = call["user_message"]
+
+    assert PERSPECTIVE_DESC_CHARS == 450
+    assert REFERENCE_DESC_CHARS == 900
+    # Résumé de perspective tronqué à la nouvelle borne (ni 300, ni 800)
+    assert "D" * PERSPECTIVE_DESC_CHARS in user_message
+    assert "D" * (PERSPECTIVE_DESC_CHARS + 1) not in user_message
+    # Résumé de l'article de référence tronqué à la nouvelle borne
+    assert "R" * REFERENCE_DESC_CHARS in user_message
+    assert "R" * (REFERENCE_DESC_CHARS + 1) not in user_message
+    # Ancrage factuel renforcé + budget de sortie pour la section « établi »
+    assert call["temperature"] == 0.3
+    assert call["max_tokens"] == 900
+
+
+@pytest.mark.asyncio
+async def test_analyze_divergences_json_contract_unchanged(fake_llm):
+    """Contrat de retour inchangé : dict {analysis, divergence_level}, et None
+    si le LLM ne renvoie pas de clé `analysis`."""
+    result = await _run_analysis()
+    assert result == {
+        "analysis": "Faits partagés.\n\n→ **Objet du désaccord** : A vs B.",
+        "divergence_level": "medium",
+    }
+    # Le premier \n\n sépare bien deux sections non vides (contrat mobile)
+    essentiel, _, divergent = result["analysis"].partition("\n\n")
+    assert essentiel.strip()
+    assert divergent.strip().startswith("→")
+
+    fake_llm.response = {"divergence_level": "high"}
+    assert await _run_analysis() is None
+
+
+@pytest.mark.asyncio
+async def test_analyze_divergences_no_perspectives_skips_llm(fake_llm):
+    """Aucune perspective → pas d'appel Mistral (garde-fou de coût inchangé)."""
+    assert await _run_analysis(perspectives=[]) is None
+    assert fake_llm.calls == []


### PR DESCRIPTION
Diagnostic du prompt analyze_divergences (lexicométrie de titres) et plan
de réécriture orienté « ce que l'on sait » / « ce qui fait débat », à
contrat API et rendu mobile inchangés.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UqRf9DYmh9umnk6vPW1VmA