### PR TITLE
docs(epic 30): plan « La lecture aboutie » — ronde 1 de design BMAD

### DIFF
--- a/apps/mobile/lib/core/services/analytics_service.dart
+++ b/apps/mobile/lib/core/services/analytics_service.dart
@@ -124,13 +124,46 @@ class AnalyticsService {
     // Story 14.1 — dedicated PostHog events for clean funnel/retention.
     if (action == 'read') {
       await _capturePostHog('article_read', props);
-      // Threshold ≥ 30 s signals a completed article (conventional for
-      // text content; videos/podcasts already have dedicated completion
-      // events in their own flows).
-      if (timeSpentSeconds >= 30) {
-        await _capturePostHog('article_completed', props);
-      }
     }
+  }
+
+  /// « Lu jusqu'au bout » (Epic 30).
+  ///
+  /// Émis **au moment de l'événement**, jamais depuis `dispose()`. Distinct de
+  /// [trackArticleRead], qui reste un événement de durée.
+  ///
+  /// Les propriétés sont là pour éviter de refaire l'erreur du seuil
+  /// `reading_progress >= 90` : sans [isPartial] ni [renderMode], on
+  /// recompterait le type d'article plutôt que la lecture. [scrollable]
+  /// désambiguïse enfin le bucket « progression 0 » (rebond vs article court lu
+  /// en entier).
+  Future<void> trackArticleFinished({
+    required String contentId,
+    required String sourceId,
+    required String completionSource,
+    required bool isPartial,
+    required String renderMode,
+    required bool reachedFooterPermanent,
+    required int progressRaw,
+    required int timeSpentSeconds,
+    required bool scrollable,
+    required int articleCharCount,
+  }) async {
+    final props = {
+      'session_id': _sessionId,
+      'content_id': contentId,
+      'source_id': sourceId,
+      'completion_source': completionSource,
+      'is_partial': isPartial,
+      'render_mode': renderMode,
+      'reached_footer_permanent': reachedFooterPermanent,
+      'progress_raw': progressRaw,
+      'time_spent_seconds': timeSpentSeconds,
+      'scrollable': scrollable,
+      'article_char_count': articleCharCount,
+    };
+    await _logEvent('article_finished', props);
+    await _capturePostHog('article_finished', props);
   }
 
   /// Enregistre une session digest complète.
@@ -223,10 +256,16 @@ class AnalyticsService {
   ///
   /// Story 14.1 — even though this is deprecated, it's still the only call
   /// site for feed/detail reading flows (which carry real `timeSpentSeconds`).
-  /// We MUST mirror to PostHog from here too, otherwise `article_read` and
-  /// `article_completed` PostHog events would never fire from the surfaces
-  /// where users actually spend reading time. The digest "save" flow that
-  /// uses `trackContentInteraction` hardcodes `timeSpentSeconds: 0`.
+  /// We MUST mirror to PostHog from here too, otherwise `article_read` would
+  /// never fire from the surfaces where users actually spend reading time. The
+  /// digest "save" flow that uses `trackContentInteraction` hardcodes
+  /// `timeSpentSeconds: 0`.
+  ///
+  /// Epic 30 — l'ancien `article_completed` dérivé d'un seuil de 30 s a été
+  /// retiré : la médiane de temps par article est de 20 s, il sous-comptait
+  /// donc structurellement, et surtout il définissait « terminé » par une
+  /// durée. La complétion est désormais un événement propre,
+  /// [trackArticleFinished].
   Future<void> trackArticleRead(
     String contentId,
     String sourceId,
@@ -241,9 +280,6 @@ class AnalyticsService {
     await _logEvent('article_read', props);
 
     await _capturePostHog('article_read', props);
-    if (timeSpentSeconds >= 30) {
-      await _capturePostHog('article_completed', props);
-    }
   }
 
   /// @deprecated Use [trackFeedSession] instead.

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -20,7 +20,9 @@ import 'dart:math' as math;
 import '../../../config/theme.dart';
 import '../../../core/api/api_client.dart';
 import '../../../core/providers/analytics_provider.dart';
+import '../../../core/services/analytics_service.dart';
 import '../../../shared/widgets/fab_nudge_bubble.dart';
+import '../../../shared/widgets/completion_stamp.dart';
 import '../../../shared/widgets/glass_pill.dart';
 import '../../../shared/widgets/navigation/swipe_back_page.dart';
 import '../../feed/models/content_model.dart';
@@ -243,6 +245,17 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   bool _isShortArticle = false;
   // true once user reaches end of displayed content
   final ValueNotifier<bool> _footerPermanent = ValueNotifier<bool>(false);
+
+  /// « Lu jusqu'au bout ». Notifier **frère** de [_footerPermanent], et non le
+  /// même : ce dernier est délibérément bloqué en mode WebView (le verrouiller
+  /// figerait le pied de page pendant toute la session), ce qui est une
+  /// contrainte de layout et non de sémantique. Or la WebView est justement le
+  /// chemin nominal — ~90 % du catalogue est du contenu partiel.
+  final ValueNotifier<bool> _articleCompleted = ValueNotifier<bool>(false);
+  CompletionSource? _completionSource;
+
+  /// Résolu en `initState` — jamais via `ref` depuis `dispose()`.
+  AnalyticsService? _analytics;
   bool _showReadOnSiteNudge = false;
   // Nudge « Sauvegarde cet article » déclenché par l'action de lettre
   // « Sauvegarder 3 articles » (pendingSaveNudgeProvider), one-shot.
@@ -537,6 +550,13 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       vsync: this,
     );
     _footerPermanent.addListener(_onFooterPermanentChanged);
+    _articleCompleted.addListener(_onArticleCompletedChanged);
+
+    // Résolu UNE fois, ici. `ref.read` dans `dispose()` levait, l'exception
+    // était avalée par le catch fourre-tout, et `article_read` /
+    // `article_completed` n'ont donc remonté aucun événement pendant des mois
+    // (régression déjà corrigée une fois dans ce fichier, cf. PR #413).
+    _analytics = ref.read(analyticsServiceProvider);
 
     WidgetsBinding.instance.addObserver(this);
 
@@ -862,6 +882,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     if (clamped > _maxReadingProgress) {
       _maxReadingProgress = clamped;
     }
+    // Chemin nominal : ~90 % du catalogue est partiel, donc la lecture aboutie
+    // se joue ici. Couvre les deux canaux (webview_flutter gratuit et
+    // `onProgress` de PremiumWebView) qui passent tous deux par cette méthode.
+    if (clamped >= 0.98) _latchCompleted(CompletionSource.web);
   }
 
   /// Whether the current article has only partial in-app content.
@@ -939,6 +963,18 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
 
     _isShortArticle = true;
     _footerPermanent.value = true;
+    _latchCompleted(CompletionSource.short);
+  }
+
+  /// Latch one-shot de la complétion. Appelé depuis le listener de scroll, donc
+  /// gardé par un test booléen en tête : pas d'allocation, pas de `setState`.
+  void _latchCompleted(CompletionSource source) {
+    if (_articleCompleted.value) return;
+    if (_isExternal) return;
+    final article = _content;
+    if (article == null) return;
+    _completionSource = source;
+    _articleCompleted.value = true;
   }
 
   /// Fires a brief scale-pop on the primary CTA when `_footerPermanent`
@@ -947,8 +983,43 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   void _onFooterPermanentChanged() {
     if (!_footerPermanent.value) return;
     if (_isWebViewActive || _ctaTapped || _showWebView) return;
+    // Anti-double-buzz : sur contenu complet les deux latches tombent dans la
+    // même frame. La complétion porte alors l'haptique, plus riche.
+    if (_articleCompleted.value) return;
     HapticFeedback.selectionClick();
     _ctaPulseController.forward(from: 0.0);
+  }
+
+  /// La lecture vient d'aboutir : un atterrissage, pas un tick. Jamais
+  /// `mediumImpact`/`heavyImpact` sur un acte de lecture.
+  void _onArticleCompletedChanged() {
+    if (!_articleCompleted.value) return;
+    final article = _content;
+    if (article == null) return;
+    final source = _completionSource ?? CompletionSource.inApp;
+
+    HapticFeedback.lightImpact();
+    unawaited(ref.read(readSyncServiceProvider).markCompleted(article.id, source));
+    _analytics?.trackArticleFinished(
+      contentId: article.id,
+      sourceId: article.source.id,
+      completionSource: source.wireValue,
+      isPartial: _isPartialContent,
+      renderMode: _completionRenderMode,
+      reachedFooterPermanent: _footerPermanent.value,
+      progressRaw: (_maxReadingProgress * 100).round().clamp(0, 100),
+      timeSpentSeconds: DateTime.now().difference(_startTime).inSeconds,
+      scrollable: _scrollController.hasClients &&
+          _scrollController.position.maxScrollExtent >= 50,
+      articleCharCount:
+          plainTextLength(article.htmlContent ?? article.description),
+    );
+  }
+
+  String get _completionRenderMode {
+    if (_isWebViewActive || _ctaTapped) return 'webview';
+    if (_isShortArticle) return 'short';
+    return 'in_app';
   }
 
   /// ScrollController actif — un seul des deux a des clients à la fois (modes
@@ -1697,13 +1768,18 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         // Accumulate reading time on user_content_status for recommendation signal.
         repository.updateContentStatusWithTimeSpent(_content!.id, duration);
 
-        // Track article read duration
-        ref
-            .read(analyticsServiceProvider)
-            .trackArticleRead(_content!.id, _content!.source.id, duration);
+        // Durée de lecture — le service a été résolu en `initState`, aucun
+        // `ref` n'est touché pendant le teardown.
+        _analytics?.trackArticleRead(
+          _content!.id,
+          _content!.source.id,
+          duration,
+        );
       }
-    } catch (e) {
+    } catch (e, stack) {
+      // Un chemin de récompense ne doit jamais échouer en silence.
       debugPrint('Error tracking on dispose: $e');
+      unawaited(Sentry.captureException(e, stackTrace: stack));
     }
 
     _readingTimer?.cancel();
@@ -1722,6 +1798,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     _footerAutoController.dispose();
     _ctaPulseController.dispose();
     _footerPermanent.removeListener(_onFooterPermanentChanged);
+    _articleCompleted.removeListener(_onArticleCompletedChanged);
+    _articleCompleted.dispose();
     WidgetsBinding.instance.removeObserver(this);
     _footerOffset.dispose();
     _footerPermanent.dispose();
@@ -2197,6 +2275,15 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                         _footerPermanent.value = true;
                         _animateFooterTo(0.0);
                       }
+                      // Complétion in-app : seulement sur contenu complet. Sur
+                      // contenu partiel, atteindre le bas de l'extrait ne veut
+                      // pas dire avoir lu l'article — la complétion arrive
+                      // alors par le pont JS de la WebView.
+                      if (!_isPartialContent &&
+                          !_ctaTapped &&
+                          rawProgress >= 0.98) {
+                        _latchCompleted(CompletionSource.inApp);
+                      }
                       // Progress bar uses article-only extent so perspectives don't dilute it
                       final articleExtent =
                           _articleContentExtent ?? metrics.maxScrollExtent;
@@ -2545,7 +2632,28 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           top: 12,
           bottom: 12 + bottomInset + _kFooterBottomMargin,
         ),
-        child: Row(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Le cachet « LU JUSQU'AU BOUT » vit dans le pied de page et non
+            // dans le flux de l'article : c'est le seul emplacement qui marche
+            // dans les quatre modes de rendu — impossible d'injecter quoi que
+            // ce soit dans le DOM de l'éditeur en WebView, qui est pourtant le
+            // chemin nominal.
+            ValueListenableBuilder<bool>(
+              valueListenable: _articleCompleted,
+              builder: (context, completed, _) {
+                if (!completed) return const SizedBox.shrink();
+                return const Padding(
+                  padding: EdgeInsets.only(bottom: 10),
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: CompletionStamp(animate: true),
+                  ),
+                );
+              },
+            ),
+            Row(
           children: [
             // CTA — sized to content for articles (laisse de la place aux 3
             // boutons icônes à droite); fills width pour video/audio.
@@ -2557,13 +2665,25 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                 child: isArticle
                     ? ValueListenableBuilder<bool>(
                         valueListenable: _footerPermanent,
-                        builder: (context, permanent, _) {
+                        builder: (context, permanent, _) =>
+                            ValueListenableBuilder<bool>(
+                          valueListenable: _articleCompleted,
+                          builder: (context, completed, _) {
                           final isWebViewMode =
                               _ctaTapped || _isWebViewActive;
                           // Primary orange ONLY when the user has reached the
                           // bottom of the article (footer locked permanent) AND
                           // the WebView hasn't been revealed yet.
-                          final usePrimary = permanent && !isWebViewMode;
+                          //
+                          // Une fois l'article terminé, le pied de page porte
+                          // l'état « succès » (cachet vert) : l'action « Lire
+                          // sur … » se retire alors en `secondary` pour ne plus
+                          // concurrencer cet état. Un bouton d'action ne prend
+                          // jamais le vert, qui signifie « déjà fait » partout
+                          // ailleurs dans le produit.
+                          final usePrimary =
+                              permanent && !isWebViewMode && !completed;
+                          final useSecondary = completed;
 
                           final label = isWebViewMode
                               ? 'Lire via Navigateur'
@@ -2591,7 +2711,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                                 label,
                                 style: textTheme.labelMedium?.copyWith(
                                   fontWeight: FontWeight.w600,
-                                  color: usePrimary
+                                  color: usePrimary || useSecondary
                                       ? Colors.white
                                       : colors.textPrimary,
                                 ),
@@ -2603,11 +2723,30 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                             Icon(
                               iconData,
                               size: 16,
-                              color: usePrimary
+                              color: usePrimary || useSecondary
                                   ? Colors.white.withValues(alpha: 0.8)
                                   : colors.textSecondary,
                             ),
                           ];
+
+                          if (useSecondary) {
+                            return FilledButton(
+                              onPressed: _onReadOnSiteTap,
+                              style: FilledButton.styleFrom(
+                                backgroundColor: colors.secondary,
+                                foregroundColor: Colors.white,
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(16),
+                                ),
+                                padding:
+                                    const EdgeInsets.symmetric(horizontal: 12),
+                              ),
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: children,
+                              ),
+                            );
+                          }
 
                           if (usePrimary) {
                             return AnimatedBuilder(
@@ -2667,7 +2806,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                             ),
                             child: Row(children: children),
                           );
-                        },
+                          },
+                        ),
                       )
                     : _buildExternalCtaButton(context, content),
               ),
@@ -2777,6 +2917,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                   ],
                 ),
               ],
+            ),
+          ],
             ),
           ],
         ),
@@ -3093,7 +3235,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   }
 
   Widget _buildReadingProgressBar(FacteurColors colors) {
-    return ValueListenableBuilder<double>(
+    return ValueListenableBuilder<bool>(
+      valueListenable: _articleCompleted,
+      builder: (context, _, __) => ValueListenableBuilder<double>(
       valueListenable: _readingProgress,
       builder: (context, progress, _) {
         // Only show after 5% to avoid flashing on open
@@ -3102,9 +3246,14 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         // Grey→primary lerp, but opacity stays capped so the bar reads discreet
         // even at full progress (15% at start → ~50% max at end).
         final alpha = 0.15 + (clamped * 0.35);
+        // Article terminé : la barre vire au vert « succès ». Elle est
+        // l'instrument de mesure de la lecture, elle porte donc l'état — pas
+        // le bouton d'action.
+        final target =
+            _articleCompleted.value ? kStampGreen : colors.primary;
         final barColor = Color.lerp(
           Colors.grey.shade400,
-          colors.primary,
+          target,
           clamped,
         )!
             .withValues(alpha: alpha);
@@ -3123,6 +3272,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           ),
         );
       },
+      ),
     );
   }
 

--- a/apps/mobile/lib/features/digest/models/digest_models.dart
+++ b/apps/mobile/lib/features/digest/models/digest_models.dart
@@ -75,6 +75,8 @@ class DigestItem with _$DigestItem {
     @JsonKey(name: 'is_saved') @Default(false) bool isSaved,
     @JsonKey(name: 'is_liked') @Default(false) bool isLiked,
     @JsonKey(name: 'is_dismissed') @Default(false) bool isDismissed,
+    /// « Lu jusqu'au bout » (Epic 30) — null = inconnu, pas « non terminé ».
+    @JsonKey(name: 'completed_at') DateTime? completedAt,
     @JsonKey(name: 'recommendation_reason')
     DigestRecommendationReason? recommendationReason,
     @JsonKey(name: 'note_text') String? noteText,

--- a/apps/mobile/lib/features/digest/models/digest_models.freezed.dart
+++ b/apps/mobile/lib/features/digest/models/digest_models.freezed.dart
@@ -695,6 +695,10 @@ mixin _$DigestItem {
   bool get isLiked => throw _privateConstructorUsedError;
   @JsonKey(name: 'is_dismissed')
   bool get isDismissed => throw _privateConstructorUsedError;
+
+  /// « Lu jusqu'au bout » (Epic 30) — null = inconnu, pas « non terminé ».
+  @JsonKey(name: 'completed_at')
+  DateTime? get completedAt => throw _privateConstructorUsedError;
   @JsonKey(name: 'recommendation_reason')
   DigestRecommendationReason? get recommendationReason =>
       throw _privateConstructorUsedError;
@@ -738,6 +742,7 @@ abstract class $DigestItemCopyWith<$Res> {
       @JsonKey(name: 'is_saved') bool isSaved,
       @JsonKey(name: 'is_liked') bool isLiked,
       @JsonKey(name: 'is_dismissed') bool isDismissed,
+      @JsonKey(name: 'completed_at') DateTime? completedAt,
       @JsonKey(name: 'recommendation_reason')
       DigestRecommendationReason? recommendationReason,
       @JsonKey(name: 'note_text') String? noteText,
@@ -779,6 +784,7 @@ class _$DigestItemCopyWithImpl<$Res, $Val extends DigestItem>
     Object? isSaved = null,
     Object? isLiked = null,
     Object? isDismissed = null,
+    Object? completedAt = freezed,
     Object? recommendationReason = freezed,
     Object? noteText = freezed,
     Object? badge = freezed,
@@ -860,6 +866,10 @@ class _$DigestItemCopyWithImpl<$Res, $Val extends DigestItem>
           ? _value.isDismissed
           : isDismissed // ignore: cast_nullable_to_non_nullable
               as bool,
+      completedAt: freezed == completedAt
+          ? _value.completedAt
+          : completedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
       recommendationReason: freezed == recommendationReason
           ? _value.recommendationReason
           : recommendationReason // ignore: cast_nullable_to_non_nullable
@@ -933,6 +943,7 @@ abstract class _$$DigestItemImplCopyWith<$Res>
       @JsonKey(name: 'is_saved') bool isSaved,
       @JsonKey(name: 'is_liked') bool isLiked,
       @JsonKey(name: 'is_dismissed') bool isDismissed,
+      @JsonKey(name: 'completed_at') DateTime? completedAt,
       @JsonKey(name: 'recommendation_reason')
       DigestRecommendationReason? recommendationReason,
       @JsonKey(name: 'note_text') String? noteText,
@@ -974,6 +985,7 @@ class __$$DigestItemImplCopyWithImpl<$Res>
     Object? isSaved = null,
     Object? isLiked = null,
     Object? isDismissed = null,
+    Object? completedAt = freezed,
     Object? recommendationReason = freezed,
     Object? noteText = freezed,
     Object? badge = freezed,
@@ -1055,6 +1067,10 @@ class __$$DigestItemImplCopyWithImpl<$Res>
           ? _value.isDismissed
           : isDismissed // ignore: cast_nullable_to_non_nullable
               as bool,
+      completedAt: freezed == completedAt
+          ? _value.completedAt
+          : completedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
       recommendationReason: freezed == recommendationReason
           ? _value.recommendationReason
           : recommendationReason // ignore: cast_nullable_to_non_nullable
@@ -1098,6 +1114,7 @@ class _$DigestItemImpl implements _DigestItem {
       @JsonKey(name: 'is_saved') this.isSaved = false,
       @JsonKey(name: 'is_liked') this.isLiked = false,
       @JsonKey(name: 'is_dismissed') this.isDismissed = false,
+      @JsonKey(name: 'completed_at') this.completedAt,
       @JsonKey(name: 'recommendation_reason') this.recommendationReason,
       @JsonKey(name: 'note_text') this.noteText,
       this.badge})
@@ -1170,6 +1187,11 @@ class _$DigestItemImpl implements _DigestItem {
   @override
   @JsonKey(name: 'is_dismissed')
   final bool isDismissed;
+
+  /// « Lu jusqu'au bout » (Epic 30) — null = inconnu, pas « non terminé ».
+  @override
+  @JsonKey(name: 'completed_at')
+  final DateTime? completedAt;
   @override
   @JsonKey(name: 'recommendation_reason')
   final DigestRecommendationReason? recommendationReason;
@@ -1181,7 +1203,7 @@ class _$DigestItemImpl implements _DigestItem {
 
   @override
   String toString() {
-    return 'DigestItem(contentId: $contentId, title: $title, url: $url, thumbnailUrl: $thumbnailUrl, description: $description, htmlContent: $htmlContent, topics: $topics, contentType: $contentType, durationSeconds: $durationSeconds, publishedAt: $publishedAt, source: $source, rank: $rank, reason: $reason, isFollowedSource: $isFollowedSource, isPaid: $isPaid, isRead: $isRead, isSaved: $isSaved, isLiked: $isLiked, isDismissed: $isDismissed, recommendationReason: $recommendationReason, noteText: $noteText, badge: $badge)';
+    return 'DigestItem(contentId: $contentId, title: $title, url: $url, thumbnailUrl: $thumbnailUrl, description: $description, htmlContent: $htmlContent, topics: $topics, contentType: $contentType, durationSeconds: $durationSeconds, publishedAt: $publishedAt, source: $source, rank: $rank, reason: $reason, isFollowedSource: $isFollowedSource, isPaid: $isPaid, isRead: $isRead, isSaved: $isSaved, isLiked: $isLiked, isDismissed: $isDismissed, completedAt: $completedAt, recommendationReason: $recommendationReason, noteText: $noteText, badge: $badge)';
   }
 
   @override
@@ -1217,6 +1239,8 @@ class _$DigestItemImpl implements _DigestItem {
             (identical(other.isLiked, isLiked) || other.isLiked == isLiked) &&
             (identical(other.isDismissed, isDismissed) ||
                 other.isDismissed == isDismissed) &&
+            (identical(other.completedAt, completedAt) ||
+                other.completedAt == completedAt) &&
             (identical(other.recommendationReason, recommendationReason) ||
                 other.recommendationReason == recommendationReason) &&
             (identical(other.noteText, noteText) ||
@@ -1247,6 +1271,7 @@ class _$DigestItemImpl implements _DigestItem {
         isSaved,
         isLiked,
         isDismissed,
+        completedAt,
         recommendationReason,
         noteText,
         badge
@@ -1291,6 +1316,7 @@ abstract class _DigestItem implements DigestItem {
       @JsonKey(name: 'is_saved') final bool isSaved,
       @JsonKey(name: 'is_liked') final bool isLiked,
       @JsonKey(name: 'is_dismissed') final bool isDismissed,
+      @JsonKey(name: 'completed_at') final DateTime? completedAt,
       @JsonKey(name: 'recommendation_reason')
       final DigestRecommendationReason? recommendationReason,
       @JsonKey(name: 'note_text') final String? noteText,
@@ -1352,6 +1378,11 @@ abstract class _DigestItem implements DigestItem {
   @override
   @JsonKey(name: 'is_dismissed')
   bool get isDismissed;
+  @override
+
+  /// « Lu jusqu'au bout » (Epic 30) — null = inconnu, pas « non terminé ».
+  @JsonKey(name: 'completed_at')
+  DateTime? get completedAt;
   @override
   @JsonKey(name: 'recommendation_reason')
   DigestRecommendationReason? get recommendationReason;

--- a/apps/mobile/lib/features/digest/models/digest_models.g.dart
+++ b/apps/mobile/lib/features/digest/models/digest_models.g.dart
@@ -90,6 +90,9 @@ _$DigestItemImpl _$$DigestItemImplFromJson(Map<String, dynamic> json) =>
       isSaved: json['is_saved'] as bool? ?? false,
       isLiked: json['is_liked'] as bool? ?? false,
       isDismissed: json['is_dismissed'] as bool? ?? false,
+      completedAt: json['completed_at'] == null
+          ? null
+          : DateTime.parse(json['completed_at'] as String),
       recommendationReason: json['recommendation_reason'] == null
           ? null
           : DigestRecommendationReason.fromJson(
@@ -119,6 +122,7 @@ Map<String, dynamic> _$$DigestItemImplToJson(_$DigestItemImpl instance) =>
       'is_saved': instance.isSaved,
       'is_liked': instance.isLiked,
       'is_dismissed': instance.isDismissed,
+      'completed_at': instance.completedAt?.toIso8601String(),
       'recommendation_reason': instance.recommendationReason,
       'note_text': instance.noteText,
       'badge': instance.badge,

--- a/apps/mobile/lib/features/feed/models/content_model.dart
+++ b/apps/mobile/lib/features/feed/models/content_model.dart
@@ -104,7 +104,17 @@ class Content {
   final List<String> topics;
   final List<ContentEntity> entities;
   final RecommendationReason? recommendationReason;
-  final int readingProgress; // 0-100 scroll depth percentage
+  /// Scroll depth 0-100.
+  ///
+  /// ⚠️ Signal gelé : plafonné à 25 pour le contenu partiel (~90 % du
+  /// catalogue), donc `readingProgress >= 90` mesure le type d'article, pas la
+  /// lecture. Conservé pour l'historique ; [completedAt] est le signal de
+  /// complétion.
+  final int readingProgress;
+
+  /// Horodatage « lu jusqu'au bout » (estampillé serveur, premier écrit gagne).
+  /// Null = inconnu, pas « non terminé ».
+  final DateTime? completedAt;
   final String? noteText;
   final DateTime? noteUpdatedAt;
   final bool isFollowedSource; // Feed fallback: source suivie par l'utilisateur
@@ -170,6 +180,7 @@ class Content {
     this.entities = const [],
     this.recommendationReason,
     this.readingProgress = 0,
+    this.completedAt,
     this.noteText,
     this.noteUpdatedAt,
     this.isFollowedSource = false,
@@ -202,28 +213,35 @@ class Content {
 
   bool get hasNote => noteText != null && noteText!.isNotEmpty;
 
-  /// Reading badge label based on reading_progress.
-  /// Returns null if article hasn't been interacted with.
-  /// readingProgress > 0 always takes priority over consumed status,
-  /// because the 30s timer can mark consumed before meaningful scroll.
+  /// « Lu jusqu'au bout » — l'utilisateur a atteint le bas de ce que Facteur
+  /// lui a présenté (contenu in-app complet, article trop court pour scroller,
+  /// ou page de l'éditeur en WebView).
+  ///
+  /// Adossé à [completedAt] et **pas** à `readingProgress >= 90` : cette
+  /// dernière borne est inatteignable pour ~90 % du catalogue (contenu partiel
+  /// plafonné à 25), ce qui étiquetait « Parcouru » des lectures pourtant
+  /// menées à leur terme.
+  bool get isCompleted => completedAt != null;
+
+  /// Libellé d'état de lecture. `null` si l'article n'a pas été ouvert.
   String? get readingLabel {
+    if (isCompleted) {
+      return isVideo ? 'Vu jusqu\'au bout' : 'Lu jusqu\'au bout';
+    }
     if (status == ContentStatus.unseen && readingProgress == 0) return null;
 
-    // Video-specific labels
-    if (contentType == ContentType.youtube || contentType == ContentType.video) {
-      if (readingProgress >= 90) return 'Vu jusqu\'au bout';
-      if (readingProgress >= 25) return 'Vu en partie';
-      // Consumed via timer but no progress tracking
-      if (status == ContentStatus.consumed) return 'Vu en partie';
+    if (isVideo) {
+      // La vidéo n'a pas de cap partiel : sa progression reste exploitable.
+      if (readingProgress >= 25 || status == ContentStatus.consumed) {
+        return 'Vu en partie';
+      }
       return null;
     }
 
-    // Article labels
-    if (readingProgress >= 90) return 'Lu jusqu\'au bout';
-    if (readingProgress >= 30) return 'Lu';
-    if (readingProgress > 0) return 'Parcouru';
-    // Consumed via 30s timer but no scroll tracking (e.g. partial content)
-    if (status == ContentStatus.consumed) return 'Lu';
+    // Ouvrir un article le marque `consumed` au bout d'1 s
+    // (`articleReadThreshold`) : « Lu » ne dit donc rien de plus que
+    // « ouvert », d'où un libellé unique et sans jugement.
+    if (readingProgress > 0 || status == ContentStatus.consumed) return 'Lu';
     return null;
   }
 
@@ -251,6 +269,7 @@ class Content {
       entities: entities,
       recommendationReason: recommendationReason,
       readingProgress: readingProgress,
+      completedAt: completedAt,
       noteText: null,
       noteUpdatedAt: null,
       isFollowedSource: isFollowedSource,
@@ -322,6 +341,9 @@ class Content {
             ? RecommendationReason.fromJson(recJson)
             : null,
         readingProgress: (json['reading_progress'] as int?) ?? 0,
+        completedAt: json['completed_at'] != null
+            ? DateTime.tryParse(json['completed_at'] as String)
+            : null,
         noteText: json['note_text'] as String?,
         noteUpdatedAt: json['note_updated_at'] != null
             ? DateTime.tryParse(json['note_updated_at'] as String)
@@ -366,6 +388,7 @@ class Content {
     List<ContentEntity>? entities,
     RecommendationReason? recommendationReason,
     int? readingProgress,
+    DateTime? completedAt,
     String? noteText,
     DateTime? noteUpdatedAt,
     bool? isFollowedSource,
@@ -412,6 +435,7 @@ class Content {
       entities: entities ?? this.entities,
       recommendationReason: recommendationReason ?? this.recommendationReason,
       readingProgress: readingProgress ?? this.readingProgress,
+      completedAt: completedAt ?? this.completedAt,
       noteText: noteText ?? this.noteText,
       noteUpdatedAt: noteUpdatedAt ?? this.noteUpdatedAt,
       isFollowedSource: isFollowedSource ?? this.isFollowedSource,

--- a/apps/mobile/lib/features/feed/repositories/feed_repository.dart
+++ b/apps/mobile/lib/features/feed/repositories/feed_repository.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import '../../../core/api/api_client.dart';
 import '../models/content_model.dart';
+import '../services/read_sync_service.dart' show CompletionSource;
 
 class FeedRepository {
   final ApiClient _apiClient;
@@ -908,6 +909,24 @@ class FeedRepository {
     await _apiClient.dio.post<void>(
       'contents/$contentId/status',
       data: {'status': ContentStatus.consumed.name},
+    );
+  }
+
+  /// Marque un article « lu jusqu'au bout ».
+  ///
+  /// Envoyé **sans** `status` : côté serveur, la garde d'idempotence de la
+  /// transition CONSUMED (`ON CONFLICT ... WHERE status != 'consumed'`)
+  /// ignorerait l'update entier sur une ligne déjà consumed, et `completed_at`
+  /// serait perdu sans bruit. L'API rejette d'ailleurs la combinaison.
+  ///
+  /// Erreurs propagées : la file durable ne retire son entrée qu'après un 2xx.
+  Future<void> markContentCompleted(
+    String contentId,
+    CompletionSource source,
+  ) async {
+    await _apiClient.dio.post<void>(
+      'contents/$contentId/status',
+      data: {'completed': true, 'completion_source': source.wireValue},
     );
   }
 

--- a/apps/mobile/lib/features/feed/services/read_sync_service.dart
+++ b/apps/mobile/lib/features/feed/services/read_sync_service.dart
@@ -8,12 +8,38 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../../core/auth/auth_state.dart';
 import '../../flux_continu/providers/flux_continu_provider.dart';
+import '../../gamification/providers/streak_provider.dart';
 import '../../flux_continu/services/flux_continu_cache_service.dart';
 import '../models/content_model.dart';
 import '../providers/feed_provider.dart';
 import 'feed_cache_service.dart';
 
 const articleReadThreshold = Duration(seconds: 1);
+
+/// D'où vient le signal « lu jusqu'au bout ». Miroir de `CompletionSource`
+/// côté backend.
+enum CompletionSource {
+  /// Contenu complet : bas de l'article atteint dans l'app.
+  inApp('in_app'),
+
+  /// Article trop court pour scroller.
+  short('short'),
+
+  /// Contenu partiel (~90 % du catalogue) : bas de la page atteint chez
+  /// l'éditeur, via le pont JS de la WebView.
+  web('web');
+
+  const CompletionSource(this.wireValue);
+
+  final String wireValue;
+
+  static CompletionSource fromWire(String? value) {
+    return CompletionSource.values.firstWhere(
+      (s) => s.wireValue == value,
+      orElse: () => CompletionSource.inApp,
+    );
+  }
+}
 
 bool shouldCommitReadOnBackground({
   required DateTime startedAt,
@@ -28,33 +54,58 @@ bool shouldCommitReadOnBackground({
 
 class PendingReadQueue {
   static const boxName = 'pending_reads';
-  static const _keyPrefix = 'read:';
+  static const readPrefix = 'read:';
+
+  /// Préfixe des lectures **abouties** (Epic 30). Même box Hive, autre espace
+  /// de clés : la durabilité offline de la complétion est acquise sans
+  /// migration ni nouvelle box.
+  static const completionPrefix = 'done:';
 
   final Box<String> box;
+  final String keyPrefix;
 
-  PendingReadQueue(this.box);
+  PendingReadQueue(this.box, {this.keyPrefix = readPrefix});
 
-  static PendingReadQueue? tryFromHive() {
+  static PendingReadQueue? tryFromHive({String keyPrefix = readPrefix}) {
     if (!Hive.isBoxOpen(boxName)) return null;
-    return PendingReadQueue(Hive.box<String>(boxName));
+    return PendingReadQueue(Hive.box<String>(boxName), keyPrefix: keyPrefix);
   }
 
   String _key(String userId, String contentId) =>
-      '$_keyPrefix$userId:$contentId';
+      '$keyPrefix$userId:$contentId';
 
-  Future<void> enqueue(String userId, String contentId) async {
+  Future<void> enqueue(
+    String userId,
+    String contentId, {
+    Map<String, dynamic>? extra,
+  }) async {
     await box.put(
       _key(userId, contentId),
       jsonEncode({
         'user_id': userId,
         'content_id': contentId,
         'queued_at': DateTime.now().toUtc().toIso8601String(),
+        ...?extra,
       }),
     );
   }
 
+  /// Payload durable d'une entrée, ou `null` si elle n'existe plus.
+  /// Permet au flush de récupérer un champ (ex. `completion_source`) que la
+  /// callback `sync` ne reçoit pas.
+  Map<String, dynamic>? payloadFor(String userId, String contentId) {
+    final raw = box.get(_key(userId, contentId));
+    if (raw == null) return null;
+    try {
+      final decoded = jsonDecode(raw);
+      return decoded is Map<String, dynamic> ? decoded : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
   Map<String, String> pendingForUser(String userId) {
-    final prefix = '$_keyPrefix$userId:';
+    final prefix = '$keyPrefix$userId:';
     return {
       for (final key in box.keys.whereType<String>())
         if (key.startsWith(prefix)) key: key.substring(prefix.length),
@@ -81,7 +132,7 @@ class PendingReadQueue {
   }
 
   Future<void> clearForUser(String userId) async {
-    final prefix = '$_keyPrefix$userId:';
+    final prefix = '$keyPrefix$userId:';
     await box.deleteAll(
       box.keys.whereType<String>().where((key) => key.startsWith(prefix)),
     );
@@ -90,6 +141,12 @@ class PendingReadQueue {
 
 final pendingReadQueueProvider = Provider<PendingReadQueue?>((ref) {
   return PendingReadQueue.tryFromHive();
+});
+
+final pendingCompletionQueueProvider = Provider<PendingReadQueue?>((ref) {
+  return PendingReadQueue.tryFromHive(
+    keyPrefix: PendingReadQueue.completionPrefix,
+  );
 });
 
 final restoredReadSessionUserIdProvider = Provider<String?>((ref) {
@@ -123,16 +180,26 @@ final consumedContentIdsProvider = StateProvider<Set<String>>(
   (ref) => <String>{},
 );
 
+/// Articles lus **jusqu'au bout** pendant la session — permet aux cartes de
+/// refléter la complétion sans attendre un refetch.
+final completedContentIdsProvider = StateProvider<Set<String>>(
+  (ref) => <String>{},
+);
+
 class ReadSyncService {
   final Ref ref;
   final void Function(String userId, String contentId)? propagateOverride;
   final Future<void> Function(String contentId)? syncOverride;
+  final Future<void> Function(String contentId, CompletionSource source)?
+      completionSyncOverride;
   final Set<String> _flushingUsers = <String>{};
+  final Set<String> _flushingCompletionUsers = <String>{};
 
   ReadSyncService(
     this.ref, {
     this.propagateOverride,
     this.syncOverride,
+    this.completionSyncOverride,
   });
 
   /// Returns true only after the durable queue entry has been written and the
@@ -163,9 +230,66 @@ class ReadSyncService {
     return true;
   }
 
+  /// Enregistre « lu jusqu'au bout ».
+  ///
+  /// Même ordre que [markConsumed] : **durabilité d'abord**, puis état local,
+  /// puis réseau — une complétion dans le métro ne doit pas être perdue, sinon
+  /// le compteur du jour est faux et visiblement injuste.
+  ///
+  /// Requête distincte de celle du statut `consumed` : les combiner ferait
+  /// perdre `completed_at` (garde d'idempotence côté serveur).
+  Future<bool> markCompleted(String contentId, CompletionSource source) async {
+    if (contentId.isEmpty) return false;
+    final userId = ref.read(readSyncUserIdProvider);
+    if (userId == null) return false;
+    final queue = ref.read(pendingCompletionQueueProvider);
+    if (queue == null) return false;
+
+    final completedIds = ref.read(completedContentIdsProvider.notifier);
+    if (completedIds.state.contains(contentId)) return false;
+
+    await queue.enqueue(userId, contentId, extra: {'source': source.wireValue});
+    completedIds.state = {...completedIds.state, contentId};
+    unawaited(flushCompletionsForUser(userId));
+    return true;
+  }
+
+  Future<void> flushCompletionsForUser(String userId) async {
+    final queue = ref.read(pendingCompletionQueueProvider);
+    if (queue == null || !_flushingCompletionUsers.add(userId)) return;
+    final hadPending = queue.pendingForUser(userId).isNotEmpty;
+    try {
+      await queue.flushForUser(
+        userId,
+        sync: (contentId) async {
+          final source = CompletionSource.fromWire(
+            queue.payloadFor(userId, contentId)?['source'] as String?,
+          );
+          if (completionSyncOverride != null) {
+            await completionSyncOverride!(contentId, source);
+            return;
+          }
+          await ref
+              .read(feedRepositoryProvider)
+              .markContentCompleted(contentId, source);
+        },
+      );
+    } finally {
+      _flushingCompletionUsers.remove(userId);
+    }
+    // Le compteur du jour est dérivé côté serveur : on le relit une fois la
+    // complétion confirmée, plutôt que de tenir un compteur local qui
+    // divergerait.
+    if (hadPending) {
+      unawaited(ref.read(streakProvider.notifier).refreshSilent());
+    }
+  }
+
   Future<void> flushCurrentUser() async {
     final userId = ref.read(readSyncUserIdProvider);
-    if (userId != null) await flushForUser(userId);
+    if (userId == null) return;
+    await flushForUser(userId);
+    await flushCompletionsForUser(userId);
   }
 
   Future<void> flushForUser(

--- a/apps/mobile/lib/features/feed/widgets/animated_feed_card.dart
+++ b/apps/mobile/lib/features/feed/widgets/animated_feed_card.dart
@@ -1,19 +1,35 @@
 import 'package:flutter/material.dart';
-import 'package:phosphor_flutter/phosphor_flutter.dart';
 
-/// Wrapper widget that shows a "Lu" (Read) overlay when content is consumed
-/// before the card is removed from the feed.
+import '../../../shared/widgets/completion_stamp.dart' show kStampGreen;
+
+/// Marque discrètement, **au retour de l'article**, la carte d'une lecture
+/// menée jusqu'au bout : un filet vertical vert se dessine sur le bord gauche.
+///
+/// Volontairement pas une célébration. La version d'origine de ce widget —
+/// restée du code mort, jamais montée — posait un scrim noir à 60 % sur la
+/// carte, une pastille grise (à rebours de la convention verte du produit) et
+/// une courbe `elasticOut` sur 1000 ms : un vocabulaire de jeu pour un
+/// non-événement. Ici : `easeOutCubic`, 320 ms, aucun scrim, et **aucune
+/// haptique** — elle a déjà eu lieu dans l'article. Un événement, une vibration.
+///
+/// Une carte seulement ouverte ne déclenche rien du tout : il ne s'est rien
+/// passé, l'annoncer serait la définition du bruit.
 class AnimatedFeedCard extends StatefulWidget {
-  final Widget child;
-  final bool isConsumed;
-  final VoidCallback? onAnimationComplete;
-
   const AnimatedFeedCard({
     super.key,
     required this.child,
-    required this.isConsumed,
-    this.onAnimationComplete,
+    required this.isCompleted,
+    this.animate = true,
   });
+
+  final Widget child;
+
+  /// L'article a été lu jusqu'au bout (`completedAt != null`).
+  final bool isCompleted;
+
+  /// `false` quand l'état était déjà connu à la construction : le filet est
+  /// alors peint d'emblée, sans animation. C'est un état, pas un événement.
+  final bool animate;
 
   @override
   State<AnimatedFeedCard> createState() => _AnimatedFeedCardState();
@@ -21,65 +37,29 @@ class AnimatedFeedCard extends StatefulWidget {
 
 class _AnimatedFeedCardState extends State<AnimatedFeedCard>
     with SingleTickerProviderStateMixin {
-  late AnimationController _controller;
-  late Animation<double> _fadeInAnimation;
-  late Animation<double> _fadeOutAnimation;
-  late Animation<double> _scaleAnimation;
-
-  bool _showOverlay = false;
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 320),
+  );
 
   @override
   void initState() {
     super.initState();
-
-    _controller = AnimationController(
-      duration: const Duration(milliseconds: 1000),
-      vsync: this,
-    );
-
-    // Fade in overlay (0-30%)
-    _fadeInAnimation = Tween<double>(
-      begin: 0.0,
-      end: 1.0,
-    ).animate(CurvedAnimation(
-      parent: _controller,
-      curve: const Interval(0.0, 0.3, curve: Curves.easeOut),
-    ));
-
-    // Fade out overlay (70-100%)
-    _fadeOutAnimation = Tween<double>(
-      begin: 1.0,
-      end: 0.0,
-    ).animate(CurvedAnimation(
-      parent: _controller,
-      curve: const Interval(0.7, 1.0, curve: Curves.easeIn),
-    ));
-
-    // Scale badge (0-40%)
-    _scaleAnimation = Tween<double>(
-      begin: 0.0,
-      end: 1.0,
-    ).animate(CurvedAnimation(
-      parent: _controller,
-      curve: const Interval(0.0, 0.4, curve: Curves.elasticOut),
-    ));
-
-    _controller.addStatusListener((status) {
-      if (status == AnimationStatus.completed) {
-        widget.onAnimationComplete?.call();
-      }
-    });
+    if (widget.isCompleted && !widget.animate) _controller.value = 1.0;
+    if (widget.isCompleted && widget.animate) _startDelayed();
   }
 
   @override
   void didUpdateWidget(AnimatedFeedCard oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.isConsumed && !oldWidget.isConsumed && !_showOverlay) {
-      setState(() {
-        _showOverlay = true;
-      });
-      _controller.forward();
-    }
+    if (widget.isCompleted && !oldWidget.isCompleted) _startDelayed();
+  }
+
+  /// Léger retard : ne pas concurrencer l'animation de retour de route.
+  void _startDelayed() {
+    Future<void>.delayed(const Duration(milliseconds: 220), () {
+      if (mounted) _controller.forward();
+    });
   }
 
   @override
@@ -88,87 +68,58 @@ class _AnimatedFeedCardState extends State<AnimatedFeedCard>
     super.dispose();
   }
 
-  double get _currentOpacity {
-    if (_controller.value <= 0.7) {
-      return _fadeInAnimation.value;
-    } else {
-      return _fadeOutAnimation.value;
-    }
+  @override
+  Widget build(BuildContext context) {
+    if (!widget.isCompleted) return widget.child;
+
+    final reduceMotion =
+        MediaQuery.maybeDisableAnimationsOf(context) ?? false;
+
+    return Semantics(
+      label: 'Lu jusqu\'au bout',
+      child: Stack(
+        children: [
+          widget.child,
+          PositionedDirectional(
+            start: 0,
+            top: 0,
+            bottom: 0,
+            child: AnimatedBuilder(
+              animation: _controller,
+              builder: (context, child) {
+                final t = reduceMotion
+                    ? 1.0
+                    : Curves.easeOutCubic.transform(_controller.value);
+                if (t == 0) return const SizedBox.shrink();
+                return Transform.scale(
+                  scaleY: t,
+                  alignment: Alignment.center,
+                  child: child,
+                );
+              },
+              child: const _CompletionRule(),
+            ),
+          ),
+        ],
+      ),
+    );
   }
+}
+
+/// Filet vertical 3 px — idiome du filet de journal. Pas de teinte de fond :
+/// sur le crème `#F2E8D5`, un vert à 4 % passe sous le seuil de perception et
+/// à 8 % il vire kaki, ce qui détruit la sensation papier.
+class _CompletionRule extends StatelessWidget {
+  const _CompletionRule();
 
   @override
   Widget build(BuildContext context) {
-    // Don't show overlay if not consumed
-    if (!_showOverlay) {
-      return widget.child;
-    }
-
-    return Stack(
-      children: [
-        // Original card
-        widget.child,
-
-        // "Lu" overlay
-        Positioned.fill(
-          child: AnimatedBuilder(
-            animation: _controller,
-            builder: (context, child) {
-              return Opacity(
-                opacity: _currentOpacity,
-                child: Container(
-                  decoration: BoxDecoration(
-                    color: Colors.black.withOpacity(0.6),
-                    borderRadius: BorderRadius.circular(16),
-                  ),
-                  child: Center(
-                    child: Transform.scale(
-                      scale: _scaleAnimation.value,
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 24,
-                          vertical: 12,
-                        ),
-                        decoration: BoxDecoration(
-                          color: Colors.grey.shade700,
-                          borderRadius: BorderRadius.circular(30),
-                          boxShadow: [
-                            BoxShadow(
-                              color: Colors.black.withOpacity(0.2),
-                              blurRadius: 8,
-                              spreadRadius: 1,
-                            ),
-                          ],
-                        ),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Icon(
-                              PhosphorIcons.checkCircle(
-                                  PhosphorIconsStyle.fill),
-                              color: Colors.white,
-                              size: 28,
-                            ),
-                            const SizedBox(width: 10),
-                            const Text(
-                              'Lu',
-                              style: TextStyle(
-                                color: Colors.white,
-                                fontSize: 20,
-                                fontWeight: FontWeight.bold,
-                                letterSpacing: 1,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-              );
-            },
-          ),
-        ),
-      ],
+    return Container(
+      width: 3,
+      decoration: const BoxDecoration(
+        color: kStampGreen,
+        borderRadius: BorderRadius.horizontal(left: Radius.circular(16)),
+      ),
     );
   }
 }

--- a/apps/mobile/lib/features/feed/widgets/reading_badge.dart
+++ b/apps/mobile/lib/features/feed/widgets/reading_badge.dart
@@ -4,12 +4,16 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../models/content_model.dart';
 
-/// Badge showing reading progress level on article cards.
+/// Badge d'état de lecture sur les cartes article.
 ///
-/// Levels:
-/// - "Parcouru" (< 30%) — neutral gray
-/// - "Lu" (30-89%) — green with single check
-/// - "Lu jusqu'au bout" (>= 90%) — green with double check
+/// Deux états seulement — « Lu » (ouvert) et « Lu jusqu'au bout » (complété) —
+/// adossés à `completedAt` et non plus à `readingProgress`, qui est plafonné à
+/// 25 pour ~90 % du catalogue et affichait donc « Parcouru » sur des lectures
+/// pourtant menées à leur terme.
+///
+/// Le niveau « Parcouru » (icône `eye`, gris) a été retiré : ce n'est pas un
+/// accomplissement, et le nommer revient à commenter la lecture superficielle
+/// de l'utilisateur. L'opacité de la carte suffit à le signaler.
 class ReadingBadge extends StatelessWidget {
   final Content content;
 
@@ -21,31 +25,12 @@ class ReadingBadge extends StatelessWidget {
     if (label == null) return const SizedBox.shrink();
 
     final colors = context.facteurColors;
-    final progress = content.readingProgress;
-    final isConsumed = content.status == ContentStatus.consumed;
 
-    // Color logic
-    final Color bgColor;
-    final Color fgColor;
-    final IconData icon;
-
-    if (progress >= 90) {
-      // Lu jusqu'au bout — strong green + double check
-      bgColor = colors.success;
-      fgColor = Colors.white;
-      icon = PhosphorIcons.checks(PhosphorIconsStyle.bold);
-    } else if (progress >= 30 || isConsumed) {
-      // Lu — green + check circle (also covers freshly-opened articles
-      // where status==consumed but scroll progress is still 0)
-      bgColor = colors.success;
-      fgColor = Colors.white;
-      icon = PhosphorIcons.checkCircle(PhosphorIconsStyle.fill);
-    } else {
-      // Parcouru — neutral gray
-      bgColor = colors.textSecondary.withOpacity(0.7);
-      fgColor = Colors.white;
-      icon = PhosphorIcons.eye(PhosphorIconsStyle.regular);
-    }
+    final Color bgColor = colors.success;
+    const Color fgColor = Colors.white;
+    final IconData icon = content.isCompleted
+        ? PhosphorIcons.checks(PhosphorIconsStyle.bold)
+        : PhosphorIcons.checkCircle(PhosphorIconsStyle.fill);
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -63,6 +63,7 @@ import '../utils/section_fit.dart' show kMinPlausibleUsableHeight;
 import '../utils/section_snap.dart';
 import '../widgets/citation_du_jour_card.dart';
 import '../widgets/closing_card_v18.dart';
+import '../widgets/daily_completion_recap.dart';
 import '../widgets/edition_timeline_sheet.dart';
 import '../widgets/flux_continu_article_card.dart';
 import '../widgets/my_interests_intro.dart';
@@ -1615,9 +1616,18 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
                     closeHint: isAndroid
                         ? null
                         : 'Vous pouvez refermer l’app — à demain',
-                    secondary: FeedbackClosingCard(
-                      embedded: true,
-                      onLayoutChanged: _scheduleAnchorRecompute,
+                    secondary: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        // Constat rétrospectif des lectures abouties — après
+                        // la lecture, jamais avant. Ne se rend pas du tout à
+                        // zéro lecture aboutie (le cas majoritaire).
+                        const DailyCompletionRecap(),
+                        FeedbackClosingCard(
+                          embedded: true,
+                          onLayoutChanged: _scheduleAnchorRecompute,
+                        ),
+                      ],
                     ),
                   ),
                 ),

--- a/apps/mobile/lib/features/flux_continu/widgets/daily_completion_recap.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/daily_completion_recap.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../config/theme.dart';
+import '../../../shared/widgets/completion_stamp.dart';
+import '../../gamification/providers/gamification_preference_provider.dart';
+import '../../gamification/providers/streak_provider.dart';
+
+/// Taglines du bloc de clôture. Ton affirmatif — proche de « Tu es à jour » et
+/// du tampon « FIN DE TOURNÉE » —, tutoiement, présent, aucun emoji, aucun
+/// point d'exclamation.
+///
+/// Volontairement **sans formulation comparative** (« deux articles lus valent
+/// mieux que vingt survolés ») : le survol est le comportement de la grande
+/// majorité des ouvertures, une telle phrase ferait honte à l'utilisateur
+/// médian.
+const List<String> kCompletionTaglines = [
+  'Moins d’info, plus de compréhension.',
+  'Tu n’as pas tout lu. Tu as bien lu.',
+  'Lire jusqu’au bout, c’est déjà comprendre.',
+  'Ce que tu retiendras demain, c’est ça.',
+  'Le reste attendra. Ça, tu le sais maintenant.',
+  'Une lecture finie vaut mieux qu’une pile commencée.',
+  'Rien de plus à lire aujourd’hui. C’est le principe.',
+];
+
+/// Rotation déterministe (FNV-1a) sur le jour — même mécanisme que la file
+/// « Notif du jour », sans son cap ni son cooldown : deux jours consécutifs ne
+/// tombent pas sur la même phrase, et un même jour est stable entre rebuilds.
+String pickCompletionTagline(DateTime now, {int index = 0}) {
+  final epochDay = now.toUtc().millisecondsSinceEpoch ~/ 86400000;
+  var hash = 2166136261;
+  for (final unit in '$epochDay#$index'.codeUnits) {
+    hash = (hash ^ unit) * 16777619 & 0xFFFFFFFF;
+  }
+  return kCompletionTaglines[hash % kCompletionTaglines.length];
+}
+
+/// Constat rétrospectif des lectures abouties du jour, embarqué dans la carte
+/// de clôture.
+///
+/// Trois règlesnon négociables, qui font toute la différence entre un constat et
+/// une injonction :
+///
+/// 1. **Aucune jauge.** Pas de barre, pas d'anneau, pas de « 2/2 », pas de
+///    cases à remplir — deux cases à remplir *sont* une jauge.
+/// 2. **Zéro lecture aboutie ⇒ le bloc ne se rend pas du tout.** C'est le cas
+///    majoritaire. Il n'y a pas d'objectif raté parce que l'objectif n'est
+///    jamais affiché comme cible.
+/// 3. **Aucun « plus qu'un ! »** à une seule lecture : on énonce ce qui a été
+///    fait, jamais ce qui manque.
+class DailyCompletionRecap extends ConsumerWidget {
+  const DailyCompletionRecap({super.key, this.now});
+
+  /// Injectable pour les tests.
+  final DateTime? now;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // L'objectif journalier est de la gamification : il passe par la même gate
+    // que la flamme. Le cachet dans le reader, lui, n'est pas gaté — c'est un
+    // affordance d'état de lecture, pas une récompense.
+    final gamificationOn =
+        ref.watch(gamificationPreferenceProvider).valueOrNull ?? false;
+    if (!gamificationOn) return const SizedBox.shrink();
+
+    final streak = ref.watch(streakProvider).valueOrNull;
+    final completed = streak?.dailyCompleted ?? 0;
+    if (completed <= 0) return const SizedBox.shrink();
+
+    final colors = context.facteurColors;
+    return Padding(
+      padding: const EdgeInsets.only(top: 4),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const CompletionStamp(),
+          const SizedBox(height: 12),
+          Text(
+            _sentence(completed),
+            textAlign: TextAlign.center,
+            style: GoogleFonts.fraunces(
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+              color: colors.textPrimary,
+              height: 1.3,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            pickCompletionTagline(now ?? DateTime.now()),
+            textAlign: TextAlign.center,
+            style: GoogleFonts.dmSans(
+              fontSize: 12,
+              color: colors.textTertiary,
+              height: 1.35,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// « Un article lu jusqu'au bout aujourd'hui. » / « Deux articles … ».
+/// Au-delà de dix on repasse au chiffre, les lettres devenant illisibles.
+String _sentence(int count) {
+  const words = [
+    '',
+    'Un',
+    'Deux',
+    'Trois',
+    'Quatre',
+    'Cinq',
+    'Six',
+    'Sept',
+    'Huit',
+    'Neuf',
+    'Dix',
+  ];
+  final label = count < words.length ? words[count] : '$count';
+  final plural = count > 1 ? 's' : '';
+  return '$label article$plural lu$plural jusqu’au bout aujourd’hui.';
+}

--- a/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
@@ -35,6 +35,10 @@ class FluxArticleVM {
   final bool isFollowedSource;
   final bool isRead;
 
+  /// « Lu jusqu'au bout » — adossé à `completedAt`, distinct de [isRead] que le
+  /// seuil d'ouverture d'1 s suffit à déclencher.
+  final bool isCompleted;
+
   const FluxArticleVM({
     required this.contentId,
     required this.title,
@@ -47,6 +51,7 @@ class FluxArticleVM {
     this.publishedAt,
     this.isFollowedSource = false,
     this.isRead = false,
+    this.isCompleted = false,
   });
 
   bool get hasBeenRead => isRead;
@@ -84,6 +89,7 @@ class FluxArticleVM {
         isFollowedSource: article.isFollowedSource,
         isRead: article.status == ContentStatus.consumed ||
             article.readingProgress > 0,
+        isCompleted: article.isCompleted,
       );
     }
     throw ArgumentError('Unsupported article type: ${article.runtimeType}');
@@ -152,6 +158,11 @@ class _FluxContinuArticleCardState
       consumedContentIdsProvider.select((ids) => ids.contains(vm.contentId)),
     );
     final hasBeenRead = vm.hasBeenRead || wasConsumedThisSession;
+    // Complétée pendant la session : la carte reflète l'état sans attendre un
+    // refetch du feed.
+    final completedThisSession = ref.watch(
+      completedContentIdsProvider.select((ids) => ids.contains(vm.contentId)),
+    );
     final colors = context.facteurColors;
     final spec = ref.watch(displayModeSpecProvider);
     // Reclaim the thumb slot when the network image fails — avoids the
@@ -207,7 +218,10 @@ class _FluxContinuArticleCardState
               Positioned(
                 top: 4,
                 right: 4,
-                child: _ReadCheckBadge(color: colors.success),
+                child: _ReadCheckBadge(
+                  color: colors.success,
+                  isCompleted: vm.isCompleted || completedThisSession,
+                ),
               ),
           ],
         ),
@@ -788,7 +802,12 @@ class _ThemePill extends StatelessWidget {
 
 class _ReadCheckBadge extends StatelessWidget {
   final Color color;
-  const _ReadCheckBadge({required this.color});
+
+  /// Double check quand l'article a été lu jusqu'au bout, simple check quand il
+  /// a seulement été ouvert (ce que le seuil d'1 s suffit à déclencher).
+  final bool isCompleted;
+
+  const _ReadCheckBadge({required this.color, this.isCompleted = false});
 
   @override
   Widget build(BuildContext context) {
@@ -808,7 +827,9 @@ class _ReadCheckBadge extends StatelessWidget {
       ),
       alignment: Alignment.center,
       child: Icon(
-        PhosphorIcons.check(PhosphorIconsStyle.bold),
+        isCompleted
+            ? PhosphorIcons.checks(PhosphorIconsStyle.bold)
+            : PhosphorIcons.check(PhosphorIconsStyle.bold),
         size: 12,
         color: Colors.white,
       ),

--- a/apps/mobile/lib/features/gamification/models/streak_model.dart
+++ b/apps/mobile/lib/features/gamification/models/streak_model.dart
@@ -6,6 +6,13 @@ class StreakModel {
   final int weeklyGoal;
   final double weeklyProgress;
 
+  /// Lectures abouties de la journée éditoriale (frontière 07h30 Paris).
+  /// Dérivé côté serveur de `completed_at`, jamais stocké.
+  final int dailyCompleted;
+
+  /// Objectif du jour. Constante serveur : recalibrable sans release client.
+  final int dailyGoal;
+
   const StreakModel({
     required this.currentStreak,
     required this.longestStreak,
@@ -13,7 +20,13 @@ class StreakModel {
     required this.weeklyCount,
     required this.weeklyGoal,
     required this.weeklyProgress,
+    this.dailyCompleted = 0,
+    this.dailyGoal = 2,
   });
+
+  /// L'objectif du jour est atteint. Volontairement pas exposé comme cible
+  /// avant l'effort : il ne sert qu'à un constat rétrospectif.
+  bool get dailyGoalReached => dailyCompleted >= dailyGoal;
 
   factory StreakModel.fromJson(Map<String, dynamic> json) {
     return StreakModel(
@@ -25,6 +38,8 @@ class StreakModel {
       weeklyCount: json['weekly_count'] as int? ?? 0,
       weeklyGoal: json['weekly_goal'] as int? ?? 10,
       weeklyProgress: (json['weekly_progress'] as num?)?.toDouble() ?? 0.0,
+      dailyCompleted: json['daily_completed'] as int? ?? 0,
+      dailyGoal: json['daily_goal'] as int? ?? 2,
     );
   }
 
@@ -35,6 +50,8 @@ class StreakModel {
     int? weeklyCount,
     int? weeklyGoal,
     double? weeklyProgress,
+    int? dailyCompleted,
+    int? dailyGoal,
   }) {
     return StreakModel(
       currentStreak: currentStreak ?? this.currentStreak,
@@ -43,6 +60,8 @@ class StreakModel {
       weeklyCount: weeklyCount ?? this.weeklyCount,
       weeklyGoal: weeklyGoal ?? this.weeklyGoal,
       weeklyProgress: weeklyProgress ?? this.weeklyProgress,
+      dailyCompleted: dailyCompleted ?? this.dailyCompleted,
+      dailyGoal: dailyGoal ?? this.dailyGoal,
     );
   }
 }

--- a/apps/mobile/lib/features/gamification/providers/gamification_preference_provider.dart
+++ b/apps/mobile/lib/features/gamification/providers/gamification_preference_provider.dart
@@ -45,6 +45,18 @@ class GamificationPreferenceRepository {
     return null;
   }
 
+  /// Bascule l'opt-out de gamification (flamme, objectif du jour, calendrier).
+  ///
+  /// Le flag existait en base avec `true` par défaut et **aucune UI** — dès
+  /// lors qu'on ajoute de la surface objectif/série, l'opt-out doit exister.
+  Future<bool> setEnabled(bool enabled) async {
+    final profile = await _userApiService.updateProfile({
+      'gamification_enabled': enabled,
+    });
+    await _writeCache(profile);
+    return profile.gamificationEnabled;
+  }
+
   Future<void> _writeCache(app_model.UserProfile profile) async {
     final box = await Hive.openBox<dynamic>(_boxName);
     await box.put(_profileKey, profile.toJson());

--- a/apps/mobile/lib/features/gamification/widgets/streak_indicator.dart
+++ b/apps/mobile/lib/features/gamification/widgets/streak_indicator.dart
@@ -7,6 +7,7 @@ import '../../../config/theme.dart';
 import '../providers/gamification_preference_provider.dart';
 import '../providers/streak_animation_provider.dart';
 import '../providers/streak_celebration_provider.dart';
+import '../../../shared/widgets/completion_stamp.dart' show kStampGreen;
 import '../providers/streak_provider.dart';
 import 'streak_explainer_modal.dart';
 
@@ -101,6 +102,7 @@ class _StreakIndicatorState extends ConsumerState<StreakIndicator>
         return streakAsync.when(
           data: (streak) {
             final isActive = streak.currentStreak > 0;
+            final dayClosed = streak.dailyGoalReached;
             final textColor = isActive
                 ? colors.primary
                 : colors.textSecondary.withValues(alpha: 0.55);
@@ -126,9 +128,15 @@ class _StreakIndicatorState extends ConsumerState<StreakIndicator>
                         alpha: isActive ? 0.03 : 0.015,
                       ),
                       borderRadius: BorderRadius.circular(16),
+                      // Journée refermée : un anneau vert fin, en **additif**.
+                      // Jamais de flamme désaturée tant que l'objectif n'est
+                      // pas atteint — ce serait un signal de déficit affiché
+                      // tous les matins. On n'enlève rien, on ajoute parfois.
                       border: Border.all(
-                        color: colors.primary.withValues(alpha: 0.06),
-                        width: 1,
+                        color: dayClosed
+                            ? kStampGreen.withValues(alpha: 0.55)
+                            : colors.primary.withValues(alpha: 0.06),
+                        width: dayClosed ? 1.5 : 1,
                       ),
                     ),
                     child: Row(

--- a/apps/mobile/lib/features/settings/screens/appearance_screen.dart
+++ b/apps/mobile/lib/features/settings/screens/appearance_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
+import '../../gamification/providers/gamification_preference_provider.dart';
 import '../../onboarding/widgets/theme_choice_bottom_sheet.dart';
 import '../providers/display_mode_provider.dart';
 import '../providers/theme_provider.dart';
@@ -54,6 +55,13 @@ class AppearanceScreen extends ConsumerWidget {
                 subtitle: displayMode.label,
                 onTap: () => showDisplayModeBottomSheet(context, ref),
               ),
+              Divider(
+                height: 1,
+                indent: FacteurSpacing.space4,
+                endIndent: FacteurSpacing.space4,
+                color: colors.border.withValues(alpha: 0.5),
+              ),
+              const _GamificationToggle(),
             ],
           ),
         ),
@@ -67,6 +75,83 @@ class AppearanceScreen extends ConsumerWidget {
       AppThemeMode.dark => 'Encre & Nuit',
       AppThemeMode.oled => 'Encre Pure',
     };
+  }
+}
+
+/// Opt-out de la flamme, de l'objectif du jour et du calendrier d'ouverture.
+///
+/// Le flag `gamification_enabled` existait en base (défaut `true`) sans aucun
+/// écran pour le changer. Ajouter de la surface objectif/série sans offrir la
+/// sortie n'aurait pas été acceptable.
+class _GamificationToggle extends ConsumerStatefulWidget {
+  const _GamificationToggle();
+
+  @override
+  ConsumerState<_GamificationToggle> createState() =>
+      _GamificationToggleState();
+}
+
+class _GamificationToggleState extends ConsumerState<_GamificationToggle> {
+  bool _saving = false;
+
+  Future<void> _toggle(bool value) async {
+    if (_saving) return;
+    setState(() => _saving = true);
+    try {
+      await ref
+          .read(gamificationPreferenceRepositoryProvider)
+          .setEnabled(value);
+      ref.invalidate(gamificationPreferenceProvider);
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final enabled =
+        ref.watch(gamificationPreferenceProvider).valueOrNull ?? true;
+
+    return Padding(
+      padding: const EdgeInsets.all(FacteurSpacing.space4),
+      child: Row(
+        children: [
+          Icon(
+            PhosphorIcons.flame(PhosphorIconsStyle.regular),
+            color: colors.primary,
+            size: 24,
+          ),
+          const SizedBox(width: FacteurSpacing.space4),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Série et objectif du jour',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w500,
+                      ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  enabled
+                      ? 'Flamme, objectif du jour et calendrier affichés'
+                      : 'Masqués — la lecture reste inchangée',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: colors.textSecondary,
+                      ),
+                ),
+              ],
+            ),
+          ),
+          Switch.adaptive(
+            value: enabled,
+            onChanged: _saving ? null : _toggle,
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/apps/mobile/lib/shared/widgets/completion_stamp.dart
+++ b/apps/mobile/lib/shared/widgets/completion_stamp.dart
@@ -1,0 +1,122 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+/// Vert des cachets de tournée. Repris **en dur** de `ClosingCardV18`
+/// (« FIN DE TOURNÉE ») et `FeedbackClosingCard` (« TON AVIS COMPTE ») pour que
+/// les trois cachets du produit soient rigoureusement identiques — c'est
+/// `sectionBonnes`, pas `colors.success`.
+const Color kStampGreen = Color(0xFF2E7D32);
+
+/// Cachet « LU JUSQU'AU BOUT ».
+///
+/// Troisième occurrence de l'idiome postal du produit : `Transform.rotate(-2°)`
+/// + bordure 1.5 px + Courier Prime 10 / w700 / letterSpacing 2.0, fond
+/// transparent. Volontairement **pas** une `checkCircle` : celle-ci est déjà le
+/// vocabulaire du « Lu » déclenché au bout d'1 seconde, la réutiliser
+/// importerait sa dévaluation.
+///
+/// [animate] joue l'apparition (opacité + translation verticale). À laisser à
+/// `false` quand l'article est rouvert alors qu'il est déjà terminé : c'est un
+/// *état*, pas un événement.
+class CompletionStamp extends StatefulWidget {
+  const CompletionStamp({
+    super.key,
+    this.animate = false,
+    this.label = 'LU JUSQU\'AU BOUT',
+  });
+
+  final bool animate;
+  final String label;
+
+  @override
+  State<CompletionStamp> createState() => _CompletionStampState();
+}
+
+class _CompletionStampState extends State<CompletionStamp>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 300),
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.animate) {
+      _controller.forward();
+    } else {
+      _controller.value = 1.0;
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant CompletionStamp oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.animate && !oldWidget.animate) _controller.forward(from: 0.0);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Reduce-motion : le cachet s'affiche plein, sans translation. L'haptique
+    // (déclenchée par l'appelant) reste, elle : c'est le canal accessible.
+    if (MediaQuery.maybeDisableAnimationsOf(context) ?? false) {
+      return _stamp(context);
+    }
+
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        final t = Curves.easeOutCubic.transform(_controller.value);
+        return Opacity(
+          opacity: t,
+          child: Transform.translate(offset: Offset(0, 6 * (1 - t)), child: child),
+        );
+      },
+      child: _stamp(context),
+    );
+  }
+
+  Widget _stamp(BuildContext context) {
+    return Semantics(
+      label: 'Lu jusqu\'au bout',
+      child: Transform.rotate(
+        angle: -2 * math.pi / 180,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          decoration: BoxDecoration(
+            border: Border.all(color: kStampGreen, width: 1.5),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                PhosphorIcons.checks(PhosphorIconsStyle.bold),
+                size: 11,
+                color: kStampGreen,
+              ),
+              const SizedBox(width: 6),
+              Text(
+                widget.label,
+                style: GoogleFonts.courierPrime(
+                  fontSize: 10,
+                  fontWeight: FontWeight.w700,
+                  color: kStampGreen,
+                  letterSpacing: 2.0,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/test/core/services/analytics_service_dual_track_test.dart
+++ b/apps/mobile/test/core/services/analytics_service_dual_track_test.dart
@@ -99,8 +99,12 @@ void main() {
   });
 
   test(
-    'content_interaction read >30s emits article_read + article_completed',
+    'content_interaction read emits article_read, never article_completed',
     () async {
+      // Epic 30 — la complétion n'est plus dérivée d'un seuil de durée. La
+      // médiane de temps par article est de 20 s : le seuil de 30 s
+      // sous-comptait structurellement, et définissait « terminé » par une
+      // durée plutôt que par le fait d'avoir atteint la fin.
       final service = AnalyticsService(api, posthog: posthog);
       await service.trackContentInteraction(
         action: 'read',
@@ -111,30 +115,37 @@ void main() {
       );
 
       final events = posthog.captured.map((e) => e.event).toList();
-      expect(
-        events,
-        containsAll(<String>['article_read', 'article_completed']),
-      );
-    },
-  );
-
-  test(
-    'content_interaction read <30s emits article_read but NOT completed',
-    () async {
-      final service = AnalyticsService(api, posthog: posthog);
-      await service.trackContentInteraction(
-        action: 'read',
-        surface: 'digest',
-        contentId: 'c1',
-        sourceId: 's1',
-        timeSpentSeconds: 12,
-      );
-
-      final events = posthog.captured.map((e) => e.event).toList();
       expect(events, contains('article_read'));
       expect(events, isNot(contains('article_completed')));
     },
   );
+
+  test('trackArticleFinished emits article_finished with its qualifiers',
+      () async {
+    final service = AnalyticsService(api, posthog: posthog);
+    await service.trackArticleFinished(
+      contentId: 'c1',
+      sourceId: 's1',
+      completionSource: 'web',
+      isPartial: true,
+      renderMode: 'webview',
+      reachedFooterPermanent: false,
+      progressRaw: 100,
+      timeSpentSeconds: 42,
+      scrollable: true,
+      articleCharCount: 320,
+    );
+
+    final captured =
+        posthog.captured.firstWhere((e) => e.event == 'article_finished');
+    // Sans `is_partial` ni `render_mode`, on recompterait le type d'article
+    // plutôt que la lecture — c'est l'erreur qu'avait produite le seuil
+    // `reading_progress >= 90`.
+    expect(captured.properties?['completion_source'], 'web');
+    expect(captured.properties?['is_partial'], isTrue);
+    expect(captured.properties?['render_mode'], 'webview');
+    expect(captured.properties?['scrollable'], isTrue);
+  });
 
   test('save action does not emit article_read', () async {
     final service = AnalyticsService(api, posthog: posthog);
@@ -186,20 +197,17 @@ void main() {
   });
 
   test(
-    'trackArticleRead mirrors article_read + article_completed when >=30s',
+    'trackArticleRead mirrors article_read only — never article_completed',
     () async {
       // Story 14.1 — feed/detail surfaces still call the legacy
-      // trackArticleRead, so it must mirror to PostHog with the same
-      // threshold logic as trackContentInteraction. Otherwise
-      // article_completed would never fire from real reading flows.
+      // trackArticleRead, so it must mirror to PostHog. Epic 30 lui retire en
+      // revanche la dérivation de complétion par seuil de durée.
       final service = AnalyticsService(api, posthog: posthog);
       await service.trackArticleRead('c1', 's1', 45);
 
       final events = posthog.captured.map((e) => e.event).toList();
-      expect(
-        events,
-        containsAll(<String>['article_read', 'article_completed']),
-      );
+      expect(events, contains('article_read'));
+      expect(events, isNot(contains('article_completed')));
     },
   );
 

--- a/apps/mobile/test/features/digest/youtube_card_test.dart
+++ b/apps/mobile/test/features/digest/youtube_card_test.dart
@@ -25,6 +25,7 @@ void main() {
     ContentStatus status = ContentStatus.unseen,
     int readingProgress = 0,
     Source? source,
+    DateTime? completedAt,
   }) {
     return Content(
       id: '123',
@@ -35,8 +36,11 @@ void main() {
       source: source ?? mockSource,
       status: status,
       readingProgress: readingProgress,
+      completedAt: completedAt,
     );
   }
+
+  final completedStamp = DateTime(2026, 7, 24, 9);
 
   // -----------------------------------------------------------------------
   // 1. isVideo getter
@@ -74,14 +78,20 @@ void main() {
       expect(c.readingLabel, isNull);
     });
 
-    test('returns "Vu jusqu\'au bout" at 90% progress', () {
-      final c = makeContent(readingProgress: 90, status: ContentStatus.seen);
+    test('returns "Vu jusqu\'au bout" once completed', () {
+      final c = makeContent(
+        readingProgress: 90,
+        status: ContentStatus.seen,
+        completedAt: completedStamp,
+      );
       expect(c.readingLabel, 'Vu jusqu\'au bout');
     });
 
-    test('returns "Vu jusqu\'au bout" at 100% progress', () {
+    test('stays "Vu en partie" at 100% progress without a completion stamp', () {
+      // Epic 30 : la progression seule ne prouve plus rien — elle est plafonnée
+      // à 25 pour ~90 % du catalogue.
       final c = makeContent(readingProgress: 100, status: ContentStatus.seen);
-      expect(c.readingLabel, 'Vu jusqu\'au bout');
+      expect(c.readingLabel, 'Vu en partie');
     });
 
     test('returns "Vu en partie" at 50% progress', () {
@@ -112,27 +122,44 @@ void main() {
         contentType: ContentType.video,
         readingProgress: 95,
         status: ContentStatus.seen,
+        completedAt: completedStamp,
       );
       expect(c.readingLabel, 'Vu jusqu\'au bout');
     });
   });
 
   // -----------------------------------------------------------------------
-  // 3. readingLabel for article types (unchanged)
+  // 3. readingLabel for article types — Epic 30 : deux états seulement,
+  //    adossés à `completedAt` et non plus au seuil de progression.
   // -----------------------------------------------------------------------
 
   group('Content.readingLabel for article', () {
-    test('returns "Lu jusqu\'au bout" at 90%+ progress', () {
+    test('returns "Lu jusqu\'au bout" once completed', () {
       final c = makeContent(
         contentType: ContentType.article,
         readingProgress: 95,
         status: ContentStatus.seen,
         source: mockArticleSource,
+        completedAt: completedStamp,
       );
       expect(c.readingLabel, 'Lu jusqu\'au bout');
     });
 
-    test('returns "Lu" at 30-89% progress', () {
+    test('a completed partial article is not downgraded by its capped progress',
+        () {
+      // Le cas nominal : ~90 % du catalogue plafonne à 25, et affichait donc
+      // « Parcouru » sur une lecture pourtant menée à son terme.
+      final c = makeContent(
+        contentType: ContentType.article,
+        readingProgress: 25,
+        status: ContentStatus.consumed,
+        source: mockArticleSource,
+        completedAt: completedStamp,
+      );
+      expect(c.readingLabel, 'Lu jusqu\'au bout');
+    });
+
+    test('returns "Lu" at mid progress without a completion stamp', () {
       final c = makeContent(
         contentType: ContentType.article,
         readingProgress: 50,
@@ -142,14 +169,14 @@ void main() {
       expect(c.readingLabel, 'Lu');
     });
 
-    test('returns "Parcouru" at low progress (1-29%)', () {
+    test('returns "Lu" at low progress — « Parcouru » a été retiré', () {
       final c = makeContent(
         contentType: ContentType.article,
         readingProgress: 15,
         status: ContentStatus.seen,
         source: mockArticleSource,
       );
-      expect(c.readingLabel, 'Parcouru');
+      expect(c.readingLabel, 'Lu');
     });
 
     test('returns "Lu" when consumed via timer with 0 scroll', () {

--- a/apps/mobile/test/features/feed/reading_completion_test.dart
+++ b/apps/mobile/test/features/feed/reading_completion_test.dart
@@ -1,0 +1,210 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import 'package:facteur/features/feed/models/content_model.dart';
+import 'package:facteur/features/feed/services/read_sync_service.dart';
+import 'package:facteur/features/flux_continu/widgets/daily_completion_recap.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
+
+/// Epic 30 — « lu jusqu'au bout ».
+///
+/// Le point à protéger : `readingProgress` est plafonné à 25 pour ~90 % du
+/// catalogue (contenu partiel), donc aucun seuil de progression ne peut servir
+/// de critère de complétion. Le libellé doit venir de `completedAt`.
+void main() {
+  final source = Source(
+    id: 's1',
+    name: 'Le Monde',
+    url: 'https://lemonde.fr',
+    type: SourceType.article,
+  );
+
+  Content content({
+    ContentType contentType = ContentType.article,
+    ContentStatus status = ContentStatus.unseen,
+    int readingProgress = 0,
+    DateTime? completedAt,
+  }) {
+    return Content(
+      id: 'c1',
+      title: 'T',
+      url: 'https://lemonde.fr/a',
+      contentType: contentType,
+      publishedAt: DateTime(2026, 7, 24),
+      source: source,
+      status: status,
+      readingProgress: readingProgress,
+      completedAt: completedAt,
+    );
+  }
+
+  group('Content.isCompleted', () {
+    test('vient de completedAt, pas de la progression', () {
+      expect(content(readingProgress: 100).isCompleted, isFalse);
+      expect(
+        content(completedAt: DateTime(2026, 7, 24, 9)).isCompleted,
+        isTrue,
+      );
+    });
+
+    test(
+      'un article partiel plafonné à 25 est bien « Lu jusqu\'au bout »',
+      () {
+        // Le cas nominal : sans completedAt, ces lectures étaient étiquetées
+        // « Parcouru » — on démotivait le comportement qu'on veut encourager.
+        final c = content(
+          readingProgress: 25,
+          status: ContentStatus.consumed,
+          completedAt: DateTime(2026, 7, 24, 9),
+        );
+        expect(c.readingLabel, 'Lu jusqu\'au bout');
+      },
+    );
+
+    test('« Parcouru » a disparu — deux états seulement', () {
+      expect(
+        content(readingProgress: 5, status: ContentStatus.seen).readingLabel,
+        'Lu',
+      );
+    });
+
+    test('un article jamais ouvert n\'a aucun libellé', () {
+      expect(content().readingLabel, isNull);
+    });
+  });
+
+  group('Content.fromJson', () {
+    test('parse completed_at', () {
+      final json = <String, dynamic>{
+        'id': 'c1',
+        'title': 'T',
+        'url': 'https://x',
+        'content_type': 'article',
+        'published_at': '2026-07-24T08:00:00Z',
+        'source': {
+          'id': 's1',
+          'name': 'S',
+          'url': 'https://s',
+          'type': 'article',
+        },
+        'completed_at': '2026-07-24T09:30:00Z',
+      };
+      expect(Content.fromJson(json).completedAt, isNotNull);
+      expect(Content.fromJson(json).isCompleted, isTrue);
+    });
+
+    test('completed_at absent ⇒ null, et non « non terminé »', () {
+      final json = <String, dynamic>{
+        'id': 'c1',
+        'title': 'T',
+        'url': 'https://x',
+        'content_type': 'article',
+        'published_at': '2026-07-24T08:00:00Z',
+        'source': {
+          'id': 's1',
+          'name': 'S',
+          'url': 'https://s',
+          'type': 'article',
+        },
+      };
+      expect(Content.fromJson(json).completedAt, isNull);
+    });
+  });
+
+  group('CompletionSource', () {
+    test('round-trip via la valeur réseau', () {
+      for (final s in CompletionSource.values) {
+        expect(CompletionSource.fromWire(s.wireValue), s);
+      }
+    });
+
+    test('valeur inconnue ⇒ in_app, jamais une exception', () {
+      expect(CompletionSource.fromWire('martian'), CompletionSource.inApp);
+      expect(CompletionSource.fromWire(null), CompletionSource.inApp);
+    });
+  });
+
+  group('PendingCompletionQueue (préfixe done:)', () {
+    late Box<String> box;
+
+    setUp(() async {
+      Hive.init('./.dart_tool/hive_test_completion');
+      box = await Hive.openBox<String>(PendingReadQueue.boxName);
+      await box.clear();
+    });
+
+    tearDown(() async => box.deleteFromDisk());
+
+    test('les deux files cohabitent dans la même box sans se voir', () async {
+      final reads = PendingReadQueue(box);
+      final completions = PendingReadQueue(
+        box,
+        keyPrefix: PendingReadQueue.completionPrefix,
+      );
+
+      await reads.enqueue('u1', 'c1');
+      await completions.enqueue('u1', 'c2', extra: {'source': 'web'});
+
+      expect(reads.pendingForUser('u1').values, ['c1']);
+      expect(completions.pendingForUser('u1').values, ['c2']);
+    });
+
+    test('payloadFor restitue la source de complétion', () async {
+      final completions = PendingReadQueue(
+        box,
+        keyPrefix: PendingReadQueue.completionPrefix,
+      );
+      await completions.enqueue('u1', 'c1', extra: {'source': 'web'});
+
+      expect(completions.payloadFor('u1', 'c1')?['source'], 'web');
+      expect(completions.payloadFor('u1', 'absent'), isNull);
+    });
+
+    test('clearForUser ne touche que son propre préfixe', () async {
+      final reads = PendingReadQueue(box);
+      final completions = PendingReadQueue(
+        box,
+        keyPrefix: PendingReadQueue.completionPrefix,
+      );
+      await reads.enqueue('u1', 'c1');
+      await completions.enqueue('u1', 'c1');
+
+      await completions.clearForUser('u1');
+
+      expect(reads.pendingForUser('u1'), isNotEmpty);
+      expect(completions.pendingForUser('u1'), isEmpty);
+    });
+  });
+
+  group('Taglines du bloc de clôture', () {
+    test('stables pour un même jour, et déterministes', () {
+      final day = DateTime.utc(2026, 7, 24, 10);
+      expect(pickCompletionTagline(day), pickCompletionTagline(day));
+    });
+
+    test('la référence produit fait partie du jeu', () {
+      expect(
+        kCompletionTaglines,
+        contains('Moins d’info, plus de compréhension.'),
+      );
+    });
+
+    test('aucune formulation comparative ni point d\'exclamation', () {
+      // Le survol est le comportement de la grande majorité des ouvertures :
+      // une phrase comparative ferait honte à l'utilisateur médian.
+      for (final t in kCompletionTaglines) {
+        expect(t, isNot(contains('!')));
+        expect(t.toLowerCase(), isNot(contains('mieux que vingt')));
+      }
+    });
+
+    test('toutes les taglines sont atteignables sur un cycle de jours', () {
+      final seen = <String>{};
+      for (var i = 0; i < 400; i++) {
+        seen.add(pickCompletionTagline(DateTime.utc(2026, 1, 1).add(Duration(days: i))));
+      }
+      expect(seen.length, kCompletionTaglines.length);
+    });
+  });
+}

--- a/docs/stories/core/30.lecture-aboutie/README.md
+++ b/docs/stories/core/30.lecture-aboutie/README.md
@@ -1,0 +1,438 @@
+# Epic 30 — La lecture aboutie
+
+> **Type** : Feature · **Cible** : `main` · **Statut** : **PLAN — en attente de GO**
+> **Date** : 24/07/2026 · **Méthode** : ronde 1 de design BMAD (UX / PM / Architecte), arbitrée sur données prod
+
+---
+
+## 1. La demande
+
+> « Rendre plus satisfaisante la lecture d'un article jusqu'au bout : coche verte dans l'article, carte
+> légèrement verte dans le feed. Réutiliser le système de notifs in-app pour un mini-objectif journalier
+> (lire 5 articles jusqu'au bout), tagline "Moins d'info, plus de compréhension", qui renforcerait les
+> flammes journalières (double flamme ?). Sans alourdir l'expérience calme. »
+
+## 2. Ce que l'analyse a changé — 5 faits qui commandent le plan
+
+### F1 — Le moment de fin d'article existe déjà. Il n'est ni récompensé, ni enregistré.
+
+`content_detail_screen.dart:2194` — `_footerPermanent` bascule à 98 % du scroll et déclenche **déjà**
+`HapticFeedback.selectionClick()` + un pulse de scale 280 ms. Le CTA passe alors en **ocre `#D35400`**
+(`colors.primary`), alors que le vert `colors.success` est la convention « lu » sur toutes les cartes.
+`grep colors.success` dans le reader → **0 occurrence**. C'est le seul écran qui ne suit pas la convention
+du produit.
+
+### F2 — `reading_progress` ne mesure pas la lecture. Il mesure le type d'article.
+
+Deux calculs cohabitent sur des dénominateurs différents (`:2185-2210`) :
+
+```dart
+final rawProgress = metrics.pixels / metrics.maxScrollExtent;   // scroll ENTIER (article + perspectives)
+if (!_footerPermanent.value && !_ctaTapped && rawProgress >= 0.98) { _footerPermanent.value = true; }
+
+final barProgress = metrics.pixels / articleExtent;             // extent ARTICLE seul
+final capped = _isPartialContent ? (barProgress * 0.25).clamp(0.0, 0.25) : barProgress.clamp(0.0, 1.0);
+_maxReadingProgress = max(_maxReadingProgress, capped);         // ← seule valeur persistée
+```
+
+Distribution réelle en base (30 j, `consumed`, progress > 0) :
+
+| valeur | occurrences | ce que c'est |
+|---|---|---|
+| **exactement 25** | **272** (~36 %) | valeur **sentinelle** du plafond `_isPartialContent` |
+| exactement 100 | 53 | 53 des 65 lignes ≥ 90 |
+| tout le reste | traîne diffuse | max 11 occurrences par valeur |
+
+Et `isPartialContent` (`html_utils.dart:159-164`) déclenche sous 500 caractères :
+**26 383 / 29 358 contenus publiés sur 14 j = 89,9 % du catalogue.**
+
+⇒ **`reading_progress ≥ 90` est inatteignable pour ~90 % des articles, quel que soit le comportement réel.**
+Conséquence directe déjà en prod : un utilisateur qui lit **intégralement** un article partiel est étiqueté
+**« Parcouru »** (`content_model.dart:209-228`, il est à 25). *On démotive activement le comportement qu'on
+veut encourager.*
+
+### F3 — L'objectif « 5 » est mathématiquement hors d'atteinte
+
+Sur 270 jours-utilisateur actifs (30 j) : **3,95 articles ouverts** par jour actif. Taux de finition estimé
+~32 %. Atteindre 5 fins/jour demanderait **~16 ouvertures/jour**, soit ×4 le volume actuel — dans une app
+dont la promesse est « moins d'info ».
+
+Recalibré sur un signal honnête (les 272 + les 65) : **≈ 1,2 fin de lecture par jour actif.**
+Temps médian par article : **20 s**.
+
+### F4 — La « double flamme » afficherait zéro
+
+`closure_streak` est calculé et stocké mais **jamais affiché** — et il est **quasi vide** :
+**14 utilisateurs sur 121** l'ont jamais eu > 0 (moyenne 0,16, max 4).
+La flamme actuelle, elle, ne récompense que **`session_start`** — ouvrir l'app, aucune lecture — et n'a
+**aucun palier, aucun message, aucune récompense**. Les seuls paliers du repo (1/7/30) dorment dans
+`digest_service.py:2958-2967` sans jamais remonter en UI.
+
+### F5 — La lecture d'article est invisible dans l'analytics
+
+`article_read` / `article_completed` : **0 événement sur 30 jours**, ni dans PostHog ni dans la table backend
+`analytics_events` — alors que `perspectives_opened` (1139 évts / 42 users) part du même écran.
+
+Deux causes cumulées, la seconde certaine :
+1. L'unique point d'émission est dans `dispose()` (`content_detail_screen.dart:1701-1703`), dans un
+   `try/catch` fourre-tout qui `debugPrint` et avale tout (`:1682-1707`). *Ce bug a déjà été corrigé une fois
+   dans ce fichier* — commit `81c6a505` (PR #413, « ref.read() after dispose »).
+2. **`article_completed` n'est émis que si `timeSpentSeconds >= 30`** (`analytics_service.dart:244`), alors
+   que la médiane est de 20 s. Même pipeline réparé, l'événement sous-compterait — et définirait « terminé »
+   par une durée, ce qui contredit la définition produit qu'on construit.
+
+**Aucun chiffrage d'objectif ne peut être arrêté avant ce fix + 2 semaines de collecte.**
+Le nombre est une **sortie** du lot 0, pas une entrée de la spec.
+
+---
+
+## 3. Le plan — 5 lots
+
+| Lot | Contenu | Backend | Mobile | SQL prod | Valeur seule |
+|---|---|---|---|---|---|
+| **0** | Rendre le succès mesurable | ✅ | ✅ | ❌ | mesure + 1 bug prod corrigé |
+| **1** | Le contrat de données | ✅ | ✅ | ✅ *(le seul)* | — (socle) |
+| **2** | L'état visuel — **la demande initiale** | ❌ | ✅ | ❌ | ✅ **oui, livrable seul** |
+| **3** | L'objectif du jour *(conditionnel)* | ✅ lecture | ✅ | ❌ | ✅ |
+| **4** | Flamme *(conditionnel)* | ❌ | ✅ | ❌ | ✅ |
+
+### Lot 0 — Rendre le succès mesurable  *(prérequis absolu, réversible, sans schéma)*
+
+1. Sortir l'analytics de `dispose()` : résoudre le service **une fois** en `initState`
+   (`late final AnalyticsService _analytics;`), plus aucun `ref.read` dans `dispose()`.
+2. Émettre `article_completed` **au moment de l'événement**, pas à la fermeture — et **découpler du seuil
+   30 s** (`analytics_service.dart:244`).
+3. Remplacer le `catch` muet (`:1705`) par une remontée Sentry. *Un chemin de récompense ne doit jamais
+   échouer en silence.*
+4. **Corriger le bug de frontière de `closure_streak`** : `_update_closure_streak` estampille
+   `last_closure_date = date.today()` (UTC serveur, `digest_service.py:2933`) alors que son déclencheur
+   `maybe_record_implicit_completion` teste `today_paris()` (`:1573`). Entre 00h et 02h Paris l'été, la
+   complétion est comptée pour J et datée J-1 → série cassée ou dédoublée.
+   **Prérequis à toute exposition de `closure_streak`.**
+5. Introduire le helper canonique `editorial_day()` dans `app/utils/time.py` (bascule **07h30 Europe/Paris**,
+   miroir exact de `TourneeProgressService.dayKey:50-58`).
+
+**Instrumentation à créer — `article_finished`**, avec les propriétés qui évitent de refaire l'erreur du
+bucket ≥90 : `is_partial`, `render_mode`, `completion_source`, `reached_footer_permanent`, `progress_raw`,
+`time_spent_seconds`, `scrollable` *(désambiguïse enfin le bucket 0 : rebond vs article court lu en entier)*,
+`article_char_count`.
+
+**Sortie attendue** : la distribution réelle des fins de lecture par jour-utilisateur (P50 / P75 / P90).
+**C'est elle qui fixe le chiffre du lot 3.**
+
+### Lot 1 — Le contrat de données  *(additif pur, aucun backfill)*
+
+```
+user_content_status.completed_at      timestamptz NULL   -- horodaté SERVEUR, first-write-wins
+user_content_status.completion_source varchar(12) NULL   -- 'in_app' | 'short' | 'web'
+```
+
+> **Sémantique retenue** : `completed_at` = « l'utilisateur a atteint le bas de ce que Facteur lui a
+> présenté ». `completion_source` conserve **gratuitement** le signal strict « lu chez l'éditeur ».
+
+| source | cas | détection | part du catalogue |
+|---|---|---|---|
+| `in_app` | contenu complet | bas de l'extent article | ~10 % |
+| `short` | article non scrollable | latch `_checkShortArticle` (`:927-942`) | — |
+| `web` | article partiel lu chez l'éditeur | pont JS, progress normalisé ≥ 0,98 | ~90 % |
+
+**Pourquoi pas un état `completed` dans l'enum `ContentStatus`** — c'est le risque le plus sérieux du dossier :
+l'exclusion des contenus vus s'écrit `status.in_([SEEN, CONSUMED])` dans `recommendation_service.py:2727-2745`
+et `digest_selector.py:833-843`. Un statut `completed` ne matcherait **ni l'un ni l'autre** → *les articles lus
+jusqu'au bout reviendraient dans le feed*. Pire : la garde d'idempotence
+(`ON CONFLICT ... WHERE status != 'consumed'`, `content_service.py:121-138`) laisserait repasser une ligne
+`completed` et re-déclencherait `increment_consumption` + `_adjust_interest_weight` +
+`maybe_record_implicit_completion`. Double comptage silencieux.
+
+**Effets de bord reco : nuls.** `completed_at` est orthogonal à `status` ; les deux filtres ne le voient pas.
+`completed` **n'implique jamais** `consumed` → le seuil de complétion implicite du digest (80 %) et donc
+`closure_streak` restent strictement inchangés.
+
+Idempotence : `completed_at = COALESCE(completed_at, now())` — premier écrit gagne, monotone, exactement
+l'idiome déjà en place pour `reading_progress` (`func.greatest`, `content_service.py:102-113`).
+Le client n'envoie **jamais** d'horodatage.
+
+**Migration** : head unique vérifié `181c618da382`. Migration miroir `rd01_ucs_completed_at`
+(`down_revision = "181c618da382"`). Le SQL prod passe par le **Supabase SQL Editor** (index partiel
+`CREATE INDEX CONCURRENTLY` en statement séparé), jamais sur Railway.
+
+**Mobile** : `_articleCompleted` (`ValueNotifier<bool>` frère de `_footerPermanent`), 3 latches
+(`:2194-2199` / `:927-942` / `:857-865`), durabilité offline via `PendingReadQueue` avec un préfixe de clé
+`done:` — **aucune migration Hive**.
+
+> ⚠️ Le latch vit dans le `NotificationListener` appelé sur **chaque frame de scroll** (`:2168-2221`) :
+> `if (_articleCompleted.value) return;` en tête, sans allocation ni `setState`.
+
+`reading_progress` : **ni réparé, ni supprimé — gelé et démoté.** En changer la formule créerait un historique
+à sémantique mixte, indistinguable a posteriori. L'UI bascule sur `completed_at`.
+
+### Lot 2 — L'état visuel  *(mobile only — c'est la demande initiale, livrable seul)*
+
+**Dans l'article** — un **cachet**, pas une coche. La `checkCircle` est déjà le vocabulaire du « Lu »
+déclenché **au bout d'1 seconde** (`articleReadThreshold`, `read_sync_service.dart:16`) : la réutiliser
+importerait sa dévaluation.
+
+Le cachet est un composant **qui existe déjà à l'identique deux fois** dans le produit
+(`closing_card_v18.dart:107-127` « FIN DE TOURNÉE », `feedback_closing_card.dart:70-73` « TON AVIS COMPTE ») :
+`Transform.rotate(-2°)` + bordure 1.5 px + Courier Prime 10 / w700 / letterSpacing 2.0, fond transparent.
+
+```
+┌──────────────────────┐   -2°, bordure + texte #2E7D32
+│ ✓✓ LU JUSQU'AU BOUT  │   Courier Prime 10 / w700 / ls 2.0
+└──────────────────────┘   PhosphorIcons.checks(bold) 11px
+```
+
+> ⚠️ Les deux cachets existants utilisent **`#2E7D32` en dur** (`sectionBonnes`), pas `colors.success`
+> (`#27AE60`). Reprendre `#2E7D32` pour la cohérence.
+
+Placement mode in-app : **dans le flux**, sous le dernier paragraphe, au-dessus des perspectives
+(`EdgeInsets.only(left: 16, top: 24, bottom: 8)`). Pas d'overlay — il reste là, et si l'utilisateur re-scrolle
+il y est encore. Mode WebView (impossible d'injecter dans un DOM tiers) : même cachet flottant 12 px au-dessus
+de la `GlassPill`, **auto-effacé après 2400 ms**.
+
+**Chronologie exacte :**
+
+| t | événement |
+|---|---|
+| 0 ms | `HapticFeedback.lightImpact()` — un atterrissage, pas un tick. Jamais `medium`/`heavyImpact`. |
+| 0 → 400 ms | barre de progression : cross-fade ocre → vert, `easeOut` |
+| 80 → 380 ms | cachet : opacity 0→1 + translateY +6→0, 300 ms `easeOutCubic` |
+| 800 → 1050 ms | retrait de la barre (opacity 1→0, 250 ms) — l'instrument de mesure se retire une fois la mesure faite |
+| 1050 ms | **fin.** Pas de toast, pas de modale, pas de son. |
+
+Anti-double-buzz : sur contenu complet, `_footerPermanent` et `_articleCompleted` tombent dans la même frame
+→ le second absorbe l'haptique.
+Ré-ouverture d'un article déjà terminé : cachet présent **dès la première frame**, sans animation ni haptique
+(c'est un *état*, pas un événement).
+Reduce-motion : cachet à opacité pleine sans translate, **haptique conservée** (c'est le canal accessible).
+
+**Dans le feed** — pas de teinte de fond. Sur crème `#F2E8D5`, un vert à 4 % est sous le seuil de perception ;
+à 8 % il vire **kaki** et détruit la sensation papier. À la place, un **filet vertical 3 px** sur le bord gauche
+(idiome du filet de journal, déjà présent dans le produit) + l'icône `checks` 13 px en fin de ligne méta,
+sans fond ni ombre. Fréquence attendue : ~1 carte sur 16 → une distinction, pas un motif.
+
+**Unification** : un seul widget `ReadStateMark` pour `FluxContinuArticleCard`, `EssentielHiFiCard`, `FeedCard`.
+*(`_ReadCheckBadge` est aujourd'hui **dupliqué** entre les deux premiers — occasion de factoriser.)*
+
+**Retraits** (le vrai travail) :
+- `_ReadCheckBadge` — le cercle vert plein déclenché après **1 seconde**. C'est ce qui a dévalué le vert.
+- le rendu **pill** de `ReadingBadge` (rectangle vert saturé + texte blanc bold + drop shadow) — sa logique
+  graduée est conservée, son rendu disparaît.
+- le libellé **« Parcouru »** + icône `eye` : ne pas renvoyer à l'utilisateur un commentaire sur sa lecture
+  superficielle. L'opacité suffit.
+
+**Réhabilitation** : `AnimatedFeedCard` (174 l.) est **du code mort — 0 référence dans `lib/` et `test/`**,
+alors que c'est littéralement « la carte verte à la sortie » demandée (overlay déclenché sur la transition
+`isConsumed` false→true, `:74-83`). Le monter, branché sur `completed`, **restylé** : sa pill est en
+`grey.shade700` (contredit la convention verte), son scrim est noir à 60 %, sa courbe est `elasticOut`
+(vocabulaire de jeu, pas celui du produit) et il dure 1000 ms. → filet + `checks`, `easeOutCubic`, 320 ms,
+sans scrim. **Pas d'haptique** : elle a déjà eu lieu dans l'article. Un événement, une vibration.
+
+Corriger au passage 3 incohérences déjà présentes : seuil vidéo `>= 25` (`readingLabel`) vs `>= 30`
+(`ReadingBadge`) ; commentaire « 30s timer » (`content_model.dart:225`) alors que le seuil réel est 1 s ;
+un `consumed` à 10 % affiche « Parcouru » sur fond **vert** (branches désaccordées, `reading_badge.dart:32-48`).
+
+**Piège de cache identifié** : `FluxContinuCacheService.patchContentStatus:147-149` **n'écrit une clé que si
+elle existe déjà** dans le payload — un champ neuf serait **silencieusement ignoré**. À traiter explicitement.
+
+### Lot 3 — L'objectif du jour  *(conditionnel — gate ci-dessous)*
+
+**Le compteur est dérivé, jamais stocké.** Aucune colonne `daily_count` / `daily_count_date`, aucun job de
+reset, aucune dérive :
+
+```sql
+SELECT count(*) FROM user_content_status
+WHERE user_id = :uid AND completed_at >= :day_start AND completed_at < :day_end;
+```
+
+C'est exactement le motif stateful qui a produit `weekly_count` + `week_start` et ses bugs de frontière
+qu'on évite ici.
+
+Exposé via `StreakResponse` (`schemas/streak.py:8`) → `daily_completed` + `daily_goal`, servie par
+`GET /api/streaks` **et** `GET /api/users/streak`, déjà consommée par `streakProvider` au démarrage.
+**Zéro nouvelle plomberie mobile.** `daily_goal` = **constante serveur** → recalibrable **sans release client**.
+
+**Frontière de jour : 07h30 Europe/Paris** (celle des éditions et du rituel). L'objectif est un objet
+*éditorial*, pas calendaire : à minuit, un lecteur de 00h30 verrait son objectif repartir à zéro alors qu'il
+lit encore l'édition de la veille. **Ne pas le brancher sur `current_streak`** (frontière minuit-device) :
+les coupler créerait un décalage visible d'un jour pendant ~7h30 chaque nuit.
+
+*(Il y a en réalité **quatre** frontières dans le repo : minuit device, minuit UTC, minuit Paris, 07h30 Paris.)*
+
+**Véhicule : la carte de clôture, pas la Notif du jour.** Unanimité des trois experts. La Notif du jour est un
+système de *messages ponctuels*, pas de compteur : slot unique en concurrence avec 9 messages scorés,
+**consommé au tap**, **cooldown 30 jours à la croix** (un dismiss accidentel tue la feature un mois), cap
+3/jour, frontière minuit local. Et surtout elle est en **tête** de l'Essentiel — **avant** la lecture :
+*un objectif montré avant l'effort est une demande.*
+
+`ClosingCardV18` a un slot `secondary` explicitement documenté (`:42-46`), elle est **après** la lecture, elle
+porte déjà « Tu es à jour » et le tampon « FIN DE TOURNÉE ». C'est le moment de fermeture du PRD (FR21.2).
+
+**Réhabilitation** : `closing_recap.dart` (99 l.) est mort en `lib/` mais **couvert par 200 lignes de tests
+verts** — `buildClosingRecap` compte déjà les articles lus par section et `formatClosingRecap` produit
+« Tu as lu sur la Tech (4) et la Politique (2). ». C'est le foyer naturel de l'objectif du jour.
+
+**Le rendu : une phrase, pas une jauge.** Pas de barre, pas d'anneau, pas de « 2/2 », pas de cases à remplir
+(deux cases à remplir *sont* une jauge) :
+
+- **objectif atteint** → cachet `LU JUSQU'AU BOUT` + « Deux articles lus jusqu'au bout aujourd'hui. » +
+  tagline. Aucun CTA.
+- **1 seule lecture aboutie** → « Un article lu jusqu'au bout aujourd'hui. » **Aucun « plus qu'un ! »,
+  aucun « 1/2 ».**
+- **0 lecture aboutie** → **le bloc ne s'affiche pas.** La carte de clôture reste ce qu'elle est aujourd'hui.
+
+> C'est la réponse au cas majoritaire : **il n'y a pas d'objectif raté, parce que l'objectif n'est jamais
+> affiché comme cible** — seulement, rétrospectivement, comme accomplissement.
+> On ne peut pas rater un objectif qu'on ne nous a jamais montré.
+
+**Où vit le chiffre, alors ?** Un seul endroit : le bottom sheet explicatif de la flamme
+(`streak_explainer_modal.dart`, qui a déjà 3 slots de métriques + un calendrier 14 j alimenté par
+`GET /api/streaks/activity`, **déjà disponible et inutilisé**). L'utilisateur y va volontairement.
+Règle consultée sur consentement, jamais poussée.
+
+**La Notif du jour garde un rôle** : la tagline de **découverte**, **une seule fois**
+(`notif_du_jour_message.dart` + candidat à relevance ~0.65). C'est exactement son usage prévu, et c'est trivial.
+
+**Taglines** — ton affirmatif (proche de « Tu es à jour » / « FIN DE TOURNÉE »), tutoiement, présent, aucun
+emoji, aucun point d'exclamation :
+
+1. **« Moins d'info, plus de compréhension. »** *(la référence, à pondérer le plus fort)*
+2. **« Tu n'as pas tout lu. Tu as bien lu. »** ⭐ *(autorise explicitement la finitude)*
+3. « Lire jusqu'au bout, c'est déjà comprendre. »
+4. « Deux articles, lus en entier. C'est une bonne journée. »
+5. « Ce que tu retiendras demain, c'est ça. »
+6. « Le reste attendra. Ça, tu le sais maintenant. »
+7. « Une lecture finie vaut mieux qu'une pile commencée. »
+8. « Rien de plus à lire aujourd'hui. C'est le principe. »
+
+⚠️ **À écarter** : toute formulation comparative type « deux articles lus valent mieux que vingt survolés ».
+Le survol est le comportement de ~94 % des ouvertures — cette phrase fait honte à l'utilisateur médian.
+
+Rotation : le jitter FNV-1a déterministe de `notif_du_jour_provider.dart:48-58` est réutilisable tel quel,
+sans le système de cap/cooldown.
+
+### Lot 4 — Flamme  *(conditionnel)*
+
+**Double flamme : coupée.** L'actif sous-jacent est vide (14/121 users), et surtout : **deux séries = deux
+façons d'échouer par jour**, dans un plan dont tout l'objet est de réduire le nombre de verdicts quotidiens.
+Contrainte de place également : le header (`main_shell.dart:157`) est un `Stack` avec logo centré ~90 pt ;
+deux indicateurs ≈ 120 pt entrent en collision avec le logo dès 390 pt de large.
+
+**À la place — flamme unique, enrichie, en additif seulement :**
+- Le chiffre reste `current_streak`. **Personne ne perd rien.** *(Basculer sur `closure_streak` ferait chuter
+  un bêta-testeur de 40 jours à 3 : la pire journée possible pour la confiance.)*
+- Un **anneau fin `#2E7D32` 1.5 px** autour du badge 29×29, présent le reste de la journée une fois la journée
+  refermée. Il ne dépend **pas** de `closure_streak` : c'est un état du jour, il fonctionne dès le jour 1.
+- Le **pulse quotidien existant** (900 ms, scale 1.0→1.22, déjà codé) **est déplacé** : il se déclenche à la
+  clôture, plus à l'ouverture de l'app. Même animation, meilleur déclencheur.
+- **Jamais d'état négatif permanent.** Pas de flamme désaturée tant que la journée n'est pas close — ce serait
+  un signal de déficit affiché tous les matins.
+
+`closure_streak` et ses paliers 1/7/30 s'expriment dans le bottom sheet explicatif, pas dans le header.
+
+---
+
+## 4. Garde-fous « expérience calme » — ce qu'on refuse explicitement
+
+| # | Refus | Raison |
+|---|---|---|
+| 1 | Aucune **push de rappel de série** | Le pattern le plus anxiogène de la catégorie. La seule push du produit reste la livraison du matin. |
+| 2 | Aucun **badge rouge / pastille de compteur** | L'état de lecture n'est pas un état d'erreur. |
+| 3 | Aucun **compte à rebours**, aucune heure limite | — |
+| 4 | Aucun **affichage d'objectif non atteint** | 0 lecture → le bloc ne se rend pas. Pas de « 0/2 », pas de case vide, pas de placeholder gris. |
+| 5 | Aucune **interruption modale** en fin d'article | Plafond : 380 ms de feedback dans le flux. L'article se termine ; il ne te félicite pas. |
+| 6 | Aucun **son** | — |
+| 7 | Aucune **escalade intra-session** | Le 2ᵉ article terminé reçoit exactement le même feedback que le 1ᵉʳ. Pas de combo. |
+| 8 | Aucun **confetti / `elasticOut` / Lottie** sur la lecture | Vocabulaire de jeu. Celui du produit est le papier, le tampon, `easeOutCubic`. |
+| 9 | Aucun **second compteur** dans le header | Cf. lot 4. |
+| 10 | Aucune **comparaison sociale**, classement, moyenne | — |
+| 11 | Aucun **« streak freeze » / « répare ta série »** | Boucle de culpabilité monétisable, et présuppose que la perte compte. |
+| 12 | Aucun **double haptique** pour un même événement (article → feed) | Un événement, une vibration. `lightImpact` maximum. |
+| 13 | Ne rien exposer qui dépende d'une **métrique cassée** | Rien de visible adossé à `article_completed` avant le lot 0. |
+| 14 | **`gamification_enabled` doit devenir un vrai interrupteur en réglages, dans la même release** | Le flag existe (défaut `true`) **sans aucune UI**. Si on ajoute de la surface objectif/série, l'opt-out doit exister au même moment. **Gate dur.** |
+
+Découpage du gate `gamification_enabled` : l'objectif journalier et la flamme sont **gatés** (c'est de la
+gamification) ; le cachet et la marque sur les cartes ne le sont **pas** (c'est un affordance d'état de lecture).
+
+---
+
+## 5. Mesure
+
+> ⚠️ **Avec 22 utilisateurs à ≥5 jours actifs, aucun A/B test n'a de puissance statistique.** On lit des
+> tendances sur cohorte avant/après (≥14 j) + du qualitatif (3-5 entretiens, mini-NPS `well_informed` déjà
+> en place).
+
+| Lot | Primaire | Contre-métriques (rollback si franchies) |
+|---|---|---|
+| **0** | `article_finished` remonte pour ≥70 % des actifs ; distribution P50/P75/P90 établie | — |
+| **2** | part des articles ouverts qui se terminent (baseline ~32 %) | temps médian **ne descend pas sous 18 s** (baseline 20) ; part des fins en < 10 s ≤ **15 %** ; articles ouverts/jour **ne dépasse pas ~6** (baseline 3,95) — au-delà, on a fabriqué du volume, l'inverse de la promesse ; crash-free ≥ niveau actuel |
+| **3** | part des jours actifs où l'objectif est atteint — cible **45-60 %**. < 40 % → on baisse. > 80 % → décoratif, on supprime | durée de session **ne monte pas** ; nb de sessions/jour stable ; taux de dismiss de la carte de clôture stable |
+| **4** | `closure_streak > 0` chez ≥40 % des users à ≥3 jours actifs | — |
+
+**Gate lot 2 → lot 3** : ≥14 jours de données propres et distribution réelle connue.
+**Gate lot 3 → lot 4** : `closure_streak > 0` chez ≥40 % des users à ≥3 jours actifs. *Si le seuil n'est pas
+atteint, le lot 4 est annulé.*
+
+---
+
+## 6. Ce que je coupe de la demande initiale
+
+| Coupé | Raison |
+|---|---|
+| **Objectif « 5 articles jusqu'au bout »** | Plafond dur à 3,95 ouvertures/jour actif ; demanderait ×4 le volume, dans une app anti-volume. Provisoirement **2**, mais le chiffre est une **sortie** du lot 0. |
+| **Double flamme** | Actif vide (14/121), et deux séries = deux façons d'échouer par jour. Remplacée par un anneau sur la flamme unique. |
+| **Objectif dans la file « Notif du jour »** | Cooldown 30 j à la croix, consommation au tap, cap 3/jour, position **avant** la lecture. La notif garde la tagline de découverte one-shot. |
+| **Carte « légèrement verte »** | Vert + crème = kaki ; et teinte + opacité + badge = 3 signaux pour un état. Remplacée par un filet 3 px. |
+| **Tagline « compréhension » sur un compteur d'articles** | C'est une promesse de **journée**, pas d'article — surtout sur 90 % de teasers. Elle reste au niveau de la carte de clôture. |
+
+---
+
+## 7. Les 4 décisions qui te reviennent
+
+1. **Le CTA de fin d'article devient-il vert ?** *(ton idée d'origine)* — Recommandation : **non pour le
+   bouton, oui pour la zone.** Le CTA reste ocre (c'est une **action** : « Lire sur Le Monde » ; un bouton vert
+   dirait « fais ceci » dans la couleur qui dit « c'est fait » partout ailleurs, et validerait le *site* plutôt
+   que la lecture). Le **footer change bien de couleur** — via le cachet vert + la barre de progression qui
+   vire au vert. Alternative si tu préfères : CTA vert uniquement sur `_articleCompleted` (2 lignes de diff).
+2. **Inverse-t-on l'opacité des cartes lues ?** *(le point le plus risqué)* — Aujourd'hui finir un article
+   fait **pâlir** la carte à 0.6 : le produit dit « ceci compte moins maintenant ». Proposition : terminé →
+   **retour à 1.0** + marque ; simplement parcouru → 0.72. Contre-argument : le grisé aide aussi à repérer le
+   non-lu dans le feed. **Ton appel.**
+3. **Sémantique de `completed_at`** = « bas de ce que Facteur affiche » (marche pour les 90 % de teasers),
+   `completion_source='web'` conservant gratuitement le signal strict « lu chez l'éditeur ».
+   **Irréversible sans migration.**
+4. **Périmètre du GO** : lots 0+1+2 seuls (la demande visuelle, livrable et mesurable), ou 0+1+2+3 d'emblée ?
+   Recommandation : **0+1+2**, puis on calibre le chiffre sur données réelles.
+
+---
+
+## 8. Divergences entre experts, tranchées
+
+| Sujet | UX (Sally) | PM (John) | Archi (Winston) | Arbitrage |
+|---|---|---|---|---|
+| CTA vert | non — collision sémantique | oui | oui | **non pour le bouton, vert sur la zone** (décision 1) |
+| `AnimatedFeedCard` | à supprimer | — | à réhabiliter | **réhabiliter restylé** — vérifié : 0 référence, c'est du code mort, pas du code vivant à retirer |
+| Objectif : chiffre | 2 | mesuré, gaté | ~1,2/jour observé | **2 provisoire, arrêté après le lot 0** |
+| Double flamme | non | non | lot 4 possible | **coupée**, anneau à la place |
+| Gradation du badge | 2 états | 3 barreaux honnêtes | `completed_at` binaire | **2 états visuels**, les 3 barreaux vivent dans la donnée |
+
+**Corrections apportées aux experts :** le PM annonçait « 66 % des utilisateurs n'ouvrent l'app qu'un jour »
+(source `Application Opened`, 80 users, **onboarding inclus**). Sur la population **authentifiée**
+(`session_start`, 56 users) : **32 %** à un seul jour, **22** à ≥5 jours, **7,36** jours actifs en moyenne
+sur 30. Les deux sont vrais mais l'écart mesure l'**activation**, pas la rétention de la lecture — sa
+conclusion « ne pas optimiser pour les réguliers » s'en trouve affaiblie.
+
+---
+
+## 9. Références vérifiées
+
+`content_detail_screen.dart` : `:245` `_footerPermanent` · `:927-942` article court · `:857-865`
+`_applyWebReadingProgress` · `:947-952` effets · `:1682-1707` `dispose()` · `:2168-2221` scroll listener ·
+`:2558-2566` `usePrimary`
+`html_utils.dart:159-164` · `read_sync_service.dart:16,29-89,122-124,205-237` ·
+`content_model.dart:209-228` · `reading_badge.dart:32-48` · `animated_feed_card.dart` *(mort)* ·
+`closing_recap.dart` *(mort, testé)* · `closing_card_v18.dart:42-46,107-127` ·
+`flux_continu_cache_service.dart:147-149` · `main_shell.dart:157` · `streak_indicator.dart` ·
+`notif_du_jour_*` · `content_service.py:74-187` · `digest_service.py:1573,2917-2973` ·
+`recommendation_service.py:2727-2745` · `digest_selector.py:833-843` · `streak_service.py:40-97` ·
+`schemas/streak.py:8` · alembic head `181c618da382` (1 seul head, 44 révisions)

--- a/docs/stories/core/30.lecture-aboutie/README.md
+++ b/docs/stories/core/30.lecture-aboutie/README.md
@@ -1,6 +1,6 @@
 # Epic 30 — La lecture aboutie
 
-> **Type** : Feature · **Cible** : `main` · **Statut** : **PLAN — en attente de GO**
+> **Type** : Feature · **Cible** : `main` · **Statut** : **CODE+TEST — lots 0 à 3 implémentés**
 > **Date** : 24/07/2026 · **Méthode** : ronde 1 de design BMAD (UX / PM / Architecte), arbitrée sur données prod
 
 ---
@@ -88,13 +88,24 @@ Le nombre est une **sortie** du lot 0, pas une entrée de la spec.
 
 ## 3. Le plan — 5 lots
 
-| Lot | Contenu | Backend | Mobile | SQL prod | Valeur seule |
+| Lot | Contenu | Backend | Mobile | Migration | Statut |
 |---|---|---|---|---|---|
-| **0** | Rendre le succès mesurable | ✅ | ✅ | ❌ | mesure + 1 bug prod corrigé |
-| **1** | Le contrat de données | ✅ | ✅ | ✅ *(le seul)* | — (socle) |
-| **2** | L'état visuel — **la demande initiale** | ❌ | ✅ | ❌ | ✅ **oui, livrable seul** |
-| **3** | L'objectif du jour *(conditionnel)* | ✅ lecture | ✅ | ❌ | ✅ |
-| **4** | Flamme *(conditionnel)* | ❌ | ✅ | ❌ | ✅ |
+| **0** | Rendre le succès mesurable | ✅ | ✅ | ❌ | ✅ fait |
+| **1** | Le contrat de données | ✅ | ✅ | ✅ *(la seule)* | ✅ fait |
+| **2** | L'état visuel — **la demande initiale** | ❌ | ✅ | ❌ | ✅ fait |
+| **3** | L'objectif du jour | ✅ lecture | ✅ | ❌ | ✅ fait |
+| **4** | Flamme — anneau des jours refermés | ❌ | ✅ | ❌ | ✅ fait (replié dans le lot 3) |
+
+> **Déploiement du schéma.** Contrairement à ce qu'indiquait la ronde 1 d'architecture,
+> **aucun SQL manuel n'est à passer dans le Supabase SQL Editor** : `CLAUDE.md` en fait
+> explicitement l'anti-pattern à l'origine du drift d'avril 2026. Le `Dockerfile`
+> (`packages/api/Dockerfile:40`) joue `alembic upgrade head` au boot de chaque conteneur
+> Railway — la migration `rd01_ucs_completed_at` s'applique donc **seule** au déploiement.
+>
+> **Expand-contract respecté** : la migration est purement additive (2 colonnes nullables
+> + 1 index partiel), donc inoffensive pour le backend `production` qui tourne sur la même
+> DB partagée avec l'ancien code jusqu'à une semaine. `user_content_status` fait 5 059
+> lignes / 2 Mo : la création d'index est instantanée, pas besoin de `CONCURRENTLY`.
 
 ### Lot 0 — Rendre le succès mesurable  *(prérequis absolu, réversible, sans schéma)*
 
@@ -152,9 +163,9 @@ Idempotence : `completed_at = COALESCE(completed_at, now())` — premier écrit 
 l'idiome déjà en place pour `reading_progress` (`func.greatest`, `content_service.py:102-113`).
 Le client n'envoie **jamais** d'horodatage.
 
-**Migration** : head unique vérifié `181c618da382`. Migration miroir `rd01_ucs_completed_at`
-(`down_revision = "181c618da382"`). Le SQL prod passe par le **Supabase SQL Editor** (index partiel
-`CREATE INDEX CONCURRENTLY` en statement séparé), jamais sur Railway.
+**Migration** : head unique vérifié `181c618da382` → `rd01_ucs_completed_at`
+(`down_revision = "181c618da382"`). `alembic upgrade head` validé localement contre une base
+**vide**, un seul head après ajout. Appliquée automatiquement au boot Railway.
 
 **Mobile** : `_articleCompleted` (`ValueNotifier<bool>` frère de `_footerPermanent`), 3 latches
 (`:2194-2199` / `:927-942` / `:857-865`), durabilité offline via `PendingReadQueue` avec un préfixe de clé
@@ -436,3 +447,49 @@ conclusion « ne pas optimiser pour les réguliers » s'en trouve affaiblie.
 `notif_du_jour_*` · `content_service.py:74-187` · `digest_service.py:1573,2917-2973` ·
 `recommendation_service.py:2727-2745` · `digest_selector.py:833-843` · `streak_service.py:40-97` ·
 `schemas/streak.py:8` · alembic head `181c618da382` (1 seul head, 44 révisions)
+
+---
+
+## 10. Journal d'implémentation (24/07/2026)
+
+### Décisions du PO au GO
+
+1. **Footer tout en vert**, et le CTA « Lire sur … » descend en **`colors.secondary`** — l'état prend
+   la couleur, l'action se retire. *(Arbitrage retenu contre la ronde 1 UX, qui voulait garder l'ocre.)*
+2. **Pas d'inversion d'opacité** : les cartes lues restent à `Opacity(0.6)`. Le grisé garde sa fonction
+   de repérage du non-lu.
+3. Sémantique `completed_at` = « bas de ce que Facteur affiche » : **validée**.
+4. Périmètre : **lots 0+1+2+3** d'emblée.
+
+### Écarts assumés par rapport au plan
+
+| Point | Plan | Livré | Pourquoi |
+|---|---|---|---|
+| Emplacement du cachet | dans le flux de l'article | **dans le pied de page** | Seul emplacement qui marche dans les 4 modes de rendu : impossible d'injecter dans le DOM de l'éditeur en WebView, qui est le chemin nominal (~90 % du catalogue). Un seul cachet au lieu de deux variantes. |
+| Filet vert sur les cartes | via un `ReadStateMark` neuf | **`AnimatedFeedCard` réhabilitée** | Le widget était déjà écrit (code mort, 0 référence). Restylé : filet vertical, `easeOutCubic` 320 ms, plus de scrim noir ni d'`elasticOut`, aucune haptique. |
+| `closing_recap.dart` | à réhabiliter | **laissé en l'état** | Le bloc de clôture n'a pas besoin du détail par section — une phrase suffit, et le récap par section rouvrirait la question du critère « lu » permissif. À reprendre si le PO veut le détail. |
+| Lot 4 (flamme) | conditionnel, après gate | **livré** | L'anneau ne dépend pas de `closure_streak` (qui est vide) : c'est un état du jour dérivé de `daily_completed`, il fonctionne dès le jour 1. Le gate ne portait que sur l'affichage d'une seconde série — toujours coupée. |
+
+### Vérifications
+
+- **Backend** : 2 485 tests passés (dont 13 nouveaux), 0 échec.
+- **Mobile** : 2 111 tests (dont 17 nouveaux). **33 échecs = exactement la baseline de `main`**, mesurée
+  en stashant la branche. **0 régression.** `flutter analyze` : 0 erreur, aucun nouveau warning.
+- **Alembic** : `upgrade head` rejoué contre une base **vide** (Postgres 16 local), 1 seul head.
+- **API** : bootée localement, contrat vérifié dans l'OpenAPI
+  (`ContentStatusUpdate.completed/completion_source`, `CompletionSource ∈ {in_app, short, web}`,
+  `StreakResponse.daily_completed/daily_goal`).
+- **Bout en bout contre une vraie base** : `completed_at` posé et estampillé serveur ; relecture
+  ne déplace pas l'horodatage (first-write-wins) ; compteur du jour dérivé correct ; un `consumed`
+  seul ne crée aucune complétion et ne bouge pas le compteur ; la combinaison
+  `completed` + `status=consumed` est rejetée ; une complétion de J-3 ne compte pas aujourd'hui.
+
+### Ce qui reste ouvert
+
+- **Le chiffre de `DAILY_COMPLETION_GOAL` (= 2) est provisoire.** Il doit être arrêté sur la
+  distribution réelle de `article_finished`, après ~2 semaines de collecte. Il est en constante
+  serveur (`streak_service.py`) précisément pour être recalibré **sans release client**.
+- **Pas encore de tagline de découverte dans la « Notif du jour »** (message one-shot expliquant
+  l'objectif). À ajouter si le PO le souhaite — le plan la prévoit, elle est triviale.
+- **Validation QA web** (`/validate-feature`) non exécutée : Flutter web n'était pas lancé dans cet
+  environnement. Les parcours visuels (cachet, CTA secondary, filet, anneau) restent à valider à l'œil.

--- a/packages/api/alembic/versions/rd01_ucs_completed_at.py
+++ b/packages/api/alembic/versions/rd01_ucs_completed_at.py
@@ -1,0 +1,52 @@
+"""user_content_status: completed_at + completion_source (« lu jusqu'au bout »)
+
+Epic 30 — La lecture aboutie.
+
+Additif pur, aucun backfill : `completed_at IS NULL` signifie « inconnu », pas
+« non terminé ». Un backfill depuis `reading_progress` serait faux, la colonne
+étant plafonnée à 25 pour ~90 % du catalogue (contenu partiel).
+
+`completed_at` est orthogonal à `status` : les filtres d'exclusion du feed et du
+digest (`status.in_([SEEN, CONSUMED])`) ne le voient pas, donc aucun impact sur
+la recommandation ni sur la complétion implicite du digest.
+
+Revision ID: rd01_ucs_completed_at
+Revises: 181c618da382
+Create Date: 2026-07-24
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "rd01_ucs_completed_at"
+down_revision: str | None = "181c618da382"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_content_status",
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "user_content_status",
+        sa.Column("completion_source", sa.String(length=12), nullable=True),
+    )
+    # Partial index — only completed rows are indexed, so the cost stays
+    # negligible while the derived daily counter reads it directly.
+    op.create_index(
+        "ix_ucs_user_completed_at",
+        "user_content_status",
+        ["user_id", "completed_at"],
+        unique=False,
+        postgresql_where=sa.text("completed_at IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ucs_user_completed_at", table_name="user_content_status")
+    op.drop_column("user_content_status", "completion_source")
+    op.drop_column("user_content_status", "completed_at")

--- a/packages/api/app/models/content.py
+++ b/packages/api/app/models/content.py
@@ -16,6 +16,7 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    text,
 )
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
@@ -132,6 +133,13 @@ class UserContentStatus(Base):
         Index("ix_user_content_status_user_saved", "user_id", "is_saved"),
         Index("ix_user_content_status_user_liked", "user_id", "is_liked"),
         Index("ix_user_content_status_user_status", "user_id", "status"),
+        # Partial index: only completed rows, for the derived daily counter.
+        Index(
+            "ix_ucs_user_completed_at",
+            "user_id",
+            "completed_at",
+            postgresql_where=text("completed_at IS NOT NULL"),
+        ),
     )
 
     id: Mapped[UUID] = mapped_column(
@@ -169,10 +177,20 @@ class UserContentStatus(Base):
     note_updated_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
-    # Reading progress: scroll depth percentage (0-100), max ever reached
+    # Reading progress: scroll depth percentage (0-100), max ever reached.
+    # ⚠️ Frozen signal — capped at 25 for partial content (~90% of the catalog),
+    # so `reading_progress >= 90` measures article type, not reading. Kept for
+    # analytics history only; `completed_at` is the completion signal.
     reading_progress: Mapped[int] = mapped_column(
         SmallInteger, default=0, server_default="0"
     )
+    # « Lu jusqu'au bout » — server-stamped, first write wins (monotonic).
+    # Orthogonal to `status`: completion never implies CONSUMED, so the feed
+    # exclusion filters and the implicit digest completion are untouched.
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    completion_source: Mapped[str | None] = mapped_column(String(12), nullable=True)
     # Feed refresh: timestamp of last time article was shown but not clicked
     last_impressed_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True

--- a/packages/api/app/models/enums.py
+++ b/packages/api/app/models/enums.py
@@ -32,6 +32,20 @@ class ContentStatus(StrEnum):
     CONSUMED = "consumed"
 
 
+class CompletionSource(StrEnum):
+    """D'où vient le signal « lu jusqu'au bout ».
+
+    `completed_at` signifie « l'utilisateur a atteint le bas de ce que Facteur
+    lui a présenté ». Cette énumération enregistre *quel* bas a été atteint —
+    ~90 % du catalogue étant du contenu partiel, `WEB` est le cas nominal d'une
+    lecture réellement menée à son terme chez l'éditeur.
+    """
+
+    IN_APP = "in_app"  # contenu complet, bas de l'article atteint dans l'app
+    SHORT = "short"  # article trop court pour scroller
+    WEB = "web"  # contenu partiel, bas de la page atteint chez l'éditeur
+
+
 class HiddenReason(StrEnum):
     """Raison pour laquelle un contenu est masqué."""
 

--- a/packages/api/app/schemas/content.py
+++ b/packages/api/app/schemas/content.py
@@ -4,11 +4,12 @@ import json
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field, field_serializer
+from pydantic import BaseModel, Field, field_serializer, model_validator
 
 from app.models.enums import (
     BiasOrigin,
     BiasStance,
+    CompletionSource,
     ContentStatus,
     ContentType,
     HiddenReason,
@@ -115,6 +116,7 @@ class ContentResponse(BaseModel):
     content_quality: str | None = None  # In-App Reading: 'full', 'partial', 'none'
     recommendation_reason: RecommendationReason | None = None
     reading_progress: int = 0
+    completed_at: datetime | None = None
     note_text: str | None = None
     note_updated_at: datetime | None = None
     is_followed_source: bool = False
@@ -159,6 +161,7 @@ class ContentDetailResponse(BaseModel):
     theme: str | None = None
     time_spent_seconds: int = 0
     reading_progress: int = 0
+    completed_at: datetime | None = None
     note_text: str | None = None
     note_updated_at: datetime | None = None
 
@@ -180,6 +183,26 @@ class ContentStatusUpdate(BaseModel):
     status: ContentStatus | None = None
     time_spent_seconds: int | None = None
     reading_progress: int | None = Field(None, ge=0, le=100)
+    # « Lu jusqu'au bout ». Le client envoie un booléen, jamais un horodatage :
+    # c'est le serveur qui estampille (pas de triche par horloge device).
+    completed: bool | None = None
+    completion_source: CompletionSource | None = None
+
+    @model_validator(mode="after")
+    def _completion_is_its_own_request(self) -> "ContentStatusUpdate":
+        """Interdit de combiner `completed` et `status=consumed` dans un appel.
+
+        L'upsert protège la transition CONSUMED par un
+        `ON CONFLICT ... WHERE status != 'consumed'` : sur une ligne déjà
+        consumed, l'update entier est ignoré. Envoyer les deux ensemble ferait
+        donc silencieusement perdre `completed_at`. On rejette explicitement
+        plutôt que de perdre la donnée — le mobile envoie deux requêtes.
+        """
+        if self.completed and self.status == ContentStatus.CONSUMED:
+            raise ValueError(
+                "`completed` and `status=consumed` must be sent in separate requests"
+            )
+        return self
 
 
 class ArticleFeedbackRequest(BaseModel):

--- a/packages/api/app/schemas/digest.py
+++ b/packages/api/app/schemas/digest.py
@@ -74,6 +74,8 @@ class DigestTopicArticle(BaseModel):
     is_liked: bool = False
     is_dismissed: bool = False
     read_at: datetime | None = None
+    # « Lu jusqu'au bout » (Epic 30) — null = inconnu, pas « non terminé ».
+    completed_at: datetime | None = None
     # Langue détectée du titre (forward-compat — label éventuel mobile).
     language: str | None = None
 
@@ -164,6 +166,7 @@ class DigestItem(BaseModel):
     is_saved: bool = False
     is_liked: bool = False
     is_dismissed: bool = False
+    completed_at: datetime | None = None
 
     @field_serializer("entities", when_used="always")
     def serialize_entities(self, value: list[str]) -> list[dict]:

--- a/packages/api/app/schemas/streak.py
+++ b/packages/api/app/schemas/streak.py
@@ -14,6 +14,10 @@ class StreakResponse(BaseModel):
     weekly_count: int
     weekly_goal: int
     weekly_progress: float  # 0.0 à 1.0
+    # Lectures abouties de la journée éditoriale (frontière 07h30 Paris).
+    # Dérivé de `completed_at`, jamais stocké.
+    daily_completed: int = 0
+    daily_goal: int = 2
 
     class Config:
         from_attributes = True

--- a/packages/api/app/services/content_service.py
+++ b/packages/api/app/services/content_service.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import func
 
 from app.models.content import UserContentStatus
-from app.models.enums import ContentStatus, HiddenReason
+from app.models.enums import CompletionSource, ContentStatus, HiddenReason
 from app.schemas.content import ContentStatusUpdate
 from app.services.streak_service import StreakService
 
@@ -64,6 +64,7 @@ class ContentService:
             "hidden_reason": user_status.hidden_reason if user_status else None,
             "time_spent_seconds": user_status.time_spent_seconds if user_status else 0,
             "reading_progress": user_status.reading_progress if user_status else 0,
+            "completed_at": user_status.completed_at if user_status else None,
             "note_text": user_status.note_text if user_status else None,
             "note_updated_at": user_status.note_updated_at if user_status else None,
             "topics": content.topics,
@@ -99,11 +100,29 @@ class ContentService:
         if update_data.reading_progress is not None:
             values["reading_progress"] = update_data.reading_progress
 
+        completion_source = (
+            update_data.completion_source or CompletionSource.IN_APP
+            if update_data.completed
+            else None
+        )
+        if update_data.completed:
+            values["completed_at"] = now
+            values["completion_source"] = completion_source
+
         # Build conflict update set — for reading_progress, keep the max
         conflict_set = dict(values)
         if update_data.reading_progress is not None:
             conflict_set["reading_progress"] = func.greatest(
                 UserContentStatus.reading_progress, update_data.reading_progress
+            )
+        # Completion is first-write-wins: re-reading an article never moves the
+        # timestamp, so the daily counter can't be farmed by re-opening.
+        if update_data.completed:
+            conflict_set["completed_at"] = func.coalesce(
+                UserContentStatus.completed_at, now
+            )
+            conflict_set["completion_source"] = func.coalesce(
+                UserContentStatus.completion_source, completion_source
             )
         # time_spent_seconds accumulates across sessions instead of being overwritten.
         if update_data.time_spent_seconds is not None:

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -52,7 +52,7 @@ from app.services.digest_selector import DigestSelector
 from app.services.editorial.schemas import EditorialPipelineResult
 from app.services.streak_service import StreakService
 from app.services.topic_selector import ScoredArticle, TopicGroup
-from app.utils.time import today_paris
+from app.utils.time import editorial_day, today_paris
 
 logger = structlog.get_logger()
 
@@ -2208,6 +2208,7 @@ class DigestService:
                     is_saved=action_state["is_saved"],
                     is_liked=action_state["is_liked"],
                     is_dismissed=action_state["is_dismissed"],
+                    completed_at=action_state.get("completed_at"),
                 )
             )
 
@@ -2350,6 +2351,7 @@ class DigestService:
                     is_saved=action_state["is_saved"],
                     is_liked=action_state["is_liked"],
                     is_dismissed=action_state["is_dismissed"],
+                    completed_at=action_state.get("completed_at"),
                     read_at=action_state.get("read_at"),
                 )
                 topic_articles.append(topic_article)
@@ -2380,6 +2382,7 @@ class DigestService:
                         is_saved=action_state["is_saved"],
                         is_liked=action_state["is_liked"],
                         is_dismissed=action_state["is_dismissed"],
+                        completed_at=action_state.get("completed_at"),
                     )
                 )
 
@@ -2600,6 +2603,7 @@ class DigestService:
                     is_saved=action_state["is_saved"],
                     is_liked=action_state["is_liked"],
                     is_dismissed=action_state["is_dismissed"],
+                    completed_at=action_state.get("completed_at"),
                     read_at=action_state.get("read_at"),
                 )
                 topic_articles.append(topic_article)
@@ -2629,6 +2633,7 @@ class DigestService:
                         is_saved=action_state["is_saved"],
                         is_liked=action_state["is_liked"],
                         is_dismissed=action_state["is_dismissed"],
+                        completed_at=action_state.get("completed_at"),
                     )
                 )
 
@@ -2692,6 +2697,7 @@ class DigestService:
                 "is_saved": False,
                 "is_liked": False,
                 "is_dismissed": False,
+                "completed_at": None,
             }
 
         return {
@@ -2699,6 +2705,7 @@ class DigestService:
             "is_saved": status.is_saved,
             "is_liked": status.is_liked,
             "is_dismissed": status.is_hidden,
+            "completed_at": status.completed_at,
         }
 
     async def _get_batch_action_states(
@@ -2728,6 +2735,7 @@ class DigestService:
                 "is_liked": status.is_liked,
                 "is_dismissed": status.is_hidden,
                 "read_at": status.seen_at,
+                "completed_at": status.completed_at,
             }
             for status in statuses
         }
@@ -2930,7 +2938,12 @@ class DigestService:
             self.session.add(streak)
             await self.session.flush()
 
-        today = date.today()
+        # Editorial day (07h30 Paris), NOT `date.today()` (server UTC). The
+        # trigger `maybe_record_implicit_completion` already gates on Paris
+        # time: stamping in UTC made a completion recorded for day D land on
+        # D-1 between 00h and 02h Paris in summer, breaking or doubling the
+        # streak.
+        today = editorial_day()
 
         # Update closure streak
         if streak.last_closure_date:

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -452,6 +452,7 @@ class RecommendationService:
                 content.hidden_reason = st.hidden_reason
                 content.status = st.status
                 content.reading_progress = st.reading_progress
+                content.completed_at = st.completed_at
                 content.note_text = st.note_text
                 content.note_updated_at = st.note_updated_at
                 results.append(content)
@@ -1056,6 +1057,7 @@ class RecommendationService:
             content.is_hidden = st.is_hidden if st else False
             content.hidden_reason = st.hidden_reason if st else None
             content.status = st.status if st else ContentStatus.UNSEEN
+            content.completed_at = st.completed_at if st else None
             if followed_source_ids is not None:
                 content.is_followed_source = content.source_id in followed_source_ids
 

--- a/packages/api/app/services/streak_service.py
+++ b/packages/api/app/services/streak_service.py
@@ -7,12 +7,20 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.analytics import AnalyticsEvent
+from app.models.content import UserContentStatus
 from app.models.user import UserProfile, UserStreak
 from app.schemas.streak import (
     StreakActivityDayResponse,
     StreakActivityResponse,
     StreakResponse,
 )
+from app.utils.time import editorial_day_bounds
+
+# Objectif journalier de lectures abouties. Constante serveur volontairement :
+# il n'existe aucune UI d'édition, et la garder ici permet de recalibrer sans
+# release client. Valeur provisoire — à arrêter sur la distribution réelle une
+# fois l'instrumentation réparée (aujourd'hui ≈ 1,2 lecture aboutie/jour actif).
+DAILY_COMPLETION_GOAL = 2
 
 
 class StreakService:
@@ -35,6 +43,31 @@ class StreakService:
             weekly_count=streak.weekly_count,
             weekly_goal=weekly_goal,
             weekly_progress=min(1.0, streak.weekly_count / weekly_goal),
+            daily_completed=await self.count_completed_today(user_id),
+            daily_goal=DAILY_COMPLETION_GOAL,
+        )
+
+    async def count_completed_today(self, user_id: str) -> int:
+        """Compte les lectures abouties de la journée éditoriale en cours.
+
+        Dérivé de `user_content_status.completed_at` — aucun compteur stocké,
+        donc aucun job de reset, aucune dérive et rien à reconstruire après
+        incident. La fenêtre suit la frontière 07h30 Paris (celle des éditions
+        et du rituel matinal), et non minuit : avant 07h30 le lecteur est
+        encore sur l'édition de la veille.
+        """
+        start, end = editorial_day_bounds()
+        return (
+            await self.db.scalar(
+                select(func.count())
+                .select_from(UserContentStatus)
+                .where(
+                    UserContentStatus.user_id == UUID(user_id),
+                    UserContentStatus.completed_at >= start,
+                    UserContentStatus.completed_at < end,
+                )
+            )
+            or 0
         )
 
     async def increment_consumption(self, user_id: str) -> UserStreak:

--- a/packages/api/app/utils/time.py
+++ b/packages/api/app/utils/time.py
@@ -6,7 +6,7 @@ Paris (summer) returns yesterday's Paris date. This helper makes "today" mean
 the same thing everywhere the digest pipeline reads or writes target_date.
 """
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
 
 PARIS_TZ = ZoneInfo("Europe/Paris")
@@ -24,6 +24,46 @@ def today_paris() -> date:
 def now_paris() -> datetime:
     """Return current datetime in Europe/Paris (timezone-aware)."""
     return datetime.now(PARIS_TZ)
+
+
+# Editorial day boundary: the "tournée" flips at 07h30 Paris, not at midnight.
+# Mirror of `TourneeProgressService.dayKey` (mobile). Kept in one place so the
+# daily reading goal, the closure streak and the implicit digest completion all
+# agree on what "today" means for the reader.
+EDITORIAL_DAY_START_HOUR = 7
+EDITORIAL_DAY_START_MINUTE = 30
+
+
+def editorial_day(now: datetime | None = None) -> date:
+    """Return the editorial day (07h30 Europe/Paris boundary) for `now`.
+
+    Before 07h30 Paris the reader is still on yesterday's edition, so the day
+    key stays on the previous date. Use this — never `date.today()` — anywhere
+    a counter or a streak must line up with what the user sees as "today's
+    edition".
+    """
+    moment = now.astimezone(PARIS_TZ) if now is not None else datetime.now(PARIS_TZ)
+    if is_before_paris_time(moment, EDITORIAL_DAY_START_HOUR, EDITORIAL_DAY_START_MINUTE):
+        return moment.date() - timedelta(days=1)
+    return moment.date()
+
+
+def editorial_day_bounds(now: datetime | None = None) -> tuple[datetime, datetime]:
+    """Return the [start, end) datetimes framing the current editorial day.
+
+    Both bounds are timezone-aware (Europe/Paris) so they can be compared
+    directly against `timestamptz` columns.
+    """
+    day = editorial_day(now)
+    start = datetime(
+        day.year,
+        day.month,
+        day.day,
+        EDITORIAL_DAY_START_HOUR,
+        EDITORIAL_DAY_START_MINUTE,
+        tzinfo=PARIS_TZ,
+    )
+    return start, start + timedelta(days=1)
 
 
 def is_before_paris_time(now: datetime, hour: int, minute: int) -> bool:

--- a/packages/api/tests/test_reading_completion.py
+++ b/packages/api/tests/test_reading_completion.py
@@ -1,0 +1,182 @@
+"""Epic 30 — « lu jusqu'au bout » : contrat de données et compteur journalier.
+
+Trois choses à protéger :
+
+1. `completed_at` est **first-write-wins** — relire un article ne doit jamais
+   déplacer l'horodatage, sinon le compteur du jour se farme en rouvrant.
+2. Complétion et transition CONSUMED ne voyagent **jamais** dans la même
+   requête : l'upsert protège CONSUMED par un `ON CONFLICT ... WHERE status !=
+   'consumed'` qui ignorerait l'update entier, donc `completed_at` serait perdu
+   silencieusement.
+3. La journée du compteur suit la frontière **07h30 Europe/Paris** (celle des
+   éditions), pas minuit.
+
+Pas de DB requise : on inspecte le SQL compilé de l'upsert.
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+from zoneinfo import ZoneInfo
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy.dialects import postgresql
+
+from app.models.content import UserContentStatus
+from app.models.enums import CompletionSource, ContentStatus
+from app.schemas.content import ContentStatusUpdate
+from app.services.content_service import ContentService
+from app.utils.time import PARIS_TZ, editorial_day, editorial_day_bounds
+
+
+def _captured_sql(session_mock) -> str:
+    stmt = session_mock.scalars.call_args.args[0]
+    return str(stmt.compile(dialect=postgresql.dialect())).lower()
+
+
+def _session_with_row() -> AsyncMock:
+    session = AsyncMock()
+    result = MagicMock()
+    result.one_or_none.return_value = UserContentStatus(
+        user_id=uuid4(), content_id=uuid4()
+    )
+    session.scalars.return_value = result
+    return session
+
+
+# ──────────────────────────────────────────────────────────────
+# 1. Upsert
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_completed_uses_coalesce_so_first_write_wins():
+    session = _session_with_row()
+
+    await ContentService(session).update_content_status(
+        user_id=uuid4(),
+        content_id=uuid4(),
+        update_data=ContentStatusUpdate(
+            completed=True, completion_source=CompletionSource.WEB
+        ),
+    )
+
+    sql = _captured_sql(session)
+    assert "on conflict" in sql
+    # Re-reading must not move the stamp: the conflict set reads the existing
+    # column rather than overwriting it with the new parameter.
+    assert "coalesce(user_content_status.completed_at" in sql
+    assert "coalesce(user_content_status.completion_source" in sql
+
+
+@pytest.mark.asyncio
+async def test_completion_source_defaults_to_in_app():
+    session = _session_with_row()
+
+    await ContentService(session).update_content_status(
+        user_id=uuid4(),
+        content_id=uuid4(),
+        update_data=ContentStatusUpdate(completed=True),
+    )
+
+    params = session.scalars.call_args.args[0].compile(
+        dialect=postgresql.dialect()
+    ).params
+    assert CompletionSource.IN_APP in params.values()
+
+
+@pytest.mark.asyncio
+async def test_completion_absent_does_not_touch_completed_columns():
+    """Un update ordinaire (progression seule) ne doit rien écrire de complétion."""
+    session = _session_with_row()
+
+    await ContentService(session).update_content_status(
+        user_id=uuid4(),
+        content_id=uuid4(),
+        update_data=ContentStatusUpdate(reading_progress=42),
+    )
+
+    # Le RETURNING renvoie toute la ligne : on n'inspecte que la clause SET.
+    conflict_set = _captured_sql(session).split("do update set")[1].split("returning")[0]
+    assert "completed_at" not in conflict_set
+    assert "completion_source" not in conflict_set
+
+
+@pytest.mark.asyncio
+async def test_completion_does_not_trigger_consumed_side_effects():
+    """`completed` est orthogonal à `status` : aucun effet de bord de transition.
+
+    C'est ce qui garantit que la reco, les poids d'intérêt et la complétion
+    implicite du digest restent strictement inchangés.
+    """
+    session = _session_with_row()
+
+    _, transitioned = await ContentService(session).update_content_status(
+        user_id=uuid4(),
+        content_id=uuid4(),
+        update_data=ContentStatusUpdate(completed=True),
+    )
+
+    assert transitioned is False
+
+
+# ──────────────────────────────────────────────────────────────
+# 2. Séparation des requêtes
+# ──────────────────────────────────────────────────────────────
+
+
+def test_completed_with_consumed_is_rejected():
+    """Les combiner ferait perdre `completed_at` sans bruit — on rejette."""
+    with pytest.raises(ValidationError):
+        ContentStatusUpdate(completed=True, status=ContentStatus.CONSUMED)
+
+
+def test_completed_with_seen_is_allowed():
+    """Seul CONSUMED porte la garde d'idempotence : SEEN reste combinable."""
+    assert ContentStatusUpdate(completed=True, status=ContentStatus.SEEN).completed
+
+
+# ──────────────────────────────────────────────────────────────
+# 3. Frontière de jour éditoriale
+# ──────────────────────────────────────────────────────────────
+
+
+def _paris(y, m, d, h, mi) -> datetime:
+    return datetime(y, m, d, h, mi, tzinfo=PARIS_TZ)
+
+
+@pytest.mark.parametrize(
+    ("moment", "expected_day"),
+    [
+        # Avant 07h30 : encore l'édition de la veille.
+        (_paris(2026, 7, 24, 0, 30), 23),
+        (_paris(2026, 7, 24, 7, 29), 23),
+        # À partir de 07h30 : édition du jour.
+        (_paris(2026, 7, 24, 7, 30), 24),
+        (_paris(2026, 7, 24, 23, 59), 24),
+    ],
+)
+def test_editorial_day_flips_at_730_paris(moment, expected_day):
+    assert editorial_day(moment).day == expected_day
+
+
+def test_editorial_day_normalizes_other_timezones():
+    """01h00 UTC le 24 = 03h00 Paris le 24 → toujours l'édition du 23."""
+    utc_moment = datetime(2026, 7, 24, 1, 0, tzinfo=ZoneInfo("UTC"))
+    assert editorial_day(utc_moment).day == 23
+
+
+def test_editorial_day_bounds_span_exactly_one_day():
+    start, end = editorial_day_bounds(_paris(2026, 7, 24, 12, 0))
+    assert (start.hour, start.minute) == (7, 30)
+    assert (end - start).days == 1
+    assert start.tzinfo is not None and end.tzinfo is not None
+
+
+def test_editorial_day_bounds_contain_a_late_night_read():
+    """Une lecture à 01h du matin tombe dans la journée éditoriale précédente."""
+    late = _paris(2026, 7, 25, 1, 0)
+    start, end = editorial_day_bounds(late)
+    assert start <= late < end
+    assert start.day == 24


### PR DESCRIPTION
Plan de la feature « rendre satisfaisante la lecture d'un article jusqu'au bout »,
arbitré sur données prod après itérations UX / PM / Architecte.

Constats structurants vérifiés en base et dans le code :
- reading_progress est plafonné à 25 pour ~90 % du catalogue (contenu partiel) —
  le seuil >= 90 est inatteignable et mesure le type d'article, pas la lecture
- le moment de fin d'article existe déjà (_footerPermanent) mais n'est pas persisté
- article_read / article_completed : 0 événement sur 30 jours (émission depuis dispose)
- bug latent : _update_closure_streak estampille en UTC alors que son déclencheur
  teste today_paris()

Découpage en 5 lots, contrat de données completed_at + completion_source, et
4 décisions produit laissées au PO.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EdVorP8ovGZi9Nn1vtY47s