### PR TITLE
perf(perspectives): index trigram contents.entities — 1er batch « Comparer les angles »

### DIFF
--- a/docs/maintenance/maintenance-perspectives-entities-trgm-index.md
+++ b/docs/maintenance/maintenance-perspectives-entities-trgm-index.md
@@ -1,0 +1,115 @@
+# Maintenance — index trigram `contents.entities` (1er batch « Comparer les angles »)
+
+> Type : Maintenance / perf. Migration : `pt01_contents_entities_trgm`.
+> Décision PO (24/07) : **Option A maintenant** (index trigram), Option B (dénorm)
+> conditionnelle à la re-mesure post-déploiement.
+
+## Problème
+
+Le carrousel « Comparer les angles » (bas d'article, alias interne *perspectives*)
+charge lentement le matin. Le goulot mesuré est le **1er batch DB** — la lecture
+`PerspectiveService.search_internal_perspectives` — pas l'enrichissement Google
+News (2e temps, en tâche de fond, hors périmètre).
+
+La requête filtre les articles partageant une entité PERSON/ORG via :
+
+```python
+func.array_to_string(Content.entities, " ").ilike(f"%{name}%")
+```
+
+`array_to_string(entities,' ') ILIKE '%nom%'` transforme la colonne puis fait un
+match sous-chaîne (wildcard en tête) → **non-sargable**. Postgres borne la fenêtre
+72h via `ix_contents_published_at` puis évalue l'ILIKE **ligne par ligne** sur toute
+la fenêtre. Coût **O(articles publiés sur 72h)** → grossit avec l'ingestion.
+EXPLAIN prod : ~**1,58 s**, `Rows Removed by Filter: 6953`.
+
+## Correctif livré (Option A) — ⚠️ dévie du plan initial
+
+Le plan supposait un index d'expression **directement** sur
+`array_to_string(entities,' ')`, requête inchangée. **Impossible en l'état** :
+
+- `array_to_string(anyarray, text)` est déclaré **STABLE** (polymorphe), or
+  Postgres exige des fonctions **IMMUTABLE** dans une expression d'index
+  → `ERROR: functions in index expression must be marked IMMUTABLE`.
+  (Validé localement : les deux formes, qualifiée ou non, échouent.)
+
+Correctif minimal, en 3 objets **additifs** :
+
+1. **Wrapper IMMUTABLE** `public.content_entities_text(text[])` =
+   `array_to_string($1, ' ')`. Pour du `text[]` la sortie est réellement immutable
+   → wrapper légitime (même pattern qu'`immutable_unaccent`).
+2. **Index GIN trigram** `ix_contents_entities_trgm` sur
+   `content_entities_text(entities)` avec l'opclass **`extensions.gin_trgm_ops`**.
+   Le baseline crée `pg_trgm WITH SCHEMA extensions` et `extensions` **n'est pas**
+   dans le `search_path` des connexions → l'opclass **doit** être qualifiée
+   (`gin_trgm_ops` nu ⇒ `operator class does not exist`).
+3. **Requête** de `search_internal_perspectives` bascule sur le wrapper
+   (`func.content_entities_text(Content.entities).ilike(...)`) — sinon l'expression
+   ne matche pas l'index et le planner reste en seq scan.
+
+L'index est aussi déclaré dans `Content.__table_args__` (via `text()` portant
+l'opclass) pour cohérence ORM↔schéma ; l'autogenerate « assume equal and skips »
+(index d'expression non réfléchissable) → il ne proposera pas de le drop.
+
+## Preuve (EXPLAIN, dataset local représentatif : 7000 lignes / fenêtre 72h)
+
+| Forme de requête | Plan | Coût |
+|---|---|---|
+| `array_to_string(...) ILIKE` (avant) | Seq Scan, `Rows Removed: 7000` | ~43 ms (128 ms au 1er run) |
+| `content_entities_text(...) ILIKE` (après) | **Bitmap Index Scan `ix_contents_entities_trgm`**, `Heap Blocks: 9` | sub-ms |
+
+Sur entité **discriminante** (cas normal) → bascule trigram. Sur terme très
+fréquent, le planner peut retomber sur `ix_contents_published_at` — acceptable,
+jamais pire que l'existant.
+
+## Fichiers
+
+- `packages/api/alembic/versions/pt01_contents_entities_trgm.py` (nouveau) —
+  fonction + index (`CREATE INDEX CONCURRENTLY` dans `autocommit_block`, `IF NOT
+  EXISTS`, idempotent ; downgrade drop index puis fonction).
+- `packages/api/app/services/perspective_service.py` — requête → wrapper.
+- `packages/api/app/models/content.py` — déclaration de l'index dans `__table_args__`.
+- `packages/api/tests/conftest.py` — pré-crée la fonction + `pg_trgm` avant
+  `Base.metadata.create_all` (même logique que l'ENUM `interest_state` déjà présent ;
+  sinon `create_all` lève `UndefinedFunction` au CREATE INDEX).
+
+## Rollout (expand-contract, DB partagée staging↔prod)
+
+Tout est **additif** : le backend prod (ancien code `production`, requête
+`array_to_string` inchangée) ignore fonction et index jusqu'au passage hebdo.
+
+**Recommandé — build hors-bande avant merge (accès Supabase requis) :**
+
+```sql
+-- 1) la fonction D'ABORD (l'index en dépend)
+CREATE OR REPLACE FUNCTION public.content_entities_text(text[])
+RETURNS text LANGUAGE sql IMMUTABLE PARALLEL SAFE
+AS $$ SELECT array_to_string($1, ' ') $$;
+-- 2) l'index CONCURRENTLY (~30-90 s sur 72k lignes, non bloquant pour l'ingestion)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_contents_entities_trgm
+ON public.contents
+USING gin (public.content_entities_text(entities) extensions.gin_trgm_ops);
+```
+
+Ensuite la migration `IF NOT EXISTS` est un no-op rapide au boot des deux services.
+Si le build hors-bande est **omis**, la migration bâtit l'index CONCURRENTLY au boot
+staging (délai ~30-90 s sur ce boot, sans bloquer les écritures).
+
+## Vérifié
+
+- `alembic upgrade head` depuis une DB vide (= CI `alembic-smoke`) : baseline →
+  pt01, index `valid`/`ready`, fonction `IMMUTABLE`+`PARALLEL SAFE`. Exactement 1 head.
+- `downgrade -1` retire index + fonction ; re-`upgrade head` idempotent.
+- EXPLAIN : bascule sur `ix_contents_entities_trgm` (cf. tableau).
+- `pytest tests/*perspective*` : 35 passés (facteur_test + DB isolée). Suite
+  perspectives/coverage/entities : 151 passés.
+
+## Suivi
+
+- **Re-mesurer en prod** (`timings_ms.cluster_internal_db` sur ouvertures
+  live-path ; viser 1er batch < 100 ms). Décide si l'**Option B** (dénormaliser
+  `entity_names text[]` + GIN array + overlap sargable, migration + backfill 72k +
+  écriture au point de classif + expand-contract 2 cycles) est nécessaire. Si B est
+  livrée, l'index trigram devient inutile (drop en cycle contract).
+- Hors périmètre : absence de cache client (re-fetch à chaque ré-open,
+  `content_detail_screen.dart`) — à traiter séparément si souhaité.

--- a/packages/api/alembic/versions/pt01_contents_entities_trgm.py
+++ b/packages/api/alembic/versions/pt01_contents_entities_trgm.py
@@ -1,0 +1,76 @@
+"""contents.entities — index trigram pour le 1er batch « Comparer les angles ».
+
+Le live path des perspectives (``PerspectiveService.search_internal_perspectives``)
+cherche les articles partageant une entité PERSON/ORG via
+``array_to_string(entities, ' ') ILIKE '%nom%'`` — non-sargable : Postgres borne
+la fenêtre 72h avec ``ix_contents_published_at`` puis évalue l'``ILIKE`` **ligne
+par ligne** sur toute la fenêtre (~1,58 s en prod, coût O(articles publiés)).
+
+Cette révision pose un index GIN trigram (pg_trgm) sur l'expression de la requête
+pour que le planner ne remonte que les lignes candidates (bitmap) au lieu de
+scanner la fenêtre entière (mesuré local : 6911 lignes filtrées → 9 candidates).
+
+Deux objets, tous deux ADDITIFS et idempotents — sûrs sur la DB partagée
+staging↔prod : le backend prod (ancien code ``production``, requête inchangée) les
+ignore jusqu'au passage hebdo :
+
+1. ``public.content_entities_text(text[])`` — wrapper **IMMUTABLE** de
+   ``array_to_string($1, ' ')``. Indispensable : le builtin polymorphe
+   ``array_to_string(anyarray, text)`` est déclaré **STABLE**, donc rejeté dans
+   une expression d'index (« functions in index expression must be marked
+   IMMUTABLE »). Pour du ``text[]`` la sortie est réellement immutable → le
+   wrapper est légitime. ``search_internal_perspectives`` bascule sur ce wrapper
+   (même PR) pour que l'expression indexée matche.
+2. ``ix_contents_entities_trgm`` — GIN sur ``content_entities_text(entities)`` avec
+   l'opclass **``extensions.gin_trgm_ops``**. Le baseline crée pg_trgm ``WITH
+   SCHEMA extensions`` ; l'opclass DOIT être qualifiée car ``extensions`` n'est
+   pas dans le ``search_path`` des connexions (vérifié : ``gin_trgm_ops`` nu ⇒
+   « operator class does not exist »).
+
+Rollout (recommandé) : construire l'index une fois via Supabase — d'abord la
+fonction, puis ``CREATE INDEX CONCURRENTLY`` (~30-90 s, non bloquant pour
+l'ingestion) — AVANT merge, puis cette migration ``IF NOT EXISTS`` est un no-op
+rapide au boot des deux services Railway.
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "pt01_contents_entities_trgm"
+down_revision: str | None = "181c618da382"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    # 1) Wrapper IMMUTABLE — instantané, sûr dans la transaction Alembic.
+    #    Idempotent (CREATE OR REPLACE) ; corps identique ⇒ l'index dépendant
+    #    survit à un rejeu au boot de la DB partagée.
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION public.content_entities_text(text[])
+        RETURNS text
+        LANGUAGE sql
+        IMMUTABLE
+        PARALLEL SAFE
+        AS $func$ SELECT array_to_string($1, ' ') $func$
+        """
+    )
+    # 2) Index GIN trigram. CREATE INDEX CONCURRENTLY ne peut pas tourner dans
+    #    la transaction Alembic (env.py enveloppe tout dans un seul begin) →
+    #    bloc autocommit. IF NOT EXISTS : no-op si déjà bâti hors-bande.
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_contents_entities_trgm "
+            "ON public.contents "
+            "USING gin (public.content_entities_text(entities) "
+            "extensions.gin_trgm_ops)"
+        )
+
+
+def downgrade() -> None:
+    # L'index dépend de la fonction → le retirer d'abord (hors transaction),
+    # puis la fonction.
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_contents_entities_trgm")
+    op.execute("DROP FUNCTION IF EXISTS public.content_entities_text(text[])")

--- a/packages/api/app/models/content.py
+++ b/packages/api/app/models/content.py
@@ -16,6 +16,7 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    text,
 )
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
@@ -47,6 +48,17 @@ class Content(Base):
         # Replaces single-column ix_contents_theme (composite is a strict superset)
         Index("ix_contents_theme_published", "theme", "published_at"),
         Index("ix_contents_entities", "entities", postgresql_using="gin"),
+        # GIN trigram sur l'expression exacte du live path perspectives
+        # (`content_entities_text(entities) ILIKE '%nom%'`). Index d'expression +
+        # opclass `extensions.gin_trgm_ops` (pg_trgm est WITH SCHEMA extensions) :
+        # créé dans la migration pt01. Déclaré ici pour cohérence ORM↔schéma
+        # (l'opclass est portée par le text() car l'autogenerate ne sait pas
+        # refléter un index d'expression trigram).
+        Index(
+            "ix_contents_entities_trgm",
+            text("content_entities_text(entities) extensions.gin_trgm_ops"),
+            postgresql_using="gin",
+        ),
     )
 
     id: Mapped[UUID] = mapped_column(

--- a/packages/api/app/services/perspective_service.py
+++ b/packages/api/app/services/perspective_service.py
@@ -660,9 +660,13 @@ class PerspectiveService:
 
         cutoff = datetime.now(UTC) - timedelta(hours=time_window_hours)
 
-        # Build OR conditions: entities text array contains entity name
+        # Build OR conditions: entities text array contains entity name.
+        # Passer par le wrapper `content_entities_text` (et non le builtin
+        # `array_to_string`, STABLE donc non-sargable) est requis ICI : c'est
+        # l'expression exacte qu'indexe `ix_contents_entities_trgm` (GIN trigram,
+        # migration pt01), sinon le planner scanne toute la fenêtre 72h.
         entity_filters = [
-            func.array_to_string(Content.entities, " ").ilike(f"%{name}%")
+            func.content_entities_text(Content.entities).ilike(f"%{name}%")
             for name in entity_names
         ]
 

--- a/packages/api/tests/conftest.py
+++ b/packages/api/tests/conftest.py
@@ -101,6 +101,23 @@ def create_tables():
                     "END $$;"
                 )
             )
+            # pt01 — `Content` déclare un index d'expression trigram sur
+            # `content_entities_text(entities)` (wrapper IMMUTABLE de
+            # array_to_string, créé par Alembic en prod). Le DROP SCHEMA public
+            # ci-dessus a effacé la fonction ; sans elle + l'opclass pg_trgm,
+            # `Base.metadata.create_all` lèverait `UndefinedFunction` /
+            # `UndefinedObject` au CREATE INDEX. Même logique que l'ENUM au-dessus.
+            await conn.execute(text("CREATE SCHEMA IF NOT EXISTS extensions"))
+            await conn.execute(
+                text("CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA extensions")
+            )
+            await conn.execute(
+                text(
+                    "CREATE OR REPLACE FUNCTION public.content_entities_text(text[]) "
+                    "RETURNS text LANGUAGE sql IMMUTABLE PARALLEL SAFE "
+                    "AS $fn$ SELECT array_to_string($1, ' ') $fn$"
+                )
+            )
             await conn.run_sync(Base.metadata.create_all)
 
     asyncio.run(_setup())


### PR DESCRIPTION
# perf(perspectives): index trigram `contents.entities` — accélère le 1er batch « Comparer les angles »

Base `main`. Option A de la décision PO (24/07).

## Résumé

Le 1er batch DB du carrousel perspectives (`search_internal_perspectives`) scanne
la fenêtre 72h ligne par ligne (`array_to_string(entities,' ') ILIKE '%nom%'`,
non-sargable) → ~1,58 s en prod, coût O(articles publiés). Cette PR pose un index
**GIN trigram (pg_trgm)** sur l'expression de la requête → bitmap sur les seules
lignes candidates (mesuré local : 9 candidates vs 6911 filtrées ; ~1,58 s → sub-ms).
Additive et compatible avec l'Option B future.

## ⚠️ Déviation du plan (validée localement)

Le plan visait un index direct sur `array_to_string(entities,' ')`, requête
inchangée. **Impossible** : `array_to_string` est **STABLE** → rejeté dans une
expression d'index (`must be marked IMMUTABLE`). Correctif minimal :

1. Wrapper **IMMUTABLE** `public.content_entities_text(text[])`.
2. Index `ix_contents_entities_trgm` sur `content_entities_text(entities)` avec
   opclass **`extensions.gin_trgm_ops`** (qualifiée — `extensions` hors search_path).
3. La requête bascule sur le wrapper (sinon l'index ne matche pas).

## Fichiers

- `packages/api/alembic/versions/pt01_contents_entities_trgm.py` (nouveau).
- `packages/api/app/services/perspective_service.py` — requête → wrapper.
- `packages/api/app/models/content.py` — index déclaré dans `__table_args__`.
- `packages/api/tests/conftest.py` — pré-crée fonction + `pg_trgm` avant `create_all`.
- `docs/maintenance/maintenance-perspectives-entities-trgm-index.md` (nouveau).

## Vérification

- `alembic upgrade head` depuis DB vide (= CI alembic-smoke) OK ; index valid/ready ;
  **1 seul head** (`pt01_contents_entities_trgm`) ; downgrade/re-upgrade idempotents.
- EXPLAIN : bascule sur `ix_contents_entities_trgm` (Bitmap Index Scan) ; l'ancienne
  forme `array_to_string` NE l'utilise pas (⇒ le changement de requête est requis).
- Tests : `*perspective*` 35 passés ; perspectives/coverage/entities 151 passés
  (DB isolée + facteur_test via `POSTGRES_TEST_*`).

## Rollout / ops (expand-contract, DB partagée staging↔prod)

Additif : le backend prod (ancien code, requête inchangée) ignore fonction+index
jusqu'au passage hebdo. **Recommandé** : build hors-bande via Supabase **avant
merge** — *fonction d'abord*, puis `CREATE INDEX CONCURRENTLY` (~30-90 s, non
bloquant) — la migration `IF NOT EXISTS` devient un no-op au boot. SQL + détails
dans le doc maintenance.

## Suivi

Re-mesurer `timings_ms.cluster_internal_db` en prod (viser < 100 ms) → décide si
l'**Option B** (dénorm `entity_names`) est nécessaire.

## Note env locale (faux négatif connu)

Auto-tests / `stop-verify-tests.sh` utilisent `DATABASE_URL` de `.env` (user
`postgres`, creds rotées → `password authentication failed`) : **faux négatif
connu** sur les tests DB. Tests réels via `POSTGRES_TEST_*` (user `facteur`) →
verts. CI (creds propres) → vert.
