### PR TITLE
feat(reader): refonte CTA « Pas de recul » (bandeau lavis) + header contextuel

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Pas de recul",
+      "summary": "La suggestion « Pas de recul » a un nouveau look : un bandeau bleu discret pleine largeur au lieu d'une carte encadrée. Et quand tu ouvres l'article proposé, un liseré bleu et un médaillon longue-vue en haut du lecteur te rappellent d'où il vient."
+    },
+    {
       "tag": "Ma Tournée",
       "summary": "Chaque jour, ta tournée te propose quelques sections « Choisie pour vous » puisées dans tes thèmes et sources préférés, même si tu as déjà beaucoup configuré. Un bouton « Ajouter à mon Essentiel » sur la carte les garde en un tap, et celles que tu personnalises restent toujours visibles."
     },

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -2,7 +2,7 @@
   "unreleased": [
     {
       "tag": "Pas de recul",
-      "summary": "La suggestion « Pas de recul » a un nouveau look : un bandeau bleu discret pleine largeur au lieu d'une carte encadrée. Et quand tu ouvres l'article proposé, un liseré bleu et un médaillon longue-vue en haut du lecteur te rappellent d'où il vient."
+      "summary": "La suggestion « Pas de recul » passe en tête des suites de lecture, juste avant « Comparer les angles », avec un bandeau bleu pleine largeur un peu plus présent. Et quand tu ouvres l'article proposé, un liseré bleu et un médaillon longue-vue en haut du lecteur te rappellent d'où il vient."
     },
     {
       "tag": "Ma Tournée",

--- a/apps/mobile/lib/config/routes.dart
+++ b/apps/mobile/lib/config/routes.dart
@@ -510,10 +510,15 @@ final routerProvider = Provider<GoRouter>((ref) {
                     pageBuilder: (context, state) {
                       final contentId = state.pathParameters['id']!;
                       final content = state.extra as Content?;
+                      // `from=pdr` → article ouvert depuis un CTA « Pas de
+                      // recul » : header contextuel (lavis bleu + médaillon 🔭).
+                      final fromDeepReco =
+                          state.uri.queryParameters['from'] == 'pdr';
                       return FullSwipeCupertinoPage(
                         child: ContentDetailScreen(
                           contentId: contentId,
                           content: content,
+                          fromDeepReco: fromDeepReco,
                         ),
                       );
                     },

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -156,8 +156,16 @@ class ContentDetailScreen extends ConsumerStatefulWidget {
   final String biasStance;
   final bool isExternal;
 
-  const ContentDetailScreen({super.key, required this.contentId, this.content})
-      : externalUrl = null,
+  /// `true` quand l'article a été ouvert depuis un CTA « Pas de recul »
+  /// (query param `from=pdr`) → header contextuel (lavis bleu + médaillon 🔭).
+  final bool fromDeepReco;
+
+  const ContentDetailScreen({
+    super.key,
+    required this.contentId,
+    this.content,
+    this.fromDeepReco = false,
+  })  : externalUrl = null,
         sourceName = null,
         sourceDomain = null,
         externalTitle = null,
@@ -177,7 +185,8 @@ class ContentDetailScreen extends ConsumerStatefulWidget {
         content = null,
         externalUrl = url,
         externalTitle = title,
-        isExternal = true;
+        isExternal = true,
+        fromDeepReco = false;
 
   @override
   ConsumerState<ContentDetailScreen> createState() =>
@@ -2143,7 +2152,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   /// route `content/:id` (re)fetch le Content depuis l'id, donc pas d'`extra`.
   void _openDeepReco(DeepRecommendation reco) {
     if (reco.contentId.isEmpty) return;
-    context.push('${RoutePaths.flaner}/content/${reco.contentId}');
+    // `from=pdr` signale au reader ouvert qu'il vient d'un CTA « Pas de recul »
+    // → header contextuel (lavis bleu + médaillon 🔭). L'`extra` étant déjà
+    // pris par `Content?`, on passe le contexte via un query param.
+    context.push('${RoutePaths.flaner}/content/${reco.contentId}?from=pdr');
   }
 
   void _schedulePerspectivesPartialRefetch(String contentId) {
@@ -3038,6 +3050,21 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       ),
       child: Stack(
         children: [
+          // Lavis bleu vertical quand l'article vient d'un CTA « Pas de recul »
+          // (écho du header CTA). Peint au-dessus du fond opaque du pill mais
+          // derrière la Row → subtil, sans nuire à la lisibilité des icônes.
+          if (widget.fromDeepReco)
+            Positioned.fill(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    colors: DeepReculMedallion.lavisColors(colors.info),
+                  ),
+                ),
+              ),
+            ),
           Container(
             padding: EdgeInsets.only(
               top: topInset + FacteurSpacing.space3,
@@ -3063,6 +3090,13 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                     onPressed: _handleReaderBack,
                   ),
                   const SizedBox(width: 4),
+
+                  // Médaillon 🔭 contextuel : marque l'origine « Pas de recul »
+                  // sans encombrer le header (uniquement si fromDeepReco).
+                  if (widget.fromDeepReco) ...[
+                    const DeepReculMedallion(size: 26),
+                    const SizedBox(width: 6),
+                  ],
 
                   // CTA source unique : logo + nom + étoile (indicateur) + heure,
                   // le tout tappable → ouvre directement la modal source (plus de

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -4066,6 +4066,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         final textTheme = Theme.of(context).textTheme;
         final articleText = content.htmlContent ?? content.description;
         final isPartial = isPartialContent(articleText);
+        // Le pas de recul est désormais surfacé EN TÊTE des suites de lecture
+        // (au-dessus de « Comparer les angles ») ; ce flag pilote l'ordre et la
+        // respiration entre les deux blocs de fin de reader.
+        final hasDeepReco =
+            _perspectivesResponse?.deepRecommendation != null && !_isExternal;
 
         String? readingTime;
         if (content.durationSeconds != null && content.durationSeconds! > 0) {
@@ -4189,11 +4194,37 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                   ],
                 ),
 
-                // ── Perspectives section (fin du reader) ───────────────────
-                // Bande frostée encastrée (hairline fine + teinte quasi-
-                // invisible) ; large respiration au-dessus pour la détacher.
-                if (_showPerspectivesBand) ...[
+                // ── « Le pas de recul » (deep reco) ─────────────────────────
+                // Carte d'analyse de fond, surfacée EN TÊTE des suites de
+                // lecture (au-dessus de « Comparer les angles ») : c'est la
+                // première proposition de suite. Silencieuse tant que
+                // deep_pending && reco null (calcul en cours).
+                if (hasDeepReco) ...[
                   const SizedBox(height: FacteurSpacing.space8),
+                  KeyedSubtree(
+                    // Clé de mesure pour le nudge de scroll « Prendre du recul ? »
+                    // (position de la carte vs pli — cf. _computeShouldShowScrollNudge).
+                    key: _deepRecoKey,
+                    child: DeepRecommendationCard(
+                      reco: _perspectivesResponse!.deepRecommendation!,
+                      onTap: () => _openDeepReco(
+                        _perspectivesResponse!.deepRecommendation!,
+                      ),
+                    ),
+                  ),
+                ],
+
+                // ── Perspectives section (« Comparer les angles ») ─────────
+                // Bande frostée encastrée (hairline fine + teinte quasi-
+                // invisible). Respiration réduite (space6) quand le pas de
+                // recul la précède, pleine respiration (space8) si elle est
+                // seule sous le corps.
+                if (_showPerspectivesBand) ...[
+                  SizedBox(
+                    height: hasDeepReco
+                        ? FacteurSpacing.space6
+                        : FacteurSpacing.space8,
+                  ),
                   RepaintBoundary(
                     // Isole les animations d'intro de la bande perspectives du
                     // corps vertical au-dessus (même motif que le reader natif).
@@ -4213,26 +4244,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                       divergenceLevel: _perspectivesResponse?.divergenceLevel,
                       partial: _perspectivesResponse?.partial ?? false,
                       onOpenAnalysis: _openPerspectivesAnalysis,
-                    ),
-                  ),
-                ],
-
-                // ── « Le pas de recul » (deep reco) ─────────────────────────
-                // Carte d'analyse de fond, surfacée SOUS la couverture
-                // médiatique (perspectives). Silencieuse tant que deep_pending
-                // && reco null (calcul en cours).
-                if (_perspectivesResponse?.deepRecommendation != null &&
-                    !_isExternal) ...[
-                  const SizedBox(height: FacteurSpacing.space4),
-                  KeyedSubtree(
-                    // Clé de mesure pour le nudge de scroll « Prendre du recul ? »
-                    // (position de la carte vs pli — cf. _computeShouldShowScrollNudge).
-                    key: _deepRecoKey,
-                    child: DeepRecommendationCard(
-                      reco: _perspectivesResponse!.deepRecommendation!,
-                      onTap: () => _openDeepReco(
-                        _perspectivesResponse!.deepRecommendation!,
-                      ),
                     ),
                   ),
                 ],

--- a/apps/mobile/lib/features/detail/widgets/deep_recommendation_card.dart
+++ b/apps/mobile/lib/features/detail/widgets/deep_recommendation_card.dart
@@ -12,9 +12,10 @@ import '../../feed/repositories/feed_repository.dart';
 /// avec une raison de match éditoriale ([DeepRecommendation.matchReason]). Un tap
 /// ouvre l'article recommandé dans le reader via [onTap].
 ///
-/// Design : composant `CardFinal` du handoff « Pas de recul · B6 final »,
-/// recoloré de la palette bleue d'origine vers l'orange `primary` Facteur (tokens
-/// dérivés de `colors.*` ⇒ cohérent en clair / sombre / oled).
+/// Design : variante « Pas de recul · B5 » du handoff Claude Design — bandeau
+/// pleine largeur discret (bord supérieur seul, dégradé horizontal en lavis,
+/// sans radius ni ombre), recoloré via le token `colors.info` (bleu ⇒ cohérent
+/// en clair / sombre / oled).
 class DeepRecommendationCard extends StatelessWidget {
   final DeepRecommendation reco;
   final VoidCallback? onTap;
@@ -28,125 +29,130 @@ class DeepRecommendationCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.facteurColors;
-    final primary = colors.primary;
-    final deep = colors.sectionEssentiel;
+    final info = colors.info;
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 18),
-      child: _PressableScale(
-        onTap: onTap,
-        child: Container(
-          padding: const EdgeInsets.fromLTRB(13, 14, 13, 14),
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(16),
-            // Dégradé linéaire simple sur une seule teinte (primary) : deux
-            // stops, progression douce, sans virer au blanc/surface.
-            gradient: LinearGradient(
-              begin: Alignment.topLeft,
-              end: Alignment.bottomRight,
-              colors: [
-                primary.withValues(alpha: 0.12),
-                primary.withValues(alpha: 0.04),
-              ],
+    return _PressableScale(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(22, 13, 22, 14),
+        decoration: BoxDecoration(
+          // Lavis horizontal (≈105°) : de gauche vers droite avec léger biais
+          // bas, s'estompant vers transparent avant le bord droit.
+          gradient: LinearGradient(
+            begin: Alignment.centerLeft,
+            end: const Alignment(1.0, 0.25),
+            colors: DeepReculMedallion.lavisColors(info),
+            stops: const [0.0, 0.5, 0.92],
+          ),
+          // Bord supérieur seul (bandeau edge-to-edge).
+          border: Border(
+            top: BorderSide(color: info.withValues(alpha: 0.18)),
+          ),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const DeepReculMedallion(size: 44),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Le pas de recul · Facteur'.toUpperCase(),
+                    style: GoogleFonts.courierPrime(
+                      fontSize: 10.5,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 1.3,
+                      height: 1.0,
+                      color: info,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 5),
+                  Text(
+                    reco.title,
+                    style: GoogleFonts.fraunces(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                      height: 1.2,
+                      letterSpacing: -0.3,
+                      color: colors.textPrimary,
+                    ),
+                    maxLines: 3,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 5),
+                  _SourceMeta(
+                    logoUrl: reco.sourceLogoUrl,
+                    sourceName: reco.sourceName,
+                    color: colors.textSecondary,
+                  ),
+                ],
+              ),
             ),
-            border: Border.all(color: primary.withValues(alpha: 0.07)),
-            boxShadow: [
-              BoxShadow(
-                color: Colors.black.withValues(alpha: 0.05),
-                offset: const Offset(0, 1),
-                blurRadius: 6,
+            const SizedBox(width: 8),
+            Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Icon(
+                PhosphorIcons.arrowRight(PhosphorIconsStyle.regular),
+                size: 18,
+                color: info,
               ),
-            ],
-          ),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _Medallion(primary: primary, deep: deep),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      'Le pas de recul · Facteur'.toUpperCase(),
-                      style: GoogleFonts.courierPrime(
-                        fontSize: 10.5,
-                        fontWeight: FontWeight.w700,
-                        letterSpacing: 1.3,
-                        height: 1.0,
-                        color: deep,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    const SizedBox(height: 5),
-                    Text(
-                      reco.title,
-                      style: GoogleFonts.fraunces(
-                        fontSize: 16,
-                        fontWeight: FontWeight.w600,
-                        height: 1.2,
-                        letterSpacing: -0.3,
-                        color: colors.textPrimary,
-                      ),
-                      maxLines: 3,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    const SizedBox(height: 5),
-                    _SourceMeta(
-                      logoUrl: reco.sourceLogoUrl,
-                      sourceName: reco.sourceName,
-                      color: colors.textSecondary,
-                    ),
-                  ],
-                ),
-              ),
-              const SizedBox(width: 8),
-              Padding(
-                padding: const EdgeInsets.only(top: 2),
-                child: Icon(
-                  PhosphorIcons.arrowRight(PhosphorIconsStyle.regular),
-                  size: 18,
-                  color: primary,
-                ),
-              ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );
   }
 }
 
-/// Médaillon circulaire 44px avec emoji longue-vue (style B5 : pas de ring ni
-/// d'ombre). Dégradé radial `primary → sectionEssentiel`.
-class _Medallion extends StatelessWidget {
-  final Color primary;
-  final Color deep;
+/// Médaillon circulaire longue-vue 🔭 (style B5 : pas de ring ni d'ombre).
+/// Dégradé radial bleu `info → navy`. Réutilisé par le header contextuel de
+/// l'article ouvert depuis un CTA « Pas de recul » (taille réduite).
+class DeepReculMedallion extends StatelessWidget {
+  /// Diamètre du médaillon ; l'emoji est dimensionné à ≈ `size * 0.48`.
+  final double size;
 
-  const _Medallion({required this.primary, required this.deep});
+  const DeepReculMedallion({super.key, this.size = 44});
+
+  /// Navy profond fixe (= `--pdr-deep` du mockup) pour le stop « lointain » du
+  /// radial, indépendant du thème pour garder la profondeur du médaillon.
+  static const Color _deep = Color(0xFF1B4F72);
+
+  /// Triple de couleurs du « lavis » Pas de recul (bleu `info` s'estompant vers
+  /// transparent). Source unique partagée par la carte CTA et le header
+  /// contextuel du reader → même tint des deux côtés (l'écho visuel est
+  /// justement l'intention de la feature). Seuls direction/stops diffèrent.
+  static List<Color> lavisColors(Color info) => [
+        info.withValues(alpha: 0.11),
+        info.withValues(alpha: 0.06),
+        Colors.transparent,
+      ];
 
   @override
   Widget build(BuildContext context) {
+    final colors = context.facteurColors;
     // Désature légèrement les deux extrémités vers la surface : couleur « moins
-    // marquée » sans perdre la chaleur ni le point focal lumineux du radial.
-    final surface = context.facteurColors.surface;
-    final softPrimary = Color.lerp(primary, surface, 0.12)!;
-    final softDeep = Color.lerp(deep, surface, 0.12)!;
+    // marquée » sans perdre le point focal lumineux du radial.
+    final surface = colors.surface;
+    final softInfo = Color.lerp(colors.info, surface, 0.12)!;
+    final softDeep = Color.lerp(_deep, surface, 0.12)!;
     return Container(
-      width: 44,
-      height: 44,
+      width: size,
+      height: size,
       decoration: BoxDecoration(
         shape: BoxShape.circle,
         gradient: RadialGradient(
           center: const Alignment(-0.4, -0.5), // focal ~30% / 25%
           radius: 0.9,
-          colors: [softPrimary, softDeep],
+          colors: [softInfo, softDeep],
           stops: const [0.0, 0.8],
         ),
       ),
       alignment: Alignment.center,
-      child: const Text('🔭', style: TextStyle(fontSize: 21)),
+      child: Text('🔭', style: TextStyle(fontSize: size * 0.48)),
     );
   }
 }

--- a/apps/mobile/lib/features/detail/widgets/deep_recommendation_card.dart
+++ b/apps/mobile/lib/features/detail/widgets/deep_recommendation_card.dart
@@ -34,26 +34,28 @@ class DeepRecommendationCard extends StatelessWidget {
     return _PressableScale(
       onTap: onTap,
       child: Container(
-        padding: const EdgeInsets.fromLTRB(22, 13, 22, 14),
+        padding: const EdgeInsets.fromLTRB(22, 16, 22, 18),
         decoration: BoxDecoration(
           // Lavis horizontal (≈105°) : de gauche vers droite avec léger biais
-          // bas, s'estompant vers transparent avant le bord droit.
+          // bas, s'estompant vers transparent avant le bord droit. Variante
+          // « strong » propre à la carte (accent PO) — le header contextuel
+          // garde le lavis standard.
           gradient: LinearGradient(
             begin: Alignment.centerLeft,
             end: const Alignment(1.0, 0.25),
-            colors: DeepReculMedallion.lavisColors(info),
+            colors: DeepReculMedallion.lavisColorsStrong(info),
             stops: const [0.0, 0.5, 0.92],
           ),
-          // Bord supérieur seul (bandeau edge-to-edge).
+          // Bord supérieur seul (bandeau edge-to-edge), accentué (PO).
           border: Border(
-            top: BorderSide(color: info.withValues(alpha: 0.18)),
+            top: BorderSide(color: info.withValues(alpha: 0.28), width: 1.0),
           ),
         ),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const DeepReculMedallion(size: 44),
-            const SizedBox(width: 12),
+            const DeepReculMedallion(size: 48),
+            const SizedBox(width: 14),
             Expanded(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -61,7 +63,7 @@ class DeepRecommendationCard extends StatelessWidget {
                   Text(
                     'Le pas de recul · Facteur'.toUpperCase(),
                     style: GoogleFonts.courierPrime(
-                      fontSize: 10.5,
+                      fontSize: 11,
                       fontWeight: FontWeight.w700,
                       letterSpacing: 1.3,
                       height: 1.0,
@@ -70,11 +72,11 @@ class DeepRecommendationCard extends StatelessWidget {
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),
-                  const SizedBox(height: 5),
+                  const SizedBox(height: 6),
                   Text(
                     reco.title,
                     style: GoogleFonts.fraunces(
-                      fontSize: 16,
+                      fontSize: 17.5,
                       fontWeight: FontWeight.w600,
                       height: 1.2,
                       letterSpacing: -0.3,
@@ -83,7 +85,7 @@ class DeepRecommendationCard extends StatelessWidget {
                     maxLines: 3,
                     overflow: TextOverflow.ellipsis,
                   ),
-                  const SizedBox(height: 5),
+                  const SizedBox(height: 6),
                   _SourceMeta(
                     logoUrl: reco.sourceLogoUrl,
                     sourceName: reco.sourceName,
@@ -97,7 +99,7 @@ class DeepRecommendationCard extends StatelessWidget {
               padding: const EdgeInsets.only(top: 2),
               child: Icon(
                 PhosphorIcons.arrowRight(PhosphorIconsStyle.regular),
-                size: 18,
+                size: 19,
                 color: info,
               ),
             ),
@@ -128,6 +130,18 @@ class DeepReculMedallion extends StatelessWidget {
   static List<Color> lavisColors(Color info) => [
         info.withValues(alpha: 0.11),
         info.withValues(alpha: 0.06),
+        Colors.transparent,
+      ];
+
+  /// Variante « dense » du lavis, réservée au bandeau de la carte CTA (accent
+  /// PO : présence visuelle qui justifie sa priorité en tête de reader). On ne
+  /// modifie **pas** [lavisColors] car ce tint est partagé avec le header
+  /// contextuel `fromDeepReco` — l'assombrir déborderait sur le header (l'écho
+  /// visuel entre les deux reste volontairement discret). Même stops/direction
+  /// que la version standard, seule l'opacité change.
+  static List<Color> lavisColorsStrong(Color info) => [
+        info.withValues(alpha: 0.16),
+        info.withValues(alpha: 0.09),
         Colors.transparent,
       ];
 


### PR DESCRIPTION
## Quoi

Refonte du CTA « Pas de recul » (deep recommendation) et de son écho dans le lecteur :
- La carte encadrée orange devient un **bandeau discret pleine largeur** (bord supérieur seul, dégradé horizontal en lavis, sans radius ni ombre), recoloré via le token `colors.info` (bleu, cohérent clair / sombre / oled).
- Quand l'article recommandé est ouvert, le **header du lecteur reçoit un contexte visuel** : liseré bleu vertical + médaillon longue-vue 🔭, pour rappeler l'origine « Pas de recul ».
- Le médaillon `_Medallion` est promu en `DeepReculMedallion` public, paramétré par `size` (44 dans la carte, 26 dans le header).

## Pourquoi

Le CTA orange encadré cassait l'altitude visuelle du reader ; le bandeau bleu discret + le rappel contextuel dans le header rendent le parcours « prendre du recul » plus cohérent et moins intrusif (design-system-first, tokens `colors.info`).

## Comment le contexte d'origine est passé

L'`extra` de la route `content/:id` étant déjà occupé par `Content?`, l'origine est transmise via le query param `?from=pdr` (`_openDeepReco` → `routes.dart` → `ContentDetailScreen.fromDeepReco`), exactement comme le précédent `?from=onboarding`.

## Comment ça a été vérifié

- [x] `flutter test test/features/detail/deep_recommendation_card_test.dart` — 3/3 OK
- [x] `flutter analyze` sur les 3 fichiers touchés — 0 nouvelle issue (les infos/warnings restants sont pré-existants, hors lignes modifiées)
- [x] `/simplify` passé (4 agents reuse/simplification/efficacité/altitude) → couleurs du lavis factorisées en source unique `DeepReculMedallion.lavisColors`, reste jugé clean
- [ ] Playwright non exécuté : atteindre un CTA « Pas de recul » live exige des données perspectives seedées côté back non disponibles en local ; couverture assurée par les widget tests

> Les 4 échecs `notification_test.dart` sont des stubs `fail('Test not implemented')` pré-existants (Issue 3), sans lien avec ce diff, et non joués en CI.

## Zones à risque

- `content_detail_screen.dart` (reader header) — les deux couches (lavis + médaillon) sont **gatées** par `if (widget.fromDeepReco)`, aucun surcoût sur le chemin par défaut.
- `routes.dart` — parse additif d'un query param, rétro-compatible.

## Impact utilisateur

Entrée changelog in-app « Pas de recul » ajoutée (impact visible).
