### PR TITLE
feat(lecture-aboutie): rendre la complétion visible, durable et non rejouable (Epic 30)

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,47 +1,107 @@
-# feat(tournee): suggestions garanties + quota visible + CTA carte + instrumentation (story 22.6)
+# feat(lecture-aboutie): rendre la complétion visible, durable et non rejouable (Epic 30)
 
-Story 22.6 (PR 2), base `main`. Rend la Tournée « vivante » : un accent quotidien
-de 4-5 sections « Choisie pour vous » **garanti pour tous** (même 8+ favoris), un
-quota de 3 suggestions visibles sous le cap pour les comptes personnalisés, un CTA
-direct sur la carte, et l'instrumentation PostHog. **Aucune migration** (additif,
-expand-safe, 1 head Alembic). Invariant 22.3 conservé (jamais hors univers suivi).
+Epic 30 « La lecture aboutie », base `main`. **Aucune migration** (1 head Alembic,
+`mg04_merge_pt01_rd01`, inchangé).
 
-> PR 1 (`promoteSuggestion` fiabilisé) vit dans un autre workspace ; cette PR
-> suppose la même signature `promoteSuggestion(section)` et ajoute seulement un
-> `origin` **optionnel** (défaut `card`) → rebase non cassante.
+L'audit fichier par fichier de `main` a établi que la moitié visible de la demande
+d'origine n'était jamais montée à l'écran, que la complétion ne survivait pas au
+redémarrage, et que deux bugs backend restaient ouverts, dont un que #1007 avait
+aggravé.
 
-## A. Backend — plancher de suggestions
+## A. Backend
 
-- `scoring_config.py` : `TOURNEE_SUGGEST_FLOOR = 4` ; `TOURNEE_SUGGEST_SUBCAP` 8 → 5.
-- `routers/users.py` `_arrange_tournee` : `sub_cap = min(SUBCAP, max(remaining, FLOOR))` ;
-  suppression de l'early-return `remaining <= 0` (gate `_smart_arrangement_enabled` conservé).
-  Effet : 0 favori → 5, 7 favoris → 4, 8+ favoris → 4. Pool pauvre → sert moins, jamais d'invention.
+- **`_update_closure_streak(user_id, target_date)` estampille l'édition close**,
+  plus une notion de « aujourd'hui ». Le correctif de #1007 avait remplacé une
+  frontière UTC (00h→02h Paris) par la frontière éditoriale 07h30 alors que ses
+  deux appelants cherchent le digest via `today_paris()` (minuit) : la fenêtre de
+  divergence avait *grandi*. Un lecteur qui clôturait l'édition D à 01h se voyait
+  estampiller D-1, puis sa série remise à 1 le lendemain. **Zéro test ne couvrait
+  la méthode** (mockée dans les 3 fichiers qui l'approchent) ; elle l'est
+  maintenant, démockée, contre une vraie base.
+- **Garde-fou édition passée** : `complete_digest` accepte n'importe quel
+  `digest_id` et le sélecteur de date sert les éditions J-7. Un `days_since`
+  négatif tombait dans la branche « série cassée » (reset à 1) *et* ramenait
+  `last_closure_date` en arrière, cassant aussi la clôture du lendemain.
+- **`week_start_paris()`** dans `app/utils/time.py` : la règle « semaine = lundi,
+  heure de Paris » était recopiée 3 fois sur un `date.today()` UTC (reset hebdo
+  une à deux heures trop tôt le lundi côté lecteur).
+- **`DAILY_COMPLETION_GOAL`** descend dans `app.schemas.streak` : le
+  `daily_goal: int = 2` du schéma était un doublon en dur, libre de diverger.
+  Sens de dépendance `services → schemas` conservé.
+- **`count_completed_today`** (le compteur exposé à l'UI) a enfin des tests
+  (J-3, frontière 07h30 des deux côtés, scope utilisateur).
+- **`EssentielArticle.completed_at`** est servi : la carte héros de la Tournée ne
+  pouvait pas connaître la complétion, alors que `_to_essentiel_article` recevait
+  déjà le champ.
 
-## B. Mobile — quota visible ≥3 sous le cap
+## B. Mobile — durabilité
 
-- `flux_continu_provider.dart` `_orderedTourneeKeys` : insertion additive à la frontière du cap ;
-  `quota = min(kTourneeSuggestQuota=3, suggestions visibles)`, favoris tronqués à `cap - quota`
-  **sans permutation**, puis les `quota` premières suggestions en queue. No-op non-personnalisé.
+- **`CompletedReadsStore`** (box Hive `completed_reads` dédiée, purge 30 j, cap
+  1000). Box séparée de `pending_reads` : cette dernière est une file de synchro
+  qui *supprime* l'entrée au succès. `markCompleted` écrit le registre d'abord,
+  puis l'état, comme `markConsumed`.
+- **Hydratation poussée** au démarrage (one-shot, post-frame), pas watchée :
+  faire dépendre `completedContentIdsProvider` de `readSyncUserIdProvider`
+  remonterait à `Supabase.instance` et casserait tout widget test montant une carte.
+- **Fuite inter-comptes** : `completedContentIdsProvider` est vidé au logout.
 
-## C. Mobile — CTA « Ajouter à mon Essentiel »
+## C. Mobile — visible
 
-- `section_block.dart` : `onPromoteSuggestion` + `_PromoteSuggestionButton` (spinner, anti
-  double-tap, SnackBar « Ajouté à ton Essentiel »). Banner (badge + info-tap → sheet) inchangé.
-- `flux_continu_screen.dart` : câble `promoteSuggestion(section, origin: 'card')` ; la sheet
-  passe `origin: 'sheet'`.
+- **`ReadStateMark`** partagé remplace 2 des 3 copies privées : celle de la carte
+  Essentiel codait `check` en dur, donc était *structurellement* incapable
+  d'afficher une complétion. `_ReadStatusPill` (timeline d'éditions) n'est pas
+  touchée : elle décrit l'état d'une *édition*, pas d'un article.
+- **`AnimatedFeedCard`** était restée orpheline (0 référence dans `lib/`) : le
+  filet vert n'existait pas à l'écran. Elle est montée sur les 3 familles de
+  cartes en `animate: false` (un état au montage, une animation seulement sur la
+  transition de retour d'article). Son `AnimationController` était `late final`
+  et n'était instancié qu'au `dispose()` d'une carte non aboutie : inoffensif
+  tant qu'elle était du code mort, systématique dès qu'elle est montée partout.
+- **Mapping** : `FluxArticleVM.from(DigestItem)` et `articleToContent` jetaient
+  `completedAt` ; le modèle mobile `EssentielArticle` ne le parsait pas.
+- **Layout du cachet** : sorti de la `Column` du pied de page (il y ajoutait
+  ~34 px alors que `_kFooterContentHeight` sert de spacer à 9 endroits) et rendu
+  **frère** du pill via `Stack` + `FractionalTranslation(0, -1)`. Aucune mesure,
+  les 9 usages inchangés.
 
-## D. Instrumentation PostHog
+## D. Mobile — réouverture
 
-- `analytics_service.dart` : `trackSuggestionImpression` / `Promoted` / `Dismissed`.
-- Impressions dédupliquées **1/section/jour, persistées** (SharedPreferences `suggestion_impressions_v1`,
-  purge des jours passés). Émission au premier build de la section suggérée.
+- **`ArticleCompletionLatch`** (Dart pur, testé) sépare l'état connu à l'ouverture
+  de l'événement de session. Rouvrir un article terminé ne rejoue plus haptique +
+  POST + `article_finished` — l'événement même qui doit servir à calibrer
+  l'objectif journalier, jusqu'ici gonflé par les relectures.
+
+## E. Silences
+
+- Le `catch (_)` du flush de la file de lectures remonte à Sentry, hors erreurs de
+  connectivité (cas nominal de cette file, `isOfflineError`).
+- L'opt-out gamification n'échoue plus en silence (relit la vérité serveur + le dit).
 
 ## Vérification
 
-- Backend : `pytest` — 37 tests top-themes/suggester/users OK ; 1 head Alembic (`181c618da382`).
-- Mobile : `flutter test` — 453 tests flux_continu OK, 29 section_block, 14 analytics ;
-  `flutter analyze` 0 erreur (5 warnings pré-existants `dio.post` hors périmètre).
-- Changelog in-app : entrée « Ma Tournée » ajoutée (impact visible).
+- Backend : `pytest` — **2514 passed**, 18 skipped, 2 xfailed, 0 échec.
+  1 head Alembic, aucune migration ajoutée.
+- Mobile : `flutter test` — **+1747 / -28**, les 28 échecs dans 8 fichiers
+  qu'aucun commit de cette PR ne touche (baseline documentée ~27 :
+  `auth/router_redirection`, `custom_topics`, `digest/bookmark`,
+  `detail/notification_test`, `feed_sources`, `perspectives_*`, `settings/*`,
+  `widget_test`). Les 53 tests des fichiers touchés/ajoutés passent.
+- `flutter analyze` : **0 erreur**.
+- Changelog in-app : entrée « Lecture » ajoutée (impact visible).
 
-Story : `docs/stories/core/22.6.tournee-suggestions-garanties-cta.md`.
-QA handoff : `.context/qa-handoff.md`.
+## Zones à risque
+
+`digest_service._update_closure_streak` (série de clôture), `read_sync_service`
+(file de synchro des lectures), boot Hive (`main.dart`, 7e box), et les 3 familles
+de cartes du feed.
+
+Story : `docs/stories/core/30.lecture-aboutie/README.md` (§11 journal
+d'implémentation).
+
+## Reste ouvert
+
+- Fenêtre de 14 j de collecte `article_finished` (PostHog) avant d'arrêter
+  `DAILY_COMPLETION_GOAL` sur P50/P75/P90. La correction de la réouverture est ce
+  qui rend cette distribution exploitable.
+- `/validate-feature` (parcours visuels : cachet, filet, anneau) non exécuté —
+  Flutter web n'était pas lancé dans cet environnement.

--- a/.context/qa-handoff.md
+++ b/.context/qa-handoff.md
@@ -1,77 +1,67 @@
-# QA Handoff — Tournée vivante : suggestions garanties + CTA (Story 22.6)
+# QA Handoff — Objectif quotidien réglable + footer validé vert (story 30.2)
 
 > Rempli par l'agent dev. Input de /validate-feature. Story :
-> `docs/stories/core/22.6.tournee-suggestions-garanties-cta.md`.
+> `docs/stories/core/30.2.objectif-quotidien-reglable.md`.
 
 ## Feature développée
-
-La Tournée du jour garantit désormais un accent quotidien de 4-5 sections
-« Choisie pour vous » **pour tous les comptes** (même 8+ favoris), avec un quota
-de 3 suggestions visibles sous le cap d'affichage pour les comptes personnalisés,
-et un CTA direct « Ajouter à mon Essentiel » sur chaque carte suggérée.
+L'objectif quotidien de lectures abouties devient réglable (1 → 7, défaut 2) via
+un curseur dans l'écran « Progression », persisté serveur (`daily_goal`). Le toast
+« objectif atteint » propose un CTA pour l'ajuster, et le footer d'un article
+terminé passe tout au vert `success`.
 
 ## PR associée
-
-À créer via `/go` (base `main`).
+À créer (`/go`) vers `main`.
 
 ## Écrans impactés
-
 | Écran | Route | Modifié / Nouveau |
 |-------|-------|-------------------|
-| Tournée du jour / Flux Continu | `/flux-continu` | Modifié |
-| Sheet « Pourquoi cette section ? » | overlay | Inchangé (toujours fonctionnel) |
+| Progression | `/lettres` | Modifié — nouvelle carte « Objectif quotidien » sous l'en-tête |
+| Lecteur d'article (détail) | `/flaner/content/:id` | Modifié — CTA toast + couleur footer |
 
 ## Scénarios de test
 
-### Scénario 1 : Happy path — CTA sur la carte suggérée
-**Parcours** :
-1. Ouvrir la Tournée du jour avec un compte qui reçoit des suggestions.
-2. Repérer une section badgée « Choisie pour vous ».
-3. Taper le bouton « Ajouter à mon Essentiel » en pied de carte.
-**Résultat attendu** : spinner bref, SnackBar « Ajouté à ton Essentiel », la
-section devient favorite (badge « Choisie pour vous » disparaît), l'ordre des
-autres favoris n'est **pas** permuté.
+### Scénario 1 : Régler l'objectif (happy path)
+1. Ouvrir « Progression » (`/lettres`).
+2. Repérer la carte « Objectif quotidien » (sous l'en-tête).
+3. Glisser le curseur de 2 à 5.
+**Attendu** : la valeur affichée passe à « 5 articles » ; après un reload de
+l'écran, la valeur reste 5 (persistée serveur).
 
-### Scénario 2 : Quota visible (compte personnalisé)
-**Parcours** :
-1. Compte avec un ordre de Tournée personnalisé et beaucoup de favoris (proche
-   du cap 13).
-2. Ouvrir la Tournée.
-**Résultat attendu** : exactement 3 sections « Choisie pour vous » restent
-visibles en queue, sous le cap — elles ne sont plus toutes coupées.
+### Scénario 2 : CTA du toast à l'objectif atteint
+1. Régler l'objectif à 1 (pour atteindre l'objectif en une lecture).
+2. Ouvrir un article et le lire jusqu'au bout.
+**Attendu** : le toast `micro` « lu jusqu'au bout » affiche la ligne tappable
+« Quel objectif on se donne ? » ; un tap ouvre l'écran Progression et ferme le
+toast.
 
-### Scénario 3 : Dismiss d'une suggestion
-**Parcours** :
-1. Sur une section suggérée, ouvrir le « i » du badge → sheet.
-2. Choisir « Retirer » (dismiss).
-**Résultat attendu** : la section disparaît (retrait local réversible) ; une
-autre suggestion coupée par le cap peut remonter à sa place.
+### Scénario 3 : Pas de CTA sous l'objectif
+1. Régler l'objectif à 3.
+2. Lire un seul article jusqu'au bout (1/3).
+**Attendu** : le toast affiche « 1/3 » sans CTA.
 
-### Scénario 4 : Anti double-tap
-**Parcours** :
-1. Taper rapidement 2× le bouton « Ajouter à mon Essentiel ».
-**Résultat attendu** : une seule promotion (bouton désactivé pendant l'attente),
-une seule SnackBar.
+### Scénario 4 : Footer validé vert
+1. Lire un article jusqu'au bout.
+**Attendu** : le pied de page passe en état validé — le bouton « Lire sur … »
+est vert `success` (plus de gris), cohérent avec la teinte du pill et le toast.
+
+### Scénario 5 : Gate gamification
+1. Désactiver la gamification (réglages).
+2. Ouvrir « Progression ».
+**Attendu** : la carte « Objectif quotidien » est masquée.
 
 ## Critères d'acceptation
-
-- [ ] 4-5 suggestions/jour garanties, y compris pour un compte 8+ favoris.
-- [ ] ≥3 suggestions visibles sous le cap pour un compte personnalisé, ordre des
-  favoris préservé.
-- [ ] CTA « Ajouter à mon Essentiel » rendu uniquement sur les sections suggérées.
-- [ ] La sheet « Pourquoi cette section ? » (garder/retirer) reste fonctionnelle.
-- [ ] Pas d'em-dash dans la copy visible.
+- [ ] Curseur 1 → 7, défaut 2, valeur persistée après reload.
+- [ ] CTA présent uniquement à `current >= total`.
+- [ ] Footer article terminé entièrement vert `success`.
+- [ ] Carte masquée si gamification désactivée.
+- [ ] Console sans erreurs, réseau sans 4xx/5xx inattendus.
 
 ## Zones de risque
-
-- Ordre des favoris jamais permuté par l'insertion du quota (vérifier visuellement).
-- Sections éditoriales (Actus, Bonnes, Grille) : sur un compte très chargé elles
-  peuvent être repoussées hors cap (comportement pré-existant, non aggravé).
-- Instrumentation PostHog : impression dédupliquée 1×/section/jour (persistée) —
-  non visible à l'écran mais à ne pas casser.
+- Optimistic UI du curseur : rollback + SnackBar si le PUT échoue.
+- Le CTA du toast n'est tappable que sur sa propre ligne (niveau `micro` non
+  tappable globalement).
 
 ## Dépendances
-
-- Backend `GET /api/users/top-themes` (plancher de suggestions, aucune migration).
-- Events PostHog : `suggestion_impression`, `suggestion_promoted`,
-  `suggestion_dismissed`.
+- `PUT /api/users/profile` avec `{"daily_goal": <1..7>}` (422 hors bornes).
+- `GET /api/streaks` (ou route streak) renvoie `daily_goal`.
+- Migration `dg01_daily_goal_user_profiles` appliquée (colonne `user_profiles.daily_goal`).

--- a/.github/workflows/alembic-smoke.yml
+++ b/.github/workflows/alembic-smoke.yml
@@ -12,6 +12,12 @@ on:
       - 'packages/api/alembic/**'
       - 'packages/api/requirements.txt'
       - '.github/workflows/alembic-smoke.yml'
+  # Sans filtre `paths` : deux PRs mergées le même jour depuis la même base
+  # créent un fork que ni l'une ni l'autre ne voyait (le smoke tourne sur la PR
+  # et ne rejoue pas quand la base bouge sous elle). Rejouer sur `main` rend le
+  # fork rouge dans la minute au lieu d'être découvert par un 503 en staging.
+  push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Lecture",
+      "summary": "Les articles que tu as lus jusqu'au bout se reconnaissent d'un coup d'œil : un fin filet vert au bord de la carte et une double coche. La marque reste après un redémarrage de l'app, et rouvrir un article terminé ne le recompte plus."
+    },
+    {
       "tag": "Pas de recul",
       "summary": "La suggestion « Pas de recul » passe en tête des suites de lecture, juste avant « Comparer les angles », avec un bandeau bleu pleine largeur un peu plus présent. Et quand tu ouvres l'article proposé, un liseré bleu et un médaillon longue-vue en haut du lecteur te rappellent d'où il vient."
     },

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Objectif du jour",
+      "summary": "Tu choisis désormais ton objectif quotidien : dans « Progression », un curseur règle le nombre d'articles à lire jusqu'au bout pour valider ta journée (de 1 à 7). Quand tu l'atteins, le message de félicitation te propose de le réajuster, et le pied de page d'un article terminé passe tout au vert."
+    },
+    {
       "tag": "Lecture",
       "summary": "Les articles que tu as lus jusqu'au bout se reconnaissent d'un coup d'œil : un fin filet vert au bord de la carte et une double coche. La marque reste après un redémarrage de l'app, et rouvrir un article terminé ne le recompte plus."
     },

--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -45,6 +45,7 @@ class FacteurApp extends ConsumerStatefulWidget {
 class _FacteurAppState extends ConsumerState<FacteurApp>
     with WidgetsBindingObserver {
   bool _deepLinksStarted = false;
+  bool _completedReadsHydrated = false;
   bool _wasBackgrounded = false;
   DateTime? _backgroundedAt;
 
@@ -280,6 +281,9 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
         unawaited(ref.read(readSyncServiceProvider).flushCurrentUser());
       } else if (prev?.isAuthenticated == true) {
         ref.read(consumedContentIdsProvider.notifier).state = <String>{};
+        // Idem pour les lectures abouties, sans quoi le compte suivant hérite
+        // du filet de complétion du précédent.
+        ref.read(completedContentIdsProvider.notifier).state = <String>{};
         _endAnalyticsSessionIfNeeded();
       }
     });
@@ -287,6 +291,22 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
     DeepLinkService.instance.setAuthenticated(
       ref.read(authStateProvider).isAuthenticated,
     );
+    // Complétions durables relues au démarrage : le filet de lecture aboutie
+    // doit survivre au kill de l'app, la session ne le porte plus seule.
+    //
+    // One-shot (même motif que `_deepLinksStarted`) et hors frame de build :
+    // `build` se rejoue à chaque changement de router/thème/preload, et
+    // l'hydratation rescanne toute la box + mute un provider — deux choses
+    // qui n'ont rien à faire dans un `build`. Si l'utilisateur n'est pas
+    // encore authentifié ici, c'est `flushCurrentUser()` du `ref.listen`
+    // ci-dessus qui hydratera à la connexion.
+    if (!_completedReadsHydrated) {
+      _completedReadsHydrated = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        ref.read(readSyncServiceProvider).hydrateCompletedReads();
+      });
+    }
 
     return MaterialApp.router(
       title: 'Facteur',

--- a/apps/mobile/lib/features/detail/models/article_completion_latch.dart
+++ b/apps/mobile/lib/features/detail/models/article_completion_latch.dart
@@ -1,0 +1,50 @@
+import '../../feed/services/read_sync_service.dart' show CompletionSource;
+
+/// Sépare l'**état** « cet article est lu jusqu'au bout » de l'**événement**
+/// « il vient de l'être dans cette session ».
+///
+/// Sans cette distinction, rouvrir un article terminé et re-scroller jusqu'en
+/// bas rejouait l'haptique, le POST de complétion et surtout `article_finished`
+/// — l'événement même qui doit servir à calibrer l'objectif journalier. Le
+/// compteur était donc gonflé par les relectures.
+///
+/// [seed] est appelé aux trois sources d'amorçage de l'écran (contenu passé au
+/// montage, registre local des complétions, réponse du fetch). Elle ne fait que
+/// *bloquer* : elle est monotone, donc un amorçage tardif ne peut jamais
+/// rouvrir un latch déjà fermé, et une source qui répond « non » après une
+/// source qui a répondu « oui » ne peut pas la contredire.
+///
+/// Classe Dart pure et non logique inline dans l'écran : `ContentDetailScreen`
+/// fait 4 800 lignes, monte une WebView et Supabase, et aucun test ne le monte.
+/// Inline, cette règle resterait non testée.
+class ArticleCompletionLatch {
+  bool _prior = false;
+  CompletionSource? _source;
+
+  /// L'article était déjà terminé à l'ouverture.
+  bool get priorCompleted => _prior;
+
+  /// État affichable : terminé, quelle que soit la session qui l'a produit.
+  /// `_source != null` *est* le drapeau de session — [latch] est son seul
+  /// écrivain et pose les deux ensemble, donc un booléen séparé ne serait
+  /// qu'un doublon à tenir synchronisé.
+  bool get completed => _prior || _source != null;
+
+  /// Source de la complétion **de cette session**, `null` s'il n'y en a pas eu.
+  CompletionSource? get source => _source;
+
+  void seed({required bool prior}) {
+    if (prior) _prior = true;
+  }
+
+  /// Tente de fermer le latch. Retourne `true` uniquement si l'appelant doit
+  /// émettre l'événement (haptique + POST + analytics).
+  ///
+  /// Le test `priorCompleted` sort **en tête** : c'est ce qui ferme la course,
+  /// plutôt qu'un drapeau de suppression consulté plus tard dans le listener.
+  bool latch(CompletionSource source, {bool isExternal = false}) {
+    if (_prior || _source != null || isExternal) return false;
+    _source = source;
+    return true;
+  }
+}

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -1112,6 +1112,13 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       total: total,
       label: 'lu jusqu\'au bout',
       accentColor: context.facteurColors.success,
+      // À l'objectif atteint (`current >= total`) : proposer d'ouvrir l'écran
+      // Progression pour régler la cible. Sinon aucun CTA (toast neutre).
+      onGoalCta: current >= total
+          ? () {
+              if (mounted) context.push(RoutePaths.lettres);
+            }
+          : null,
     );
     return true;
   }
@@ -2871,12 +2878,13 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                           // bottom of the article (footer locked permanent) AND
                           // the WebView hasn't been revealed yet.
                           //
-                          // Une fois l'article terminé, le pied de page porte
-                          // l'état « succès » (cachet vert) : l'action « Lire
-                          // sur … » se retire alors en `secondary` pour ne plus
-                          // concurrencer cet état. Un bouton d'action ne prend
-                          // jamais le vert, qui signifie « déjà fait » partout
-                          // ailleurs dans le produit.
+                          // Une fois l'article terminé, tout le pied de page
+                          // porte l'état « succès » (cachet + teinte vert) :
+                          // l'action « Lire sur … » passe elle aussi au vert
+                          // `success` pour un footer validé cohérent. La règle
+                          // antérieure (« un bouton d'action ne prend jamais le
+                          // vert ») est explicitement levée par le PO pour cette
+                          // itération (story 30.2).
                           final usePrimary =
                               permanent && !isWebViewMode && !completed;
                           final useSecondary = completed;
@@ -2929,7 +2937,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                             return FilledButton(
                               onPressed: _onReadOnSiteTap,
                               style: FilledButton.styleFrom(
-                                backgroundColor: colors.secondary,
+                                backgroundColor: colors.success,
                                 foregroundColor: Colors.white,
                                 shape: RoundedRectangleBorder(
                                   borderRadius: BorderRadius.circular(16),

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -22,7 +22,6 @@ import '../../../core/api/api_client.dart';
 import '../../../core/providers/analytics_provider.dart';
 import '../../../core/services/analytics_service.dart';
 import '../../../shared/widgets/fab_nudge_bubble.dart';
-import '../../../shared/widgets/completion_stamp.dart';
 import '../../../shared/widgets/glass_pill.dart';
 import '../../../shared/widgets/navigation/swipe_back_page.dart';
 import '../../feed/models/content_model.dart';
@@ -32,6 +31,10 @@ import '../../../config/routes.dart';
 import '../../feed/repositories/feed_repository.dart';
 import '../../feed/services/read_sync_service.dart';
 import '../../feed/widgets/perspectives_bottom_sheet.dart';
+import '../../gamification/providers/gamification_preference_provider.dart';
+import '../../gamification/providers/streak_provider.dart';
+import '../../lettres/widgets/progress_toast.dart';
+import '../models/article_completion_latch.dart';
 import '../../my_interests/models/user_interests_state.dart' show InterestState;
 import '../../my_interests/providers/user_sources_state_provider.dart';
 import '../../sources/providers/sources_providers.dart';
@@ -286,7 +289,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   /// contrainte de layout et non de sémantique. Or la WebView est justement le
   /// chemin nominal — ~90 % du catalogue est du contenu partiel.
   final ValueNotifier<bool> _articleCompleted = ValueNotifier<bool>(false);
-  CompletionSource? _completionSource;
+
+  /// Sépare l'état connu à l'ouverture de l'événement de cette session (cf.
+  /// [ArticleCompletionLatch]). [_articleCompleted] ne porte plus que
+  /// l'événement ; l'affichage lit `_completion.completed`.
+  final ArticleCompletionLatch _completion = ArticleCompletionLatch();
 
   /// Résolu en `initState` — jamais via `ref` depuis `dispose()`.
   AnalyticsService? _analytics;
@@ -520,6 +527,8 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       if (_content != null) {
         _isConsumed = _content!.status == ContentStatus.consumed ||
             ref.read(consumedContentIdsProvider).contains(_content!.id);
+        // Source d'amorçage n°1 : l'état porté par la carte d'où l'on vient.
+        _completion.seed(prior: _content!.isCompleted);
       }
       // Always fetch fresh content to accept latest metadata/status/theme
       _fetchContent();
@@ -598,6 +607,14 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     );
     _footerPermanent.addListener(_onFooterPermanentChanged);
     _articleCompleted.addListener(_onArticleCompletedChanged);
+
+    // Source d'amorçage n°2 : le registre local des complétions. Ne dépend pas
+    // de `_content`, donc couvre aussi les deep links et les notifications —
+    // et s'exécute **avant** que le listener ci-dessus puisse être déclenché.
+    // C'est cette ligne qui ferme la course.
+    _completion.seed(
+      prior: ref.read(completedContentIdsProvider).contains(widget.contentId),
+    );
 
     // Résolu UNE fois, ici. `ref.read` dans `dispose()` levait, l'exception
     // était avalée par le catch fourre-tout, et `article_read` /
@@ -1016,11 +1033,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   /// Latch one-shot de la complétion. Appelé depuis le listener de scroll, donc
   /// gardé par un test booléen en tête : pas d'allocation, pas de `setState`.
   void _latchCompleted(CompletionSource source) {
-    if (_articleCompleted.value) return;
-    if (_isExternal) return;
-    final article = _content;
-    if (article == null) return;
-    _completionSource = source;
+    if (_content == null) return;
+    // `ArticleCompletionLatch` refuse de se fermer si l'article était **déjà**
+    // terminé à l'ouverture : le notifier ne bascule alors jamais, donc le
+    // listener ne peut pas rejouer haptique + POST + `article_finished`.
+    if (!_completion.latch(source, isExternal: _isExternal)) return;
     _articleCompleted.value = true;
   }
 
@@ -1043,9 +1060,17 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     if (!_articleCompleted.value) return;
     final article = _content;
     if (article == null) return;
-    final source = _completionSource ?? CompletionSource.inApp;
+    final source = _completion.source ?? CompletionSource.inApp;
 
-    HapticFeedback.lightImpact();
+    // Toast « X/Y lu jusqu'au bout » à chaque complétion neuve — le PO inverse
+    // le garde-fou §4 (« aucun X/Y ») pour rendre l'objectif du jour palpable.
+    // Le latch garantit qu'une réouverture ne rejoue pas cet événement.
+    final showedToast = _maybeShowCompletionToast();
+    // Le toast `micro` joue déjà `selectionClick()` : ne pas doubler l'haptique
+    // (garde-fou §12). Sans toast (gamification off ou série inconnue), on garde
+    // l'haptique d'atterrissage.
+    if (!showedToast) HapticFeedback.lightImpact();
+
     unawaited(ref.read(readSyncServiceProvider).markCompleted(article.id, source));
     _analytics?.trackArticleFinished(
       contentId: article.id,
@@ -1061,6 +1086,34 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       articleCharCount:
           plainTextLength(article.htmlContent ?? article.description),
     );
+  }
+
+  /// Affiche le toast `micro` « X/Y lu jusqu'au bout » à la complétion. Renvoie
+  /// `true` si un toast a bien été montré (l'appelant saute alors l'haptique de
+  /// complétion pour éviter le double-buzz — le toast joue déjà `selectionClick`).
+  ///
+  /// Gaté par la préférence gamification (même gate que `DailyCompletionRecap`,
+  /// garde-fou §14). Compteur **optimiste** : `streakProvider` est dérivé serveur
+  /// et rafraîchi en asynchrone → on anticipe la complétion courante
+  /// (`dailyCompleted + 1`, borné par l'objectif). Série inconnue ⇒ pas de toast.
+  bool _maybeShowCompletionToast() {
+    if (!mounted) return false;
+    if (ref.read(gamificationPreferenceProvider).valueOrNull != true) {
+      return false;
+    }
+    final streak = ref.read(streakProvider).valueOrNull;
+    if (streak == null) return false;
+    final total = streak.dailyGoal;
+    final current = math.min(streak.dailyCompleted + 1, total);
+    showProgressToast(
+      context,
+      level: ProgressToastLevel.micro,
+      current: current,
+      total: total,
+      label: 'lu jusqu\'au bout',
+      accentColor: context.facteurColors.success,
+    );
+    return true;
   }
 
   String get _completionRenderMode {
@@ -1534,6 +1587,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
             _contentResolved = true;
             _isConsumed = _content!.status == ContentStatus.consumed ||
                 ref.read(consumedContentIdsProvider).contains(_content!.id);
+            // Source d'amorçage n°3 : la vérité serveur. Tardive, mais
+            // inoffensive — `seed` ne fait que bloquer.
+            _completion.seed(prior: merged.isCompleted);
           });
           // « Ouvrir = Lu » : redémarre le timer dès que le contenu est résolu
           // si on ne l'a pas encore marqué Lu (cas où _content était null au
@@ -2767,7 +2823,16 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     // Pill « verre » flottant, détaché des bords (marges + safe area gérées par
     // le Padding du Column parent). Rebord statique (cf. GlassPill) → aucun swap
     // au scroll, le logo de source ne se re-monte plus (fin de la vibration).
-    final footerContent = GlassPill(
+    //
+    // Article terminé → le pill se lave d'une teinte `success` (décision PO :
+    // « footer tout en vert »). Le `ValueListenableBuilder` sur
+    // `_articleCompleted` évite un `setState` dans le listener de scroll.
+    final footerContent = ValueListenableBuilder<bool>(
+      valueListenable: _articleCompleted,
+      builder: (context, _, __) => GlassPill(
+      fillTint: _completion.completed
+          ? colors.success.withValues(alpha: 0.14)
+          : null,
       shadowOffset: const Offset(0, -4),
       borderRadius: const BorderRadius.only(
         topLeft: Radius.circular(_kFrameRadius),
@@ -2783,24 +2848,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            // Le cachet « LU JUSQU'AU BOUT » vit dans le pied de page et non
-            // dans le flux de l'article : c'est le seul emplacement qui marche
-            // dans les quatre modes de rendu — impossible d'injecter quoi que
-            // ce soit dans le DOM de l'éditeur en WebView, qui est pourtant le
-            // chemin nominal.
-            ValueListenableBuilder<bool>(
-              valueListenable: _articleCompleted,
-              builder: (context, completed, _) {
-                if (!completed) return const SizedBox.shrink();
-                return const Padding(
-                  padding: EdgeInsets.only(bottom: 10),
-                  child: Align(
-                    alignment: Alignment.centerLeft,
-                    child: CompletionStamp(animate: true),
-                  ),
-                );
-              },
-            ),
             Row(
           children: [
             // CTA — sized to content for articles (laisse de la place aux 3
@@ -2813,10 +2860,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                 child: isArticle
                     ? ValueListenableBuilder<bool>(
                         valueListenable: _footerPermanent,
-                        builder: (context, permanent, _) =>
-                            ValueListenableBuilder<bool>(
-                          valueListenable: _articleCompleted,
-                          builder: (context, completed, _) {
+                        builder: (context, permanent, _) {
+                          // Le footer parent (`footerContent`) se reconstruit
+                          // déjà sur `_articleCompleted` : inutile de le réécouter
+                          // ici, on lit directement l'état de complétion.
+                          final completed = _completion.completed;
                           final isWebViewMode =
                               _ctaTapped || _isWebViewActive;
                           // Primary orange ONLY when the user has reached the
@@ -2955,7 +3003,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
                             child: Row(children: children),
                           );
                           },
-                        ),
                       )
                     : _buildExternalCtaButton(context, content),
               ),
@@ -3071,7 +3118,14 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           ],
         ),
       ),
+      ),
     );
+
+    // Le cachet « LU JUSQU'AU BOUT » a été retiré du reader (décision PO) : posé
+    // en overlay à fond transparent, il se superposait au carrousel Perspectives
+    // qui défile sous le footer. Le signal de complétion est désormais porté par
+    // le lavis `success` du pill (point B) et la barre de progression épaissie
+    // (point C). Le cachet reste utilisé ailleurs (`DailyCompletionRecap`).
 
     return ValueListenableBuilder<double>(
       valueListenable: _footerOffset,
@@ -3413,32 +3467,37 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         // Only show after 5% to avoid flashing on open
         if (progress < 0.05) return const SizedBox.shrink();
         final clamped = progress.clamp(0.0, 1.0);
-        // Grey→primary lerp, but opacity stays capped so the bar reads discreet
-        // even at full progress (15% at start → ~50% max at end).
-        final alpha = 0.15 + (clamped * 0.35);
-        // Article terminé : la barre vire au vert « succès ». Elle est
-        // l'instrument de mesure de la lecture, elle porte donc l'état — pas
-        // le bouton d'action.
-        final target =
-            _articleCompleted.value ? kStampGreen : colors.primary;
+        final completed = _completion.completed;
+        // Grey→target lerp. Article terminé : la barre devient le signal de
+        // complétion principal (elle remplace le cachet retiré du reader) — vert
+        // `success` plein et opacité relevée. Sinon elle reste discrète : opacité
+        // capée (15% au départ → ~50% en fin de lecture).
+        final alpha = completed ? 0.9 : 0.15 + (clamped * 0.35);
+        // Article terminé : la barre vire au vert « succès » (`colors.success`,
+        // le vert « lu » du produit). Elle est l'instrument de mesure de la
+        // lecture, elle porte donc l'état — pas le bouton d'action.
+        final target = completed ? colors.success : colors.primary;
         final barColor = Color.lerp(
           Colors.grey.shade400,
           target,
           clamped,
         )!
             .withValues(alpha: alpha);
+        // Complétion → barre plus épaisse (6 px) pour asseoir le signal
+        // « success » qui remplace le cachet ; sinon fine (3,5 px) et discrète.
+        final barHeight = completed ? 6.0 : 3.5;
         // Alimente la barre directement depuis `clamped` (déjà lissé par frame
         // par le scroll natif). Le `TweenAnimationBuilder` 300 ms était relancé
         // à CHAQUE frame de scroll → re-raster inutile. En mode WebView la
         // progression arrive throttlée (~300 ms) : la barre « step » au lieu
-        // d'interpoler, coût cosmétique négligeable sur 3,5 px semi-transparents.
+        // d'interpoler, coût cosmétique négligeable.
         return SizedBox(
-          height: 3.5,
+          height: barHeight,
           child: LinearProgressIndicator(
             value: clamped,
             backgroundColor: Colors.transparent,
             valueColor: AlwaysStoppedAnimation<Color>(barColor),
-            minHeight: 3.5,
+            minHeight: barHeight,
           ),
         );
       },

--- a/apps/mobile/lib/features/feed/services/completed_reads_store.dart
+++ b/apps/mobile/lib/features/feed/services/completed_reads_store.dart
@@ -1,0 +1,83 @@
+import 'package:hive_flutter/hive_flutter.dart';
+
+/// Registre durable des lectures **abouties** (Epic 30).
+///
+/// Box dédiée, séparée de `pending_reads` : cette dernière est une file de
+/// synchro dont `flushForUser` **supprime** l'entrée au succès. File de synchro
+/// et registre d'état ont des cycles de vie opposés — les mélanger ferait
+/// disparaître la complétion au premier flush réussi.
+///
+/// Elle est aussi préférée à un patch des snapshots de cache : `feed_cache` a
+/// un TTL de 10 min et `flux_continu_cache` s'invalide au changement de
+/// `day_key`, alors qu'une lecture aboutie est définitive.
+class CompletedReadsStore {
+  static const boxName = 'completed_reads';
+
+  /// Au-delà, une complétion n'éclaire plus aucune carte à l'écran : le feed
+  /// ne remonte pas si loin. Le serveur reste la source de vérité longue durée.
+  static const maxAge = Duration(days: 30);
+
+  /// ~2 ans à 1,2 complétion/jour actif, pour ~50 Ko sur disque.
+  static const maxEntries = 1000;
+
+  final Box<String> box;
+
+  CompletedReadsStore(this.box);
+
+  /// `null` si la box n'a pas pu être ouverte au boot — l'appelant retombe
+  /// alors sur l'état mémoire seul, jamais sur une exception.
+  static CompletedReadsStore? tryFromHive() {
+    if (!Hive.isBoxOpen(boxName)) return null;
+    return CompletedReadsStore(Hive.box<String>(boxName));
+  }
+
+  String _key(String userId, String contentId) => '$userId:$contentId';
+
+  Set<String> idsForUser(String userId) {
+    final prefix = '$userId:';
+    return {
+      for (final key in box.keys.whereType<String>())
+        if (key.startsWith(prefix)) key.substring(prefix.length),
+    };
+  }
+
+  Future<void> add(String userId, String contentId) async {
+    if (userId.isEmpty || contentId.isEmpty) return;
+    await box.put(_key(userId, contentId), DateTime.now().toIso8601String());
+    // Bornage à l'écriture et non au boot : le cold start est le chemin
+    // critique de l'app, et la box n'a de raison de grandir qu'ici.
+    await _prune();
+  }
+
+  Future<void> clearForUser(String userId) async {
+    final prefix = '$userId:';
+    await box.deleteAll(
+      box.keys.whereType<String>().where((key) => key.startsWith(prefix)),
+    );
+  }
+
+  Future<void> _prune() async {
+    final now = DateTime.now();
+    final expired = <String>[];
+    final dated = <MapEntry<String, DateTime>>[];
+
+    for (final key in box.keys.whereType<String>()) {
+      final stamp = DateTime.tryParse(box.get(key) ?? '');
+      // Valeur illisible : on la traite comme expirée plutôt que de la garder
+      // indéfiniment hors de portée du cap par âge.
+      if (stamp == null || now.difference(stamp) > maxAge) {
+        expired.add(key);
+        continue;
+      }
+      dated.add(MapEntry(key, stamp));
+    }
+
+    if (expired.isNotEmpty) await box.deleteAll(expired);
+    if (dated.length <= maxEntries) return;
+
+    dated.sort((a, b) => a.value.compareTo(b.value));
+    await box.deleteAll(
+      dated.take(dated.length - maxEntries).map((e) => e.key),
+    );
+  }
+}

--- a/apps/mobile/lib/features/feed/services/read_sync_service.dart
+++ b/apps/mobile/lib/features/feed/services/read_sync_service.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_flutter/hive_flutter.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../../core/auth/auth_state.dart';
@@ -12,6 +14,7 @@ import '../../gamification/providers/streak_provider.dart';
 import '../../flux_continu/services/flux_continu_cache_service.dart';
 import '../models/content_model.dart';
 import '../providers/feed_provider.dart';
+import 'completed_reads_store.dart';
 import 'feed_cache_service.dart';
 
 const articleReadThreshold = Duration(seconds: 1);
@@ -39,6 +42,22 @@ enum CompletionSource {
       orElse: () => CompletionSource.inApp,
     );
   }
+}
+
+/// Vrai pour les échecs de connectivité — le cas **nominal** de cette file
+/// (lire dans le métro), qu'il ne faut donc pas remonter : les noyer sous le
+/// bruit rendrait le signal inutile.
+bool isOfflineError(Object error) {
+  if (error is DioException) {
+    return error.type == DioExceptionType.connectionTimeout ||
+        error.type == DioExceptionType.receiveTimeout ||
+        error.type == DioExceptionType.sendTimeout ||
+        error.type == DioExceptionType.connectionError;
+  }
+  // `SocketException` n'est pas référençable ici (`dart:io` casse le build
+  // web) ; le type nu remonte de toute façon rarement jusqu'ici, Dio
+  // l'enveloppant presque toujours.
+  return error.runtimeType.toString() == 'SocketException';
 }
 
 bool shouldCommitReadOnBackground({
@@ -125,8 +144,20 @@ class PendingReadQueue {
       try {
         await sync(entry.value);
         await remove(entry.key);
-      } catch (_) {
-        // Keep the durable entry for the next cold-start/foreground retry.
+      } catch (e, st) {
+        // Keep the durable entry for the next cold-start/foreground retry —
+        // sémantique inchangée. Mais un échec durable (contrat cassé, 4xx)
+        // laissait la file grossir sans le moindre signal, et c'est cette file
+        // qui alimente le compteur de lectures abouties.
+        if (!isOfflineError(e)) {
+          unawaited(
+            Sentry.captureException(
+              e,
+              stackTrace: st,
+              withScope: (scope) => scope.setTag('op', 'read_sync_flush'),
+            ),
+          );
+        }
       }
     }
   }
@@ -180,8 +211,21 @@ final consumedContentIdsProvider = StateProvider<Set<String>>(
   (ref) => <String>{},
 );
 
-/// Articles lus **jusqu'au bout** pendant la session — permet aux cartes de
-/// refléter la complétion sans attendre un refetch.
+final completedReadsStoreProvider = Provider<CompletedReadsStore?>((ref) {
+  return CompletedReadsStore.tryFromHive();
+});
+
+/// Articles lus **jusqu'au bout** — permet aux cartes de refléter la complétion
+/// sans attendre un refetch.
+///
+/// Alimenté par [ReadSyncService.hydrateCompletedReads] depuis
+/// [CompletedReadsStore] : sans ça le filet de complétion disparaissait au
+/// premier cold start, alors qu'une lecture aboutie est définitive.
+///
+/// Hydratation **poussée** et non `ref.watch(readSyncUserIdProvider)` : ce
+/// dernier remonte jusqu'à `Supabase.instance`, et toutes les cartes watchent
+/// ce provider — les faire dépendre de l'init Supabase casserait chaque test
+/// de widget qui monte une carte, pour un gain nul en production.
 final completedContentIdsProvider = StateProvider<Set<String>>(
   (ref) => <String>{},
 );
@@ -249,6 +293,9 @@ class ReadSyncService {
     if (completedIds.state.contains(contentId)) return false;
 
     await queue.enqueue(userId, contentId, extra: {'source': source.wireValue});
+    // Durabilité d'abord (même ordre que `markConsumed`) : le registre survit
+    // au kill de l'app, contrairement au provider qui n'existe qu'en mémoire.
+    await ref.read(completedReadsStoreProvider)?.add(userId, contentId);
     completedIds.state = {...completedIds.state, contentId};
     unawaited(flushCompletionsForUser(userId));
     return true;
@@ -285,9 +332,27 @@ class ReadSyncService {
     }
   }
 
+  /// Recharge les complétions durables de l'utilisateur courant dans
+  /// [completedContentIdsProvider]. Appelée au démarrage et à chaque connexion :
+  /// c'est ce qui fait survivre le filet de complétion au kill de l'app.
+  void hydrateCompletedReads() {
+    final userId = ref.read(readSyncUserIdProvider);
+    if (userId == null) return;
+    final stored = ref.read(completedReadsStoreProvider)?.idsForUser(userId);
+    if (stored == null || stored.isEmpty) return;
+    final completedIds = ref.read(completedContentIdsProvider.notifier);
+    // Sortie sèche si le registre n'apporte rien : la méthode est appelée à
+    // chaque build de `FacteurApp`, et réassigner un `Set` neuf changerait son
+    // identité à chaque fois — donc rebâtirait toutes les cartes qui watchent
+    // ce provider, à contenu identique.
+    if (stored.every(completedIds.state.contains)) return;
+    completedIds.state = {...completedIds.state, ...stored};
+  }
+
   Future<void> flushCurrentUser() async {
     final userId = ref.read(readSyncUserIdProvider);
     if (userId == null) return;
+    hydrateCompletedReads();
     await flushForUser(userId);
     await flushCompletionsForUser(userId);
   }

--- a/apps/mobile/lib/features/feed/widgets/animated_feed_card.dart
+++ b/apps/mobile/lib/features/feed/widgets/animated_feed_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../config/theme.dart' show FacteurRadius;
 import '../../../shared/widgets/completion_stamp.dart' show kStampGreen;
 
 /// Marque discrètement, **au retour de l'article**, la carte d'une lecture
@@ -37,14 +38,21 @@ class AnimatedFeedCard extends StatefulWidget {
 
 class _AnimatedFeedCardState extends State<AnimatedFeedCard>
     with SingleTickerProviderStateMixin {
-  late final AnimationController _controller = AnimationController(
-    vsync: this,
-    duration: const Duration(milliseconds: 320),
-  );
+  // Créé en `initState` et **pas** `late final` : en `late`, une carte non
+  // aboutie ne touchait jamais le champ (initState et build sortent tous deux
+  // en amont), si bien que `dispose()` l'initialisait au moment même de la
+  // destruction — `vsync: this` allait alors chercher un ancêtre désactivé et
+  // levait. Invisible tant que le widget était du code mort, systématique dès
+  // qu'il est monté sur chaque carte.
+  late final AnimationController _controller;
 
   @override
   void initState() {
     super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 320),
+    );
     if (widget.isCompleted && !widget.animate) _controller.value = 1.0;
     if (widget.isCompleted && widget.animate) _startDelayed();
   }
@@ -118,7 +126,12 @@ class _CompletionRule extends StatelessWidget {
       width: 3,
       decoration: const BoxDecoration(
         color: kStampGreen,
-        borderRadius: BorderRadius.horizontal(left: Radius.circular(16)),
+        // Suit le rayon des cartes (`FacteurRadius.large`) : le filet doit
+        // épouser l'angle, pas déborder. Constante et non littéral 16 —
+        // l'égalité était une coïncidence.
+        borderRadius: BorderRadius.horizontal(
+          left: Radius.circular(FacteurRadius.large),
+        ),
       ),
     );
   }

--- a/apps/mobile/lib/features/feed/widgets/feed_card.dart
+++ b/apps/mobile/lib/features/feed/widgets/feed_card.dart
@@ -5,6 +5,8 @@ import 'package:facteur/config/theme.dart';
 import 'package:facteur/core/utils/html_utils.dart';
 import 'package:facteur/features/feed/models/content_model.dart';
 import 'package:facteur/features/feed/utils/article_title_layout.dart';
+import 'package:facteur/features/feed/services/read_sync_service.dart';
+import 'package:facteur/features/feed/widgets/animated_feed_card.dart';
 import 'package:facteur/features/feed/widgets/reading_badge.dart';
 import 'package:facteur/features/settings/models/display_mode_spec.dart';
 import 'package:facteur/widgets/design/facteur_card.dart';
@@ -15,10 +17,11 @@ import 'package:facteur/widgets/design/video_play_overlay.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:timeago/timeago.dart' as timeago;
 
-class FeedCard extends StatefulWidget {
+class FeedCard extends ConsumerStatefulWidget {
   final Content content;
   final VoidCallback? onTap;
   final GestureLongPressStartCallback? onLongPressStart;
@@ -116,10 +119,10 @@ class FeedCard extends StatefulWidget {
   });
 
   @override
-  State<FeedCard> createState() => _FeedCardState();
+  ConsumerState<FeedCard> createState() => _FeedCardState();
 }
 
-class _FeedCardState extends State<FeedCard>
+class _FeedCardState extends ConsumerState<FeedCard>
     with SingleTickerProviderStateMixin {
   late final AnimationController _pressController;
   late final Animation<double> _pressScale;
@@ -152,11 +155,25 @@ class _FeedCardState extends State<FeedCard>
     final isVideo = widget.content.contentType == ContentType.youtube || widget.content.contentType == ContentType.video;
 
     final hasBeenRead = isConsumed || widget.content.readingProgress > 0;
+    // Complété pendant la session : la carte reflète l'état sans refetch.
+    final isCompleted = widget.content.isCompleted ||
+        ref.watch(
+          completedContentIdsProvider.select(
+            (ids) => ids.contains(widget.content.id),
+          ),
+        );
     final card = Opacity(
       opacity: hasBeenRead ? 0.6 : 1.0,
       child: Stack(
         fit: widget.expandContent ? StackFit.expand : StackFit.loose,
         children: [
+          // Filet de complétion posé ici plutôt que sur les 6 call sites de
+          // `FeedCard` : un seul point d'accroche, et il englobe tout le
+          // chrome de la carte.
+          AnimatedFeedCard(
+            isCompleted: isCompleted,
+            animate: false,
+            child:
           // ScaleTransition wraps the ENTIRE card so the whole thing shrinks
           // uniformly (no white border gap between image+body and footer).
           ScaleTransition(
@@ -491,6 +508,7 @@ class _FeedCardState extends State<FeedCard>
                 // if (widget.clusterChipWidget != null) widget.clusterChipWidget!,
               ],
             ),
+          ),
           ),
           ), // ScaleTransition
           if (widget.content.hasNote)

--- a/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
+++ b/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
@@ -165,6 +165,11 @@ class EssentielArticle {
   final bool isSaved;
   final bool isLiked;
   final bool isDismissed;
+
+  /// « Lu jusqu'au bout ». Servi par `/api/essentiel`, distinct de [isRead] que
+  /// le seuil d'ouverture d'1 s suffit à déclencher.
+  final DateTime? completedAt;
+
   // Signaux user-aware servis par /api/essentiel pour rendre la personnalisation
   // et l'Actu du jour visibles côté carte (pastille, badges, avatar accent).
   final bool isFollowedSource;
@@ -189,6 +194,7 @@ class EssentielArticle {
     this.isSaved = false,
     this.isLiked = false,
     this.isDismissed = false,
+    this.completedAt,
     this.isFollowedSource = false,
     this.isFollowedTopic = false,
     this.isActuDuJour = false,
@@ -218,6 +224,7 @@ class EssentielArticle {
       isSaved: (json['is_saved'] as bool?) ?? false,
       isLiked: (json['is_liked'] as bool?) ?? false,
       isDismissed: (json['is_dismissed'] as bool?) ?? false,
+      completedAt: DateTime.tryParse(json['completed_at'] as String? ?? ''),
       isFollowedSource: (json['is_followed_source'] as bool?) ?? false,
       isFollowedTopic: (json['is_followed_topic'] as bool?) ?? false,
       isActuDuJour: (json['is_actu_du_jour'] as bool?) ?? false,
@@ -242,6 +249,7 @@ class EssentielArticle {
     'is_saved': isSaved,
     'is_liked': isLiked,
     'is_dismissed': isDismissed,
+    'completed_at': completedAt?.toIso8601String(),
     'is_followed_source': isFollowedSource,
     'is_followed_topic': isFollowedTopic,
     'is_actu_du_jour': isActuDuJour,

--- a/apps/mobile/lib/features/flux_continu/widgets/edition_timeline_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/edition_timeline_sheet.dart
@@ -298,8 +298,10 @@ class _ReadStatusPill extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         // État lu : coche verte (même motif que le badge « read » app-wide).
-        // (`_ReadCheckBadge` est privé/dupliqué ailleurs → on inline l'icône
-        // plutôt que d'introduire un import croisé.)
+        // Volontairement **pas** `ReadStateMark` : la pastille décrit l'état
+        // d'une *édition* (bascule `success`/`primary`), pas la complétion d'un
+        // article. Partager le widget ferait entrer un « lu jusqu'au bout » qui
+        // n'a aucun sens ici.
         if (read)
           Icon(
             PhosphorIcons.check(PhosphorIconsStyle.bold),

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -4,10 +4,12 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
+import '../../../shared/widgets/read_state_mark.dart';
 import '../../../widgets/article_preview_modal.dart';
+import '../../feed/services/read_sync_service.dart';
+import '../../feed/widgets/animated_feed_card.dart';
 import '../../detail/content_preview_mapper.dart';
 import '../../tour/tour_anchors.dart';
 import '../../settings/models/display_mode_spec.dart';
@@ -52,6 +54,12 @@ class EssentielHiFiCard extends ConsumerWidget {
     final colors = Theme.of(context).extension<FacteurColors>()!;
     final accent = colors.sectionEssentiel;
     final spec = ref.watch(displayModeSpecProvider);
+
+    // Un seul point de lecture du provider : le booléen descend ensuite dans
+    // les tuiles, qui restent des `StatelessWidget`.
+    final completedIds = ref.watch(completedContentIdsProvider);
+    bool isCompleted(EssentielArticle a) =>
+        a.completedAt != null || completedIds.contains(a.contentId);
 
     final lead = articles.isNotEmpty ? articles.first : null;
     final remaining = articles.length > 1
@@ -134,6 +142,7 @@ class EssentielHiFiCard extends ConsumerWidget {
                 article: lead,
                 accent: accent,
                 spec: spec,
+                isCompleted: isCompleted(lead),
                 onTap: () => onTapArticle(lead),
               ),
             for (final a in remaining) ...[
@@ -142,7 +151,12 @@ class EssentielHiFiCard extends ConsumerWidget {
               const SizedBox(height: 6),
               const _Hairline(),
               const SizedBox(height: 6),
-              _MediumTile(article: a, spec: spec, onTap: () => onTapArticle(a)),
+              _MediumTile(
+                article: a,
+                spec: spec,
+                isCompleted: isCompleted(a),
+                onTap: () => onTapArticle(a),
+              ),
             ],
           ],
         ),
@@ -611,6 +625,11 @@ class _LeadTile extends StatelessWidget {
   final EssentielArticle article;
   final Color accent;
   final DisplayModeSpec spec;
+
+  /// Lu jusqu'au bout : double coche + filet vert au bord gauche. Descendu par
+  /// la carte plutôt que relu ici — un seul point de lecture du provider.
+  final bool isCompleted;
+
   final VoidCallback onTap;
 
   const _LeadTile({
@@ -618,6 +637,7 @@ class _LeadTile extends StatelessWidget {
     required this.accent,
     required this.spec,
     required this.onTap,
+    required this.isCompleted,
   });
 
   @override
@@ -640,7 +660,10 @@ class _LeadTile extends StatelessWidget {
         // l'Opacity pour s'estomper de concert avec le contenu.
         child: Opacity(
           opacity: article.isRead ? 0.6 : 1.0,
-          child: Stack(
+          child: AnimatedFeedCard(
+            isCompleted: isCompleted,
+            animate: false,
+            child: Stack(
             children: [
               Container(
                 // Compaction passe 2 (validée UX) : padding héro 12→10. Plancher
@@ -686,9 +709,13 @@ class _LeadTile extends StatelessWidget {
                 Positioned(
                   top: 8,
                   right: 8,
-                  child: _ReadCheckBadge(color: colors.success),
+                  child: ReadStateMark(
+                    color: colors.success,
+                    isCompleted: isCompleted,
+                  ),
                 ),
             ],
+          ),
           ),
         ),
           ),
@@ -701,12 +728,14 @@ class _LeadTile extends StatelessWidget {
 class _MediumTile extends StatelessWidget {
   final EssentielArticle article;
   final DisplayModeSpec spec;
+  final bool isCompleted;
   final VoidCallback onTap;
 
   const _MediumTile({
     required this.article,
     required this.spec,
     required this.onTap,
+    required this.isCompleted,
   });
 
   @override
@@ -726,7 +755,10 @@ class _MediumTile extends StatelessWidget {
         // Lu : grise la tuile (0.6) + petite coche verte (cf. _LeadTile).
         child: Opacity(
           opacity: article.isRead ? 0.6 : 1.0,
-          child: Stack(
+          child: AnimatedFeedCard(
+            isCompleted: isCompleted,
+            animate: false,
+            child: Stack(
             children: [
               Padding(
                 padding: const EdgeInsets.symmetric(vertical: 2),
@@ -770,9 +802,14 @@ class _MediumTile extends StatelessWidget {
                 Positioned(
                   top: 0,
                   right: 0,
-                  child: _ReadCheckBadge(color: colors.success, size: 18),
+                  child: ReadStateMark(
+                    color: colors.success,
+                    isCompleted: isCompleted,
+                    size: 18,
+                  ),
                 ),
             ],
+          ),
           ),
         ),
           ),
@@ -862,42 +899,6 @@ class _SourceRow extends StatelessWidget {
           ),
         ),
       ],
-    );
-  }
-}
-
-/// Coche « lu » verte, reproduite à l'identique du motif de
-/// `flux_continu_article_card.dart` pour une cohérence visuelle entre la carte
-/// Essentiel et les cartes des autres sections. [size] permet une coche plus
-/// compacte sur les tuiles médiums.
-class _ReadCheckBadge extends StatelessWidget {
-  final Color color;
-  final double size;
-
-  const _ReadCheckBadge({required this.color, this.size = 22});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: size,
-      height: size,
-      decoration: BoxDecoration(
-        color: color,
-        shape: BoxShape.circle,
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.12),
-            blurRadius: 4,
-            offset: const Offset(0, 1),
-          ),
-        ],
-      ),
-      alignment: Alignment.center,
-      child: Icon(
-        PhosphorIcons.check(PhosphorIconsStyle.bold),
-        size: size * 0.55,
-        color: Colors.white,
-      ),
     );
   }
 }

--- a/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
@@ -6,12 +6,14 @@ import 'package:timeago/timeago.dart' as timeago;
 
 import '../../../config/theme.dart';
 import '../../../config/topic_labels.dart';
+import '../../../shared/widgets/read_state_mark.dart';
 import '../../../widgets/article_preview_modal.dart';
 import '../../../widgets/design/facteur_image.dart';
 import '../../digest/models/digest_models.dart';
 import '../../digest/widgets/divergence_inline_badge.dart';
 import '../../feed/models/content_model.dart';
 import '../../feed/services/read_sync_service.dart';
+import '../../feed/widgets/animated_feed_card.dart';
 import '../../feed/widgets/swipe_to_open_card.dart';
 import '../../settings/models/display_mode_spec.dart';
 import '../../settings/providers/display_mode_provider.dart';
@@ -73,6 +75,10 @@ class FluxArticleVM {
         publishedAt: article.publishedAt,
         isFollowedSource: article.isFollowedSource,
         isRead: article.isRead,
+        // `DigestItem` n'a pas de getter `isCompleted` : freezed exigerait un
+        // `const DigestItem._();` que la classe n'a pas. Inliné plutôt que
+        // régénéré.
+        isCompleted: article.completedAt != null,
       );
     }
     if (article is Content) {
@@ -163,6 +169,7 @@ class _FluxContinuArticleCardState
     final completedThisSession = ref.watch(
       completedContentIdsProvider.select((ids) => ids.contains(vm.contentId)),
     );
+    final isCompleted = vm.isCompleted || completedThisSession;
     final colors = context.facteurColors;
     final spec = ref.watch(displayModeSpecProvider);
     // Reclaim the thumb slot when the network image fails — avoids the
@@ -181,7 +188,13 @@ class _FluxContinuArticleCardState
         opacity: hasBeenRead ? 0.6 : 1.0,
         child: Stack(
           children: [
-            Material(
+            // `animate: false` au montage : le filet d'une carte déjà aboutie
+            // est peint d'emblée (c'est un état). `didUpdateWidget` anime la
+            // seule transition qui est un événement — le retour d'article.
+            AnimatedFeedCard(
+              isCompleted: isCompleted,
+              animate: false,
+              child: Material(
               color: colors.surface,
               borderRadius: cardRadius,
               elevation: 0,
@@ -214,13 +227,14 @@ class _FluxContinuArticleCardState
                 ),
               ),
             ),
+            ),
             if (hasBeenRead)
               Positioned(
                 top: 4,
                 right: 4,
-                child: _ReadCheckBadge(
+                child: ReadStateMark(
                   color: colors.success,
-                  isCompleted: vm.isCompleted || completedThisSession,
+                  isCompleted: isCompleted,
                 ),
               ),
           ],
@@ -425,6 +439,10 @@ Content articleToContent(Object article) {
       isPaid: article.isPaid,
       isSaved: article.isSaved,
       isLiked: article.isLiked,
+      // Sans ça l'écran de détail ouvert depuis une carte du flux rejouait la
+      // complétion (haptique + POST + `article_finished`) sur un article déjà
+      // terminé.
+      completedAt: article.completedAt,
     );
   }
   throw ArgumentError('Unsupported article type: ${article.runtimeType}');
@@ -800,39 +818,3 @@ class _ThemePill extends StatelessWidget {
   }
 }
 
-class _ReadCheckBadge extends StatelessWidget {
-  final Color color;
-
-  /// Double check quand l'article a été lu jusqu'au bout, simple check quand il
-  /// a seulement été ouvert (ce que le seuil d'1 s suffit à déclencher).
-  final bool isCompleted;
-
-  const _ReadCheckBadge({required this.color, this.isCompleted = false});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: 22,
-      height: 22,
-      decoration: BoxDecoration(
-        color: color,
-        shape: BoxShape.circle,
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.12),
-            blurRadius: 4,
-            offset: const Offset(0, 1),
-          ),
-        ],
-      ),
-      alignment: Alignment.center,
-      child: Icon(
-        isCompleted
-            ? PhosphorIcons.checks(PhosphorIconsStyle.bold)
-            : PhosphorIcons.check(PhosphorIconsStyle.bold),
-        size: 12,
-        color: Colors.white,
-      ),
-    );
-  }
-}

--- a/apps/mobile/lib/features/lettres/screens/courrier_screen.dart
+++ b/apps/mobile/lib/features/lettres/screens/courrier_screen.dart
@@ -10,6 +10,7 @@ import '../models/facteur_grade.dart';
 import '../models/letter.dart';
 import '../models/letter_progress.dart';
 import '../providers/letters_provider.dart';
+import '../widgets/daily_goal_card.dart';
 import '../widgets/grade_ladder.dart';
 import '../widgets/leaderboard_teaser_card.dart';
 import '../widgets/letter_row.dart';
@@ -138,6 +139,7 @@ class _Body extends ConsumerWidget {
           slivers: [
             const SliverToBoxAdapter(child: _TopBar()),
             SliverToBoxAdapter(child: ProgressionHeader(state: state)),
+            const SliverToBoxAdapter(child: DailyGoalCard()),
             SliverPadding(
               padding: const EdgeInsets.symmetric(horizontal: 18),
               sliver: SliverList(

--- a/apps/mobile/lib/features/lettres/widgets/daily_goal_card.dart
+++ b/apps/mobile/lib/features/lettres/widgets/daily_goal_card.dart
@@ -1,0 +1,194 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../../config/theme.dart';
+import '../../../core/api/providers.dart';
+import '../../gamification/providers/gamification_preference_provider.dart';
+import '../../gamification/providers/streak_provider.dart';
+
+/// Carte de réglage de l'objectif quotidien de lectures abouties (story 30.2).
+///
+/// L'objectif (« lire N articles jusqu'au bout pour valider sa journée ») vivait
+/// en constante serveur ; il devient réglable ici (1 → 7, défaut 2), persisté
+/// via la colonne profil `daily_goal`. La valeur courante est lue depuis
+/// `streakProvider` (source de vérité serveur) ; l'écriture invalide le streak
+/// pour resynchroniser toutes les surfaces objectif (toast, anneau, recap).
+///
+/// Gate : masquée si la gamification est explicitement désactivée (même famille
+/// de surfaces objectif). Le curseur applique une valeur optimiste pendant le
+/// glissement et persiste sur `onChangeEnd`, avec rollback + SnackBar en échec.
+class DailyGoalCard extends ConsumerStatefulWidget {
+  const DailyGoalCard({super.key});
+
+  static const int minGoal = 1;
+  static const int maxGoal = 7;
+  static const int defaultGoal = 2;
+
+  @override
+  ConsumerState<DailyGoalCard> createState() => _DailyGoalCardState();
+}
+
+class _DailyGoalCardState extends ConsumerState<DailyGoalCard> {
+  // Valeur optimiste pendant le drag / la persistance (null = on suit le streak).
+  int? _pending;
+  bool _saving = false;
+
+  @override
+  Widget build(BuildContext context) {
+    // Masquée uniquement si la gamification est explicitement désactivée.
+    final gamificationEnabled =
+        ref.watch(gamificationPreferenceProvider).valueOrNull;
+    if (gamificationEnabled == false) {
+      return const SizedBox.shrink();
+    }
+
+    final colors = context.facteurColors;
+    final serverGoal =
+        ref.watch(streakProvider).valueOrNull?.dailyGoal ??
+        DailyGoalCard.defaultGoal;
+    final value = (_pending ?? serverGoal).clamp(
+      DailyGoalCard.minGoal,
+      DailyGoalCard.maxGoal,
+    );
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(18, 4, 18, 4),
+      child: Container(
+        decoration: BoxDecoration(
+          color: colors.surface,
+          borderRadius: BorderRadius.circular(FacteurRadius.large),
+          border: Border.all(color: colors.border.withValues(alpha: 0.6)),
+        ),
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Objectif quotidien',
+                        style: GoogleFonts.fraunces(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w600,
+                          letterSpacing: -0.2,
+                          color: colors.textPrimary,
+                        ),
+                      ),
+                      const SizedBox(height: 3),
+                      Text(
+                        "Nombre d'articles lus jusqu'au bout pour valider ta "
+                        'journée',
+                        style: GoogleFonts.dmSans(
+                          fontSize: 12.5,
+                          height: 1.35,
+                          color: colors.textSecondary,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 12),
+                _GoalPill(value: value),
+              ],
+            ),
+            const SizedBox(height: 6),
+            SliderTheme(
+              data: SliderThemeData(
+                trackHeight: 4,
+                activeTrackColor: colors.success,
+                inactiveTrackColor: colors.textPrimary.withValues(alpha: 0.12),
+                thumbColor: colors.success,
+                overlayColor: colors.success.withValues(alpha: 0.16),
+                thumbShape:
+                    const RoundSliderThumbShape(enabledThumbRadius: 9),
+                tickMarkShape: SliderTickMarkShape.noTickMark,
+              ),
+              child: Slider(
+                value: value.toDouble(),
+                min: DailyGoalCard.minGoal.toDouble(),
+                max: DailyGoalCard.maxGoal.toDouble(),
+                divisions: DailyGoalCard.maxGoal - DailyGoalCard.minGoal,
+                onChanged: _saving
+                    ? null
+                    : (v) => setState(() => _pending = v.round()),
+                onChangeEnd: _saving
+                    ? null
+                    : (v) => _commit(v.round(), serverGoal),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _commit(int picked, int previous) async {
+    if (picked == previous) {
+      setState(() => _pending = null);
+      return;
+    }
+    setState(() {
+      _pending = picked;
+      _saving = true;
+    });
+    try {
+      await ref.read(userApiServiceProvider).updateProfile({
+        'daily_goal': picked,
+      });
+      if (!mounted) return;
+      // Resynchronise streak (source de la valeur) + toutes les surfaces objectif.
+      ref.invalidate(streakProvider);
+      setState(() {
+        _pending = null;
+        _saving = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      // Rollback optimiste vers la valeur serveur.
+      setState(() {
+        _pending = null;
+        _saving = false;
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text("Impossible d'enregistrer l'objectif. Réessaie."),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    }
+  }
+}
+
+class _GoalPill extends StatelessWidget {
+  final int value;
+
+  const _GoalPill({required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final label = value == 1 ? '1 article' : '$value articles';
+    return Container(
+      decoration: BoxDecoration(
+        color: colors.success.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(FacteurRadius.pill),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      child: Text(
+        label,
+        style: GoogleFonts.dmSans(
+          fontSize: 12.5,
+          fontWeight: FontWeight.w700,
+          letterSpacing: -0.1,
+          color: colors.success,
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/lettres/widgets/progress_toast.dart
+++ b/apps/mobile/lib/features/lettres/widgets/progress_toast.dart
@@ -23,6 +23,8 @@ void showProgressToast(
   String? stepTitle,
   Color? accentColor,
   VoidCallback? onOpen,
+  VoidCallback? onGoalCta,
+  String ctaLabel = 'Quel objectif on se donne ?',
 }) {
   final overlay = Overlay.maybeOf(context, rootOverlay: true);
   if (overlay == null) return;
@@ -56,6 +58,8 @@ void showProgressToast(
       stepTitle: stepTitle,
       accentColor: accentColor,
       onOpen: onOpen,
+      onGoalCta: onGoalCta,
+      ctaLabel: ctaLabel,
       onDismissed: onDismissed,
       onRequestClose: (cb) {
         dismiss = cb;
@@ -94,6 +98,8 @@ class _ProgressToast extends StatefulWidget {
   final String? stepTitle;
   final Color? accentColor;
   final VoidCallback? onOpen;
+  final VoidCallback? onGoalCta;
+  final String ctaLabel;
   final VoidCallback onDismissed;
   final ValueChanged<VoidCallback> onRequestClose;
 
@@ -109,6 +115,8 @@ class _ProgressToast extends StatefulWidget {
     this.stepTitle,
     this.accentColor,
     this.onOpen,
+    this.onGoalCta,
+    this.ctaLabel = 'Quel objectif on se donne ?',
   });
 
   @override
@@ -125,9 +133,22 @@ class _ProgressToastState extends State<_ProgressToast>
   Timer? _holdTimer;
   bool _leaving = false;
 
-  Duration get _hold => widget.level == ProgressToastLevel.step
+  bool get _hasGoalCta =>
+      widget.level == ProgressToastLevel.micro &&
+      widget.onGoalCta != null &&
+      (widget.current ?? 0) >= (widget.total ?? 0);
+
+  Duration get _hold =>
+      widget.level == ProgressToastLevel.step || _hasGoalCta
       ? const Duration(milliseconds: 4500)
       : const Duration(milliseconds: 3000);
+
+  /// Déclenche le CTA « objectif » puis referme le toast.
+  void _handleGoalCta() {
+    final cb = widget.onGoalCta;
+    _close();
+    cb?.call();
+  }
 
   @override
   void initState() {
@@ -206,7 +227,11 @@ class _ProgressToastState extends State<_ProgressToast>
             : colors.success);
 
     final body = switch (widget.level) {
-      ProgressToastLevel.micro => _MicroBody(accent: accent, toast: widget),
+      ProgressToastLevel.micro => _MicroBody(
+        accent: accent,
+        toast: widget,
+        onGoalCta: _hasGoalCta ? _handleGoalCta : null,
+      ),
       ProgressToastLevel.section => _SectionBody(accent: accent, toast: widget),
       ProgressToastLevel.step => _StepBody(accent: accent, toast: widget),
     };
@@ -288,7 +313,15 @@ class _MicroBody extends StatelessWidget {
   final Color accent;
   final _ProgressToast toast;
 
-  const _MicroBody({required this.accent, required this.toast});
+  /// Non nul uniquement quand l'objectif est atteint (`current >= total`) et
+  /// qu'un CTA a été fourni : rend la ligne tappable « Quel objectif … ? ».
+  final VoidCallback? onGoalCta;
+
+  const _MicroBody({
+    required this.accent,
+    required this.toast,
+    this.onGoalCta,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -338,8 +371,65 @@ class _MicroBody extends StatelessWidget {
               padding: const EdgeInsets.only(left: 26),
               child: _Segments(current: current, total: total, accent: accent),
             ),
+            if (onGoalCta != null) ...[
+              const SizedBox(height: 8),
+              Padding(
+                padding: const EdgeInsets.only(left: 26),
+                child: _GoalCtaLine(
+                  label: toast.ctaLabel,
+                  accent: accent,
+                  onTap: onGoalCta!,
+                ),
+              ),
+            ],
           ],
         ),
+      ),
+    );
+  }
+}
+
+/// Ligne tappable affichée sous les segments quand l'objectif du jour est
+/// atteint : invite discrète à régler l'objectif (ouvre l'écran Progression).
+class _GoalCtaLine extends StatelessWidget {
+  final String label;
+  final Color accent;
+  final VoidCallback onTap;
+
+  const _GoalCtaLine({
+    required this.label,
+    required this.accent,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.opaque,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Flexible(
+            child: Text(
+              label,
+              style: GoogleFonts.dmSans(
+                fontSize: 11.5,
+                fontWeight: FontWeight.w600,
+                letterSpacing: -0.1,
+                color: accent,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const SizedBox(width: 4),
+          Icon(
+            PhosphorIcons.arrowRight(),
+            size: 12,
+            color: accent,
+          ),
+        ],
       ),
     );
   }

--- a/apps/mobile/lib/features/settings/screens/appearance_screen.dart
+++ b/apps/mobile/lib/features/settings/screens/appearance_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
+import '../../../core/ui/notification_service.dart';
 import '../../gamification/providers/gamification_preference_provider.dart';
 import '../../onboarding/widgets/theme_choice_bottom_sheet.dart';
 import '../providers/display_mode_provider.dart';
@@ -102,6 +103,16 @@ class _GamificationToggleState extends ConsumerState<_GamificationToggle> {
           .read(gamificationPreferenceRepositoryProvider)
           .setEnabled(value);
       ref.invalidate(gamificationPreferenceProvider);
+    } catch (_) {
+      // Sans `catch`, l'opt-out échouait en silence : l'interrupteur revenait
+      // seul à sa position et le lecteur croyait avoir désactivé la
+      // gamification. On relit la vérité serveur et on le dit.
+      ref.invalidate(gamificationPreferenceProvider);
+      if (mounted) {
+        NotificationService.showError(
+          'Impossible d’enregistrer ce réglage. Réessaye dans un instant.',
+        );
+      }
     } finally {
       if (mounted) setState(() => _saving = false);
     }

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -25,6 +25,7 @@ import 'core/services/push_notification_service.dart';
 import 'core/services/server_push_service.dart';
 import 'core/errors/user_facing_error_notifier.dart';
 import 'core/ui/notification_service.dart';
+import 'features/feed/services/completed_reads_store.dart';
 import 'features/flux_continu/services/tournee_progress_service.dart';
 
 import 'package:timeago/timeago.dart' as timeago;
@@ -146,14 +147,17 @@ Future<void> _bootstrap() async {
     _openBoxSafe<String>('feed_cache'),
     _openBoxSafe<String>('flux_continu_cache'),
     _openBoxSafe<String>('pending_reads'),
+    // Registre durable des lectures abouties — ouvert au boot pour que
+    // `completedContentIdsProvider` puisse s'hydrater dès la première frame.
+    _openBoxSafe<String>(CompletedReadsStore.boxName),
     SharedPreferences.getInstance(),
   ]);
-  final boxes = initResults.take(6).cast<Box<dynamic>>().toList();
-  final sharedPreferences = initResults[6] as SharedPreferences;
+  final boxes = initResults.take(7).cast<Box<dynamic>>().toList();
+  final sharedPreferences = initResults[7] as SharedPreferences;
   final authBox = boxes[1];
   final supabaseBox = boxes[2];
   debugPrint(
-    '[PERF] boot.hive_boxes_ms=${boxesSw.elapsedMilliseconds} (6 boxes + prefs parallel)',
+    '[PERF] boot.hive_boxes_ms=${boxesSw.elapsedMilliseconds} (7 boxes + prefs parallel)',
   );
 
   debugPrint('Main: Hive auth_prefs keys: ${authBox.keys.toList()}');

--- a/apps/mobile/lib/models/user_profile.dart
+++ b/apps/mobile/lib/models/user_profile.dart
@@ -8,6 +8,7 @@ class UserProfile {
   final bool onboardingCompleted;
   final bool gamificationEnabled;
   final int weeklyGoal;
+  final int dailyGoal;
   final DateTime createdAt;
   final DateTime updatedAt;
 
@@ -20,6 +21,7 @@ class UserProfile {
     required this.onboardingCompleted,
     required this.gamificationEnabled,
     required this.weeklyGoal,
+    this.dailyGoal = 2,
     required this.createdAt,
     required this.updatedAt,
   });
@@ -36,6 +38,7 @@ class UserProfile {
         onboardingCompleted: (json['onboarding_completed'] as bool?) ?? false,
         gamificationEnabled: (json['gamification_enabled'] as bool?) ?? true,
         weeklyGoal: (json['weekly_goal'] as num?)?.toInt() ?? 10,
+        dailyGoal: (json['daily_goal'] as num?)?.toInt() ?? 2,
         createdAt: DateTime.tryParse(json['created_at'] as String? ?? '') ??
             DateTime.now(),
         updatedAt: DateTime.tryParse(json['updated_at'] as String? ?? '') ??
@@ -69,6 +72,7 @@ class UserProfile {
       'onboarding_completed': onboardingCompleted,
       'gamification_enabled': gamificationEnabled,
       'weekly_goal': weeklyGoal,
+      'daily_goal': dailyGoal,
       'created_at': createdAt.toIso8601String(),
       'updated_at': updatedAt.toIso8601String(),
     };
@@ -84,6 +88,7 @@ class UserProfile {
     bool? onboardingCompleted,
     bool? gamificationEnabled,
     int? weeklyGoal,
+    int? dailyGoal,
     DateTime? createdAt,
     DateTime? updatedAt,
   }) {
@@ -96,6 +101,7 @@ class UserProfile {
       onboardingCompleted: onboardingCompleted ?? this.onboardingCompleted,
       gamificationEnabled: gamificationEnabled ?? this.gamificationEnabled,
       weeklyGoal: weeklyGoal ?? this.weeklyGoal,
+      dailyGoal: dailyGoal ?? this.dailyGoal,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
     );
@@ -118,7 +124,8 @@ class UserProfile {
         other.gender == gender &&
         other.onboardingCompleted == onboardingCompleted &&
         other.gamificationEnabled == gamificationEnabled &&
-        other.weeklyGoal == weeklyGoal;
+        other.weeklyGoal == weeklyGoal &&
+        other.dailyGoal == dailyGoal;
   }
 
   @override
@@ -132,6 +139,7 @@ class UserProfile {
       onboardingCompleted,
       gamificationEnabled,
       weeklyGoal,
+      dailyGoal,
     );
   }
 }

--- a/apps/mobile/lib/shared/widgets/glass_pill.dart
+++ b/apps/mobile/lib/shared/widgets/glass_pill.dart
@@ -18,11 +18,18 @@ class GlassPill extends StatelessWidget {
   /// Direction de l'ombre : (0, 4) pour un header, (0, -4) pour un footer.
   final Offset shadowOffset;
 
+  /// Teinte optionnelle mélangée **par-dessus** le fond quasi-opaque du pill.
+  /// `null` (défaut) ⇒ comportement inchangé pour tous les autres appelants
+  /// (header, etc.). Non-null ⇒ `Color.alphaBlend(fillTint, fond)` : sert au
+  /// footer « lavé success » quand l'article est terminé.
+  final Color? fillTint;
+
   const GlassPill({
     super.key,
     required this.child,
     this.borderRadius = const BorderRadius.all(Radius.circular(20)),
     this.shadowOffset = const Offset(0, 4),
+    this.fillTint,
   });
 
   @override
@@ -30,9 +37,13 @@ class GlassPill extends StatelessWidget {
     final isDark = context.isDarkMode;
     // Fond quasi-opaque dérivé du token de thème : masque le corps du pill,
     // ne laisse « passer » le contenu qu'aux coins arrondis.
-    final fillColor = context.facteurColors.backgroundPrimary.withValues(
+    final baseFill = context.facteurColors.backgroundPrimary.withValues(
       alpha: isDark ? 0.97 : 0.98,
     );
+    // Teinte optionnelle mélangée par-dessus le fond (footer « lavé success »).
+    final fillColor = fillTint == null
+        ? baseFill
+        : Color.alphaBlend(fillTint!, baseFill);
     // Arête extérieure sombre (hairline discret, proche de l'existant).
     final outerEdge = isDark
         ? Colors.white.withValues(alpha: 0.12)

--- a/apps/mobile/lib/shared/widgets/read_state_mark.dart
+++ b/apps/mobile/lib/shared/widgets/read_state_mark.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+/// Pastille d'état de lecture d'un article : simple coche s'il a été ouvert,
+/// double coche s'il a été lu **jusqu'au bout**.
+///
+/// Widget partagé et non recopié : la duplication précédente avait déjà produit
+/// un bug — la copie de la carte Essentiel codait `check` en dur, donc était
+/// structurellement incapable d'afficher une complétion. Le choix
+/// `check`/`checks` ne doit vivre qu'à un seul endroit.
+///
+/// Ne rend rien de plus pour un article non abouti : même taille, même couleur,
+/// un chevron de plus. Aucun état vide, aucun contre-signal.
+class ReadStateMark extends StatelessWidget {
+  const ReadStateMark({
+    super.key,
+    required this.color,
+    this.isCompleted = false,
+    this.size = 22,
+  });
+
+  final Color color;
+
+  /// Lu jusqu'au bout (`completedAt != null`), pas seulement ouvert — ce que le
+  /// seuil d'1 s suffit à déclencher.
+  final bool isCompleted;
+
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: color,
+        shape: BoxShape.circle,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.12),
+            blurRadius: 4,
+            offset: const Offset(0, 1),
+          ),
+        ],
+      ),
+      alignment: Alignment.center,
+      child: Icon(
+        isCompleted
+            ? PhosphorIcons.checks(PhosphorIconsStyle.bold)
+            : PhosphorIcons.check(PhosphorIconsStyle.bold),
+        size: size * 0.55,
+        color: Colors.white,
+      ),
+    );
+  }
+}

--- a/apps/mobile/test/features/detail/article_completion_latch_test.dart
+++ b/apps/mobile/test/features/detail/article_completion_latch_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/detail/models/article_completion_latch.dart';
+import 'package:facteur/features/feed/services/read_sync_service.dart'
+    show CompletionSource;
+
+/// Epic 30 — réouverture d'un article terminé.
+///
+/// Le compteur de lectures abouties doit servir à calibrer l'objectif
+/// journalier : chaque relecture qui réémettait `article_finished` le gonflait
+/// et rendait la distribution inexploitable.
+void main() {
+  test('latch n\'émet qu\'une fois', () {
+    final latch = ArticleCompletionLatch();
+
+    expect(latch.latch(CompletionSource.inApp), isTrue);
+    expect(latch.latch(CompletionSource.inApp), isFalse);
+    expect(latch.completed, isTrue);
+    expect(latch.source, CompletionSource.inApp);
+  });
+
+  test('seed(prior) bloque l\'émission mais pas l\'affichage', () {
+    final latch = ArticleCompletionLatch();
+    latch.seed(prior: true);
+
+    // Le test central : l'article est terminé (le cachet et le filet doivent
+    // s'afficher), mais rien ne doit être réémis.
+    expect(latch.completed, isTrue);
+    expect(latch.priorCompleted, isTrue);
+    expect(latch.latch(CompletionSource.inApp), isFalse);
+    expect(latch.source, isNull);
+  });
+
+  test('seed est monotone : un amorçage négatif ne rouvre rien', () {
+    final latch = ArticleCompletionLatch();
+    latch.seed(prior: true);
+    // Source tardive et moins fiable (ex. fetch qui ne connaît pas encore la
+    // complétion locale) : elle ne doit pas contredire la précédente.
+    latch.seed(prior: false);
+
+    expect(latch.priorCompleted, isTrue);
+    expect(latch.latch(CompletionSource.web), isFalse);
+  });
+
+  test('un amorçage tardif ne contredit pas une complétion de session', () {
+    final latch = ArticleCompletionLatch();
+    expect(latch.latch(CompletionSource.web), isTrue);
+
+    latch.seed(prior: true);
+
+    expect(latch.completed, isTrue);
+    // L'événement a bien eu lieu dans cette session.
+    expect(latch.source, CompletionSource.web);
+  });
+
+  test('un contenu externe ne latche jamais', () {
+    final latch = ArticleCompletionLatch();
+
+    expect(latch.latch(CompletionSource.inApp, isExternal: true), isFalse);
+    expect(latch.completed, isFalse);
+  });
+}

--- a/apps/mobile/test/features/feed/animated_feed_card_test.dart
+++ b/apps/mobile/test/features/feed/animated_feed_card_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/feed/widgets/animated_feed_card.dart';
+import 'package:facteur/shared/widgets/completion_stamp.dart' show kStampGreen;
+
+/// Epic 30 — le filet vert de la lecture aboutie.
+///
+/// `AnimatedFeedCard` n'avait **aucune référence** dans `lib/` : le filet
+/// n'existait pas à l'écran. Ces tests fixent la distinction état/événement qui
+/// justifie son existence.
+void main() {
+  Widget wrap(Widget child, {bool disableAnimations = false}) => MediaQuery(
+        data: MediaQueryData(disableAnimations: disableAnimations),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(child: SizedBox(width: 200, height: 100, child: child)),
+        ),
+      );
+
+  Finder rule() => find.byWidgetPredicate(
+        (w) =>
+            w is Container &&
+            w.decoration is BoxDecoration &&
+            (w.decoration as BoxDecoration).color == kStampGreen,
+      );
+
+  testWidgets('rien n\'est ajouté à une carte non aboutie', (tester) async {
+    await tester.pumpWidget(
+      wrap(const AnimatedFeedCard(isCompleted: false, child: Text('carte'))),
+    );
+
+    expect(rule(), findsNothing);
+    // Pas de Stack, pas de Semantics : le rendu est strictement inchangé.
+    expect(find.byType(Stack), findsNothing);
+  });
+
+  testWidgets('animate:false peint le filet dès la première frame',
+      (tester) async {
+    await tester.pumpWidget(
+      wrap(
+        const AnimatedFeedCard(
+          isCompleted: true,
+          animate: false,
+          child: Text('carte'),
+        ),
+      ),
+    );
+
+    // Aucun `pump` supplémentaire : c'est un état, pas une entrée en scène.
+    expect(rule(), findsOneWidget);
+    expect(tester.widget<Transform>(find.ancestor(
+      of: rule(),
+      matching: find.byType(Transform),
+    )).transform.getMaxScaleOnAxis(), 1.0);
+  });
+
+  testWidgets('la transition false → true est animée (retour d\'article)',
+      (tester) async {
+    Widget build(bool completed) => wrap(
+          AnimatedFeedCard(
+            isCompleted: completed,
+            animate: false,
+            child: const Text('carte'),
+          ),
+        );
+
+    await tester.pumpWidget(build(false));
+    await tester.pumpWidget(build(true));
+
+    // `_startDelayed` attend 220 ms non annulables : on avance explicitement
+    // par pas — `pumpAndSettle` masquerait la distinction état/événement.
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(rule(), findsNothing, reason: 'le filet ne s\'est pas encore levé');
+
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pump(const Duration(milliseconds: 160));
+    expect(rule(), findsOneWidget);
+
+    await tester.pump(const Duration(milliseconds: 200));
+  });
+
+  testWidgets('reduce-motion peint le filet plein immédiatement',
+      (tester) async {
+    await tester.pumpWidget(
+      wrap(
+        const AnimatedFeedCard(isCompleted: true, child: Text('carte')),
+        disableAnimations: true,
+      ),
+    );
+
+    expect(rule(), findsOneWidget);
+
+    // `_startDelayed` (220 ms, non annulable) est armé par `animate: true` :
+    // on le laisse expirer, sinon le binding signale un Timer pendant.
+    await tester.pump(const Duration(milliseconds: 250));
+    await tester.pump(const Duration(milliseconds: 350));
+  });
+
+  testWidgets('une carte jamais aboutie se démonte sans lever', (tester) async {
+    // Régression : le contrôleur était `late final` et n'était instancié qu'au
+    // `dispose()` d'une carte non aboutie — `vsync: this` allait alors chercher
+    // un ancêtre désactivé.
+    await tester.pumpWidget(
+      wrap(const AnimatedFeedCard(isCompleted: false, child: Text('carte'))),
+    );
+    await tester.pumpWidget(wrap(const SizedBox()));
+
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/apps/mobile/test/features/feed/completed_reads_cold_start_test.dart
+++ b/apps/mobile/test/features/feed/completed_reads_cold_start_test.dart
@@ -1,0 +1,139 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import 'package:facteur/features/feed/services/completed_reads_store.dart';
+import 'package:facteur/features/feed/services/read_sync_service.dart';
+import 'package:facteur/features/gamification/models/streak_model.dart';
+import 'package:facteur/features/gamification/providers/streak_provider.dart';
+
+/// Epic 30 — la complétion doit survivre au redémarrage de l'app.
+///
+/// Avant, `markCompleted` ne touchait aucun stockage durable : la lecture
+/// aboutie ne vivait que dans `completedContentIdsProvider`, en mémoire.
+void main() {
+  late Directory tempDir;
+  late Box<String> readsBox;
+  late Box<String> completedBox;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('completed_cold_start_');
+    Hive.init(tempDir.path);
+    readsBox = await Hive.openBox<String>(PendingReadQueue.boxName);
+    completedBox = await Hive.openBox<String>(CompletedReadsStore.boxName);
+  });
+
+  setUp(() async {
+    await readsBox.clear();
+    await completedBox.clear();
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    await tempDir.delete(recursive: true);
+  });
+
+  /// Laisse le flush asynchrone (`unawaited` dans `markCompleted`) se terminer
+  /// avant la fin du test, sinon il lit un conteneur déjà disposé.
+  ///
+  /// Des tours de boucle *réels* (1 ms) et non `Duration.zero` : le flush
+  /// traverse des E/S Hive, et 4 microtâches suffisaient à vide mais pas sous
+  /// la charge de la suite complète — le conteneur était disposé en plein vol.
+  Future<void> settle() async {
+    for (var i = 0; i < 20; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 1));
+    }
+  }
+
+  ProviderContainer container({required String userId}) {
+    final c = ProviderContainer(
+      overrides: [
+        // Court-circuite `Supabase.instance` (non initialisé en test unitaire).
+        readSyncUserIdProvider.overrideWithValue(userId),
+        // Le flush relit le compteur du jour côté serveur : hors périmètre.
+        streakProvider.overrideWith(_FakeStreakNotifier.new),
+        readSyncServiceProvider.overrideWith(
+          (ref) => ReadSyncService(
+            ref,
+            // Pas de réseau : on teste la durabilité, pas la synchro.
+            completionSyncOverride: (_, __) async {},
+          ),
+        ),
+      ],
+    );
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  test('une complétion survit à un nouveau ProviderContainer', () async {
+    final first = container(userId: 'u1');
+    await first
+        .read(readSyncServiceProvider)
+        .markCompleted('c1', CompletionSource.web);
+
+    await settle();
+    expect(first.read(completedContentIdsProvider), contains('c1'));
+
+    // Redémarrage de l'app : nouveau conteneur, mêmes boxes Hive.
+    final second = container(userId: 'u1');
+    expect(second.read(completedContentIdsProvider), isEmpty);
+
+    second.read(readSyncServiceProvider).hydrateCompletedReads();
+
+    expect(second.read(completedContentIdsProvider), contains('c1'));
+  });
+
+  test('l\'hydratation est scopée à l\'utilisateur', () async {
+    await container(userId: 'u1')
+        .read(readSyncServiceProvider)
+        .markCompleted('c1', CompletionSource.inApp);
+
+    await settle();
+
+    final other = container(userId: 'u2');
+    other.read(readSyncServiceProvider).hydrateCompletedReads();
+
+    expect(other.read(completedContentIdsProvider), isEmpty);
+  });
+
+  test('markCompleted est idempotent', () async {
+    final c = container(userId: 'u1');
+    final service = c.read(readSyncServiceProvider);
+
+    expect(await service.markCompleted('c1', CompletionSource.inApp), isTrue);
+    expect(await service.markCompleted('c1', CompletionSource.inApp), isFalse);
+    await settle();
+  });
+
+  test('les erreurs de connectivité ne sont pas remontées', () {
+    // Hors-ligne est le cas nominal de cette file : la noyer sous ce bruit
+    // rendrait le signal inutile.
+    expect(
+      isOfflineError(
+        DioException.connectionError(
+          requestOptions: RequestOptions(),
+          reason: 'offline',
+        ),
+      ),
+      isTrue,
+    );
+    expect(isOfflineError(StateError('contrat cassé')), isFalse);
+  });
+}
+
+class _FakeStreakNotifier extends StreakNotifier {
+  @override
+  Future<StreakModel> build() async => const StreakModel(
+        currentStreak: 0,
+        longestStreak: 0,
+        weeklyCount: 0,
+        weeklyGoal: 10,
+        weeklyProgress: 0.0,
+      );
+
+  @override
+  Future<void> refreshSilent() async {}
+}

--- a/apps/mobile/test/features/feed/completed_reads_store_test.dart
+++ b/apps/mobile/test/features/feed/completed_reads_store_test.dart
@@ -1,0 +1,107 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+import 'package:facteur/features/feed/services/completed_reads_store.dart';
+
+/// Epic 30 — durabilité de la lecture aboutie.
+///
+/// Avant ce registre, la complétion ne vivait qu'en mémoire : le filet vert
+/// disparaissait au premier redémarrage de l'app, alors qu'une lecture aboutie
+/// est définitive.
+void main() {
+  late Directory dir;
+  late Box<String> box;
+  late CompletedReadsStore store;
+
+  setUp(() async {
+    // Répertoire temporaire et non chemin en dur : deux fichiers de test qui
+    // partagent un chemin Hive se marchent dessus en exécution parallèle.
+    dir = Directory.systemTemp.createTempSync('completed_reads_test');
+    Hive.init(dir.path);
+    box = await Hive.openBox<String>(CompletedReadsStore.boxName);
+    store = CompletedReadsStore(box);
+  });
+
+  tearDown(() async {
+    await box.deleteFromDisk();
+    await Hive.close();
+    dir.deleteSync(recursive: true);
+  });
+
+  test('une complétion écrite est relue (cold start)', () async {
+    await store.add('u1', 'c1');
+
+    // Nouvelle instance sur la même box : ce que fait le boot de l'app.
+    expect(CompletedReadsStore(box).idsForUser('u1'), {'c1'});
+  });
+
+  test('les utilisateurs sont isolés', () async {
+    await store.add('u1', 'c1');
+    await store.add('u2', 'c2');
+
+    expect(store.idsForUser('u1'), {'c1'});
+    expect(store.idsForUser('u2'), {'c2'});
+  });
+
+  test('clearForUser ne touche que son utilisateur', () async {
+    await store.add('u1', 'c1');
+    await store.add('u2', 'c2');
+
+    await store.clearForUser('u1');
+
+    expect(store.idsForUser('u1'), isEmpty);
+    expect(store.idsForUser('u2'), {'c2'});
+  });
+
+  test('les entrées de plus de 30 jours sont purgées à l\'écriture', () async {
+    final old = DateTime.now().subtract(const Duration(days: 31));
+    await box.put('u1:vieux', old.toIso8601String());
+    await box.put(
+      'u1:recent',
+      DateTime.now().subtract(const Duration(days: 29)).toIso8601String(),
+    );
+
+    await store.add('u1', 'neuf');
+
+    expect(store.idsForUser('u1'), {'recent', 'neuf'});
+  });
+
+  test('une valeur illisible est traitée comme expirée', () async {
+    await box.put('u1:corrompu', 'pas-une-date');
+
+    await store.add('u1', 'c1');
+
+    expect(store.idsForUser('u1'), {'c1'});
+  });
+
+  test('le cap en volume garde les entrées les plus récentes', () async {
+    final base = DateTime.now().subtract(const Duration(days: 10));
+    for (var i = 0; i < CompletedReadsStore.maxEntries + 5; i++) {
+      await box.put(
+        'u1:c$i',
+        base.add(Duration(seconds: i)).toIso8601String(),
+      );
+    }
+
+    // Déclenche la purge : maxEntries + 5 existantes + celle-ci.
+    await store.add('u1', 'dernier');
+
+    final ids = store.idsForUser('u1');
+    expect(ids.length, CompletedReadsStore.maxEntries);
+    expect(ids, contains('dernier'));
+    // Les plus anciennes sont tombées en premier.
+    expect(ids, isNot(contains('c0')));
+    expect(ids, contains('c${CompletedReadsStore.maxEntries + 4}'));
+  });
+
+  test('box absente → tryFromHive rend null, jamais une exception', () async {
+    await box.close();
+
+    expect(CompletedReadsStore.tryFromHive(), isNull);
+
+    // Réouverte pour le tearDown.
+    box = await Hive.openBox<String>(CompletedReadsStore.boxName);
+  });
+}

--- a/apps/mobile/test/features/feed/feed_card_test.dart
+++ b/apps/mobile/test/features/feed/feed_card_test.dart
@@ -6,6 +6,7 @@ import 'package:facteur/features/feed/models/content_model.dart';
 import 'package:facteur/features/feed/widgets/feed_card.dart';
 import 'package:facteur/features/sources/models/source_model.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -14,8 +15,11 @@ void main() {
   });
 
   // Helper to pump the widget with Theme
+  // `FeedCard` est un `ConsumerStatefulWidget` (il watche les complétions) :
+  // sans `ProviderScope` au-dessus, tout montage lève.
   Widget createWidget(Widget child) {
-    return MaterialApp(
+    return ProviderScope(
+      child: MaterialApp(
       theme: FacteurTheme.darkTheme,
       home: Scaffold(
         body: SingleChildScrollView(
@@ -24,6 +28,7 @@ void main() {
             child: child,
           ),
         ),
+      ),
       ),
     );
   }

--- a/apps/mobile/test/features/feed/widgets/feed_card_longpress_test.dart
+++ b/apps/mobile/test/features/feed/widgets/feed_card_longpress_test.dart
@@ -4,6 +4,7 @@ import 'package:facteur/features/feed/widgets/feed_card.dart';
 import 'package:facteur/features/sources/models/source_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
 
@@ -24,7 +25,9 @@ Widget _carousel({
   required void Function() onLongPressStart,
   required void Function() onMoveUpdate,
 }) {
-  return MaterialApp(
+  // `FeedCard` watche les complétions → `ProviderScope` obligatoire.
+  return ProviderScope(
+    child: MaterialApp(
     theme: ThemeData(extensions: [FacteurPalettes.light]),
     home: Scaffold(
       body: Center(
@@ -46,6 +49,7 @@ Widget _carousel({
           ),
         ),
       ),
+    ),
     ),
   );
 }

--- a/apps/mobile/test/features/flux_continu/flux_article_vm_completion_test.dart
+++ b/apps/mobile/test/features/flux_continu/flux_article_vm_completion_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/digest/models/digest_models.dart';
+import 'package:facteur/features/flux_continu/widgets/flux_continu_article_card.dart';
+
+/// Epic 30 — le backend sert `completed_at`, `DigestItem` le désérialise… et la
+/// couche de rendu le jetait. Deux conversions à protéger.
+void main() {
+  DigestItem item({DateTime? completedAt}) => DigestItem(
+        contentId: 'c-1',
+        title: 'Titre',
+        url: 'https://example.com/1',
+        completedAt: completedAt,
+      );
+
+  test('FluxArticleVM.from(DigestItem) mappe la complétion', () {
+    expect(FluxArticleVM.from(item()).isCompleted, isFalse);
+    expect(
+      FluxArticleVM.from(item(completedAt: DateTime(2026, 7, 24, 9)))
+          .isCompleted,
+      isTrue,
+    );
+  });
+
+  test('articleToContent préserve completedAt', () {
+    final completedAt = DateTime(2026, 7, 24, 9);
+
+    final content = articleToContent(item(completedAt: completedAt));
+
+    // Sans ça, l'écran de détail ouvert depuis le flux rejouait la complétion.
+    expect(content.completedAt, completedAt);
+    expect(content.isCompleted, isTrue);
+    expect(articleToContent(item()).isCompleted, isFalse);
+  });
+}

--- a/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
@@ -19,6 +19,8 @@ import 'package:facteur/features/gamification/models/streak_activity_model.dart'
 import 'package:facteur/features/gamification/providers/streak_activity_provider.dart';
 import 'package:facteur/features/settings/models/display_mode_spec.dart';
 import 'package:facteur/features/settings/providers/display_mode_provider.dart';
+import 'package:facteur/shared/widgets/completion_stamp.dart' show kStampGreen;
+import 'package:facteur/shared/widgets/read_state_mark.dart';
 import 'package:facteur/widgets/design/facteur_thumbnail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:visibility_detector/visibility_detector.dart';
@@ -81,6 +83,7 @@ EssentielArticle _article({
   String source = 'Le Monde',
   bool isActuDuJour = false,
   bool isRead = false,
+  DateTime? completedAt,
 }) {
   return EssentielArticle(
     contentId: 'c-$rank',
@@ -95,6 +98,7 @@ EssentielArticle _article({
     perspectiveCount: 3,
     isActuDuJour: isActuDuJour,
     isRead: isRead,
+    completedAt: completedAt,
   );
 }
 
@@ -130,6 +134,66 @@ void main() {
         reason: 'Vague 2 hotfix: gray "ÉDITION DU [day]" banner removed.',
       );
       expect(find.text('Titre 1'), findsOneWidget);
+    });
+
+    testWidgets('la tuile lead affiche le filet et la double coche quand '
+        'l\'article est lu jusqu\'au bout', (tester) async {
+      // Impossible avant : la copie locale de la pastille codait `check` en
+      // dur, et `AnimatedFeedCard` n'était monté nulle part.
+      await tester.pumpWidget(_wrap(
+        EssentielHiFiCard(
+          articles: [
+            _article(
+              rank: 1,
+              isRead: true,
+              completedAt: DateTime(2026, 5, 23, 9),
+            ),
+          ],
+          onTapArticle: (_) {},
+        ),
+      ));
+
+      expect(
+        find.byWidgetPredicate(
+          (w) =>
+              w is Container &&
+              w.decoration is BoxDecoration &&
+              (w.decoration as BoxDecoration).color == kStampGreen,
+        ),
+        findsOneWidget,
+      );
+      expect(
+        tester
+            .widget<ReadStateMark>(find.byType(ReadStateMark))
+            .isCompleted,
+        isTrue,
+      );
+    });
+
+    testWidgets('une tuile seulement ouverte reste strictement inchangée',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        EssentielHiFiCard(
+          articles: [_article(rank: 1, isRead: true)],
+          onTapArticle: (_) {},
+        ),
+      ));
+
+      expect(
+        find.byWidgetPredicate(
+          (w) =>
+              w is Container &&
+              w.decoration is BoxDecoration &&
+              (w.decoration as BoxDecoration).color == kStampGreen,
+        ),
+        findsNothing,
+      );
+      expect(
+        tester
+            .widget<ReadStateMark>(find.byType(ReadStateMark))
+            .isCompleted,
+        isFalse,
+      );
     });
 
     testWidgets('tap on the lead fires onTapArticle with the right article',

--- a/apps/mobile/test/features/lettres/screens/courrier_screen_test.dart
+++ b/apps/mobile/test/features/lettres/screens/courrier_screen_test.dart
@@ -121,6 +121,10 @@ void main() {
     expect(find.text('GRADES'), findsOneWidget);
     expect(find.byType(GradeLadder), findsOneWidget);
     expect(find.text('Facteur Stagiaire'), findsWidgets);
+    // La carte « Objectif quotidien » + la ladder poussent les sections sous le
+    // fold (build paresseux du sliver) → petit scroll avant de les asserter.
+    await tester.drag(find.byType(CustomScrollView), const Offset(0, -250));
+    await tester.pumpAndSettle();
     // Les libellés section existent aussi en pill sur les rows → findsWidgets.
     expect(find.text('EN COURS'), findsWidgets);
     expect(find.text('À VENIR'), findsWidgets);

--- a/apps/mobile/test/features/lettres/widgets/daily_goal_card_test.dart
+++ b/apps/mobile/test/features/lettres/widgets/daily_goal_card_test.dart
@@ -1,0 +1,102 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/gamification/models/streak_model.dart';
+import 'package:facteur/features/gamification/providers/gamification_preference_provider.dart';
+import 'package:facteur/features/gamification/providers/streak_provider.dart';
+import 'package:facteur/features/lettres/widgets/daily_goal_card.dart';
+
+class _FakeStreakNotifier extends StreakNotifier {
+  _FakeStreakNotifier(this._model);
+
+  final StreakModel _model;
+
+  @override
+  FutureOr<StreakModel> build() => _model;
+}
+
+class _LoadingStreakNotifier extends StreakNotifier {
+  @override
+  FutureOr<StreakModel> build() => Completer<StreakModel>().future;
+}
+
+Widget _wrap(List<Override> overrides) {
+  return ProviderScope(
+    overrides: overrides,
+    child: MaterialApp(
+      theme: ThemeData(extensions: [FacteurPalettes.light]),
+      home: const Scaffold(
+        body: SingleChildScrollView(child: DailyGoalCard()),
+      ),
+    ),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  const streak = StreakModel(
+    currentStreak: 3,
+    longestStreak: 5,
+    weeklyCount: 2,
+    weeklyGoal: 10,
+    weeklyProgress: 0.2,
+    dailyGoal: 5,
+  );
+
+  testWidgets('affiche l\'objectif courant et le curseur quand la '
+      'gamification est active', (tester) async {
+    await tester.pumpWidget(
+      _wrap([
+        gamificationPreferenceProvider.overrideWith((ref) async => true),
+        streakProvider.overrideWith(() => _FakeStreakNotifier(streak)),
+      ]),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Objectif quotidien'), findsOneWidget);
+    expect(find.text('5 articles'), findsOneWidget);
+    expect(find.byType(Slider), findsOneWidget);
+
+    final slider = tester.widget<Slider>(find.byType(Slider));
+    expect(slider.value, 5.0);
+    expect(slider.min, 1.0);
+    expect(slider.max, 7.0);
+    expect(slider.divisions, 6);
+  });
+
+  testWidgets('reste masquée quand la gamification est désactivée', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap([
+        gamificationPreferenceProvider.overrideWith((ref) async => false),
+        streakProvider.overrideWith(() => _FakeStreakNotifier(streak)),
+      ]),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Objectif quotidien'), findsNothing);
+    expect(find.byType(Slider), findsNothing);
+  });
+
+  testWidgets('retombe sur 2 articles sans valeur de streak', (tester) async {
+    await tester.pumpWidget(
+      _wrap([
+        gamificationPreferenceProvider.overrideWith((ref) async => true),
+        // Streak en cours de chargement → valeur indisponible → défaut 2.
+        streakProvider.overrideWith(_LoadingStreakNotifier.new),
+      ]),
+    );
+    await tester.pump();
+
+    expect(find.text('2 articles'), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/features/lettres/widgets/progress_toast_test.dart
+++ b/apps/mobile/test/features/lettres/widgets/progress_toast_test.dart
@@ -106,6 +106,59 @@ void main() {
     );
   });
 
+  testWidgets(
+    'micro à l\'objectif atteint (N/N) affiche le CTA et l\'invoque au tap',
+    (tester) async {
+      var tapped = 0;
+      await tester.pumpWidget(
+        _harness(
+          onReady: (ctx) => showProgressToast(
+            ctx,
+            level: ProgressToastLevel.micro,
+            current: 2,
+            total: 2,
+            label: 'lu jusqu\'au bout',
+            onGoalCta: () => tapped++,
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(find.text('Quel objectif on se donne ?'), findsOneWidget);
+
+      await tester.tap(find.text('Quel objectif on se donne ?'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(tapped, 1);
+      // Le toast se referme après le tap sur le CTA.
+      expect(find.text('Quel objectif on se donne ?'), findsNothing);
+    },
+  );
+
+  testWidgets('micro en dessous de l\'objectif (N-1/N) n\'affiche pas de CTA', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _harness(
+        onReady: (ctx) => showProgressToast(
+          ctx,
+          level: ProgressToastLevel.micro,
+          current: 1,
+          total: 2,
+          label: 'lu jusqu\'au bout',
+          onGoalCta: () {},
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(find.text('1/2'), findsOneWidget);
+    expect(find.text('Quel objectif on se donne ?'), findsNothing);
+  });
+
   testWidgets('niveau section affiche titre Fraunces + sous-titre 100%', (
     tester,
   ) async {

--- a/apps/mobile/test/shared/widgets/glass_pill_test.dart
+++ b/apps/mobile/test/shared/widgets/glass_pill_test.dart
@@ -1,0 +1,60 @@
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/shared/widgets/glass_pill.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Résout la couleur de fond effective du pill : le `DecoratedBox` qui porte à
+/// la fois une `color` non-null ET une bordure (l'arête extérieure sombre) —
+/// c'est celui qui reçoit `fillColor`.
+Color _fillColorOf(WidgetTester tester) {
+  final boxes = tester.widgetList<DecoratedBox>(find.byType(DecoratedBox));
+  for (final box in boxes) {
+    final deco = box.decoration;
+    if (deco is BoxDecoration && deco.color != null && deco.border != null) {
+      return deco.color!;
+    }
+  }
+  fail('Aucun DecoratedBox de fond trouvé dans le GlassPill');
+}
+
+Future<Color> _pumpAndReadFill(WidgetTester tester, {Color? fillTint}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: FacteurTheme.lightTheme,
+      home: Scaffold(
+        body: Center(
+          child: GlassPill(
+            fillTint: fillTint,
+            child: const SizedBox(width: 100, height: 40),
+          ),
+        ),
+      ),
+    ),
+  );
+  return _fillColorOf(tester);
+}
+
+void main() {
+  group('GlassPill.fillTint', () {
+    testWidgets('sans fillTint → fond inchangé (aucune régression call-sites)',
+        (tester) async {
+      final fill = await _pumpAndReadFill(tester);
+      // Fond quasi-opaque dérivé du token clair (alpha 0.98), aucune teinte.
+      expect(fill.a, closeTo(0.98, 0.001));
+    });
+
+    testWidgets('avec fillTint success → fond teinté (alphaBlend)',
+        (tester) async {
+      const tint = Color(0x2427AE60); // success @ ~14% alpha
+      final base = await _pumpAndReadFill(tester);
+      final tinted = await _pumpAndReadFill(tester, fillTint: tint);
+
+      // Le fond change et bascule vers le vert : l'écart vert-rouge grimpe
+      // (le fond crème est légèrement rougeâtre, la teinte success l'inverse).
+      expect(tinted, isNot(equals(base)));
+      expect(tinted.g - tinted.r, greaterThan(base.g - base.r));
+      // Le fond reste opaque (alphaBlend sur un fond déjà à alpha 0.98).
+      expect(tinted.a, greaterThanOrEqualTo(base.a));
+    });
+  });
+}

--- a/apps/mobile/test/shared/widgets/read_state_mark_test.dart
+++ b/apps/mobile/test/shared/widgets/read_state_mark_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import 'package:facteur/shared/widgets/read_state_mark.dart';
+
+/// La duplication de cette pastille en trois copies avait déjà produit un bug :
+/// celle de la carte Essentiel codait `check` en dur, donc ne pouvait pas
+/// afficher une complétion. Le choix `check`/`checks` ne vit plus qu'ici.
+void main() {
+  Widget wrap(Widget child) => Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(child: child),
+      );
+
+  IconData iconOf(WidgetTester tester) =>
+      tester.widget<Icon>(find.byType(Icon)).icon!;
+
+  testWidgets('ouvert seulement → simple coche', (tester) async {
+    await tester.pumpWidget(wrap(const ReadStateMark(color: Colors.green)));
+
+    expect(iconOf(tester), PhosphorIcons.check(PhosphorIconsStyle.bold));
+  });
+
+  testWidgets('lu jusqu\'au bout → double coche', (tester) async {
+    await tester.pumpWidget(
+      wrap(const ReadStateMark(color: Colors.green, isCompleted: true)),
+    );
+
+    expect(iconOf(tester), PhosphorIcons.checks(PhosphorIconsStyle.bold));
+  });
+
+  testWidgets('même taille et même couleur dans les deux états',
+      (tester) async {
+    Size sizeOf(Finder f) => tester.getSize(f);
+
+    await tester.pumpWidget(
+      wrap(const ReadStateMark(color: Colors.green, size: 18)),
+    );
+    final open = sizeOf(find.byType(ReadStateMark));
+    final openColor = tester.widget<Icon>(find.byType(Icon)).color;
+
+    await tester.pumpWidget(
+      wrap(
+        const ReadStateMark(
+          color: Colors.green,
+          size: 18,
+          isCompleted: true,
+        ),
+      ),
+    );
+
+    // Un chevron de plus, rien d'autre : aucune surface où lire un reproche.
+    expect(sizeOf(find.byType(ReadStateMark)), open);
+    expect(tester.widget<Icon>(find.byType(Icon)).color, openColor);
+  });
+}

--- a/docs/stories/core/30.2.objectif-quotidien-reglable.md
+++ b/docs/stories/core/30.2.objectif-quotidien-reglable.md
@@ -1,0 +1,95 @@
+# Story 30.2 — Objectif quotidien réglable + footer validé aligné success
+
+**Type** : Feature (full-stack) · **Epic** : 30 (La lecture aboutie)
+**Statut** : implémenté, en attente de review
+
+## Contexte
+
+L'objectif quotidien (« lire N articles jusqu'au bout ») valait `2` en dur via la
+constante serveur `DAILY_COMPLETION_GOAL`, exposée par le streak mais non
+modifiable. À chaque lecture aboutie, un toast `micro` « X/2 lu jusqu'au bout »
+s'affiche ; à `N/N` l'objectif est validé.
+
+Cette story rend l'objectif **réglable** (1 → 7, défaut 2), ajoute un **CTA** dans
+le toast qui valide l'objectif, et **corrige la couleur** du bouton du footer de
+lecture en état « validé » (gris `secondary` → vert `success`).
+
+## Décisions (validées PO)
+
+- **Persistance** : colonne profil `daily_goal` synchronisée serveur (calquée sur
+  `weekly_goal`), migration Alembic **additive** `NOT NULL DEFAULT 2`.
+- **Slider** : plage 1 → 7, défaut 2, dans l'écran « Progression ».
+- **CTA** : uniquement dans le toast objectif atteint (`current >= total`).
+- **Footer** : bouton complété `colors.secondary` → `colors.success` (la règle
+  « un bouton d'action ne prend jamais le vert » est explicitement levée pour
+  cette itération).
+
+## Implémentation
+
+### Backend — `daily_goal` champ profil synchronisé
+
+- `models/user.py` : `daily_goal: Mapped[int] = mapped_column(Integer, default=2,
+  server_default="2")` (parité model↔DB, backfill additif).
+- Migration `alembic/versions/dg01_daily_goal_user_profiles.py` : `add_column`
+  `NOT NULL server_default 2`. 1 seul head, idempotent, additif (DB partagée
+  staging/prod : l'ancien backend prod ignore la colonne).
+- `schemas/user.py` : `UserProfileUpdate.daily_goal: int | None = Field(None,
+  ge=1, le=7)` ; `UserProfileResponse.daily_goal: int`.
+- `services/streak_service.py` : `daily_goal=profile.daily_goal if profile else
+  DAILY_COMPLETION_GOAL` (fallback constante conservé).
+- `update_profile` (déjà `model_dump(exclude_unset=True)` + `setattr`) : aucun
+  changement.
+
+### Mobile
+
+- `models/user_profile.dart` : ajout `dailyGoal` (champ, ctor, `fromJson`
+  `daily_goal ?? 2`, `toJson`, `copyWith`, `==`/`hashCode`).
+- `StreakModel` parse déjà `daily_goal` → aucun changement (tous les
+  consommateurs suivent la nouvelle valeur).
+- **Nouveau** `features/lettres/widgets/daily_goal_card.dart` (`DailyGoalCard`),
+  inséré en `SliverToBoxAdapter` après `ProgressionHeader` dans
+  `courrier_screen.dart`. Gate : masquée si gamification explicitement désactivée.
+  Curseur `min:1 max:7 divisions:6`, valeur optimiste pendant le drag, commit sur
+  `onChangeEnd` (`updateProfile({'daily_goal': v})` + `invalidate(streakProvider)`),
+  rollback + SnackBar en échec. Valeur initiale = `streakProvider.dailyGoal ?? 2`.
+- `progress_toast.dart` : `showProgressToast` / `_ProgressToast` gagnent
+  `onGoalCta` (`VoidCallback?`) + `ctaLabel`. `_MicroBody` rend, quand
+  `current >= total` et `onGoalCta != null`, une ligne tappable
+  « Quel objectif on se donne ? » (accent `success`) qui invoque le callback puis
+  ferme le toast. Hold allongé à 4500 ms quand le CTA est présent.
+- `content_detail_screen.dart` : `_maybeShowCompletionToast()` passe
+  `onGoalCta: () => context.push(RoutePaths.lettres)` seulement à `current >= total`.
+- `content_detail_screen.dart` : footer complété `colors.secondary` →
+  `colors.success` (commentaire PO mis à jour).
+
+## Tests
+
+- Backend : `test_lecture_aboutie_backend.py` — `get_streak` reflète
+  `profile.daily_goal` + fallback constante sans profil. Migration : `upgrade
+  head` OK sur DB vide, 1 head.
+- Mobile : `daily_goal_card_test.dart` (rendu + valeur curseur + gate masquée +
+  défaut 2) ; `progress_toast_test.dart` (CTA à N/N, pas de CTA à N-1/N) ;
+  `courrier_screen_test.dart` mis à jour (scroll pour les sections poussées par
+  la carte).
+
+## Tasks
+
+- [x] Backend : modèle + migration + schémas + streak service
+- [x] Mobile : `UserProfile.dailyGoal`
+- [x] Mobile : `DailyGoalCard` + insertion dans « Progression »
+- [x] Mobile : CTA toast objectif atteint
+- [x] Mobile : footer validé `secondary` → `success`
+- [x] Tests backend + mobile
+- [x] changelog `unreleased`
+
+## Fichiers touchés
+
+Backend : `models/user.py`, `alembic/versions/dg01_daily_goal_user_profiles.py`,
+`schemas/user.py`, `services/streak_service.py`,
+`tests/test_lecture_aboutie_backend.py`,
+`tests/test_onboarding_digest_pregeneration.py`.
+Mobile : `models/user_profile.dart`, `features/lettres/screens/courrier_screen.dart`,
+`features/lettres/widgets/daily_goal_card.dart`,
+`features/lettres/widgets/progress_toast.dart`,
+`features/detail/screens/content_detail_screen.dart`,
+`assets/changelog.json`, + tests associés.

--- a/docs/stories/core/30.lecture-aboutie/README.md
+++ b/docs/stories/core/30.lecture-aboutie/README.md
@@ -115,7 +115,8 @@ Le nombre est une **sortie** du lot 0, pas une entrée de la spec.
    30 s** (`analytics_service.dart:244`).
 3. Remplacer le `catch` muet (`:1705`) par une remontée Sentry. *Un chemin de récompense ne doit jamais
    échouer en silence.*
-4. **Corriger le bug de frontière de `closure_streak`** : `_update_closure_streak` estampille
+4. **Corriger le bug de frontière de `closure_streak`** *(⚠️ le correctif de #1007 était lui-même
+   une régression — cf. §11)* : `_update_closure_streak` estampille
    `last_closure_date = date.today()` (UTC serveur, `digest_service.py:2933`) alors que son déclencheur
    `maybe_record_implicit_completion` teste `today_paris()` (`:1573`). Entre 00h et 02h Paris l'été, la
    complétion est comptée pour J et datée J-1 → série cassée ou dédoublée.
@@ -466,7 +467,7 @@ conclusion « ne pas optimiser pour les réguliers » s'en trouve affaiblie.
 | Point | Plan | Livré | Pourquoi |
 |---|---|---|---|
 | Emplacement du cachet | dans le flux de l'article | **dans le pied de page** | Seul emplacement qui marche dans les 4 modes de rendu : impossible d'injecter dans le DOM de l'éditeur en WebView, qui est le chemin nominal (~90 % du catalogue). Un seul cachet au lieu de deux variantes. |
-| Filet vert sur les cartes | via un `ReadStateMark` neuf | **non livré** ⚠️ | `AnimatedFeedCard` a été *restylée* (filet vertical, `easeOutCubic` 320 ms, plus de scrim noir ni d'`elasticOut`, aucune haptique) mais **reste orpheline : 0 référence dans `lib/` et `test/`**. Le filet vert n'existe pas à l'écran. Le tableau annonçait « réhabilitée » à tort — corrigé le 25/07. À brancher en PR 2 mobile. |
+| Filet vert sur les cartes | via un `ReadStateMark` neuf | **livré le 25/07** (PR « lecture aboutie visible ») | `AnimatedFeedCard` était restée orpheline (0 référence dans `lib/`) : le filet n'existait pas à l'écran. Elle est désormais montée sur les 3 familles de cartes, et `ReadStateMark` existe bel et bien, partagé. |
 | `closing_recap.dart` | à réhabiliter | **laissé en l'état** | Le bloc de clôture n'a pas besoin du détail par section — une phrase suffit, et le récap par section rouvrirait la question du critère « lu » permissif. À reprendre si le PO veut le détail. |
 | Lot 4 (flamme) | conditionnel, après gate | **livré** | L'anneau ne dépend pas de `closure_streak` (qui est vide) : c'est un état du jour dérivé de `daily_completed`, il fonctionne dès le jour 1. Le gate ne portait que sur l'affichage d'une seconde série — toujours coupée. |
 
@@ -499,3 +500,111 @@ conclusion « ne pas optimiser pour les réguliers » s'en trouve affaiblie.
   l'objectif). À ajouter si le PO le souhaite — le plan la prévoit, elle est triviale.
 - **Validation QA web** (`/validate-feature`) non exécutée : Flutter web n'était pas lancé dans cet
   environnement. Les parcours visuels (cachet, CTA secondary, filet, anneau) restent à valider à l'œil.
+
+
+## 11. Journal d'implémentation — 25/07/2026 (« rendre la lecture aboutie visible »)
+
+L'audit fichier par fichier de `main` a établi que **la moitié visible de la demande d'origine
+n'était jamais montée à l'écran**, que la complétion **ne survivait pas au redémarrage**, et que
+deux bugs backend restaient ouverts — dont un que #1007 avait *aggravé*.
+
+### Ce qui est refermé
+
+**Backend**
+
+- `_update_closure_streak(user_id, target_date)` estampille désormais **l'édition close** et non une
+  notion de « aujourd'hui ». Le correctif de #1007 avait remplacé une frontière UTC (00h→02h Paris)
+  par la frontière éditoriale 07h30, alors que ses deux appelants cherchent le digest via
+  `today_paris()` (minuit) : la fenêtre de divergence avait *grandi* (00h→07h30). Un lecteur qui
+  clôturait l'édition D à 01h se voyait estampiller D-1, puis voyait sa série remise à 1 le
+  lendemain soir. **Zéro test ne couvrait la méthode** (mockée dans les 3 fichiers qui l'approchent) ;
+  elle l'est maintenant, démockée, contre une vraie base.
+- `week_start` calculé en `today_paris()` (`digest_service`, `streak_service` ×2), plus en UTC.
+- `DAILY_COMPLETION_GOAL` descend dans `app.schemas.streak` : le `daily_goal: int = 2` du schéma
+  était un doublon en dur, libre de diverger. Sens de dépendance `services → schemas` conservé.
+- `count_completed_today` — le compteur exposé à l'UI — a enfin des tests (J-3, frontière 07h30
+  exercée des deux côtés, scope utilisateur).
+- `EssentielArticle` sert `completed_at` : la carte héros de la Tournée ne pouvait pas connaître la
+  complétion, alors que `_to_essentiel_article` recevait déjà le champ.
+
+**Mobile**
+
+- **Durabilité** : nouveau `CompletedReadsStore` (box Hive `completed_reads` dédiée, purge 30 j,
+  cap 1000). `markCompleted` écrit d'abord le registre, puis l'état — comme `markConsumed`.
+  L'hydratation est *poussée* au démarrage (`hydrateCompletedReads`) plutôt que watchée : faire
+  dépendre `completedContentIdsProvider` de `readSyncUserIdProvider` remonterait jusqu'à
+  `Supabase.instance` et casserait tout widget test montant une carte.
+- **Fuite inter-comptes** : `completedContentIdsProvider` est vidé au logout (il ne l'était pas).
+- **Mapping** : `FluxArticleVM.from(DigestItem)` et `articleToContent` jetaient `completedAt` ;
+  le modèle mobile `EssentielArticle` ne le parsait pas.
+- **Visuel** : `ReadStateMark` partagé (`lib/shared/widgets/`) remplace 2 des 3 copies privées —
+  celle de la carte Essentiel codait `check` en dur, donc était *structurellement* incapable
+  d'afficher une complétion. `_ReadStatusPill` (timeline d'éditions) n'est **pas** touchée :
+  sémantique différente. `AnimatedFeedCard` est montée sur les 3 familles de cartes en
+  `animate: false` — un état au montage, une animation seulement sur la transition (retour
+  d'article). Au passage, son `AnimationController` était `late final` et n'était instancié qu'au
+  `dispose()` d'une carte non aboutie : inoffensif tant qu'elle était du code mort, systématique
+  dès qu'elle est montée partout.
+- **Réouverture** : `ArticleCompletionLatch` (Dart pur, testé) sépare l'état connu à l'ouverture de
+  l'événement de session. Rouvrir un article terminé ne rejoue plus haptique + POST +
+  `article_finished` — l'événement même qui doit servir à calibrer l'objectif.
+- **Layout du cachet** : sorti de la `Column` du pied de page (il y ajoutait ~34 px alors que
+  `_kFooterContentHeight` sert de spacer à 9 endroits) et rendu **frère** du pill via
+  `Stack` + `FractionalTranslation(0, -1)`. Aucune mesure, les 9 usages inchangés.
+- **Silences** : le `catch (_)` du flush de la file de lectures remonte à Sentry (hors erreurs de
+  connectivité, cas nominal de cette file) ; l'opt-out gamification n'échoue plus en silence.
+
+### Ce qui reste ouvert
+
+- La fenêtre de 14 jours de collecte `article_finished` (PostHog) avant d'arrêter
+  `DAILY_COMPLETION_GOAL` sur P50/P75/P90. La correction de la réouverture est ce qui rend cette
+  distribution exploitable.
+- Tagline de découverte one-shot dans la « Notif du jour » ; chiffre du jour dans
+  `streak_explainer_modal`.
+- `/validate-feature` (parcours visuels) : toujours à passer.
+
+## 12. Journal d'implémentation — 25/07/2026 (correctif E2E : reconverger le livré avec le plan)
+
+Les retours E2E du PO ont révélé trois écarts entre le plan acté (§10-11) et le livré. **Le PO
+inverse explicitement deux arbitrages** posés plus haut — cette entrée les acte sans réécrire
+l'historique §10-11.
+
+### Décisions du PO — arbitrages inversés
+
+- **Footer lavé `colors.success`.** Décision PO n°1 (« footer tout en vert, CTA en `secondary` »)
+  était sous-livrée : le CTA passait bien en `secondary` mais le seul signal vert était un cachet à
+  bordure + une barre 3,5 px, tous deux en `kStampGreen` (#2E7D32, vert forêt terne) et non en
+  `colors.success` (#27AE60, le vert « lu » du produit). Correctif : le `GlassPill` du pied de page
+  reçoit un `fillTint: colors.success @ 14 %` quand l'article est terminé (nouveau paramètre optionnel
+  de `GlassPill`, `null` = call-sites inchangés). Le CTA reste en `secondary`.
+- **Toast `X/Y lu jusqu'au bout` à la complétion — override des garde-fous §4 #4 et #5.** Le plan
+  avait *délibérément* coupé toute notif de progression (« aucun X/Y », « aucune interruption en fin
+  d'article ») au profit d'une phrase rétrospective (`DailyCompletionRecap`). Le PO **inverse** cet
+  arbitrage : réutilisation de `showProgressToast` (déjà utilisé par Lettres/Veille) en niveau `micro`
+  à chaque complétion neuve. On **assume le X/Y**. Reste gaté par `gamificationPreferenceProvider`
+  (garde-fou §14 respecté). Compteur **optimiste** (`streakProvider` est dérivé serveur, rafraîchi en
+  asynchrone) : `current = min(dailyCompleted + 1, dailyGoal)` ; série inconnue → pas de toast.
+  Garde-fou §12 (double-buzz) **maintenu** : le toast `micro` joue déjà `selectionClick()`, donc on
+  saute le `lightImpact()` du handler → une seule vibration.
+- **Cachet retiré du reader ; la barre devient le signal principal.** Posé en overlay à fond
+  transparent (`PositionedDirectional` + `FractionalTranslation(0, -1)` + `Clip.none`), le cachet
+  flottait au-dessus du pied de page et se **superposait au carrousel Perspectives** qui défile
+  dessous. Retiré du reader. Le signal de complétion est désormais porté par le lavis `success` du
+  pill **et** la barre de progression, qui vire au `colors.success` plein, s'épaissit (3,5 → 6 px) et
+  monte en opacité (~0,9) une fois l'article terminé. Le cachet **reste** utilisé ailleurs
+  (`DailyCompletionRecap`, carte de clôture) — non touché.
+
+### Vérifications
+
+- `flutter analyze` : 0 nouvelle erreur (baseline d'infos/warnings pré-existante inchangée).
+- Test unitaire `GlassPill.fillTint` : `null` → fond inchangé (aucune régression call-sites) ;
+  non-null → fond teinté vers le vert (`Color.alphaBlend`).
+- Le retrait du cachet du reader est **structurel** : l'import `completion_stamp.dart` (et
+  `kStampGreen`) a disparu de `content_detail_screen.dart` — aucun `CompletionStamp` ne peut plus
+  apparaître dans l'arbre du reader. Le one-shot du toast est garanti par `ArticleCompletionLatch`
+  (déjà testé) : une réouverture ne rejoue pas l'événement de complétion.
+
+### Ce qui reste ouvert
+
+- `/validate-feature` (web, 390×844) : passage visuel — footer vert franc, barre épaisse verte,
+  toast « X/Y lu jusqu'au bout », plus de superposition cachet/carrousel en présence de Perspectives.

--- a/docs/stories/core/30.lecture-aboutie/README.md
+++ b/docs/stories/core/30.lecture-aboutie/README.md
@@ -466,7 +466,7 @@ conclusion « ne pas optimiser pour les réguliers » s'en trouve affaiblie.
 | Point | Plan | Livré | Pourquoi |
 |---|---|---|---|
 | Emplacement du cachet | dans le flux de l'article | **dans le pied de page** | Seul emplacement qui marche dans les 4 modes de rendu : impossible d'injecter dans le DOM de l'éditeur en WebView, qui est le chemin nominal (~90 % du catalogue). Un seul cachet au lieu de deux variantes. |
-| Filet vert sur les cartes | via un `ReadStateMark` neuf | **`AnimatedFeedCard` réhabilitée** | Le widget était déjà écrit (code mort, 0 référence). Restylé : filet vertical, `easeOutCubic` 320 ms, plus de scrim noir ni d'`elasticOut`, aucune haptique. |
+| Filet vert sur les cartes | via un `ReadStateMark` neuf | **non livré** ⚠️ | `AnimatedFeedCard` a été *restylée* (filet vertical, `easeOutCubic` 320 ms, plus de scrim noir ni d'`elasticOut`, aucune haptique) mais **reste orpheline : 0 référence dans `lib/` et `test/`**. Le filet vert n'existe pas à l'écran. Le tableau annonçait « réhabilitée » à tort — corrigé le 25/07. À brancher en PR 2 mobile. |
 | `closing_recap.dart` | à réhabiliter | **laissé en l'état** | Le bloc de clôture n'a pas besoin du détail par section — une phrase suffit, et le récap par section rouvrirait la question du critère « lu » permissif. À reprendre si le PO veut le détail. |
 | Lot 4 (flamme) | conditionnel, après gate | **livré** | L'anneau ne dépend pas de `closure_streak` (qui est vide) : c'est un état du jour dérivé de `daily_completed`, il fonctionne dès le jour 1. Le gate ne portait que sur l'affichage d'une seconde série — toujours coupée. |
 
@@ -475,7 +475,13 @@ conclusion « ne pas optimiser pour les réguliers » s'en trouve affaiblie.
 - **Backend** : 2 485 tests passés (dont 13 nouveaux), 0 échec.
 - **Mobile** : 2 111 tests (dont 17 nouveaux). **33 échecs = exactement la baseline de `main`**, mesurée
   en stashant la branche. **0 régression.** `flutter analyze` : 0 erreur, aucun nouveau warning.
-- **Alembic** : `upgrade head` rejoué contre une base **vide** (Postgres 16 local), 1 seul head.
+- **Alembic** : ⚠️ **affirmation fausse au moment du merge** — `rd01` a bien été jouée contre une
+  base vide, mais depuis la *branche*, où elle était seule. Sur `main`, `pt01` (PR #1008, mergée
+  2 h plus tôt) porte le même `down_revision = 181c618da382` : **deux heads, aucune révision de
+  merge**, `alembic upgrade head` sans cible. Le boot staging démarrait quand même l'app sur un ORM
+  mappant `completed_at` / `completion_source` absentes → 500 sur feed, digest, statut, streaks.
+  Réparé par la révision de merge `mg04_merge_pt01_rd01` + garde `len(heads) != 1` au boot et sur
+  la sonde readiness + rejeu du smoke Alembic sur `push: main`. Voir la PR « hotfix Alembic ».
 - **API** : bootée localement, contrat vérifié dans l'OpenAPI
   (`ContentStatusUpdate.completed/completion_source`, `CompletionSource ∈ {in_app, short, web}`,
   `StreakResponse.daily_completed/daily_goal`).

--- a/packages/api/alembic/versions/dg01_daily_goal_user_profiles.py
+++ b/packages/api/alembic/versions/dg01_daily_goal_user_profiles.py
@@ -1,0 +1,33 @@
+"""add daily_goal to user_profiles
+
+Objectif journalier de lectures abouties réglable par l'utilisateur (story 30.2).
+Calqué sur `weekly_goal`. Colonne **additive** `NOT NULL DEFAULT 2` : Postgres
+backfille les lignes existantes via le server_default, donc pas de multi-étape
+expand/contract nécessaire (aucun DROP/rename). DB partagée staging/prod :
+l'ancien backend prod ignore simplement la colonne → sûr.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "dg01_daily_goal_user_profiles"
+down_revision: str | None = "mg04_merge_pt01_rd01"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_profiles",
+        sa.Column(
+            "daily_goal",
+            sa.Integer(),
+            nullable=False,
+            server_default="2",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_profiles", "daily_goal")

--- a/packages/api/alembic/versions/mg04_merge_pt01_rd01.py
+++ b/packages/api/alembic/versions/mg04_merge_pt01_rd01.py
@@ -1,0 +1,29 @@
+"""merge pt01 (index trigram entities) et rd01 (user_content_status.completed_at).
+
+Aucun changement de schéma. Les deux révisions ont été mergées sur `main` le
+même jour, chacune avec `down_revision = "181c618da382"` et sans révision de
+merge : `alembic upgrade head` n'avait plus de cible unique, le boot Railway
+échouait et l'app démarrait quand même (« Migrations failed … starting app
+anyway ») sur un ORM mappant des colonnes absentes → 500 généralisés sur
+staging.
+
+Les deux branches ne touchent aucun objet commun (index d'expression sur
+`contents` d'un côté, colonnes de `user_content_status` de l'autre), donc la
+révision est vide.
+"""
+
+revision: str = "mg04_merge_pt01_rd01"
+down_revision: tuple[str, ...] = (
+    "pt01_contents_entities_trgm",
+    "rd01_ucs_completed_at",
+)
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/packages/api/alembic/versions/pt01_contents_entities_trgm.py
+++ b/packages/api/alembic/versions/pt01_contents_entities_trgm.py
@@ -22,16 +22,24 @@ ignore jusqu'au passage hebdo :
    wrapper est légitime. ``search_internal_perspectives`` bascule sur ce wrapper
    (même PR) pour que l'expression indexée matche.
 2. ``ix_contents_entities_trgm`` — GIN sur ``content_entities_text(entities)`` avec
-   l'opclass **``extensions.gin_trgm_ops``**. Le baseline crée pg_trgm ``WITH
-   SCHEMA extensions`` ; l'opclass DOIT être qualifiée car ``extensions`` n'est
-   pas dans le ``search_path`` des connexions (vérifié : ``gin_trgm_ops`` nu ⇒
-   « operator class does not exist »).
+   l'opclass ``gin_trgm_ops`` **qualifiée par le schéma réel de pg_trgm**, résolu
+   au runtime. Elle DOIT être qualifiée car le schéma d'extension n'est pas dans
+   le ``search_path`` des connexions (vérifié : ``gin_trgm_ops`` nu ⇒ « operator
+   class does not exist ») — mais le schéma varie selon l'âge de la base : le
+   baseline crée pg_trgm ``WITH SCHEMA extensions`` (CI, base neuve) alors que la
+   base Supabase partagée, plus ancienne, l'a en ``public``. Coder ``extensions``
+   en dur faisait échouer la migration en prod (« operator class
+   extensions.gin_trgm_ops does not exist ») après le commit de la fonction par
+   l'``autocommit_block()`` — état partiellement appliqué, ``alembic_version``
+   inchangé.
 
 Rollout (recommandé) : construire l'index une fois via Supabase — d'abord la
 fonction, puis ``CREATE INDEX CONCURRENTLY`` (~30-90 s, non bloquant pour
 l'ingestion) — AVANT merge, puis cette migration ``IF NOT EXISTS`` est un no-op
 rapide au boot des deux services Railway.
 """
+
+import sqlalchemy as sa
 
 from alembic import op
 
@@ -40,6 +48,25 @@ revision: str = "pt01_contents_entities_trgm"
 down_revision: str | None = "181c618da382"
 branch_labels: str | None = None
 depends_on: str | None = None
+
+
+def _trgm_schema() -> str:
+    """Schéma réel de l'extension pg_trgm (``extensions`` en CI, ``public`` en prod).
+
+    Le fallback ``public`` ne sert qu'au cas dégénéré « extension absente » : le
+    ``CREATE INDEX`` échouera alors franchement, ce qui est le bon comportement.
+    """
+    return (
+        op.get_bind()
+        .execute(
+            sa.text(
+                "SELECT extnamespace::regnamespace::text "
+                "FROM pg_extension WHERE extname = 'pg_trgm'"
+            )
+        )
+        .scalar()
+        or "public"
+    )
 
 
 def upgrade() -> None:
@@ -56,15 +83,36 @@ def upgrade() -> None:
         AS $func$ SELECT array_to_string($1, ' ') $func$
         """
     )
-    # 2) Index GIN trigram. CREATE INDEX CONCURRENTLY ne peut pas tourner dans
-    #    la transaction Alembic (env.py enveloppe tout dans un seul begin) →
-    #    bloc autocommit. IF NOT EXISTS : no-op si déjà bâti hors-bande.
+    # 2) Index GIN trigram. Le schéma de l'opclass est résolu AVANT le bloc
+    #    autocommit (op.get_bind() y reste utilisable, mais on garde la lecture
+    #    dans la transaction principale).
+    ns = _trgm_schema()
+    # Un CREATE INDEX CONCURRENTLY interrompu (healthcheck Railway qui tue le
+    # conteneur pendant la construction) laisse un index INVALID, que le
+    # `IF NOT EXISTS` du rejeu suivant ignorerait silencieusement — la migration
+    # s'estampillerait alors comme réussie sur un index inutilisable. On le
+    # balaie donc avant de reconstruire.
+    invalid = (
+        op.get_bind()
+        .execute(
+            sa.text(
+                "SELECT 1 FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid "
+                "WHERE c.relname = 'ix_contents_entities_trgm' AND NOT i.indisvalid"
+            )
+        )
+        .scalar()
+    )
+    # CREATE INDEX CONCURRENTLY ne peut pas tourner dans la transaction Alembic
+    # (env.py enveloppe tout dans un seul begin) → bloc autocommit.
+    # IF NOT EXISTS : no-op si déjà bâti hors-bande.
     with op.get_context().autocommit_block():
+        if invalid:
+            op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_contents_entities_trgm")
         op.execute(
             "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_contents_entities_trgm "
             "ON public.contents "
             "USING gin (public.content_entities_text(entities) "
-            "extensions.gin_trgm_ops)"
+            f"{ns}.gin_trgm_ops)"
         )
 
 

--- a/packages/api/alembic/versions/rd01_ucs_completed_at.py
+++ b/packages/api/alembic/versions/rd01_ucs_completed_at.py
@@ -17,7 +17,6 @@ Create Date: 2026-07-24
 
 from collections.abc import Sequence
 
-import sqlalchemy as sa
 from alembic import op
 
 revision: str = "rd01_ucs_completed_at"
@@ -27,26 +26,27 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    op.add_column(
-        "user_content_status",
-        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+    # Rejouable (IF NOT EXISTS) : la DB Supabase est partagée staging↔prod et le
+    # Dockerfile rejoue `alembic upgrade head` au boot des deux services.
+    op.execute(
+        "ALTER TABLE user_content_status ADD COLUMN IF NOT EXISTS completed_at TIMESTAMPTZ"
     )
-    op.add_column(
-        "user_content_status",
-        sa.Column("completion_source", sa.String(length=12), nullable=True),
+    op.execute(
+        "ALTER TABLE user_content_status "
+        "ADD COLUMN IF NOT EXISTS completion_source VARCHAR(12)"
     )
     # Partial index — only completed rows are indexed, so the cost stays
     # negligible while the derived daily counter reads it directly.
-    op.create_index(
-        "ix_ucs_user_completed_at",
-        "user_content_status",
-        ["user_id", "completed_at"],
-        unique=False,
-        postgresql_where=sa.text("completed_at IS NOT NULL"),
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_ucs_user_completed_at "
+        "ON user_content_status (user_id, completed_at) "
+        "WHERE completed_at IS NOT NULL"
     )
 
 
 def downgrade() -> None:
-    op.drop_index("ix_ucs_user_completed_at", table_name="user_content_status")
-    op.drop_column("user_content_status", "completion_source")
-    op.drop_column("user_content_status", "completed_at")
+    op.execute("DROP INDEX IF EXISTS ix_ucs_user_completed_at")
+    op.execute(
+        "ALTER TABLE user_content_status DROP COLUMN IF EXISTS completion_source"
+    )
+    op.execute("ALTER TABLE user_content_status DROP COLUMN IF EXISTS completed_at")

--- a/packages/api/app/checks.py
+++ b/packages/api/app/checks.py
@@ -23,6 +23,26 @@ _ALEMBIC_INI_PATH = os.path.join(
 MIGRATION_BYPASS_ENV = "FACTEUR_MIGRATION_IN_PROGRESS"
 
 
+class MultipleAlembicHeadsError(RuntimeError):
+    """Le code embarque plusieurs heads Alembic — l'image est cassée.
+
+    Deux PRs mergées le même jour depuis la même base sans révision de merge
+    suffisent (incident du 25/07/2026). ``alembic upgrade head`` n'a alors plus
+    de cible : le boot Railway démarre l'app quand même et l'ORM mappe des
+    colonnes jamais créées → 500 sur tout le trafic authentifié. Prendre
+    ``heads[0]`` masquait la panne : selon l'ordre retourné, le contrôle de
+    démarrage et la sonde readiness pouvaient passer au vert.
+    """
+
+
+def _single_head(script_directory: "script.ScriptDirectory") -> str | None:
+    """Head unique du code, ou ``MultipleAlembicHeadsError`` s'il y en a plusieurs."""
+    heads = script_directory.get_heads()
+    if len(heads) > 1:
+        raise MultipleAlembicHeadsError(f"Multiple Alembic heads: {heads}")
+    return heads[0] if heads else None
+
+
 def _get_current_revision_sync(connection: AsyncConnection):
     """Sync function to get current revision from DB context."""
     context = migration.MigrationContext.configure(connection)
@@ -68,8 +88,11 @@ async def check_migrations_up_to_date():
     try:
         alembic_cfg = Config(_ALEMBIC_INI_PATH)
         script_directory = script.ScriptDirectory.from_config(alembic_cfg)
-        heads = script_directory.get_heads()
-        head_rev = heads[0] if heads else None
+        head_rev = _single_head(script_directory)
+    except MultipleAlembicHeadsError as e:
+        # Fatal, comme un schéma en retard : l'image ne peut pas migrer.
+        logger.critical("startup_check_migrations_multiple_heads", error=str(e))
+        raise
     except Exception as e:
         # G2: Non-essential config errors should warn, not crash
         logger.warning("startup_check_migrations_skipped_config", error=str(e))
@@ -100,12 +123,12 @@ def _code_head_and_ancestors() -> tuple[str | None, frozenset[str]]:
     """Code-side head revision + the full set of its ancestors (incl. head).
 
     Derived only from the Alembic script files bundled in this image, so it is
-    static per process — memoised. Raises on config error (caller catches).
+    static per process — memoised. Raises on config error, ou
+    ``MultipleAlembicHeadsError`` si l'image embarque un fork (caller catches).
     """
     alembic_cfg = Config(_ALEMBIC_INI_PATH)
     script_directory = script.ScriptDirectory.from_config(alembic_cfg)
-    heads = script_directory.get_heads()
-    head_rev = heads[0] if heads else None
+    head_rev = _single_head(script_directory)
     if head_rev is None:
         return None, frozenset()
     ancestors = frozenset(
@@ -135,6 +158,11 @@ async def get_migration_readiness() -> dict[str, str | bool | None]:
     """
     try:
         head_rev, ancestors = _code_head_and_ancestors()
+    except MultipleAlembicHeadsError as e:
+        # Pas un hoquet : l'image ne peut pas migrer, son schéma attendu est
+        # indéterminé. Le fail-open ne s'applique pas — on sort du LB.
+        logger.critical("readiness_migration_multiple_heads", error=str(e))
+        return {"behind": True, "head": None, "current": None}
     except Exception as e:
         logger.warning("readiness_migration_check_config_error", error=str(e))
         return {"behind": False, "head": None, "current": None}

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -120,7 +120,12 @@ settings = get_settings()
 
 
 def _get_alembic_head() -> str:
-    """Retourne la révision Alembic HEAD depuis le code (ou 'unknown')."""
+    """Retourne la révision Alembic HEAD depuis le code (ou 'unknown').
+
+    Un fork (>1 head) est rapporté tel quel plutôt que masqué par ``heads[0]`` :
+    c'est ce silence qui a rendu l'incident du 25/07/2026 invisible dans les logs
+    de boot.
+    """
     try:
         from alembic.config import Config
 
@@ -132,6 +137,8 @@ def _get_alembic_head() -> str:
         cfg = Config(alembic_ini)
         script_dir = script.ScriptDirectory.from_config(cfg)
         heads = script_dir.get_heads()
+        if len(heads) > 1:
+            return f"multiple-heads:{','.join(heads)}"
         return heads[0] if heads else "no-heads"
     except Exception:
         return "unknown"

--- a/packages/api/app/models/user.py
+++ b/packages/api/app/models/user.py
@@ -36,6 +36,10 @@ class UserProfile(Base):
     onboarding_completed: Mapped[bool] = mapped_column(Boolean, default=False)
     gamification_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
     weekly_goal: Mapped[int] = mapped_column(Integer, default=10)
+    # Objectif journalier de lectures abouties (« valider sa journée »), réglable
+    # par l'utilisateur (1→7, défaut 2). server_default pour backfill additif sur
+    # table peuplée et parité model↔DB (cf. closure_streak).
+    daily_goal: Mapped[int] = mapped_column(Integer, default=2, server_default="2")
     # Soft-delete (App Store 5.1.1(v) + Play Store account deletion).
     # `deleted_at` set by DELETE /api/users/me ; cron purge after 30 days.
     deleted_at: Mapped[datetime | None] = mapped_column(

--- a/packages/api/app/schemas/essentiel.py
+++ b/packages/api/app/schemas/essentiel.py
@@ -60,6 +60,9 @@ class EssentielArticle(BaseModel):
     is_liked: bool = False
     is_dismissed: bool = False
     read_at: datetime | None = None
+    # Lecture aboutie (fin d'article atteinte), pas seulement ouverte : c'est ce
+    # qui permet à la carte héros de la Tournée d'afficher le filet de complétion.
+    completed_at: datetime | None = None
     # Signaux user-aware pour affichage mobile (badges "Tu suis", pastille "Actu du jour").
     is_followed_source: bool = False
     is_followed_topic: bool = False

--- a/packages/api/app/schemas/streak.py
+++ b/packages/api/app/schemas/streak.py
@@ -4,6 +4,15 @@ from datetime import date
 
 from pydantic import BaseModel
 
+# Objectif journalier de lectures abouties. Constante serveur volontairement :
+# il n'existe aucune UI d'édition, et la garder ici permet de recalibrer sans
+# release client. Valeur provisoire — à arrêter sur la distribution réelle une
+# fois l'instrumentation réparée (aujourd'hui ≈ 1,2 lecture aboutie/jour actif).
+# Elle vit dans `schemas` et non dans `streak_service` : `schemas` n'importe
+# rien d'applicatif, donc le sens de dépendance reste `services → schemas` et
+# le défaut du champ ne peut plus diverger de la valeur servie.
+DAILY_COMPLETION_GOAL = 2
+
 
 class StreakResponse(BaseModel):
     """Réponse streak et progression."""
@@ -17,7 +26,7 @@ class StreakResponse(BaseModel):
     # Lectures abouties de la journée éditoriale (frontière 07h30 Paris).
     # Dérivé de `completed_at`, jamais stocké.
     daily_completed: int = 0
-    daily_goal: int = 2
+    daily_goal: int = DAILY_COMPLETION_GOAL
 
     class Config:
         from_attributes = True

--- a/packages/api/app/schemas/user.py
+++ b/packages/api/app/schemas/user.py
@@ -18,6 +18,7 @@ class UserProfileUpdate(BaseModel):
     display_name: str | None = None
     gamification_enabled: bool | None = None
     weekly_goal: int | None = Field(None, ge=3, le=7)
+    daily_goal: int | None = Field(None, ge=1, le=7)
 
 
 class UserProfileResponse(BaseModel):
@@ -31,6 +32,7 @@ class UserProfileResponse(BaseModel):
     onboarding_completed: bool
     gamification_enabled: bool
     weekly_goal: int
+    daily_goal: int
     created_at: datetime
     updated_at: datetime
 

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -52,7 +52,7 @@ from app.services.digest_selector import DigestSelector
 from app.services.editorial.schemas import EditorialPipelineResult
 from app.services.streak_service import StreakService
 from app.services.topic_selector import ScoredArticle, TopicGroup
-from app.utils.time import editorial_day, today_paris
+from app.utils.time import today_paris, week_start_paris
 
 logger = structlog.get_logger()
 
@@ -1534,8 +1534,8 @@ class DigestService:
         )
         await self.session.execute(upsert_stmt)
 
-        # Update closure streak (idempotent same-day via last_closure_date).
-        streak_update = await self._update_closure_streak(user_id)
+        # Update closure streak (idempotent same-edition via last_closure_date).
+        streak_update = await self._update_closure_streak(user_id, digest.target_date)
 
         await self.session.flush()
 
@@ -1626,11 +1626,11 @@ class DigestService:
                     inserted=inserted_id is not None,
                 )
                 # Keep the closure streak in sync when we actually inserted a
-                # new row — `_update_closure_streak` is itself same-day
+                # new row — `_update_closure_streak` is itself same-edition
                 # idempotent, but skipping the call when we no-opped on
                 # conflict avoids an unnecessary UserStreak read/write.
                 if inserted_id is not None:
-                    await self._update_closure_streak(user_id)
+                    await self._update_closure_streak(user_id, digest.target_date)
                 return True
         except Exception as exc:  # noqa: BLE001 — never break the caller
             logger.warning(
@@ -2922,8 +2922,19 @@ class DigestService:
 
         return {"read": read_count, "saved": saved_count, "dismissed": dismissed_count}
 
-    async def _update_closure_streak(self, user_id: UUID) -> dict[str, Any]:
-        """Update user's closure streak for digest completion."""
+    async def _update_closure_streak(
+        self, user_id: UUID, target_date: date
+    ) -> dict[str, Any]:
+        """Update user's closure streak for digest completion.
+
+        `target_date` is the *edition* that was just closed, never a notion of
+        "today". Deriving it server-side is what broke the streak: the two call
+        sites look up the digest with `today_paris()` (midnight boundary) while
+        this method stamped `editorial_day()` (07h30 boundary), so a reader
+        closing edition D at 01h got stamped D-1, and closing D+1 the next
+        evening saw `days_since == 2` — streak reset. Stamping the edition
+        itself removes the boundary question entirely.
+        """
         # Get or create streak record
         streak = await self.session.scalar(
             select(UserStreak).where(UserStreak.user_id == user_id)
@@ -2933,21 +2944,30 @@ class DigestService:
             streak = UserStreak(
                 id=uuid4(),
                 user_id=user_id,
-                week_start=date.today() - timedelta(days=date.today().weekday()),
+                week_start=week_start_paris(),
             )
             self.session.add(streak)
             await self.session.flush()
 
-        # Editorial day (07h30 Paris), NOT `date.today()` (server UTC). The
-        # trigger `maybe_record_implicit_completion` already gates on Paris
-        # time: stamping in UTC made a completion recorded for day D land on
-        # D-1 between 00h and 02h Paris in summer, breaking or doubling the
-        # streak.
-        today = editorial_day()
+        today = target_date
 
         # Update closure streak
         if streak.last_closure_date:
             days_since = (today - streak.last_closure_date).days
+
+            if days_since < 0:
+                # Édition *passée* refermée : le sélecteur de date sert les
+                # éditions J-7 et `complete_digest` accepte n'importe quel
+                # `digest_id`. Elle ne peut ni prolonger ni casser la série en
+                # cours. Sans cette sortie, `days_since` négatif tombait dans
+                # le `else` (reset à 1) et ramenait en plus le curseur
+                # `last_closure_date` en arrière — regression introduite en
+                # même temps que l'estampillage sur l'édition.
+                return {
+                    "current": streak.closure_streak,
+                    "longest": streak.longest_closure_streak,
+                    "message": None,
+                }
 
             if days_since == 0:
                 # Already completed today - don't increment

--- a/packages/api/app/services/essentiel_service.py
+++ b/packages/api/app/services/essentiel_service.py
@@ -705,6 +705,7 @@ def _to_essentiel_article(
         is_liked=article.is_liked,
         is_dismissed=article.is_dismissed,
         read_at=article.read_at,
+        completed_at=article.completed_at,
         is_followed_source=_is_followed_source(article, ctx),
         is_followed_topic=_is_followed_topic(topic, ctx),
         is_actu_du_jour=_is_actu_du_jour(topic, article),

--- a/packages/api/app/services/push_dispatcher.py
+++ b/packages/api/app/services/push_dispatcher.py
@@ -285,9 +285,7 @@ async def dispatch_daily_essentiel_pushes(
                 continue
 
             if cache_key not in composed_cache:
-                composed_cache[cache_key] = compose_daily_digest(
-                    essentiel, target_date
-                )
+                composed_cache[cache_key] = compose_daily_digest(essentiel, target_date)
             composed = composed_cache[cache_key]
             delivery.attempt_count += 1
             delivery.last_attempt_at = utc_now

--- a/packages/api/app/services/push_governor.py
+++ b/packages/api/app/services/push_governor.py
@@ -74,9 +74,7 @@ async def check_push_budget(
             return GovernorDecision(allowed=False, reason="ritual_upcoming")
 
     budget_rows = [
-        row
-        for row in rows
-        if not (row.kind == kind and row.target_date == target_date)
+        row for row in rows if not (row.kind == kind and row.target_date == target_date)
     ]
     daily_count = sum(1 for row in budget_rows if row.last_sent_at >= day_ago)
     if daily_count >= DAILY_BUDGET:

--- a/packages/api/app/services/streak_service.py
+++ b/packages/api/app/services/streak_service.py
@@ -10,17 +10,12 @@ from app.models.analytics import AnalyticsEvent
 from app.models.content import UserContentStatus
 from app.models.user import UserProfile, UserStreak
 from app.schemas.streak import (
+    DAILY_COMPLETION_GOAL,
     StreakActivityDayResponse,
     StreakActivityResponse,
     StreakResponse,
 )
-from app.utils.time import editorial_day_bounds
-
-# Objectif journalier de lectures abouties. Constante serveur volontairement :
-# il n'existe aucune UI d'édition, et la garder ici permet de recalibrer sans
-# release client. Valeur provisoire — à arrêter sur la distribution réelle une
-# fois l'instrumentation réparée (aujourd'hui ≈ 1,2 lecture aboutie/jour actif).
-DAILY_COMPLETION_GOAL = 2
+from app.utils.time import editorial_day_bounds, today_paris, week_start_paris
 
 
 class StreakService:
@@ -78,10 +73,12 @@ class StreakService:
         cette méthode conserve uniquement le suivi de progression hebdo.
         """
         streak = await self._get_or_create_streak(user_id)
-        today = date.today()
+        # Semaine calée sur Paris : `date.today()` (UTC) fait basculer le reset
+        # hebdo une à deux heures trop tôt le lundi matin côté lecteur.
+        today = today_paris()
 
         # Vérifier si on doit reset la semaine
-        week_start = today - timedelta(days=today.weekday())
+        week_start = week_start_paris(today)
         if streak.week_start != week_start:
             streak.weekly_count = 0
             streak.week_start = week_start
@@ -208,7 +205,7 @@ class StreakService:
             streak = UserStreak(
                 id=uuid4(),
                 user_id=UUID(user_id),
-                week_start=date.today() - timedelta(days=date.today().weekday()),
+                week_start=week_start_paris(),
             )
             self.db.add(streak)
             await self.db.flush()

--- a/packages/api/app/services/streak_service.py
+++ b/packages/api/app/services/streak_service.py
@@ -39,7 +39,7 @@ class StreakService:
             weekly_goal=weekly_goal,
             weekly_progress=min(1.0, streak.weekly_count / weekly_goal),
             daily_completed=await self.count_completed_today(user_id),
-            daily_goal=DAILY_COMPLETION_GOAL,
+            daily_goal=profile.daily_goal if profile else DAILY_COMPLETION_GOAL,
         )
 
     async def count_completed_today(self, user_id: str) -> int:

--- a/packages/api/app/utils/time.py
+++ b/packages/api/app/utils/time.py
@@ -26,6 +26,19 @@ def now_paris() -> datetime:
     return datetime.now(PARIS_TZ)
 
 
+def week_start_paris(day: date | None = None) -> date:
+    """Return the Monday of `day`'s ISO week, `today_paris()` by default.
+
+    La règle « la semaine commence lundi, en heure de Paris » était recopiée
+    à trois endroits (`streak_service` ×2, `digest_service`) : sur un
+    `date.today()` UTC, le reset hebdomadaire basculait une à deux heures trop
+    tôt le lundi matin côté lecteur. Une seule définition évite que le prochain
+    correctif de fuseau ait à les retrouver toutes.
+    """
+    day = day or today_paris()
+    return day - timedelta(days=day.weekday())
+
+
 # Editorial day boundary: the "tournée" flips at 07h30 Paris, not at midnight.
 # Mirror of `TourneeProgressService.dayKey` (mobile). Kept in one place so the
 # daily reading goal, the closure streak and the implicit digest completion all

--- a/packages/api/app/utils/time.py
+++ b/packages/api/app/utils/time.py
@@ -43,7 +43,9 @@ def editorial_day(now: datetime | None = None) -> date:
     edition".
     """
     moment = now.astimezone(PARIS_TZ) if now is not None else datetime.now(PARIS_TZ)
-    if is_before_paris_time(moment, EDITORIAL_DAY_START_HOUR, EDITORIAL_DAY_START_MINUTE):
+    if is_before_paris_time(
+        moment, EDITORIAL_DAY_START_HOUR, EDITORIAL_DAY_START_MINUTE
+    ):
         return moment.date() - timedelta(days=1)
     return moment.date()
 

--- a/packages/api/tests/test_digest_completion_implicit.py
+++ b/packages/api/tests/test_digest_completion_implicit.py
@@ -226,7 +226,10 @@ async def test_updates_closure_streak_on_successful_insert(
     ):
         await service.maybe_record_implicit_completion(user_id, content_ids[0])
 
-    service._update_closure_streak.assert_awaited_once_with(user_id)
+    # Stamped on the edition that was closed, never on a server-side "today".
+    service._update_closure_streak.assert_awaited_once_with(
+        user_id, date(2026, 4, 24)
+    )
 
 
 @pytest.mark.asyncio

--- a/packages/api/tests/test_health_readiness_migrations.py
+++ b/packages/api/tests/test_health_readiness_migrations.py
@@ -14,7 +14,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from app.checks import get_migration_readiness
+from app.checks import (
+    MultipleAlembicHeadsError,
+    _single_head,
+    check_migrations_up_to_date,
+    get_migration_readiness,
+)
 from app.database import get_db
 from app.main import app
 
@@ -107,6 +112,59 @@ async def test_fail_open_on_config_error():
     ):
         status = await get_migration_readiness()
     assert status["behind"] is False
+
+
+# --- Fork Alembic (incident 2026-07-25) ---------------------------------------
+
+
+def _script_dir(*heads: str):
+    script_directory = MagicMock()
+    script_directory.get_heads.return_value = list(heads)
+    return script_directory
+
+
+def test_single_head_returns_the_head():
+    assert _single_head(_script_dir("mg04_merge_pt01_rd01")) == "mg04_merge_pt01_rd01"
+
+
+def test_single_head_returns_none_when_no_revision():
+    assert _single_head(_script_dir()) is None
+
+
+def test_single_head_raises_on_fork():
+    """`heads[0]` masquait le fork : selon l'ordre, le boot passait au vert avec
+    une révision jamais appliquée → 500 généralisés, readiness verte."""
+    with pytest.raises(MultipleAlembicHeadsError, match="pt01"):
+        _single_head(
+            _script_dir("pt01_contents_entities_trgm", "rd01_ucs_completed_at")
+        )
+
+
+@pytest.mark.asyncio
+async def test_readiness_not_ready_on_fork():
+    """Le fail-open ne s'applique pas au fork : l'image ne peut pas migrer."""
+    with patch(
+        "app.checks._code_head_and_ancestors",
+        side_effect=MultipleAlembicHeadsError("Multiple Alembic heads: ['a', 'b']"),
+    ):
+        status = await get_migration_readiness()
+    assert status["behind"] is True
+
+
+@pytest.mark.asyncio
+async def test_startup_check_crashes_on_fork(monkeypatch):
+    """Le contrôle de démarrage est fatal sur un fork, comme sur un schéma en retard."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    with (
+        patch(
+            "app.checks.script.ScriptDirectory.from_config",
+            return_value=_script_dir(
+                "pt01_contents_entities_trgm", "rd01_ucs_completed_at"
+            ),
+        ),
+        pytest.raises(MultipleAlembicHeadsError),
+    ):
+        await check_migrations_up_to_date()
 
 
 # --- Endpoint: 503 vs 200 -----------------------------------------------------

--- a/packages/api/tests/test_lecture_aboutie_backend.py
+++ b/packages/api/tests/test_lecture_aboutie_backend.py
@@ -17,7 +17,7 @@ import pytest
 from sqlalchemy import select
 
 from app.models.content import Content, ContentType, UserContentStatus
-from app.models.user import UserStreak
+from app.models.user import UserProfile, UserStreak
 from app.schemas.content import SourceMini
 from app.schemas.digest import DigestTopic, DigestTopicArticle
 from app.schemas.essentiel import EssentielArticle
@@ -241,6 +241,37 @@ def test_daily_goal_default_tracks_the_constant():
         weekly_progress=0.0,
     )
     assert response.daily_goal == DAILY_COMPLETION_GOAL
+
+
+@pytest.mark.asyncio
+async def test_get_streak_reflects_profile_daily_goal(db_session):
+    """L'objectif quotidien réglable (colonne profil `daily_goal`) doit être
+    servi par `get_streak`, et non plus la constante en dur (story 30.2)."""
+    user_id = uuid4()
+    db_session.add(
+        UserProfile(
+            user_id=user_id,
+            gamification_enabled=True,
+            weekly_goal=10,
+            daily_goal=5,
+        )
+    )
+    await db_session.flush()
+
+    streak = await StreakService(db_session).get_streak(str(user_id))
+
+    assert streak.daily_goal == 5
+
+
+@pytest.mark.asyncio
+async def test_get_streak_falls_back_to_constant_without_profile(db_session):
+    """Sans profil (ex. utilisateur legacy), l'objectif retombe sur la constante
+    serveur plutôt que de planter."""
+    user_id = uuid4()
+
+    streak = await StreakService(db_session).get_streak(str(user_id))
+
+    assert streak.daily_goal == DAILY_COMPLETION_GOAL
 
 
 def test_essentiel_article_carries_completed_at():

--- a/packages/api/tests/test_lecture_aboutie_backend.py
+++ b/packages/api/tests/test_lecture_aboutie_backend.py
@@ -1,0 +1,278 @@
+"""Epic 30 « La lecture aboutie » — garde-fous des compteurs de complétion.
+
+Trois zones qui n'avaient aucun test alors qu'elles pilotent la calibration de
+`DAILY_COMPLETION_GOAL` :
+
+1. `_update_closure_streak` — était systématiquement mocké dans les 3 fichiers
+   qui l'approchent, ce qui a laissé passer un décalage de frontière (édition
+   estampillée `editorial_day()` / digest cherché en `today_paris()`).
+2. `count_completed_today` — le compteur exposé à l'UI.
+3. `StreakResponse.daily_goal` — dupliqué en dur, donc libre de diverger.
+"""
+
+from datetime import UTC, date, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+
+from app.models.content import Content, ContentType, UserContentStatus
+from app.models.user import UserStreak
+from app.schemas.content import SourceMini
+from app.schemas.digest import DigestTopic, DigestTopicArticle
+from app.schemas.essentiel import EssentielArticle
+from app.schemas.streak import DAILY_COMPLETION_GOAL
+from app.services.digest_service import DigestService
+from app.services.essentiel_service import EssentielUserContext, _to_essentiel_article
+from app.services.streak_service import StreakService
+from app.utils.time import PARIS_TZ
+
+# --------------------------------------------------------------------------
+# 1. closure streak — démocké
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_closure_streak_counts_consecutive_editions(db_session):
+    """Clore l'édition D puis l'édition D+1 donne une série de 2.
+
+    Test de non-régression du bug : la méthode estampillait une notion de
+    « aujourd'hui » (frontière 07h30) alors que ses appelants trouvent le
+    digest via `today_paris()` (minuit). Entre 00h et 07h30 Paris, clore
+    l'édition D estampillait D-1, puis clore D+1 le lendemain soir voyait
+    `days_since == 2` → série remise à 1.
+    """
+    user_id = uuid4()
+    service = DigestService(db_session)
+
+    first = await service._update_closure_streak(user_id, date(2026, 4, 24))
+    second = await service._update_closure_streak(user_id, date(2026, 4, 25))
+
+    assert first["current"] == 1
+    assert second["current"] == 2
+
+    streak = await db_session.scalar(
+        select(UserStreak).where(UserStreak.user_id == user_id)
+    )
+    assert streak.last_closure_date == date(2026, 4, 25)
+    assert streak.longest_closure_streak == 2
+
+
+@pytest.mark.asyncio
+async def test_closure_streak_is_idempotent_per_edition(db_session):
+    """Re-clore la même édition (chemin explicite après le chemin implicite)
+    ne double pas la série."""
+    user_id = uuid4()
+    service = DigestService(db_session)
+
+    await service._update_closure_streak(user_id, date(2026, 4, 24))
+    again = await service._update_closure_streak(user_id, date(2026, 4, 24))
+
+    assert again["current"] == 1
+
+
+@pytest.mark.asyncio
+async def test_closure_streak_resets_after_a_skipped_edition(db_session):
+    """Une édition sautée casse bien la série — la correction ne rend pas la
+    méthode permissive, elle la rend seulement indépendante de l'heure."""
+    user_id = uuid4()
+    service = DigestService(db_session)
+
+    await service._update_closure_streak(user_id, date(2026, 4, 24))
+    resumed = await service._update_closure_streak(user_id, date(2026, 4, 26))
+
+    assert resumed["current"] == 1
+
+
+@pytest.mark.asyncio
+async def test_closure_streak_ignores_a_past_edition(db_session):
+    """Refermer une édition passée ne touche pas la série en cours.
+
+    Le sélecteur de date sert les éditions J-7 et `complete_digest` accepte
+    n'importe quel `digest_id` : depuis l'estampillage sur l'édition, un
+    `days_since` négatif tombait dans la branche « série cassée » (reset à 1)
+    et ramenait `last_closure_date` en arrière — donc cassait aussi la clôture
+    du lendemain.
+    """
+    user_id = uuid4()
+    service = DigestService(db_session)
+
+    await service._update_closure_streak(user_id, date(2026, 4, 24))
+    await service._update_closure_streak(user_id, date(2026, 4, 25))
+
+    backfill = await service._update_closure_streak(user_id, date(2026, 4, 20))
+
+    assert backfill["current"] == 2
+
+    streak = await db_session.scalar(
+        select(UserStreak).where(UserStreak.user_id == user_id)
+    )
+    assert streak.last_closure_date == date(2026, 4, 25)
+
+    # Et la clôture du lendemain prolonge toujours la série.
+    tomorrow = await service._update_closure_streak(user_id, date(2026, 4, 26))
+    assert tomorrow["current"] == 3
+
+
+# --------------------------------------------------------------------------
+# 2. count_completed_today — frontière 07h30 Paris
+# --------------------------------------------------------------------------
+
+
+async def _content(db_session, test_source) -> Content:
+    content = Content(
+        id=uuid4(),
+        source_id=test_source.id,
+        title="Un article",
+        url=f"https://example.com/{uuid4()}",
+        guid=str(uuid4()),
+        published_at=datetime.now(UTC),
+        content_type=ContentType.ARTICLE,
+    )
+    db_session.add(content)
+    await db_session.flush()
+    return content
+
+
+async def _complete(db_session, test_source, user_id, completed_at: datetime | None):
+    content = await _content(db_session, test_source)
+    db_session.add(
+        UserContentStatus(
+            user_id=user_id,
+            content_id=content.id,
+            completed_at=completed_at,
+        )
+    )
+    await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_count_completed_today_ignores_older_days(
+    db_session, test_source, monkeypatch
+):
+    """Une complétion de J-3 ne compte pas dans la journée éditoriale en cours."""
+    user_id = uuid4()
+    now = datetime(2026, 4, 24, 12, 0, tzinfo=PARIS_TZ)
+    monkeypatch.setattr(
+        "app.services.streak_service.editorial_day_bounds",
+        lambda: (
+            datetime(2026, 4, 24, 7, 30, tzinfo=PARIS_TZ),
+            datetime(2026, 4, 25, 7, 30, tzinfo=PARIS_TZ),
+        ),
+    )
+
+    await _complete(db_session, test_source, user_id, now)
+    await _complete(db_session, test_source, user_id, now - timedelta(days=3))
+    # Article ouvert mais jamais abouti — ne doit jamais compter.
+    await _complete(db_session, test_source, user_id, None)
+
+    assert await StreakService(db_session).count_completed_today(str(user_id)) == 1
+
+
+@pytest.mark.asyncio
+async def test_count_completed_today_exercises_the_0730_boundary(
+    db_session, test_source, monkeypatch
+):
+    """La fenêtre suit 07h30 Paris des deux côtés : 07h29 appartient encore à
+    l'édition de la veille, 07h31 à celle du jour."""
+    user_id = uuid4()
+    monkeypatch.setattr(
+        "app.services.streak_service.editorial_day_bounds",
+        lambda: (
+            datetime(2026, 4, 24, 7, 30, tzinfo=PARIS_TZ),
+            datetime(2026, 4, 25, 7, 30, tzinfo=PARIS_TZ),
+        ),
+    )
+
+    # Hors fenêtre : juste avant l'ouverture, et juste après la fermeture.
+    await _complete(
+        db_session, test_source, user_id, datetime(2026, 4, 24, 7, 29, tzinfo=PARIS_TZ)
+    )
+    await _complete(
+        db_session, test_source, user_id, datetime(2026, 4, 25, 7, 30, tzinfo=PARIS_TZ)
+    )
+    # Dans la fenêtre : à l'ouverture pile, et juste avant la fermeture.
+    await _complete(
+        db_session, test_source, user_id, datetime(2026, 4, 24, 7, 30, tzinfo=PARIS_TZ)
+    )
+    await _complete(
+        db_session, test_source, user_id, datetime(2026, 4, 25, 7, 29, tzinfo=PARIS_TZ)
+    )
+
+    assert await StreakService(db_session).count_completed_today(str(user_id)) == 2
+
+
+@pytest.mark.asyncio
+async def test_count_completed_today_is_scoped_to_the_user(
+    db_session, test_source, monkeypatch
+):
+    user_id = uuid4()
+    monkeypatch.setattr(
+        "app.services.streak_service.editorial_day_bounds",
+        lambda: (
+            datetime(2026, 4, 24, 7, 30, tzinfo=PARIS_TZ),
+            datetime(2026, 4, 25, 7, 30, tzinfo=PARIS_TZ),
+        ),
+    )
+    inside = datetime(2026, 4, 24, 12, 0, tzinfo=PARIS_TZ)
+
+    await _complete(db_session, test_source, user_id, inside)
+    await _complete(db_session, test_source, uuid4(), inside)
+
+    assert await StreakService(db_session).count_completed_today(str(user_id)) == 1
+
+
+# --------------------------------------------------------------------------
+# 3. contrats — objectif journalier et complétion servie par /api/essentiel
+# --------------------------------------------------------------------------
+
+
+def test_daily_goal_default_tracks_the_constant():
+    """Garde anti-re-duplication : le défaut du schéma ne doit plus être un
+    littéral libre de diverger de la valeur servie par le service."""
+    from app.schemas.streak import StreakResponse
+
+    response = StreakResponse(
+        current_streak=0,
+        longest_streak=0,
+        last_activity_date=None,
+        weekly_count=0,
+        weekly_goal=10,
+        weekly_progress=0.0,
+    )
+    assert response.daily_goal == DAILY_COMPLETION_GOAL
+
+
+def test_essentiel_article_carries_completed_at():
+    """`/api/essentiel` doit servir `completed_at` : sans lui la carte héros de
+    la Tournée ne peut pas connaître la complétion."""
+    completed_at = datetime(2026, 4, 24, 9, 0, tzinfo=UTC)
+    article = DigestTopicArticle(
+        content_id=uuid4(),
+        title="Un article",
+        url="https://example.com/a",
+        published_at=datetime.now(UTC),
+        source=SourceMini(
+            id=uuid4(),
+            name="Le Monde",
+            logo_url=None,
+            type="article",
+            theme="society",
+        ),
+        rank=1,
+        reason="test",
+        completed_at=completed_at,
+    )
+    topic = DigestTopic(
+        topic_id="t1",
+        label="Société",
+        rank=1,
+        reason="test",
+        theme="society",
+        articles=[article],
+    )
+
+    projected = _to_essentiel_article(topic, article, 1, EssentielUserContext())
+
+    assert isinstance(projected, EssentielArticle)
+    assert projected.completed_at == completed_at

--- a/packages/api/tests/test_onboarding_digest_pregeneration.py
+++ b/packages/api/tests/test_onboarding_digest_pregeneration.py
@@ -182,6 +182,7 @@ async def test_onboarding_schedules_initial_digest_generation():
         onboarding_completed=True,
         gamification_enabled=True,
         weekly_goal=5,
+        daily_goal=2,
         created_at=now,
         updated_at=now,
     )


### PR DESCRIPTION
# feat(lecture-aboutie): rendre la complétion visible, durable et non rejouable (Epic 30)

Epic 30 « La lecture aboutie », base `main`. **Aucune migration** (1 head Alembic,
`mg04_merge_pt01_rd01`, inchangé).

L'audit fichier par fichier de `main` a établi que la moitié visible de la demande
d'origine n'était jamais montée à l'écran, que la complétion ne survivait pas au
redémarrage, et que deux bugs backend restaient ouverts, dont un que #1007 avait
aggravé.

## A. Backend

- **`_update_closure_streak(user_id, target_date)` estampille l'édition close**,
  plus une notion de « aujourd'hui ». Le correctif de #1007 avait remplacé une
  frontière UTC (00h→02h Paris) par la frontière éditoriale 07h30 alors que ses
  deux appelants cherchent le digest via `today_paris()` (minuit) : la fenêtre de
  divergence avait *grandi*. Un lecteur qui clôturait l'édition D à 01h se voyait
  estampiller D-1, puis sa série remise à 1 le lendemain. **Zéro test ne couvrait
  la méthode** (mockée dans les 3 fichiers qui l'approchent) ; elle l'est
  maintenant, démockée, contre une vraie base.
- **Garde-fou édition passée** : `complete_digest` accepte n'importe quel
  `digest_id` et le sélecteur de date sert les éditions J-7. Un `days_since`
  négatif tombait dans la branche « série cassée » (reset à 1) *et* ramenait
  `last_closure_date` en arrière, cassant aussi la clôture du lendemain.
- **`week_start_paris()`** dans `app/utils/time.py` : la règle « semaine = lundi,
  heure de Paris » était recopiée 3 fois sur un `date.today()` UTC (reset hebdo
  une à deux heures trop tôt le lundi côté lecteur).
- **`DAILY_COMPLETION_GOAL`** descend dans `app.schemas.streak` : le
  `daily_goal: int = 2` du schéma était un doublon en dur, libre de diverger.
  Sens de dépendance `services → schemas` conservé.
- **`count_completed_today`** (le compteur exposé à l'UI) a enfin des tests
  (J-3, frontière 07h30 des deux côtés, scope utilisateur).
- **`EssentielArticle.completed_at`** est servi : la carte héros de la Tournée ne
  pouvait pas connaître la complétion, alors que `_to_essentiel_article` recevait
  déjà le champ.

## B. Mobile — durabilité

- **`CompletedReadsStore`** (box Hive `completed_reads` dédiée, purge 30 j, cap
  1000). Box séparée de `pending_reads` : cette dernière est une file de synchro
  qui *supprime* l'entrée au succès. `markCompleted` écrit le registre d'abord,
  puis l'état, comme `markConsumed`.
- **Hydratation poussée** au démarrage (one-shot, post-frame), pas watchée :
  faire dépendre `completedContentIdsProvider` de `readSyncUserIdProvider`
  remonterait à `Supabase.instance` et casserait tout widget test montant une carte.
- **Fuite inter-comptes** : `completedContentIdsProvider` est vidé au logout.

## C. Mobile — visible

- **`ReadStateMark`** partagé remplace 2 des 3 copies privées : celle de la carte
  Essentiel codait `check` en dur, donc était *structurellement* incapable
  d'afficher une complétion. `_ReadStatusPill` (timeline d'éditions) n'est pas
  touchée : elle décrit l'état d'une *édition*, pas d'un article.
- **`AnimatedFeedCard`** était restée orpheline (0 référence dans `lib/`) : le
  filet vert n'existait pas à l'écran. Elle est montée sur les 3 familles de
  cartes en `animate: false` (un état au montage, une animation seulement sur la
  transition de retour d'article). Son `AnimationController` était `late final`
  et n'était instancié qu'au `dispose()` d'une carte non aboutie : inoffensif
  tant qu'elle était du code mort, systématique dès qu'elle est montée partout.
- **Mapping** : `FluxArticleVM.from(DigestItem)` et `articleToContent` jetaient
  `completedAt` ; le modèle mobile `EssentielArticle` ne le parsait pas.
- **Layout du cachet** : sorti de la `Column` du pied de page (il y ajoutait
  ~34 px alors que `_kFooterContentHeight` sert de spacer à 9 endroits) et rendu
  **frère** du pill via `Stack` + `FractionalTranslation(0, -1)`. Aucune mesure,
  les 9 usages inchangés.

## D. Mobile — réouverture

- **`ArticleCompletionLatch`** (Dart pur, testé) sépare l'état connu à l'ouverture
  de l'événement de session. Rouvrir un article terminé ne rejoue plus haptique +
  POST + `article_finished` — l'événement même qui doit servir à calibrer
  l'objectif journalier, jusqu'ici gonflé par les relectures.

## E. Silences

- Le `catch (_)` du flush de la file de lectures remonte à Sentry, hors erreurs de
  connectivité (cas nominal de cette file, `isOfflineError`).
- L'opt-out gamification n'échoue plus en silence (relit la vérité serveur + le dit).

## Vérification

- Backend : `pytest` — **2514 passed**, 18 skipped, 2 xfailed, 0 échec.
  1 head Alembic, aucune migration ajoutée.
- Mobile : `flutter test` — **+1747 / -28**, les 28 échecs dans 8 fichiers
  qu'aucun commit de cette PR ne touche (baseline documentée ~27 :
  `auth/router_redirection`, `custom_topics`, `digest/bookmark`,
  `detail/notification_test`, `feed_sources`, `perspectives_*`, `settings/*`,
  `widget_test`). Les 53 tests des fichiers touchés/ajoutés passent.
- `flutter analyze` : **0 erreur**.
- Changelog in-app : entrée « Lecture » ajoutée (impact visible).

## Zones à risque

`digest_service._update_closure_streak` (série de clôture), `read_sync_service`
(file de synchro des lectures), boot Hive (`main.dart`, 7e box), et les 3 familles
de cartes du feed.

Story : `docs/stories/core/30.lecture-aboutie/README.md` (§11 journal
d'implémentation).

## Reste ouvert

- Fenêtre de 14 j de collecte `article_finished` (PostHog) avant d'arrêter
  `DAILY_COMPLETION_GOAL` sur P50/P75/P90. La correction de la réouverture est ce
  qui rend cette distribution exploitable.
- `/validate-feature` (parcours visuels : cachet, filet, anneau) non exécuté —
  Flutter web n'était pas lancé dans cet environnement.
