### PR TITLE
feat(flux-continu): snap « passer à la suite » sur fling rapide + CTA « Tout lire (N+) »

### DIFF
--- a/apps/mobile/lib/features/flux_continu/utils/section_snap.dart
+++ b/apps/mobile/lib/features/flux_continu/utils/section_snap.dart
@@ -26,6 +26,15 @@ const double kSectionEdgeMargin = 160.0;
 /// rewind (more sections stay snapped on the way up); lower ⇒ easier to escape.
 const double kFastUpwardVelocity = 1400.0;
 
+/// px/s. Seuil « geste rapide » **en descente**. En dessous, un scroll qui
+/// atterrit dans l'intérieur d'une section plus haute que l'écran reste en
+/// lecture libre (on suit le doigt). Au-dessus, l'intention lue est « passer à
+/// la suite » : le snap reprend la main et vise le **haut de la section
+/// suivante**, en ignorant le point de repos intermédiaire (bas de la carte
+/// courante) — sinon une carte longue exige deux gestes. Plus haut ⇒ plus
+/// difficile de sauter une carte longue ; plus bas ⇒ snap plus mordant.
+const double kFastDownwardVelocity = 900.0;
+
 // ── Réglages du ressort de snap (le « grain » du switch vers une section) ──
 // Le snap est un [ScrollSpringSimulation] : on tune ces 3 leviers à l'œil pour
 // le rendre à la fois smooth ET net. Repères :
@@ -33,19 +42,23 @@ const double kFastUpwardVelocity = 1400.0;
 /// La **force / vitesse** du tir vers la cible. Plus haut ⇒ snap plus rapide et
 /// « net » (claque vers la section) ; plus bas ⇒ plus lent et mou. C'est le
 /// premier levier pour la « vitesse de switch ».
-const double kSnapStiffness = 700.0;
+const double kSnapStiffness = 900.0;
 
 /// L'**amortissement**. Plus haut ⇒ aucune oscillation, arrivée « posée » et
 /// smooth (mais trop haut = traînant) ; plus bas ⇒ vif, voire un léger rebond.
 /// À monter avec [kSnapStiffness] pour rester net sans wobble.
-const double kSnapDamping = 40.0;
+/// Baissé à 36 (ex-40) pour retirer un peu d'« amorti » en fin de geste : le
+/// système reste **suramorti** (`c² = 1296 > 4mk = 108`, aucun wobble), mais la
+/// racine lente passe de ≈ 17.7 s⁻¹ à ≈ 25.5 s⁻¹. Ne pas descendre sous ≈ 30
+/// avec cette raideur : en dessous on entre en zone de rebond.
+const double kSnapDamping = 36.0;
 
 /// L'**inertie** de la masse animée. Plus haut ⇒ démarrage plus pesant / lent ;
 /// plus bas ⇒ réaction plus immédiate. À laisser ≈ 0.5 sauf besoin précis.
 const double kSnapMass = 0.03;
 
-/// Ressort de pose du snap, assemblé depuis les 3 leviers ci-dessus. Visible
-/// « pose » (~250-350ms) sans wobble — le snap fait partie de la décélération
+/// Ressort de pose du snap, assemblé depuis les 3 leviers ci-dessus. Pose
+/// visible (~180-250ms) sans wobble — le snap fait partie de la décélération
 /// du fling, pas d'une seconde animation.
 const SpringDescription kSnapSpring = SpringDescription(
   mass: kSnapMass,
@@ -66,7 +79,9 @@ typedef SectionFrame = ({double top, double bottom});
 ///
 /// The feel: the reader is **free** while a section fully fills the viewport
 /// (its top is above the sticky header *and* its bottom is below the footer —
-/// no edge shows). Once an edge crosses into the viewport the scroll **snaps**,
+/// no edge shows) **and** their gesture is slow: a downward fling past
+/// [kFastDownwardVelocity] reads as "passer à la suite" and snaps to the next
+/// section top. Once an edge crosses into the viewport the scroll **snaps**,
 /// with a hard **one-step cap**: whatever the fling's strength, the commit
 /// target is always the frame **adjacent to the finger-lift position**
 /// ([currentPixels]) in the travel direction — never bracketed around where the
@@ -119,12 +134,20 @@ double? resolveSnapTarget({
   final freeUpwardEscape = dir < 0 && velocity.abs() >= kFastUpwardVelocity;
   if (freeUpwardEscape) return null;
 
+  // DOWN-only "passer à la suite": a vigorous downward fling reads as an intent
+  // to leave the current section, even a tall one. It disables the free-reading
+  // gate below and targets section **tops** only — so a card taller than the
+  // screen is cleared in a single gesture instead of two. See
+  // [kFastDownwardVelocity].
+  final isFastDown = dir > 0 && velocity.abs() >= kFastDownwardVelocity;
+
   // Free reading: the landing rests inside a section that fully fills the
   // viewport (a tall section's open interior). No edge shows ⇒ leave it free —
-  // but only on descent/idle (`dir >= 0`). On a slow upward scroll we fall
-  // through to the snap logic so the section above re-frames under the header
-  // instead of drifting (the fix for the "too permissive" rewind).
-  if (dir >= 0) {
+  // but only on a *slow* descent/idle (`dir >= 0 && !isFastDown`). On a slow
+  // upward scroll we fall through to the snap logic so the section above
+  // re-frames under the header instead of drifting (the fix for the "too
+  // permissive" rewind).
+  if (dir >= 0 && !isFastDown) {
     for (final f in frames) {
       if (f.bottom > f.top + kSnapEpsilon &&
           naturalLanding > f.top + kSnapEpsilon &&
@@ -137,6 +160,18 @@ double? resolveSnapTarget({
   // Every framing offset is a snap point: each section top, plus the bottom of
   // each tall section (rest on its last cards). Sorted ascending.
   final points = snapPointsOf(frames);
+
+  // Geste rapide en descente : viser le **haut de la section suivante**, en
+  // ignorant le point de repos intermédiaire (bas de la section courante) —
+  // sinon une carte plus haute que l'écran exige deux gestes. Placé avant le
+  // deadband : un fling ≥ [kFastDownwardVelocity] dépasse de toute façon la
+  // marge, et la règle reste lisible sans en dépendre. Toujours **un cran**,
+  // mesuré en sections au lieu de frames.
+  if (isFastDown) {
+    final tops = [for (final f in frames) f.top]..sort();
+    final next = _firstStrictlyAfter(tops, currentPixels);
+    return _commit(next ?? _nearest(points, currentPixels), currentPixels);
+  }
 
   // Deadband (« marge »): how far the fling's inertia carries past the lift
   // point. A small overshoot — or no direction at all — re-frames the section

--- a/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_banner.dart
@@ -48,11 +48,6 @@ class SectionBanner extends StatelessWidget {
   /// (page Flâner : pas de navigation de section).
   final VoidCallback? onTap;
 
-  /// Nombre d'articles non affichés (`totalCount - coreVisibleCount`).
-  /// Rendu en « +X » gris discret après le chevron quand > 0 et [onTap]
-  /// est câblé.
-  final int hiddenCount;
-
   /// Story 22.3 — quand true, le banner pose un badge « Choisie pour vous »
   /// au-dessus du titre, tappable via [onTapInfo] (ouvre la sheet « Pourquoi
   /// cette section ? »). Signale une section suggérée par le facteur.
@@ -81,7 +76,6 @@ class SectionBanner extends StatelessWidget {
     this.large = false,
     this.logoUrl,
     this.onTap,
-    this.hiddenCount = 0,
     this.suggested = false,
     this.onTapInfo,
     this.onPromote,

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../config/theme.dart';
 import '../../feed/widgets/feedback_inline.dart';
 import '../models/flux_continu_models.dart';
 import 'essentiel_hi_fi_card.dart';
@@ -443,7 +444,10 @@ class SectionBlock extends StatelessWidget {
     // (padded par défaut) → c'est cette hauteur fantôme, pas la marge, qui
     // éloignait « Tout lire › » de sa section. On la collapse au contenu réel.
     tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-    textStyle: const TextStyle(fontSize: 12.5, fontWeight: FontWeight.w500),
+    // Typo du DS (DM Sans via `labelMedium`) : le `TextStyle` brut précédent
+    // n'avait pas de `fontFamily` → rendu dans la police système, hors DS. La
+    // couleur reste portée par `foregroundColor` (texte + chevron).
+    textStyle: FacteurTypography.labelMedium(const Color(0xFF5D5B5A)),
   );
 
   Widget _seeAllFooter() {

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -116,10 +116,6 @@ class SectionBlock extends StatelessWidget {
       );
     }
     final cards = _buildCards();
-    final hiddenCount = (section.totalCount - section.coreVisibleCount).clamp(
-      0,
-      999,
-    );
     // Section source sans article récent (≤72h) mais avec des cartes plus
     // anciennes (repli 30 j backend) → on signale « Pas d'article récent. » dans
     // la blurb du banner. L'empty-state (aucun article même vieux) reste géré
@@ -152,7 +148,6 @@ class SectionBlock extends StatelessWidget {
           onTapFavorite: onTapFavorite,
           onTapSettings: onTapSettings,
           onTap: onSeeAll,
-          hiddenCount: hiddenCount,
           // Story 22.3 — badge « Choisie pour vous » sur les sections suggérées.
           suggested: isSuggested,
           onTapInfo: onTapSuggestionInfo,
@@ -452,6 +447,11 @@ class SectionBlock extends StatelessWidget {
   );
 
   Widget _seeAllFooter() {
+    // Volume promis par la page dédiée, borné [3, 9] : le compte vient du
+    // snapshot client (`totalCount`, déjà en mémoire), jamais d'une requête —
+    // ce CTA ne doit rien coûter au chargement. Le « + » assume la borne haute
+    // (la page dédiée pagine au-delà).
+    final count = section.totalCount.clamp(3, 9);
     return Container(
       // Marges resserrées : le CTA colle au bas de la dernière carte (qui porte
       // déjà 12px de padding bas). `kSeeAllFooterHeight` reflète la hauteur
@@ -461,12 +461,12 @@ class SectionBlock extends StatelessWidget {
       child: TextButton(
         onPressed: onSeeAll,
         style: _seeAllFooterStyle,
-        child: const Row(
+        child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text('Tout lire'),
-            SizedBox(width: 2),
-            Icon(Icons.chevron_right_rounded, size: 16),
+            Text('Tout lire ($count+)'),
+            const SizedBox(width: 2),
+            const Icon(Icons.chevron_right_rounded, size: 16),
           ],
         ),
       ),

--- a/apps/mobile/test/features/flux_continu/utils/section_snap_test.dart
+++ b/apps/mobile/test/features/flux_continu/utils/section_snap_test.dart
@@ -210,18 +210,101 @@ void main() {
     });
 
     test(
-        'a hard fling from inside a tall section stops at its bottom (one step)',
-        () {
-      // Lift inside the (300, 600) interior, huge landing past the section.
-      // The cap advances to the section's own bottom frame (600), not beyond.
+        'a moderate fling from inside a tall section stops at its bottom '
+        '(one step)', () {
+      // Lift inside the (300, 600) interior, landing past the section but
+      // BELOW kFastDownwardVelocity. The cap advances to the section's own
+      // bottom frame (600), not beyond (a *fast* fling skips it — see the
+      // fast-descent group).
       final target = resolveSnapTarget(
         currentPixels: 320,
         naturalLanding: 5000,
-        velocity: 9000,
-        scrollDirection: 1, // down
+        velocity: kFastDownwardVelocity - 1,
+        scrollDirection: 1, // down, sub-threshold
         frames: frames,
       );
       expect(target, 600.0);
+    });
+
+    // --- Task: fast DOWNWARD fling clears a tall section in one gesture -----
+
+    test('a slow descent inside a tall section stays free (non-regression)',
+        () {
+      // Landing at 450 inside the (300,600) interior with a velocity under
+      // kFastDownwardVelocity ⇒ free reading, exactly as before.
+      final target = resolveSnapTarget(
+        currentPixels: 430,
+        naturalLanding: 450,
+        velocity: kFastDownwardVelocity - 1,
+        scrollDirection: 1,
+        frames: frames,
+      );
+      expect(target, isNull);
+    });
+
+    test('a fast descent inside a tall section snaps to the NEXT section top',
+        () {
+      // Same landing, but past the threshold: the intent reads as "passer à la
+      // suite" ⇒ target the next section top (1200), never the current
+      // section's bottom (600) — otherwise a long card needs two gestures.
+      final target = resolveSnapTarget(
+        currentPixels: 430,
+        naturalLanding: 450,
+        velocity: 2000,
+        scrollDirection: 1,
+        frames: frames,
+      );
+      expect(target, 1200.0);
+    });
+
+    test('a fast descent from a tall section bottom targets the next top', () {
+      final target = resolveSnapTarget(
+        currentPixels: 600,
+        naturalLanding: 5000,
+        velocity: 2000,
+        scrollDirection: 1,
+        frames: frames,
+      );
+      expect(target, 1200.0);
+    });
+
+    test('the fast-descent target is a different section ⇒ haptic fires', () {
+      // frameIndexOfTarget must differ from the active section (index 1, the
+      // tall one) so the screen fires exactly one settle haptic.
+      final target = resolveSnapTarget(
+        currentPixels: 430,
+        naturalLanding: 450,
+        velocity: 2000,
+        scrollDirection: 1,
+        frames: frames,
+      );
+      expect(frameIndexOfTarget(frames, target!), isNot(1));
+    });
+
+    test('a fast descent past the last section falls back to the nearest frame',
+        () {
+      // No section top after the lift point (already on the finale) ⇒ fall back
+      // to the nearest snap point rather than returning a runaway target.
+      final target = resolveSnapTarget(
+        currentPixels: 1250,
+        naturalLanding: 9000,
+        velocity: 3000,
+        scrollDirection: 1,
+        frames: frames,
+      );
+      expect(target, 1200.0);
+    });
+
+    test('a fast UPWARD fling is unaffected by the downward threshold', () {
+      // kFastDownwardVelocity is DOWN-only: the up escape still wins.
+      final target = resolveSnapTarget(
+        currentPixels: 430,
+        naturalLanding: 450,
+        velocity: -kFastUpwardVelocity - 100,
+        scrollDirection: -1,
+        frames: frames,
+      );
+      expect(target, isNull);
     });
 
     // --- Directional one-step commits --------------------------------------

--- a/apps/mobile/test/features/flux_continu/widgets/section_block_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/section_block_test.dart
@@ -457,8 +457,9 @@ void main() {
         ),
       ));
 
-      expect(find.text('Tout lire'), findsOneWidget);
-      await tester.tap(find.text('Tout lire'));
+      // Le CTA porte le volume promis, borné [3, 9] : 5 sujets ⇒ « (5+) ».
+      expect(find.text('Tout lire (5+)'), findsOneWidget);
+      await tester.tap(find.text('Tout lire (5+)'));
       await tester.pumpAndSettle();
       expect(opened, isTrue);
     });
@@ -472,7 +473,30 @@ void main() {
         ),
       ));
 
-      expect(find.text('Tout lire'), findsOneWidget);
+      expect(find.text('Tout lire (3+)'), findsOneWidget);
+    });
+
+    testWidgets('le compte annoncé est borné [3, 9] (snapshot client only)',
+        (tester) async {
+      // Plancher : 1 article ⇒ « (3+) » (on ne promet jamais moins de 3).
+      await tester.pumpWidget(_wrap(
+        SectionBlock(
+          section: _sourceSection(items: 1),
+          onTapArticle: (_) {},
+          onSeeAll: () {},
+        ),
+      ));
+      expect(find.text('Tout lire (3+)'), findsOneWidget);
+
+      // Plafond : 20 articles ⇒ « (9+) », le « + » assume la pagination.
+      await tester.pumpWidget(_wrap(
+        SectionBlock(
+          section: _sourceSection(items: 20),
+          onTapArticle: (_) {},
+          onSeeAll: () {},
+        ),
+      ));
+      expect(find.text('Tout lire (9+)'), findsOneWidget);
     });
 
     testWidgets('section source vide (empty-state) : pas de « Tout lire › » '
@@ -485,7 +509,7 @@ void main() {
         ),
       ));
 
-      expect(find.text('Tout lire'), findsNothing);
+      expect(find.textContaining('Tout lire'), findsNothing);
       expect(find.text('Voir toute la curation'), findsOneWidget);
     });
 
@@ -529,8 +553,9 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Ajouter plus de sources'), findsNothing);
-      expect(find.text('Tout lire'), findsOneWidget);
-      await tester.tap(find.text('Tout lire'));
+      // 7 articles ⇒ « (7+) » (sous la borne haute 9).
+      expect(find.text('Tout lire (7+)'), findsOneWidget);
+      await tester.tap(find.text('Tout lire (7+)'));
       await tester.pumpAndSettle();
       expect(opened, isTrue);
     });


### PR DESCRIPTION
## Quoi

Deux ajustements du Flux Continu (mobile, aucun backend / migration) :

- **Snap « passer à la suite »** : un fling descendant vigoureux (≥ `kFastDownwardVelocity` = 900 px/s) lit l'intention de quitter la section courante et vise le **haut de la section suivante**, en ignorant le point de repos intermédiaire (bas de la carte courante). Une carte plus haute que l'écran se franchit désormais en **un** geste au lieu de deux. La lecture libre reste intacte sur descente lente (non-régression testée). Ressort retuné (`stiffness` 700→900, `damping` 40→36) pour une pose plus mordante sans wobble — le système reste suramorti.
- **CTA « Tout lire (N+) »** : le footer « Tout lire › » annonce le volume, `N = totalCount` borné `[3, 9]`, lu du snapshot client déjà en mémoire (aucune requête). Le champ mort `hiddenCount` de `SectionBanner`/`SectionBlock` est retiré.

## Pourquoi

Une carte plus haute que l'écran exigeait deux flings pour passer à la section suivante (le snap s'arrêtait au bas de la carte). Le CTA « Tout lire » ne disait pas ce qu'il y avait derrière.

## Comment ça a été vérifié

- [x] `flutter test` — suite complète : +1769 / -27 (les 27 échecs = baseline pré-existante documentée, aucun fichier touché par cette PR). Les tests des 2 fichiers touchés passent, avec nouveaux cas fast-down (next top, fallback dernière section, up-fling non affecté, haptique) et CTA borné [3,9].
- [x] `flutter analyze` (flux_continu) — 0 issue.
- [x] `/simplify` passé — diff jugé propre (retire de la complexité).
- [ ] Playwright / `/validate-feature` non exécuté (feel de snap = geste natif, non testable au canvas web fiablement).

## Zones à risque

`resolveSnapTarget` (`section_snap.dart`) — logique de snap sur chaque fling ; nouveau branchement fast-down placé avant le deadband. `_seeAllFooter` (`section_block.dart`).