### PR TITLE
fix(observability): mesurer la pression du pool DB sur la capacité, pas sur les connexions vivantes (PYTHON-63)

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -46,6 +46,17 @@ réelle), puis restait bloqué à 100 %.
 artefact. Le fix d'alors n'a pas « lâché » — il n'y avait rien à corriger côté capacité.
 Ses mitigations ne sont **pas** revert.
 
+## Conséquence indirecte — le watchdog d'auto-remédiation
+
+`.github/workflows/pool-saturation-watchdog.yml` sonde `/api/health/pool` **toutes les
+5 minutes** et déclenche sa branche « saturation confirmée » si `status == "saturated"` ou
+`usage_pct > 90`. Il s'appuyait donc sur le même signal faux. Il n'a pas encore déclenché
+(aucune issue ouverte — la double sonde à 30 s a filtré les pics), mais l'en-tête du workflow
+prévoit de remplacer la branche dry-run par la mutation Railway `serviceInstanceRedeploy`
+après 24 h sans faux positif. **Un redeploy automatique du backend aurait pu être armé sur un
+seuil atteint à 45 % de charge réelle.** Ce correctif désamorce le risque sans toucher au
+workflow, qui consomme `read_pool_stats`.
+
 ## Changements
 
 - `app/observability/pool_stats.py` — capacité lue via `pool._max_overflow` (pas

--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,92 +1,115 @@
-# feat(recherche): recherche universelle — sources · sujets · thèmes · articles (story 30.1)
+# fix(observability): la métrique de pression du pool DB divisait par les connexions vivantes, pas par la capacité
 
-Story 30.1, base `main`. La loupe du 2ᵉ onglet ne savait chercher qu'une chose : un
-mot dans un titre d'article, parmi les seules sources suivies. Elle devient un **point
-d'entrée de navigation** : trouver une source, un sujet, un thème ou un article — et,
-quand ce qu'on cherche n'existe pas encore dans le compte, enchaîner sans friction sur
-l'**ajout de source**. **Aucun changement backend, aucune migration.**
+## Résumé
 
-## Ce qui n'allait pas (constaté dans le code)
+L'alerte Sentry [PYTHON-63](https://facteur.sentry.io/issues/PYTHON-63)
+`DB pool pressure CRITICAL: 91.7% (>= 90%)` (`level=fatal`, 2 occurrences depuis le 21/07)
+est un **faux positif**. Le pool n'a jamais été proche de la saturation : la métrique était
+fausse.
 
-| Constat | Fichier |
-|---|---|
-| La sheet n'affichait **rien pendant la frappe** (`if (!hasQuery)` gardait tout le contenu) | `search_filter_sheet.dart` |
-| La recherche ne renvoyait **que des articles** — `title ILIKE %q%` | `filter_presets.py:368` |
-| Aucune recherche de source / sujet / thème, alors que les 3 filtres existaient déjà | `feed_provider.dart` |
-| **Zéro résultat → écran blanc.** `EmptyFilterState` existait mais n'était jamais monté | `empty_filter_state.dart` |
-| `CompactSearchChip` : code mort, aucune référence | `compact_search_chip.dart` |
-| `includeUnfollowed` n'était activable que depuis une chip « sujet du moment » | `feed_filter_bar.dart` |
-| Aucun événement analytics sur la recherche | `analytics_service.dart` |
+Base `main`. **Aucune migration.** Aucun impact mobile.
 
-## A. Recherche multi-entités (100 % locale)
+## Cause racine
 
-- `utils/search_matcher.dart` — primitives pures : `foldForSearch` (casse + accents FR,
-  longueur préservée), `matchQuality` (exact > prefix > wordPrefix > contains),
-  `rankMatches` (tri déterministe : qualité, puis libellé le plus court, puis alpha),
-  `looksLikeSourceQuery` (URL / domaine collé).
-- `utils/search_results_builder.dart` — `buildSearchSections` compose 5 sections à partir
-  de données **déjà en mémoire** (`userSourcesProvider` porte tout le catalogue avec les
-  drapeaux `isTrusted` / `isMuted`) : `Articles`, `Tes sources`, `Sujets suivis`, `Thèmes`,
-  `Ajouter une source`. **Aucun appel réseau pendant la frappe** (debounce 180 ms).
-- **Ordre adaptatif** : un match exact sur une source, ou un domaine saisi, remonte les
-  sections source devant `Articles` — taper « Mediapart » est une intention source, pas une
-  intention mot-clé.
-- `models/search_result.dart` — sealed class des 5 natures de résultat ; chacune mappe sur
-  un geste déjà supporté par `FeedNotifier`.
+`app/observability/pool_stats.py` calculait :
 
-## B. Le pont vers l'ajout de source
+```python
+usage_pct = checked_out / (size + max(overflow or 0, 0))
+```
 
-- **Source du catalogue non suivie** → bouton **Ajouter** inline : `trustSource()` puis
-  filtre immédiat sur la source, sans quitter la sheet ni écran intermédiaire. Les sources
-  en **sourdine** sont exclues (les re-proposer contredirait un choix explicite).
-- **Source inconnue** → `AddSourceScreen` avec la recherche intelligente **déjà lancée** :
-  nouveau paramètre `initialQuery` sur `SourceAddPanel`, propagé par l'écran et lu depuis
-  `state.extra` dans `routes.dart`. Pas de re-saisie.
+Le dénominateur était censé être la capacité (`pool_size + max_overflow` = 10+10 = **20**).
+Mais `pool.overflow()` de SQLAlchemy ne renvoie pas `max_overflow` : c'est `_overflow`, le
+nombre de connexions **vivantes** au-delà de `pool_size` (initialisé à `-pool_size`).
 
-## C. L'état vide de Flâner
+Le dénominateur suivait donc les connexions vivantes, pas la capacité. En injectant
+`checkedout() = maxsize - qsize + _overflow` (source SQLAlchemy 2.0.25), la formule se
+réduit à `usage_pct = 1 - checked_in / (size + overflow)` : **elle ne dépendait que du
+nombre de connexions idle en file**, et saturait à 100 % dès que la file se vidait.
 
-`EmptyFilterState` (code mort) est ressuscité, doté d'une variante mot-clé et **monté** dans
-`flaner_screen.dart` quand la liste est vide et qu'un filtre est actif. Rattrapages, du moins
-au plus engageant : élargir · ajouter la source · suivre le sujet · revenir au feed. La carte
-`FollowKeywordSuggestionCard` est masquée dans ce cas (doublon avec « suivre ce sujet »).
+Mesuré sur un vrai `QueuePool(pool_size=10, max_overflow=10)` :
 
-## D. Élargir la recherche
+| checked_out | AVANT | APRÈS |
+|---|---|---|
+| 9 / 20 | **90,0 %** → page `fatal` | 45,0 % |
+| 10 / 20 | **100,0 %** → `saturated` | 50,0 % |
+| 11 / 20 (l'événement réel) | **100,0 %** | 55,0 % |
+| 18 / 20 | 100,0 % | 90,0 % → page `fatal` |
+| 20 / 20 | 100,0 % | 100,0 % → `saturated` |
 
-- Bandeau « N résultats dans tes sources → **Élargir** » quand un mot-clé ramène 1 à 4
-  articles.
-- `includeUnfollowed` **déplacé dans `FeedFilterSelection`** : `setKeyword(q,
-  includeUnfollowed: true)` avec le même mot-clé ne changeait pas la sélection, donc l'UI ne
-  se redessinait pas (`==` ignorait le périmètre). `_restoreFiltersFromSelection` le restaure
-  désormais au lieu de le remettre à `false` — ce qui rétrécissait silencieusement une
-  recherche élargie après un rebuild du notifier.
-- La pill de la barre de filtres affiche « mot-clé · toutes sources » quand le périmètre est
-  élargi.
+Le seuil de page était donc franchi dès **9 connexions sorties sur 20** (45 % de charge
+réelle), puis restait bloqué à 100 %.
 
-## E. Découvrabilité (décision PO : header partagé)
+`91,7 % = 11/12` ⇒ `overflow=2`, `checked_in=1`, `checked_out=11` → charge réelle
+**11/20 = 55 %**, avec 9 connexions d'overflow libres.
 
-- Loupe 40 px dans `_SharedTopHeader` (`main_shell.dart`), à gauche de l'avatar : présente
-  sur les **deux** onglets, hors de la zone filtre. Teinte accent quand une recherche est
-  active.
-- Depuis L'Essentiel, valider une recherche **bascule sur Flâner** avec le filtre appliqué.
-- Le trigger de la barre de filtres est rétrogradé en **affichage d'état** : la pill
-  « 🔍 mot-clé ✕ » quand une recherche est active, **rien** sinon (au lieu d'occuper 34 px en
-  permanence pour une loupe redondante).
-- Suppression de `compact_search_chip.dart` (code mort).
+**Corollaire** : le « 100 % » de **PYTHON-5M** (25/06) était très probablement le même
+artefact. Le fix d'alors n'a pas « lâché » — il n'y avait rien à corriger côté capacité.
+Ses mitigations ne sont **pas** revert.
 
-## F. Instrumentation
+## Changements
 
-`search_opened` · `search_result_selected` (type + rang) · `search_submitted_empty` ·
-`search_add_source_bridged` · `search_broadened`. Le funnel visé : ouverture → sélection
-(succès) vs impasse → rattrapage. `search_submitted_empty` est dédupliqué par signature
-`mot-clé|périmètre` (l'état vide est reconstruit à chaque rebuild du sliver).
+- `app/observability/pool_stats.py` — capacité lue via `pool._max_overflow` (pas
+  d'accesseur public ; stable SQLAlchemy 1.4→2.0) ; expose `capacity` et `max_overflow` ;
+  `usage_pct = checked_out / capacity` ; `saturated = checked_out >= capacity`. `overflow`
+  reste exposé pour le diagnostic mais sort du dénominateur.
+- `app/observability/pool_stats.py` — **garde-fou anti-silence** : si le pool est dimensionné
+  mais que la capacité est illisible (attribut privé renommé par une future version de
+  SQLAlchemy, ou `max_overflow < 0`), on loggue `pool_capacity_unreadable` en `error`. Sans
+  ça, `usage_pct` disparaîtrait, la sonde prendrait sa branche « NullPool » et **cesserait
+  d'alerter silencieusement** — le pire mode de défaillance pour une métrique d'alerte.
+- `app/workers/scheduler.py` — les `capture_message` n'interpolent plus de chiffre variable
+  dans le texte (Sentry groupe par message : `usage_pct` dans le texte crée **une issue par
+  valeur**). Les compteurs partent dans le contexte Sentry `db_pool`, via un helper local
+  qui dédoublonne les deux branches d'alerte.
+- `app/main.py` — le log `db_pool_pressure_high` de `/api/health/pool` expose désormais
+  `capacity` (le dénominateur réel) en plus d'`overflow`, qui avait induit en erreur.
+- Docs : `docs/bugs/bug-pool-pressure-metric-false-positive.md` (neuf) + encart de
+  correction en tête de `docs/maintenance/maintenance-saturation-pool-db-nocturne.md`.
 
-## Vérification
+**Seuils inchangés** (warn 70 %, page 90 %) : ils portent désormais sur la capacité réelle,
+soit 14 et 18 connexions sorties. Le pic observé (11) reste silencieux — c'est voulu.
 
-- `flutter analyze` : **0 erreur**, aucun nouveau warning sur les fichiers touchés.
-- **47 nouveaux tests, tous verts** : 17 matcher · 13 builder · 5 état vide · 9 sheet ·
-  3 pont ajout de source.
-- Suite complète : **1740 passants / 33 échecs, tous préexistants** — vérifié en rejouant les
-  mêmes fichiers sur `main` sans le diff (mêmes 33 : stubs `fail('Test not implemented')` de
-  `feed_sources_test.dart`, goldens `ring_avatar`, `widget_test.dart`…).
-- Pas d'E2E Playwright : le build web n'a pas été exercé dans cet environnement.
-  QA handoff prêt dans `.context/qa-handoff.md` (10 scénarios) pour `/validate-feature`.
+**Aucun changement de `pool_size`/`max_overflow`** : le pic réel est 11/20. Interdit sans
+preuve métrique (`docs/bugs/bug-infinite-load-requests.md`).
+
+Clés ajoutées uniquement (`capacity`, `max_overflow`) → `/api/health/pool` gagne des champs,
+rien ne casse.
+
+## Tests
+
+`packages/api/tests/test_pool_observability.py` :
+
+- `test_read_pool_stats_does_not_page_on_engaged_overflow` — rejoue l'événement du 25/07
+  (`size=10, overflow=2, checked_out=11`) et exige 55 %, sous le seuil de page.
+- `test_read_pool_stats_capacity_matches_real_queuepool` — **le garde-fou qui manquait** :
+  construit un vrai `QueuePool` avec les kwargs de prod et vérifie le ratio à 9 puis 20
+  connexions sorties. Les fakes ne protégeaient pas contre une mécompréhension de l'API
+  SQLAlchemy, qui est l'origine exacte du bug.
+- `test_read_pool_stats_logs_when_sized_pool_has_unreadable_capacity` — supprime
+  `_max_overflow` pour simuler un renommage SQLAlchemy et exige le log `error`.
+- `test_read_pool_stats_nullpool_stays_quiet` — NullPool ne doit pas déclencher ce log.
+- `test_read_pool_stats_unbounded_overflow_has_no_usage_pct` — `max_overflow < 0`.
+- `test_read_pool_stats_ok_with_negative_overflow` — attendu corrigé 50 % → 25 %.
+
+Suite backend complète : `1992 passed, 1 failed, 547 errors` — l'échec
+(`test_essentiel_endpoint.py::test_get_essentiel_uses_user_context_from_router`) et les 547
+erreurs sont dus à l'absence de Postgres local sur le port 54322, et sont **reproduits à
+l'identique sur `origin/main`** (vérifié via worktree).
+
+## ⚠️ Après merge (actions PO)
+
+1. Le texte du message Sentry change → **nouveau groupe d'issue**. Résoudre **PYTHON-63**
+   en « faux positif — métrique corrigée ».
+2. Surveiller 1 semaine les logs `db_pool_probe` (info, 5 min) pour établir le p95 réel de
+   `checked_out` avant toute autre action.
+
+## Suivi identifié (hors périmètre, non prouvé par cette alerte)
+
+- `app/services/push_dispatcher.py` — transaction ouverte pendant les envois FCM
+  (`await asyncio.to_thread`) avec `idle_in_transaction_session_timeout = 10 s` : un envoi
+  lent peut tuer la transaction et faire perdre les écritures `status='sent'`.
+  **Bug de correction en soi**, à traiter séparément.
+- `app/services/recommendation_service.py` — jusqu'à 3 connexions simultanées par
+  `/api/feed`.
+- `app/services/grille_selector.py` — `asyncio.gather` sur la **même** `AsyncSession`.
+- `app/workers/classification_worker.py` — engine `NullPool` séparé, invisible de la sonde.

--- a/docs/bugs/bug-pool-pressure-metric-false-positive.md
+++ b/docs/bugs/bug-pool-pressure-metric-false-positive.md
@@ -1,0 +1,139 @@
+# Bug — « DB pool pressure CRITICAL » est un faux positif (PYTHON-63)
+
+- **Sentry** : [PYTHON-63](https://facteur.sentry.io/issues/PYTHON-63) — `level=fatal`
+- **Occurrences** : 2 (première 2026-07-21 18:30 UTC, dernière 2026-07-25 14:20 UTC)
+- **Message** : `DB pool pressure CRITICAL: 91.7% (>= 90%)`
+- **Impact utilisateur** : aucun
+- **Statut** : corrigé — la métrique était fausse, il n'y a jamais eu d'incident de capacité
+
+## Symptôme
+
+La sonde `_pool_health_probe` (`app/workers/scheduler.py`, toutes les 5 min) a levé une
+alerte Sentry `fatal` annonçant un pool de connexions DB à 91,7 % de sa capacité, à deux
+reprises en journée (18h30 puis 14h20 UTC — hors fenêtre des jobs de nuit). Aucune lenteur,
+aucune erreur, aucun symptôme côté app.
+
+## Cause racine — le dénominateur n'était pas la capacité
+
+`app/observability/pool_stats.py` calculait :
+
+```python
+usage_pct = checked_out / (size + max(overflow or 0, 0))
+```
+
+L'intention était de diviser par la **capacité** du pool, soit
+`pool_size + max_overflow` = 10 + 10 = **20** (`app/database.py`, `PROD_POOL_KWARGS`).
+
+Mais `pool.overflow()` de SQLAlchemy ne renvoie **pas** `max_overflow`. Il renvoie
+`_overflow`, le nombre de connexions **actuellement vivantes au-delà de `pool_size`** —
+initialisé à `-pool_size` et incrémenté à chaque connexion créée :
+
+```python
+# sqlalchemy/pool/impl.py (2.0.25)
+def size(self)       -> int: return self._pool.maxsize          # pool_size, constant
+def overflow(self)   -> int: return self._overflow              # vivantes au-delà de pool_size
+def checkedin(self)  -> int: return self._pool.qsize()          # idle en file
+def checkedout(self) -> int: return self._pool.maxsize - self._pool.qsize() + self._overflow
+```
+
+Le dénominateur suivait donc les connexions vivantes, pas la capacité. En injectant
+`checkedout()` dans la formule, elle se réduit à :
+
+```
+usage_pct = 1 - checked_in / (size + overflow)
+```
+
+⇒ **la métrique ne dépendait que du nombre de connexions idle en file.** Elle atteignait
+100 % dès que la file se vidait momentanément, avec encore 10 connexions d'overflow
+disponibles — et ne pouvait plus jamais en redescendre tant que l'overflow restait engagé.
+
+Le flag `status: "saturated"` (`checked_out >= size + max(overflow, 0)`) souffrait du même
+défaut : il se réduisait à `checked_in <= 0`, pas à « pool épuisé ».
+
+### Mesure sur un vrai `QueuePool` (pool_size=10, max_overflow=10)
+
+| checked_out | overflow() | usage_pct AVANT | usage_pct APRÈS |
+|---|---|---|---|
+| 9 / 20 | -1 | **90,0 %** → page `fatal` | 45,0 % |
+| 10 / 20 | 0 | **100,0 %** → `saturated` | 50,0 % |
+| 11 / 20 | 1 | **100,0 %** | 55,0 % |
+| 18 / 20 | 8 | 100,0 % | 90,0 % → page `fatal` |
+| 20 / 20 | 10 | 100,0 % | 100,0 % → `saturated` |
+
+Le seuil de page (90 %) était donc franchi dès **9 connexions sorties sur 20**, soit 45 % de
+charge réelle.
+
+### Décodage de l'événement du 25/07
+
+`91,7 % = 11/12` ⇒ `overflow = 2`, `checked_in = 1`, `checked_out = 11`.
+Charge réelle : **11 / 20 = 55 %**, avec 9 connexions d'overflow encore libres.
+
+### Corollaire sur PYTHON-5M
+
+L'alerte historique PYTHON-5M (25/06, « pool à 100 % », marquée Résolue après limitation de
+la concurrence des jobs de nuit) était très probablement **le même artefact** : la formule
+renvoyait 100 % dès que `checked_in == 0`. Le fix PYTHON-5M n'a donc pas « lâché » — il n'y
+avait vraisemblablement rien à corriger côté capacité.
+
+Les mitigations mises en place à l'époque (`concurrency_limit=5` sur le job digest, decay
+décalé à 06h50, `max_instances=1`) restent saines et **n'ont pas été revert**.
+
+## Correctif
+
+1. `app/observability/pool_stats.py` — lire `max_overflow` via `pool._max_overflow` (aucun
+   accesseur public n'existe ; l'attribut est stable de SQLAlchemy 1.4 à 2.0), exposer
+   `capacity = size + max_overflow`, et calculer `usage_pct = checked_out / capacity`.
+   `saturated` devient `checked_out >= capacity`. `overflow` reste exposé pour le
+   diagnostic, mais n'entre plus dans le dénominateur. Si `max_overflow < 0` (illimité), pas
+   de `usage_pct`.
+2. `app/observability/pool_stats.py` — **garde-fou anti-silence** : si le pool est
+   dimensionné (`size()` répond) mais que la capacité est illisible (attribut privé renommé
+   par une future version de SQLAlchemy, ou `max_overflow < 0`), on loggue
+   `pool_capacity_unreadable` en `error`. Sans ça, `usage_pct` disparaîtrait, la sonde
+   prendrait sa branche « NullPool » et **cesserait d'alerter silencieusement** — le pire
+   mode de défaillance pour une métrique d'alerte.
+3. `app/workers/scheduler.py` — les `capture_message` n'interpolent plus de chiffre variable
+   dans le texte (Sentry groupe par message : `usage_pct` dans le texte crée une issue par
+   valeur). Les compteurs partent dans le contexte Sentry `db_pool`.
+4. `app/main.py` — le log `db_pool_pressure_high` de `/api/health/pool` expose désormais
+   `capacity` (le dénominateur réel) en plus d'`overflow`, qui avait induit en erreur.
+
+**Seuils inchangés** (warn 70 %, page 90 %, sustained 2) : ils portent désormais sur la
+capacité réelle, soit 14 et 18 connexions sorties.
+
+**Pas de changement de `pool_size`/`max_overflow`** — le pic réel observé est 11/20 (55 %).
+Cf. `docs/bugs/bug-infinite-load-requests.md` : interdit sans preuve métrique.
+
+## Non-régression
+
+`packages/api/tests/test_pool_observability.py` :
+
+- `test_read_pool_stats_does_not_page_on_engaged_overflow` — rejoue l'événement du 25/07
+  (`size=10, overflow=2, checked_out=11`) et exige 55 %, sous le seuil de page.
+- `test_read_pool_stats_capacity_matches_real_queuepool` — le garde-fou qui manquait :
+  construit un **vrai** `QueuePool` avec les kwargs de prod et vérifie la capacité et le
+  ratio à 9 puis 20 connexions sorties. Les fakes ne protégeaient pas contre une
+  mécompréhension de l'API SQLAlchemy, qui est exactement l'origine du bug.
+- `test_read_pool_stats_logs_when_sized_pool_has_unreadable_capacity` — supprime
+  `_max_overflow` pour simuler un renommage SQLAlchemy et exige le log `error`.
+- `test_read_pool_stats_nullpool_stays_quiet` — NullPool (dev) ne doit pas déclencher ce log.
+
+## Suites à décider après ré-observation
+
+Le nouveau signal étant fiable, surveiller une semaine les logs `db_pool_probe` (info, 5 min)
+pour établir le p95 réel de `checked_out`. Pistes de pression identifiées pendant
+l'investigation mais **non prouvées** par cette alerte :
+
+- `app/services/push_dispatcher.py` — transaction ouverte pendant les envois FCM
+  (`await asyncio.to_thread(sender, ...)`), avec `idle_in_transaction_session_timeout = 10 s`
+  posé par `safe_async_session()` : un envoi lent peut tuer la transaction et faire perdre
+  les écritures `status='sent'` de la boucle. **C'est un bug de correction en soi**, à traiter
+  indépendamment de la pression pool.
+- `app/services/recommendation_service.py` — jusqu'à 3 connexions simultanées par
+  `/api/feed` (session request-scope idle-in-tx + 2 sessions courtes en `asyncio.gather`),
+  amplifié par le single-flight de `app/routers/feed.py` qui fait attendre les waiters
+  connexion déjà sortie.
+- `app/services/grille_selector.py` — `asyncio.gather` de deux requêtes sur la **même**
+  `AsyncSession` (`InterfaceError: another operation is in progress`).
+- `app/workers/classification_worker.py` — engine séparé en `NullPool`, donc invisible de
+  cette sonde et de `/api/health/pool`.

--- a/docs/bugs/bug-pool-pressure-metric-false-positive.md
+++ b/docs/bugs/bug-pool-pressure-metric-false-positive.md
@@ -104,6 +104,23 @@ capacité réelle, soit 14 et 18 connexions sorties.
 **Pas de changement de `pool_size`/`max_overflow`** — le pic réel observé est 11/20 (55 %).
 Cf. `docs/bugs/bug-infinite-load-requests.md` : interdit sans preuve métrique.
 
+## Conséquence indirecte — le watchdog d'auto-remédiation
+
+`.github/workflows/pool-saturation-watchdog.yml` interroge `/api/health/pool` **toutes les
+5 minutes** et déclenche sa branche « saturation confirmée » si
+`status == "saturated"` **ou** `usage_pct > 90`, sur deux sondes à 30 s d'intervalle.
+
+Or l'ancienne formule mettait `status = "saturated"` dès que `checked_in == 0` et
+`usage_pct > 90` dès 9 connexions sorties sur 20. Le watchdog s'appuyait donc sur le même
+signal faux. Il n'a pas encore déclenché (aucune issue ouverte à ce jour — la double sonde à
+30 s a filtré les pics transitoires), mais l'en-tête du workflow annonce qu'après 24 h sans
+faux positif, la branche dry-run devait être remplacée par la mutation Railway
+`serviceInstanceRedeploy`. **Un redeploy automatique du backend aurait donc pu être armé sur
+un seuil atteint à 45 % de charge réelle.**
+
+Ce correctif désamorce le risque sans toucher au workflow, puisque celui-ci consomme
+`read_pool_stats` via `/api/health/pool`.
+
 ## Non-régression
 
 `packages/api/tests/test_pool_observability.py` :

--- a/docs/maintenance/maintenance-saturation-pool-db-nocturne.md
+++ b/docs/maintenance/maintenance-saturation-pool-db-nocturne.md
@@ -1,5 +1,18 @@
 # Maintenance — Saturation pool DB nocturne (PYTHON-5M / 5G / 4X)
 
+> ⚠️ **Mise à jour 2026-07-26 — le « 100 % » de PYTHON-5M était un artefact de mesure.**
+> L'investigation de [PYTHON-63](../bugs/bug-pool-pressure-metric-false-positive.md) a
+> montré que `usage_pct` divisait par les connexions *vivantes* (`size + overflow()`) au
+> lieu de la capacité (`pool_size + max_overflow` = 20). La métrique atteignait donc 100 %
+> dès que la file d'idle se vidait, avec encore 10 connexions libres — et franchissait le
+> seuil de page dès **9 connexions sorties sur 20**. Le pool n'a vraisemblablement jamais
+> été saturé.
+>
+> Les axes A/C/D ci-dessous (discipline rollback, allègement du cleanup, observabilité)
+> restent pertinents sur le fond et **ne sont pas revert**. L'axe B (concurrence digest
+> 10 → 5, decay décalé à 06h50) est conservé par prudence, mais son gain réel est à
+> reconsidérer maintenant que la sonde dit vrai.
+
 ## Contexte
 Trois issues Sentry corrélées sur la fenêtre matinale ~07h20-07h35 Paris (même
 trace) : **PYTHON-5M** « DB pool pressure high: 100 % » (saturation pool app),

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -697,6 +697,11 @@ async def pool_metrics() -> dict[str, Any]:
             "db_pool_pressure_high",
             checked_out=metrics.get("checked_out"),
             size=metrics.get("size"),
+            # `capacity` (pool_size + max_overflow) est le dénominateur réel :
+            # c'est lui qui rend le ratio lisible pour l'astreinte. `overflow`
+            # (connexions vivantes au-delà de pool_size) reste en second, il
+            # avait induit en erreur lors de PYTHON-63.
+            capacity=metrics.get("capacity"),
             overflow=metrics.get("overflow"),
             usage_pct=usage_pct,
         )

--- a/packages/api/app/observability/pool_stats.py
+++ b/packages/api/app/observability/pool_stats.py
@@ -12,39 +12,69 @@ from __future__ import annotations
 
 from typing import Any
 
+import structlog
 from sqlalchemy.ext.asyncio import AsyncEngine
+
+logger = structlog.get_logger()
 
 
 def read_pool_stats(engine: AsyncEngine) -> dict[str, Any]:
     """Lit les compteurs du pool dans un dict simple.
 
-    Défensif : NullPool (dev local) n'expose pas `size()`/`checkedout()`, donc
-    chaque getter retombe sur `None`. `usage_pct` n'est calculé que lorsque la
-    taille est connue et > 0.
+    `usage_pct` rapporte `checked_out` à la **capacité** du pool
+    (`pool_size + max_overflow`, = 20 en prod). Piège SQLAlchemy à l'origine du
+    faux positif PYTHON-63 : `pool.overflow()` n'est pas `max_overflow`, c'est
+    le nombre de connexions *vivantes* au-delà de `pool_size` — s'en servir au
+    dénominateur fait saturer la métrique à 100 % dès que la file d'idle se
+    vide. Cf. docs/bugs/bug-pool-pressure-metric-false-positive.md.
+
+    Défensif : NullPool (dev local) n'expose aucun compteur, donc chaque getter
+    retombe sur `None` et `usage_pct` est omis.
     """
     pool = engine.pool
     size = getattr(pool, "size", lambda: None)()
     checked_in = getattr(pool, "checkedin", lambda: None)()
     checked_out = getattr(pool, "checkedout", lambda: None)()
     overflow = getattr(pool, "overflow", lambda: None)()
+    # Pas d'accesseur public pour max_overflow ; `_max_overflow` est stable de
+    # SQLAlchemy 1.4 à 2.0. NullPool ne l'expose pas → None (comme size()).
+    max_overflow = getattr(pool, "_max_overflow", None)
 
-    saturated = (
-        checked_out is not None
-        and size is not None
-        and checked_out >= size + max(overflow or 0, 0)
+    # Capacité inconnue si le pool n'est pas dimensionné (NullPool) ou si
+    # max_overflow est illisible / négatif (= illimité côté SQLAlchemy).
+    capacity = (
+        size + max_overflow
+        if size is not None and max_overflow is not None and max_overflow >= 0
+        else None
     )
 
+    if capacity is None and size is not None:
+        # Pool dimensionné mais capacité illisible : sans `usage_pct` la sonde
+        # de `scheduler.py` prend la branche « NullPool » et n'alerte plus du
+        # tout. Ce silence est le pire mode de défaillance pour une métrique
+        # d'alerte — on le rend bruyant plutôt que de le laisser passer.
+        logger.error(
+            "pool_capacity_unreadable",
+            pool_class=type(pool).__name__,
+            size=size,
+            max_overflow=max_overflow,
+        )
+
+    measurable = checked_out is not None and capacity is not None and capacity > 0
+
     stats: dict[str, Any] = {
-        "status": "saturated" if saturated else "ok",
+        "status": "saturated" if measurable and checked_out >= capacity else "ok",
         "pool_class": type(pool).__name__,
         "size": size,
         "checked_in": checked_in,
         "checked_out": checked_out,
+        # Diagnostic seulement — jamais un dénominateur (cf. docstring).
         "overflow": overflow,
+        "max_overflow": max_overflow,
+        "capacity": capacity,
     }
 
-    if checked_out is not None and size is not None and size > 0:
-        usage_pct = checked_out / (size + max(overflow or 0, 0))
-        stats["usage_pct"] = round(usage_pct * 100, 1)
+    if measurable:
+        stats["usage_pct"] = round(checked_out / capacity * 100, 1)
 
     return stats

--- a/packages/api/app/workers/scheduler.py
+++ b/packages/api/app/workers/scheduler.py
@@ -297,6 +297,12 @@ async def _pool_health_probe() -> None:
       (early warning sans bruit sur les pics transitoires du rituel matinal).
     - **page** (`pool_page_threshold_pct`, défaut 90 %) : alerte Sentry
       `level=fatal` immédiate, dès la première sonde (saturation imminente).
+
+    Les seuils portent sur la **capacité** du pool (`pool_size + max_overflow`
+    = 20 en prod), soit 14 et 18 connexions sorties. Avant le correctif
+    PYTHON-63 le dénominateur suivait les connexions vivantes, ce qui faisait
+    pager dès 9 connexions sur 20 (cf.
+    docs/bugs/bug-pool-pressure-metric-false-positive.md).
     """
     global _pool_warn_streak
     import sentry_sdk
@@ -326,6 +332,17 @@ async def _pool_health_probe() -> None:
         # (page >= warn par construction), puis on choisit la sévérité.
         _pool_warn_streak += 1
 
+        def alert(message: str, level: str, **extra: object) -> None:
+            """Alerte Sentry avec les compteurs en contexte.
+
+            Le message ne doit porter AUCUN chiffre variable : Sentry groupe
+            les `capture_message` par texte, donc y interpoler `usage_pct`
+            créerait une issue par valeur mesurée.
+            """
+            with sentry_sdk.push_scope() as scope:
+                scope.set_context("db_pool", {**stats, **extra})
+                sentry_sdk.capture_message(message, level=level)
+
         if usage_pct >= page_threshold:
             logger.error(
                 "db_pool_pressure_critical",
@@ -334,9 +351,9 @@ async def _pool_health_probe() -> None:
                 threshold=page_threshold,
                 **stats,
             )
-            sentry_sdk.capture_message(
-                f"DB pool pressure CRITICAL: {usage_pct}% (>= {page_threshold}%)",
-                level="fatal",
+            alert(
+                f"DB pool pressure CRITICAL (>= {page_threshold}% of capacity)",
+                "fatal",
             )
         elif _pool_warn_streak >= settings.pool_warn_sustained_probes:
             logger.warning(
@@ -347,10 +364,10 @@ async def _pool_health_probe() -> None:
                 sustained_probes=_pool_warn_streak,
                 **stats,
             )
-            sentry_sdk.capture_message(
-                f"DB pool pressure sustained: {usage_pct}% (>= "
-                f"{warn_threshold}% for {_pool_warn_streak} consecutive probes)",
-                level="warning",
+            alert(
+                f"DB pool pressure sustained (>= {warn_threshold}% of capacity)",
+                "warning",
+                sustained_probes=_pool_warn_streak,
             )
         else:
             # Seuil franchi mais pas encore soutenu : on garde la trace en

--- a/packages/api/tests/test_pool_observability.py
+++ b/packages/api/tests/test_pool_observability.py
@@ -10,11 +10,13 @@ from app.observability.pool_stats import read_pool_stats
 
 
 class _FakePool:
-    def __init__(self, size, checked_in, checked_out, overflow):
+    def __init__(self, size, checked_in, checked_out, overflow, max_overflow=10):
         self._size = size
         self._ci = checked_in
         self._co = checked_out
         self._ov = overflow
+        # Nom calqué sur SQLAlchemy : `read_pool_stats` lit `_max_overflow`.
+        self._max_overflow = max_overflow
 
     def size(self):
         return self._size
@@ -35,24 +37,141 @@ class _FakeEngine:
 
 
 def test_read_pool_stats_saturated():
-    """checked_out >= size + overflow ⇒ status saturated, usage_pct 100."""
+    """checked_out >= pool_size + max_overflow ⇒ status saturated, usage 100 %."""
     stats = read_pool_stats(
         _FakeEngine(_FakePool(size=10, checked_in=0, checked_out=20, overflow=10))
     )
     assert stats["status"] == "saturated"
     assert stats["size"] == 10
+    assert stats["capacity"] == 20
     assert stats["checked_out"] == 20
     assert stats["usage_pct"] == 100.0
 
 
 def test_read_pool_stats_ok_with_negative_overflow():
-    """QueuePool renvoie un overflow négatif sous capacité ⇒ clamp à 0, ok."""
+    """QueuePool renvoie un overflow négatif sous capacité ⇒ sans effet.
+
+    `overflow()` ne doit jamais entrer dans le calcul : seule la capacité
+    (`pool_size + max_overflow` = 20) compte.
+    """
     stats = read_pool_stats(
         _FakeEngine(_FakePool(size=10, checked_in=5, checked_out=5, overflow=-5))
     )
     assert stats["status"] == "ok"
-    # usage = 5 / (10 + max(-5, 0)) = 50 %
-    assert stats["usage_pct"] == 50.0
+    # usage = 5 / 20 = 25 % (et non 5 / (10 + max(-5, 0)) = 50 %)
+    assert stats["usage_pct"] == 25.0
+
+
+def test_read_pool_stats_does_not_page_on_engaged_overflow():
+    """Régression PYTHON-63 — l'overflow engagé ne doit pas simuler la saturation.
+
+    Événement réel du 2026-07-25 : `size=10, overflow=2, checked_out=11`, soit
+    11 connexions sur une capacité de 20 (55 %). L'ancienne formule divisait par
+    `size + overflow()` = 12 et rapportait 91,7 %, déclenchant une alerte Sentry
+    `fatal` (seuil page 90 %) alors qu'il restait 9 connexions libres.
+    """
+    stats = read_pool_stats(
+        _FakeEngine(_FakePool(size=10, checked_in=1, checked_out=11, overflow=2))
+    )
+    assert stats["usage_pct"] == 55.0
+    assert stats["status"] == "ok"
+    assert stats["capacity"] == 20
+    # `overflow` reste exposé pour le diagnostic, mais hors du dénominateur.
+    assert stats["overflow"] == 2
+
+
+def test_read_pool_stats_unbounded_overflow_has_no_usage_pct():
+    """max_overflow < 0 (illimité) ⇒ pas de capacité bornée, donc pas de ratio."""
+    stats = read_pool_stats(
+        _FakeEngine(
+            _FakePool(
+                size=10, checked_in=0, checked_out=30, overflow=20, max_overflow=-1
+            )
+        )
+    )
+    assert stats["capacity"] is None
+    assert stats["status"] == "ok"
+    assert "usage_pct" not in stats
+
+
+def test_read_pool_stats_logs_when_sized_pool_has_unreadable_capacity():
+    """Un pool dimensionné dont la capacité est illisible doit être BRUYANT.
+
+    `read_pool_stats` lit `max_overflow` sur l'attribut privé `_max_overflow`.
+    Si une version de SQLAlchemy le renomme, `usage_pct` disparaît — et la sonde
+    de `scheduler.py` prend alors la branche « NullPool » et cesse d'alerter,
+    silencieusement. C'est le pire mode de défaillance possible pour une
+    métrique d'alerte, donc il doit laisser une trace `error`.
+    """
+    pool = _FakePool(size=10, checked_in=0, checked_out=8, overflow=0)
+    del pool._max_overflow  # simule le renommage de l'attribut privé
+
+    with patch("app.observability.pool_stats.logger") as mock_logger:
+        stats = read_pool_stats(_FakeEngine(pool))
+
+    assert stats["capacity"] is None
+    assert "usage_pct" not in stats
+    assert mock_logger.error.call_args.args[0] == "pool_capacity_unreadable"
+
+
+def test_read_pool_stats_nullpool_stays_quiet():
+    """NullPool n'est pas une anomalie : pas de capacité, mais pas d'erreur."""
+    with patch("app.observability.pool_stats.logger") as mock_logger:
+        read_pool_stats(_FakeEngine(object()))
+
+    mock_logger.error.assert_not_called()
+
+
+def test_read_pool_stats_capacity_matches_real_queuepool():
+    """Garde-fou sémantique : la capacité est lue sur un VRAI pool SQLAlchemy.
+
+    Les fakes ci-dessus ne protègent pas contre une mécompréhension de l'API
+    SQLAlchemy — c'est précisément ce qui a produit PYTHON-63. Ici on construit
+    un pool réel avec les kwargs de prod et on vérifie que `read_pool_stats`
+    voit bien 20 connexions de capacité, y compris en cours de montée en charge
+    (là où `overflow()` est négatif puis positif).
+    """
+    from sqlalchemy.pool import QueuePool
+
+    from app.database import PROD_POOL_KWARGS
+
+    class _StubDBAPIConnection:
+        def rollback(self): ...
+
+        def close(self): ...
+
+    pool = QueuePool(
+        lambda: _StubDBAPIConnection(),
+        pool_size=PROD_POOL_KWARGS["pool_size"],
+        max_overflow=PROD_POOL_KWARGS["max_overflow"],
+        pre_ping=False,
+    )
+    engine = _FakeEngine(pool)
+
+    assert read_pool_stats(engine)["capacity"] == 20
+
+    held = []
+    try:
+        # 9 connexions : l'ancienne formule affichait déjà 90 % (seuil page !)
+        # parce que overflow() vaut encore -1 à ce stade.
+        for _ in range(9):
+            held.append(pool.connect())
+        stats = read_pool_stats(engine)
+        assert stats["checked_out"] == 9
+        assert stats["usage_pct"] == 45.0
+        assert stats["status"] == "ok"
+
+        # Capacité réellement atteinte (20/20) ⇒ là, et seulement là, saturated.
+        for _ in range(11):
+            held.append(pool.connect())
+        stats = read_pool_stats(engine)
+        assert stats["checked_out"] == 20
+        assert stats["usage_pct"] == 100.0
+        assert stats["status"] == "saturated"
+    finally:
+        for conn in held:
+            conn.close()
+        pool.dispose()
 
 
 def test_read_pool_stats_nullpool_returns_none_fields():


### PR DESCRIPTION
# fix(observability): la métrique de pression du pool DB divisait par les connexions vivantes, pas par la capacité

## Résumé

L'alerte Sentry [PYTHON-63](https://facteur.sentry.io/issues/PYTHON-63)
`DB pool pressure CRITICAL: 91.7% (>= 90%)` (`level=fatal`, 2 occurrences depuis le 21/07)
est un **faux positif**. Le pool n'a jamais été proche de la saturation : la métrique était
fausse.

Base `main`. **Aucune migration.** Aucun impact mobile.

## Cause racine

`app/observability/pool_stats.py` calculait :

```python
usage_pct = checked_out / (size + max(overflow or 0, 0))
```

Le dénominateur était censé être la capacité (`pool_size + max_overflow` = 10+10 = **20**).
Mais `pool.overflow()` de SQLAlchemy ne renvoie pas `max_overflow` : c'est `_overflow`, le
nombre de connexions **vivantes** au-delà de `pool_size` (initialisé à `-pool_size`).

Le dénominateur suivait donc les connexions vivantes, pas la capacité. En injectant
`checkedout() = maxsize - qsize + _overflow` (source SQLAlchemy 2.0.25), la formule se
réduit à `usage_pct = 1 - checked_in / (size + overflow)` : **elle ne dépendait que du
nombre de connexions idle en file**, et saturait à 100 % dès que la file se vidait.

Mesuré sur un vrai `QueuePool(pool_size=10, max_overflow=10)` :

| checked_out | AVANT | APRÈS |
|---|---|---|
| 9 / 20 | **90,0 %** → page `fatal` | 45,0 % |
| 10 / 20 | **100,0 %** → `saturated` | 50,0 % |
| 11 / 20 (l'événement réel) | **100,0 %** | 55,0 % |
| 18 / 20 | 100,0 % | 90,0 % → page `fatal` |
| 20 / 20 | 100,0 % | 100,0 % → `saturated` |

Le seuil de page était donc franchi dès **9 connexions sorties sur 20** (45 % de charge
réelle), puis restait bloqué à 100 %.

`91,7 % = 11/12` ⇒ `overflow=2`, `checked_in=1`, `checked_out=11` → charge réelle
**11/20 = 55 %**, avec 9 connexions d'overflow libres.

**Corollaire** : le « 100 % » de **PYTHON-5M** (25/06) était très probablement le même
artefact. Le fix d'alors n'a pas « lâché » — il n'y avait rien à corriger côté capacité.
Ses mitigations ne sont **pas** revert.

## Conséquence indirecte — le watchdog d'auto-remédiation

`.github/workflows/pool-saturation-watchdog.yml` sonde `/api/health/pool` **toutes les
5 minutes** et déclenche sa branche « saturation confirmée » si `status == "saturated"` ou
`usage_pct > 90`. Il s'appuyait donc sur le même signal faux. Il n'a pas encore déclenché
(aucune issue ouverte — la double sonde à 30 s a filtré les pics), mais l'en-tête du workflow
prévoit de remplacer la branche dry-run par la mutation Railway `serviceInstanceRedeploy`
après 24 h sans faux positif. **Un redeploy automatique du backend aurait pu être armé sur un
seuil atteint à 45 % de charge réelle.** Ce correctif désamorce le risque sans toucher au
workflow, qui consomme `read_pool_stats`.

## Changements

- `app/observability/pool_stats.py` — capacité lue via `pool._max_overflow` (pas
  d'accesseur public ; stable SQLAlchemy 1.4→2.0) ; expose `capacity` et `max_overflow` ;
  `usage_pct = checked_out / capacity` ; `saturated = checked_out >= capacity`. `overflow`
  reste exposé pour le diagnostic mais sort du dénominateur.
- `app/observability/pool_stats.py` — **garde-fou anti-silence** : si le pool est dimensionné
  mais que la capacité est illisible (attribut privé renommé par une future version de
  SQLAlchemy, ou `max_overflow < 0`), on loggue `pool_capacity_unreadable` en `error`. Sans
  ça, `usage_pct` disparaîtrait, la sonde prendrait sa branche « NullPool » et **cesserait
  d'alerter silencieusement** — le pire mode de défaillance pour une métrique d'alerte.
- `app/workers/scheduler.py` — les `capture_message` n'interpolent plus de chiffre variable
  dans le texte (Sentry groupe par message : `usage_pct` dans le texte crée **une issue par
  valeur**). Les compteurs partent dans le contexte Sentry `db_pool`, via un helper local
  qui dédoublonne les deux branches d'alerte.
- `app/main.py` — le log `db_pool_pressure_high` de `/api/health/pool` expose désormais
  `capacity` (le dénominateur réel) en plus d'`overflow`, qui avait induit en erreur.
- Docs : `docs/bugs/bug-pool-pressure-metric-false-positive.md` (neuf) + encart de
  correction en tête de `docs/maintenance/maintenance-saturation-pool-db-nocturne.md`.

**Seuils inchangés** (warn 70 %, page 90 %) : ils portent désormais sur la capacité réelle,
soit 14 et 18 connexions sorties. Le pic observé (11) reste silencieux — c'est voulu.

**Aucun changement de `pool_size`/`max_overflow`** : le pic réel est 11/20. Interdit sans
preuve métrique (`docs/bugs/bug-infinite-load-requests.md`).

Clés ajoutées uniquement (`capacity`, `max_overflow`) → `/api/health/pool` gagne des champs,
rien ne casse.

## Tests

`packages/api/tests/test_pool_observability.py` :

- `test_read_pool_stats_does_not_page_on_engaged_overflow` — rejoue l'événement du 25/07
  (`size=10, overflow=2, checked_out=11`) et exige 55 %, sous le seuil de page.
- `test_read_pool_stats_capacity_matches_real_queuepool` — **le garde-fou qui manquait** :
  construit un vrai `QueuePool` avec les kwargs de prod et vérifie le ratio à 9 puis 20
  connexions sorties. Les fakes ne protégeaient pas contre une mécompréhension de l'API
  SQLAlchemy, qui est l'origine exacte du bug.
- `test_read_pool_stats_logs_when_sized_pool_has_unreadable_capacity` — supprime
  `_max_overflow` pour simuler un renommage SQLAlchemy et exige le log `error`.
- `test_read_pool_stats_nullpool_stays_quiet` — NullPool ne doit pas déclencher ce log.
- `test_read_pool_stats_unbounded_overflow_has_no_usage_pct` — `max_overflow < 0`.
- `test_read_pool_stats_ok_with_negative_overflow` — attendu corrigé 50 % → 25 %.

Suite backend complète : `1992 passed, 1 failed, 547 errors` — l'échec
(`test_essentiel_endpoint.py::test_get_essentiel_uses_user_context_from_router`) et les 547
erreurs sont dus à l'absence de Postgres local sur le port 54322, et sont **reproduits à
l'identique sur `origin/main`** (vérifié via worktree).

## ⚠️ Après merge (actions PO)

1. Le texte du message Sentry change → **nouveau groupe d'issue**. Résoudre **PYTHON-63**
   en « faux positif — métrique corrigée ».
2. Surveiller 1 semaine les logs `db_pool_probe` (info, 5 min) pour établir le p95 réel de
   `checked_out` avant toute autre action.

## Suivi identifié (hors périmètre, non prouvé par cette alerte)

- `app/services/push_dispatcher.py` — transaction ouverte pendant les envois FCM
  (`await asyncio.to_thread`) avec `idle_in_transaction_session_timeout = 10 s` : un envoi
  lent peut tuer la transaction et faire perdre les écritures `status='sent'`.
  **Bug de correction en soi**, à traiter séparément.
- `app/services/recommendation_service.py` — jusqu'à 3 connexions simultanées par
  `/api/feed`.
- `app/services/grille_selector.py` — `asyncio.gather` sur la **même** `AsyncSession`.
- `app/workers/classification_worker.py` — engine `NullPool` séparé, invisible de la sonde.