### PR TITLE
fix(mot-du-jour): streak fiable + grille responsive anti-chevauchement clavier

### DIFF
--- a/apps/mobile/lib/features/grille/grille_constants.dart
+++ b/apps/mobile/lib/features/grille/grille_constants.dart
@@ -47,6 +47,11 @@ class GrilleConstants {
   /// Côté d'une tuile sur l'écran de jeu. (`.mot-grid { --tile: 50px }`)
   static const double tileSize = 50;
 
+  /// Plancher de taille de tuile quand [tileSize] est réduit pour tenir dans
+  /// la hauteur disponible (cf. `grille_fit.dart`) — sous cette valeur les
+  /// lettres deviennent illisibles.
+  static const double tileSizeFitFloor = 34;
+
   /// Côté d'une tuile sur l'écran résultat. (`.mot-grid.v-resultat { --tile: 44px }`)
   static const double tileSizeResult = 44;
 

--- a/apps/mobile/lib/features/grille/screens/grille_screen.dart
+++ b/apps/mobile/lib/features/grille/screens/grille_screen.dart
@@ -14,6 +14,7 @@ import '../models/grille_models.dart';
 import '../providers/grille_intro_provider.dart';
 import '../providers/grille_provider.dart';
 import '../repositories/grille_repository.dart';
+import '../utils/grille_fit.dart';
 import '../widgets/azerty_keyboard.dart';
 import '../widgets/g_app_bar.dart';
 import '../widgets/grille_button.dart';
@@ -184,17 +185,23 @@ class _GrilleScreenState extends ConsumerState<GrilleScreen> {
           essai: today.nbEssais + 1,
         ),
         Expanded(
-          child: Center(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: MotGrid(
-                longueur: today.longueur,
-                essaisMax: today.essaisMax,
-                premiereLettre: today.premiereLettre,
-                essais: today.essais,
-                draft: state.draft,
-                revealRow: state.revealRow,
-                shakeNonce: state.invalidNonce,
+          child: LayoutBuilder(
+            builder: (context, constraints) => Center(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: MotGrid(
+                  longueur: today.longueur,
+                  essaisMax: today.essaisMax,
+                  premiereLettre: today.premiereLettre,
+                  essais: today.essais,
+                  draft: state.draft,
+                  revealRow: state.revealRow,
+                  shakeNonce: state.invalidNonce,
+                  tileSizeOverride: fittedTileSize(
+                    constraints.maxHeight,
+                    today.essaisMax,
+                  ),
+                ),
               ),
             ),
           ),

--- a/apps/mobile/lib/features/grille/utils/grille_fit.dart
+++ b/apps/mobile/lib/features/grille/utils/grille_fit.dart
@@ -1,0 +1,21 @@
+/// Pure, unit-testable tile-size estimator — dérive la taille de tuile
+/// [MotGrid] qui fait tenir `essaisMax` lignes dans la hauteur disponible.
+/// Calqué sur `section_fit.dart` : arithmétique seule, aucun binding Flutter.
+library;
+
+import '../grille_constants.dart';
+
+/// Taille de tuile (px) qui tient [essaisMax] lignes dans [availableHeight],
+/// plafonnée à la taille design ([GrilleConstants.tileSize], rendu inchangé
+/// quand la place suffit) et plancher à [GrilleConstants.tileSizeFitFloor]
+/// (lisibilité) — évite que la grille (hauteur sinon fixe) chevauche le bloc
+/// CTA/nudge/clavier du bas quand celui-ci grandit (ex. nudge affiché après 2
+/// essais) ou sur petit écran.
+double fittedTileSize(double availableHeight, int essaisMax) {
+  const gap = GrilleConstants.tileGap;
+  const maxSize = GrilleConstants.tileSize;
+  const minSize = GrilleConstants.tileSizeFitFloor;
+  if (essaisMax <= 0 || !availableHeight.isFinite) return maxSize;
+  final raw = (availableHeight - gap * (essaisMax - 1)) / essaisMax;
+  return raw.clamp(minSize, maxSize);
+}

--- a/apps/mobile/lib/features/grille/widgets/mot_grid.dart
+++ b/apps/mobile/lib/features/grille/widgets/mot_grid.dart
@@ -26,6 +26,7 @@ class MotGrid extends StatelessWidget {
     this.revealRow = -1,
     this.bounceRevealRow = false,
     this.shakeNonce = 0,
+    this.tileSizeOverride,
   });
 
   final int longueur;
@@ -46,11 +47,15 @@ class MotGrid extends StatelessWidget {
   /// Incrément de shake pour la ligne courante (essai refusé).
   final int shakeNonce;
 
+  /// Taille de tuile forcée (px), calculée par l'appelant pour tenir dans la
+  /// hauteur disponible. `null` = taille design par défaut.
+  final double? tileSizeOverride;
+
   bool get _isJeu => variant == MotGridVariant.jeu;
 
-  double get _tileSize => _isJeu
-      ? GrilleConstants.tileSize
-      : GrilleConstants.tileSizeResult;
+  double get _tileSize =>
+      tileSizeOverride ??
+      (_isJeu ? GrilleConstants.tileSize : GrilleConstants.tileSizeResult);
   double get _gap =>
       _isJeu ? GrilleConstants.tileGap : GrilleConstants.tileGapResult;
 

--- a/apps/mobile/test/features/grille/utils/grille_fit_test.dart
+++ b/apps/mobile/test/features/grille/utils/grille_fit_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/grille/grille_constants.dart';
+import 'package:facteur/features/grille/utils/grille_fit.dart';
+
+void main() {
+  group('fittedTileSize', () {
+    test('taille design inchangée quand la place suffit', () {
+      expect(fittedTileSize(400, 6), GrilleConstants.tileSize);
+    });
+
+    test('rétrécit pour tenir essaisMax lignes dans la hauteur restante', () {
+      final size = fittedTileSize(250, 6);
+      const gap = GrilleConstants.tileGap;
+      expect(size * 6 + gap * 5, closeTo(250, 0.01));
+      expect(size, lessThan(GrilleConstants.tileSize));
+      expect(size, greaterThan(GrilleConstants.tileSizeFitFloor));
+    });
+
+    test('plancher lisible sur très petit écran', () {
+      expect(fittedTileSize(10, 6), GrilleConstants.tileSizeFitFloor);
+    });
+
+    test('hauteur infinie (pas de contrainte) → taille design', () {
+      expect(fittedTileSize(double.infinity, 6), GrilleConstants.tileSize);
+    });
+
+    test('essaisMax nul → taille design (garde-fou division)', () {
+      expect(fittedTileSize(200, 0), GrilleConstants.tileSize);
+    });
+  });
+}

--- a/docs/bugs/bug-grille-nudge-superposition-clavier.md
+++ b/docs/bugs/bug-grille-nudge-superposition-clavier.md
@@ -1,0 +1,53 @@
+# Bug — le nudge « Indice : le mot est dans l'actu » se superpose parfois à la grille
+
+- **Signalé par** : PO, 2026-07-27
+- **Impact utilisateur** : chevauchement visuel grille/texte d'instruction sur petit écran
+- **Statut** : corrigé
+
+## Symptôme
+
+Le petit texte d'instruction (« Indice : le mot est dans l'actu du jour — aller lire »),
+affiché juste au-dessus du clavier virtuel et en dessous de la grille, se superpose parfois
+avec la grille elle-même.
+
+## Cause racine
+
+`MotGrid` (`apps/mobile/lib/features/grille/widgets/mot_grid.dart`) rend `essaisMax` lignes
+à une taille de tuile **fixe** (`GrilleConstants.tileSize = 50px`), posée dans
+`Expanded > Center > Padding` (`grille_screen.dart`, `_buildJeu`) — sans
+`SingleChildScrollView` de secours.
+
+Le bloc du bas (statut, CTA, nudge, clavier `AzertyKeyboard`) a lui une hauteur
+**variable** : `_buildActusHint` (le nudge) ne s'affiche qu'après le 2e essai raté
+(`today.nbEssais >= 2`), ce qui réduit l'espace `Expanded` restant en cours de partie.
+
+Comme la grille ne s'adapte jamais à l'espace réellement disponible et qu'il n'y a pas de
+scroll de secours, tout espace insuffisant (petit écran, ou apparition du nudge) se traduit
+par un chevauchement visuel plutôt qu'un rétrécissement ou un scroll.
+
+## Correctif
+
+`MotGrid` accepte désormais un `tileSizeOverride` optionnel. `grille_screen.dart` enveloppe
+la zone de la grille dans un `LayoutBuilder` et appelle la nouvelle fonction pure
+`fittedTileSize` (`apps/mobile/lib/features/grille/utils/grille_fit.dart`, calquée sur le
+pattern `section_fit.dart` : arithmétique seule, testable sans bootstrap Flutter), qui
+calcule la taille de tuile faisant tenir `essaisMax` lignes dans `constraints.maxHeight`,
+plafonnée à la taille design (`GrilleConstants.tileSize` = 50px, rendu inchangé quand la
+place suffit) et plancher à `GrilleConstants.tileSizeFitFloor` (34px, lisibilité).
+
+La grille rétrécit désormais avec l'espace disponible plutôt que de déborder par-dessus le
+bloc du bas, que ce soit à cause d'un petit écran ou de l'apparition dynamique du nudge.
+
+Note : ce mécanisme (tuile dimensionnée via `LayoutBuilder`, plafond/plancher) est le même
+chantier que prévoyait PR1 du plan `mot-du-jour-leaderboard` pour la largeur (longueur de
+mot variable 4-8) — il est donc réutilisable tel quel pour la dimension largeur quand cette
+PR sera implémentée.
+
+## Tests
+
+`flutter analyze lib/features/grille test/features/grille` : clean. Suite
+`flutter test test/features/grille` : 51 tests, tous passants (dont 5 nouveaux tests unitaires
+sur `fittedTileSize` — taille design inchangée si la place suffit, rétrécissement borné,
+plancher lisible, garde-fous hauteur infinie / `essaisMax=0` — et aucune régression sur les
+widgets `MotGrid` existants, qui restent à leur taille design par défaut quand
+`tileSizeOverride` est omis).

--- a/docs/bugs/bug-grille-streak-compte-consultation-sans-jeu.md
+++ b/docs/bugs/bug-grille-streak-compte-consultation-sans-jeu.md
@@ -1,0 +1,57 @@
+# Bug — le streak « Mot du jour » compte les jours simplement consultés, pas joués
+
+- **Signalé par** : PO, 2026-07-27
+- **Impact utilisateur** : streak affiché (`GAppBar`) incohérent avec l'assiduité réelle
+- **Statut** : corrigé
+
+## Symptôme
+
+Le compteur de streak affiché en haut de l'écran « La Grille du jour » ne reflète pas
+fidèlement les jours où l'utilisateur a réellement joué.
+
+## Cause racine
+
+`GrilleService._compute_streak` (`packages/api/app/services/grille_service.py`) dérive le
+streak des `puzzle_date` distincts présents dans `grille_game_states`, sans filtrer sur une
+partie réellement jouée :
+
+```python
+rows = (
+    await self.db.scalars(
+        select(GrilleGameState.puzzle_date)
+        .where(GrilleGameState.user_id == user_id)
+        .distinct()
+    )
+).all()
+```
+
+Or `GrilleService.get_today` appelle `_get_or_create_game` (qui insère une ligne
+`status=in_progress, attempts=0`) **avant** de calculer le streak. Résultat : ouvrir
+simplement l'écran de la grille — sans taper une seule lettre — suffit à faire compter la
+journée comme « jouée » dans le streak, pour toujours (la ligne reste en base).
+
+## Correctif
+
+`_compute_streak` filtre désormais sur les lignes ayant un essai soumis
+(`attempts > 0`) ou un statut qui n'est plus `in_progress` (couvre `reveal_word`, qui
+termine une partie sans jamais incrémenter `attempts` — « donner sa langue au chat » doit
+rester compté comme joué, cf. test `test_reveal_preserves_streak`) :
+
+```python
+.where(
+    GrilleGameState.user_id == user_id,
+    or_(
+        GrilleGameState.attempts > 0,
+        GrilleGameState.status != STATUS_IN_PROGRESS,
+    ),
+)
+```
+
+Aucune migration : pas de nouvelle colonne, juste un filtre de requête.
+
+## Tests
+
+`packages/api/tests/test_grille_api.py::test_streak_excludes_screen_view_without_attempt`
+(nouveau) — une ligne `in_progress`/`attempts=0` créée par simple ouverture d'écran
+n'interrompt/n'alimente pas le streak. Suite streak complète (5 tests, dont
+`test_reveal_preserves_streak` en non-régression) : `PASSED`.

--- a/packages/api/app/services/grille_service.py
+++ b/packages/api/app/services/grille_service.py
@@ -9,7 +9,7 @@ import hashlib
 from collections import Counter
 from datetime import date, datetime, timedelta
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.grille_game_state import (
@@ -362,14 +362,24 @@ class GrilleService:
     async def _compute_streak(self, user_id: str) -> int:
         """Jours consécutifs joués en remontant depuis aujourd'hui (Paris).
 
-        Dérivé des `puzzle_date` distincts du joueur — ne touche jamais
+        Dérivé des `puzzle_date` distincts du joueur ayant réellement « joué »
+        (au moins un essai soumis, ou une partie terminée par un autre biais
+        comme `reveal_word`) — `_get_or_create_game` crée une ligne
+        `in_progress`/`attempts=0` dès la simple ouverture de l'écran, ce qui
+        ne doit pas compter comme « joué ». Ne touche jamais
         `UserStreak`/`streak_service` (zone digest). Un « aujourd'hui » non
         encore joué ne casse pas une série acquise la veille.
         """
         rows = (
             await self.db.scalars(
                 select(GrilleGameState.puzzle_date)
-                .where(GrilleGameState.user_id == user_id)
+                .where(
+                    GrilleGameState.user_id == user_id,
+                    or_(
+                        GrilleGameState.attempts > 0,
+                        GrilleGameState.status != STATUS_IN_PROGRESS,
+                    ),
+                )
                 .distinct()
             )
         ).all()

--- a/packages/api/tests/test_grille_api.py
+++ b/packages/api/tests/test_grille_api.py
@@ -531,6 +531,32 @@ async def test_streak_resets_on_gap(db_session):
 
 
 @pytest.mark.asyncio
+async def test_streak_excludes_screen_view_without_attempt(db_session):
+    """Une ligne créée par `_get_or_create_game` (écran ouvert, `attempts=0`)
+    ne doit pas compter comme un jour joué."""
+    service = GrilleService(db_session)
+    user_id = uuid4()
+    today = today_paris()
+    # hier : vraie partie jouée
+    await _add_game(
+        db_session,
+        user_id,
+        status=STATUS_SOLVED,
+        attempts=3,
+        on_date=today - timedelta(days=1),
+    )
+    # aujourd'hui : écran simplement ouvert, aucun essai soumis
+    await _add_game(
+        db_session,
+        user_id,
+        status=STATUS_IN_PROGRESS,
+        attempts=0,
+        on_date=today,
+    )
+    assert await service._compute_streak(str(user_id)) == 1
+
+
+@pytest.mark.asyncio
 async def test_streak_zero_when_never_played(db_session):
     service = GrilleService(db_session)
     assert await service._compute_streak(str(uuid4())) == 0


### PR DESCRIPTION
## Résumé

Deux bugs signalés par le PO sur « La Grille du jour » (mot du jour) :

1. **Le streak ne fonctionnait pas correctement.** `GrilleService._compute_streak` comptait tout `puzzle_date` distinct présent en base, y compris les lignes créées par simple ouverture de l'écran (`_get_or_create_game` insère `status=in_progress, attempts=0` dès le `GET /today`, avant même le calcul du streak). Résultat : le streak montait sans qu'aucun essai n'ait été soumis.
2. **Le nudge d'instruction se superposait à la grille.** `MotGrid` avait une taille de tuile fixe (50px), posée dans un `Expanded/Center` sans scroll de secours, pendant que le bloc du bas (CTA + nudge « Indice : le mot est dans l'actu » + clavier) grandit dynamiquement après le 2e essai raté — d'où chevauchement visuel sur petit écran.

Détails complets : `docs/bugs/bug-grille-streak-compte-consultation-sans-jeu.md`, `docs/bugs/bug-grille-nudge-superposition-clavier.md`.

## Changements

- `grille_service.py::_compute_streak` — filtre désormais sur `attempts > 0 OR status != in_progress` (préserve `reveal_word`, qui termine une partie sans jamais incrémenter `attempts`). Aucune migration.
- Nouvelle fonction pure `fittedTileSize` (`apps/mobile/lib/features/grille/utils/grille_fit.dart`, calquée sur le pattern `section_fit.dart` — arithmétique seule, testable sans bootstrap Flutter) qui rétrécit la taille de tuile pour tenir `essaisMax` lignes dans la hauteur disponible, plafonnée à la taille design (`GrilleConstants.tileSize`) et plancher à `GrilleConstants.tileSizeFitFloor` (34px).
- `MotGrid` accepte un `tileSizeOverride` optionnel (rétrocompatible, `null` = comportement inchangé) ; `grille_screen.dart` le calcule via `LayoutBuilder`.

## Test plan

- [x] Backend : `pytest tests/test_grille_api.py tests/test_grille_selector.py tests/test_grille_seed.py tests/test_grille_quality_pool.py tests/test_grille_matcher.py` → 61 passed (dont le nouveau `test_streak_excludes_screen_view_without_attempt` + non-régression `test_reveal_preserves_streak`)
- [x] Mobile : `flutter analyze lib/features/grille test/features/grille` → clean ; `flutter test test/features/grille` → 51 passed (dont 5 nouveaux tests unitaires `fittedTileSize`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)