### PR TITLE
fix(widget): refonte fiabilité du widget d'accueil (6 causes racines)

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,126 +1,176 @@
-# fix(observability): la métrique de pression du pool DB divisait par les connexions vivantes, pas par la capacité
+# fix(widget): refonte fiabilité du widget d'accueil — 6 causes racines
 
 ## Résumé
 
-L'alerte Sentry [PYTHON-63](https://facteur.sentry.io/issues/PYTHON-63)
-`DB pool pressure CRITICAL: 91.7% (>= 90%)` (`level=fatal`, 2 occurrences depuis le 21/07)
-est un **faux positif**. Le pool n'a jamais été proche de la saturation : la métrique était
-fausse.
+Les 5 symptômes remontés sur le widget Android ne sont pas 5 bugs indépendants.
+Ce sont **6 causes racines**, dont une seule (`applicationId ≠ namespace`)
+explique déjà la moitié des plaintes.
 
-Base `main`. **Aucune migration.** Aucun impact mobile.
+Base `main`. **Aucune migration.** Aucun impact backend. Android uniquement
+(il n'y a pas de widget iOS : ni extension, ni app group).
 
-## Cause racine
+Doc complète : `docs/bugs/bug-widget-fiabilite.md`.
 
-`app/observability/pool_stats.py` calculait :
+## Causes racines et correctifs
 
-```python
-usage_pct = checked_out / (size + max(overflow or 0, 0))
-```
+### C1 — `home_widget` n'a **jamais** pu atteindre les receivers
 
-Le dénominateur était censé être la capacité (`pool_size + max_overflow` = 10+10 = **20**).
-Mais `pool.overflow()` de SQLAlchemy ne renvoie pas `max_overflow` : c'est `_overflow`, le
-nombre de connexions **vivantes** au-delà de `pool_size` (initialisé à `-pool_size`).
+`HomeWidgetPlugin.kt` résout un `androidName` nu en
+`"${context.packageName}.$className"`, où `context.packageName` est
+l'**applicationId** (`com.example.facteur.staging` / `facteur.app`). Les
+receivers vivent dans le **namespace** `com.example.facteur`.
 
-Le dénominateur suivait donc les connexions vivantes, pas la capacité. En injectant
-`checkedout() = maxsize - qsize + _overflow` (source SQLAlchemy 2.0.25), la formule se
-réduit à `usage_pct = 1 - checked_in / (size + overflow)` : **elle ne dépendait que du
-nombre de connexions idle en file**, et saturait à 100 % dès que la file se vidait.
+⇒ `ClassNotFoundException` sur les deux flavors, à chaque appel, avalé par un
+`catch`. Donc : « Ajouter un Widget » mort, et **zéro `ACTION_APPWIDGET_UPDATE`
+jamais envoyé** — le widget ne repeignait que sur l'alarme système de 30 min.
 
-Mesuré sur un vrai `QueuePool(pool_size=10, max_overflow=10)` :
+Cohérent avec Sentry : **zéro** `PlatformException` remontée (tout est catché).
 
-| checked_out | AVANT | APRÈS |
-|---|---|---|
-| 9 / 20 | **90,0 %** → page `fatal` | 45,0 % |
-| 10 / 20 | **100,0 %** → `saturated` | 50,0 % |
-| 11 / 20 (l'événement réel) | **100,0 %** | 55,0 % |
-| 18 / 20 | 100,0 % | 90,0 % → page `fatal` |
-| 20 / 20 | 100,0 % | 100,0 % → `saturated` |
+**Fix** : `qualifiedAndroidName:` sur tous les appels, dérivé du namespace.
+Garde anti-régression : un test lit le `namespace` directement dans
+`build.gradle.kts` et vérifie qu'il diffère bien des applicationId des flavors.
 
-Le seuil de page était donc franchi dès **9 connexions sorties sur 20** (45 % de charge
-réelle), puis restait bloqué à 100 %.
+### C2 — Crash **fatal** sur le chemin de fraîcheur (Sentry FLUTTER-1E, 23 events / 11 users)
 
-`91,7 % = 11/12` ⇒ `overflow=2`, `checked_in=1`, `checked_out=11` → charge réelle
-**11/20 = 55 %**, avec 9 connexions d'overflow libres.
+`app.dart` faisait `unawaited(ensureWidgetFresh())`, qui `await refresh()` sans
+try/catch → l'erreur async n'avait aucun handler → crash *unhandled* via
+`PlatformDispatcher.onError`.
 
-**Corollaire** : le « 100 % » de **PYTHON-5M** (25/06) était très probablement le même
-artefact. Le fix d'alors n'a pas « lâché » — il n'y avait rien à corriger côté capacité.
-Ses mitigations ne sont **pas** revert.
+**Fix** : try/catch (log Sentry `warning`, pas de rethrow) + `.catchError` sur le
+`unawaited`. Feeder amont FLUTTER-6 traité aussi : le timeout de
+`SessionRefresher` devient adaptatif (8 s `resumed`, 20 s au cold boot / réveil
+par tap widget), les 5 s fixes expiraient systématiquement.
 
-## Conséquence indirecte — le watchdog d'auto-remédiation
+### C3 — Le deep-link widget **déconnectait** l'utilisateur
 
-`.github/workflows/pool-saturation-watchdog.yml` sonde `/api/health/pool` **toutes les
-5 minutes** et déclenche sa branche « saturation confirmée » si `status == "saturated"` ou
-`usage_pct > 90`. Il s'appuyait donc sur le même signal faux. Il n'a pas encore déclenché
-(aucune issue ouverte — la double sonde à 30 s a filtré les pics), mais l'en-tête du workflow
-prévoit de remplacer la branche dry-run par la mutation Railway `serviceInstanceRedeploy`
-après 24 h sans faux positif. **Un redeploy automatique du backend aurait pu être armé sur un
-seuil atteint à 45 % de charge réelle.** Ce correctif désamorce le risque sans toucher au
-workflow, qui consomme `read_pool_stats`.
+C'est le vrai « j'ouvre le widget avant ma tournée et ensuite plus rien ne
+charge » : ce n'est pas une panne de requêtes, c'est un **`signOut()`**.
 
-## Changements
+La branche deep-link de `routes.dart` retournait sa route **avant** le gate
+`authState.isLoading`. Cold-open depuis le widget → le reader se montait alors
+que `Supabase.currentSession` était encore `null` → `ApiClient` attendait
+**100 ms** puis partait en anonyme → 401 → refresh 5 s en échec au cold boot →
+`onAuthError(401)` → `handleSessionExpired` → `signOut()` → `WidgetService.clear()`.
 
-- `app/observability/pool_stats.py` — capacité lue via `pool._max_overflow` (pas
-  d'accesseur public ; stable SQLAlchemy 1.4→2.0) ; expose `capacity` et `max_overflow` ;
-  `usage_pct = checked_out / capacity` ; `saturated = checked_out >= capacity`. `overflow`
-  reste exposé pour le diagnostic mais sort du dénominateur.
-- `app/observability/pool_stats.py` — **garde-fou anti-silence** : si le pool est dimensionné
-  mais que la capacité est illisible (attribut privé renommé par une future version de
-  SQLAlchemy, ou `max_overflow < 0`), on loggue `pool_capacity_unreadable` en `error`. Sans
-  ça, `usage_pct` disparaîtrait, la sonde prendrait sa branche « NullPool » et **cesserait
-  d'alerter silencieusement** — le pire mode de défaillance pour une métrique d'alerte.
-- `app/workers/scheduler.py` — les `capture_message` n'interpolent plus de chiffre variable
-  dans le texte (Sentry groupe par message : `usage_pct` dans le texte crée **une issue par
-  valeur**). Les compteurs partent dans le contexte Sentry `db_pool`, via un helper local
-  qui dédoublonne les deux branches d'alerte.
-- `app/main.py` — le log `db_pool_pressure_high` de `/api/health/pool` expose désormais
-  `capacity` (le dénominateur réel) en plus d'`overflow`, qui avait induit en erreur.
-- Docs : `docs/bugs/bug-pool-pressure-metric-false-positive.md` (neuf) + encart de
-  correction en tête de `docs/maintenance/maintenance-saturation-pool-db-nocturne.md`.
+**Fix, en trois points de coupure** :
+- `routes.dart` : la branche **seed** le pending et retourne `/splash`. Le bloc 3
+  existant le consomme une fois l'auth résolue — le chemin déjà prévu par le
+  design. Les auth callbacks restent traités avant les gates (ils portent la
+  session que les gates attendent).
+- `api_client.dart` : attente de session portée de 100 ms à un budget borné de
+  2 s. **Écart assumé au plan** : la requête part quand même en anonyme si le
+  budget est épuisé (certains endpoints sont publics ; échouer localement aurait
+  été une régression à large rayon). Elle est en revanche **marquée**, et un 401
+  sur une requête partie sans header ne déclenche **jamais**
+  `handleSessionExpired`.
+- `feed_repository.dart` : le cache statique `_defaultViewLastResult` (fenêtre
+  5 s) ne mémorise plus une réponse obtenue sans session — il propageait un feed
+  dégradé à tous les appelants, widget compris.
 
-**Seuils inchangés** (warn 70 %, page 90 %) : ils portent désormais sur la capacité réelle,
-soit 14 et 18 connexions sorties. Le pic observé (11) reste silencieux — c'est voulu.
+Corrige aussi **FLUTTER-Y** (`type 'Null' is not a subtype of type
+'Perspective'`, 20 events) : les 9 `state.extra as X?` passent par un helper
+unique `extraAs<T>(state)`.
 
-**Aucun changement de `pool_size`/`max_overflow`** : le pic réel est 11/20. Interdit sans
-preuve métrique (`docs/bugs/bug-infinite-load-requests.md`).
+### C4 — Bouton refresh : no-op à froid, effets de bord violents à chaud
 
-Clés ajoutées uniquement (`capacity`, `max_overflow`) → `/api/health/pool` gagne des champs,
-rien ne casse.
+- **Cold start** : le flag `refresh=1` était **jeté**. `pendingRoute()` ne
+  renvoyait que la route → `_onRefreshRequested` jamais appelé → no-op littéral.
+- **À chaud** : `ref.read(digestProvider.notifier)` **construit** le provider,
+  dont le `build()` lance `_loadBothDigests` (45 s × 5 retries, ~80 s de chaîne
+  réseau pour un tap) et appelle `sereinToggleProvider.initFromApi()` → pouvait
+  **basculer le toggle Serein** sous l'utilisateur. Et `refreshForWidget()`
+  faisait `state = AsyncData(...)` juste après `router.go('/flaner')` → l'état
+  visible était remplacé pendant que `FlanerScreen` se montait. C'est le
+  « plante Flâner ».
 
-## Tests
+**Fix** : `pendingAction()` expose l'action complète et `replayRefreshIfRequested()`
+rejoue le side-effect (le bouton marche donc au cold start) ;
+`container.exists(digestProvider)` avant tout `ref.read(...notifier)` ;
+`syncWidgetFromRefresh()` devient **mémoire seule** ; `refreshForWidget()`
+**n'écrit plus dans `state`**.
 
-`packages/api/tests/test_pool_observability.py` :
+### C5 — « le widget n'affiche que 9 articles »
 
-- `test_read_pool_stats_does_not_page_on_engaged_overflow` — rejoue l'événement du 25/07
-  (`size=10, overflow=2, checked_out=11`) et exige 55 %, sous le seuil de page.
-- `test_read_pool_stats_capacity_matches_real_queuepool` — **le garde-fou qui manquait** :
-  construit un vrai `QueuePool` avec les kwargs de prod et vérifie le ratio à 9 puis 20
-  connexions sorties. Les fakes ne protégeaient pas contre une mécompréhension de l'API
-  SQLAlchemy, qui est l'origine exacte du bug.
-- `test_read_pool_stats_logs_when_sized_pool_has_unreadable_capacity` — supprime
-  `_max_overflow` pour simuler un renommage SQLAlchemy et exige le log `error`.
-- `test_read_pool_stats_nullpool_stays_quiet` — NullPool ne doit pas déclencher ce log.
-- `test_read_pool_stats_unbounded_overflow_has_no_usage_pct` — `max_overflow < 0`.
-- `test_read_pool_stats_ok_with_negative_overflow` — attendu corrigé 50 % → 25 %.
+Les caps sont à 80 partout et le parsing Kotlin est non destructif : **rien ne
+tronque à 9**. Le payload contenait réellement ~9 lignes, parce que les pushes
+poussaient `state.items` — la liste **visible** de Flâner, qui *rétrécit* au fil
+de la lecture (overlay `_consumedContentIds`) — et que rien ne reconstituait la
+profondeur.
 
-Suite backend complète : `1992 passed, 1 failed, 547 errors` — l'échec
-(`test_essentiel_endpoint.py::test_get_essentiel_uses_user_context_from_router`) et les 547
-erreurs sont dus à l'absence de Postgres local sur le port 54322, et sont **reproduits à
-l'identique sur `origin/main`** (vérifié via worktree).
+**Fix** : buffer widget dédié (cap 80), alimenté en **union** dédupliquée et
+**découplé** de l'overlay ; lire un article dans l'app ne vide plus le widget.
+Le garde de signature passe de `len|first|last` (aveugle à un réordonnancement
+du milieu) à **tous** les ids, avec péremption 6 h.
 
-## ⚠️ Après merge (actions PO)
+### C6 — Rien ne rafraîchissait le widget app fermée
 
-1. Le texte du message Sentry change → **nouveau groupe d'issue**. Résoudre **PYTHON-63**
-   en « faux positif — métrique corrigée ».
-2. Surveiller 1 semaine les logs `db_pool_probe` (info, 5 min) pour établir le p95 réel de
-   `checked_out` avant toute autre action.
+L'alarme 30 min ne fait que **repeindre les mêmes octets** (`onUpdate` relit
+SharedPreferences, aucun réseau). `initWidgetIfNeeded()` était **du code mort**
+— zéro appelant → un widget fraîchement épinglé restait vide.
 
-## Suivi identifié (hors périmètre, non prouvé par cette alerte)
+**Fix** : `workmanager` (~1 h, `NetworkType.connected`, `requiresBatteryNotLow`).
+Contraintes de conception, toutes tirées des autres causes :
+- **Dio nu**, sans les interceptors `onAuthError` : un 401 en tâche de fond ne
+  peut pas délogger (leçon de C3) ;
+- pas de session restaurable → **abandon silencieux**, jamais de `signOut` ;
+- `updateWidgetMergingFlux()` **fusionne** au lieu de remplacer (une page = 20
+  articles ; remplacer ferait retomber le payload de 80 à 20, soit exactement
+  le symptôme C5) ;
+- annulé au logout, à côté de `WidgetService.clear()`.
 
-- `app/services/push_dispatcher.py` — transaction ouverte pendant les envois FCM
-  (`await asyncio.to_thread`) avec `idle_in_transaction_session_timeout = 10 s` : un envoi
-  lent peut tuer la transaction et faire perdre les écritures `status='sent'`.
-  **Bug de correction en soi**, à traiter séparément.
-- `app/services/recommendation_service.py` — jusqu'à 3 connexions simultanées par
-  `/api/feed`.
-- `app/services/grille_selector.py` — `asyncio.gather` sur la **même** `AsyncSession`.
-- `app/workers/classification_worker.py` — engine `NullPool` séparé, invisible de la sonde.
+### CTA « Ajouter le widget »
+
+L'entrée était enterrée dans Compte **et** ne faisait rien. Nouveau bandeau en
+tête de Flâner, bâti sur les tokens existants, affiché seulement si aucun widget
+n'est épinglé (en cas d'incertitude → masqué). Throttle 7 j via le **registre
+unifié des nudges**. `WidgetPinPrompt` rend toujours compte du résultat
+(`unsupported` → explication, `failed` → erreur), au lieu du silence d'avant.
+
+## Comment ça a été vérifié
+
+- `flutter analyze` : **0 erreur**. 532 issues, toutes pré-existantes (aucune
+  nouvelle sur les fichiers touchés).
+- `flutter test` : **1859 passés / 27 échecs**.
+  Les 27 échecs sont **exactement la baseline** : vérifié en montant un worktree
+  sur `origin/main` et en rejouant les fichiers à risque
+  (`router_redirection_test` ×2, `feed_sources_test` ×5, `widget_test` ×1) —
+  ils échouent à l'identique sans ce diff.
+- Tests ajoutés : garde namespace (lit `build.gradle.kts`), `pendingAction` +
+  `refresh=1` au cold start, buffer qui ne rétrécit pas, `refreshForWidget` qui
+  ne mute plus `state`, réponse sans session jamais mémorisée.
+
+### Non vérifié — vérification device (la seule qui prouve C1)
+
+Conductor n'a pas de JDK, donc **aucun APK n'a été construit**. C1, C6 et le
+CTA d'épinglage ne sont prouvés que par lecture du plugin et des tests de garde.
+Le protocole device est écrit dans la doc du bug (§ Vérification) : épingler
+depuis le bandeau, `adb logcat -s FacteurWidget:D`, vérifier `count=` > 9 et
+croissant, tap refresh app tuée, et le scénario clé « widget avant la tournée →
+rester connecté ».
+
+## Zones à risque
+
+- **Auth / Router** (`api_client.dart`, `routes.dart`, `session_refresher.dart`,
+  `auth_state.dart`) — cf. Safety Guardrails. Le changement le plus sensible est
+  le passage du deep-link widget par `/splash` : à relire en priorité.
+- `feed_provider.dart` : `refreshForWidget()` n'écrit plus dans `state` (un test
+  existant a été inversé en conséquence, volontairement).
+- `_prefetchForWidget` : le bail `!_hasNext` est levé, borné par un **cooldown
+  30 min** — sans lui, un compte qui n'a pas 80 articles disponibles relancerait
+  4 appels `/api/feed/` à chaque build de feed et chaque retour de premier plan.
+
+## Hors scope (à signaler au PO)
+
+- Crashes **Flux Continu** (FLUTTER-1R/1M/1S/1T/1K/1N, ~30 events fatals sur 5 j)
+  et **FLUTTER-1X** (guided tour, marqué *escalating*) : famille distincte,
+  workspace dédié.
+- **FLUTTER-1D** (trampoline Glance, 3 users, fatal) : la dépendance
+  `androidx.glance:glance-appwidget` est confirmée, mais le manifest mergé n'est
+  pas inspectable sans JDK. On ne retire pas une activité tierce exportée sans
+  preuve. Reste en suivi.
+
+## Après merge sur `main` (staging)
+
+- Sentry `flutter` : **FLUTTER-1E** et **FLUTTER-Y** doivent tomber à zéro ;
+  surveiller FLUTTER-6 et FLUTTER-1D.
+- Vérifier `widget_last_push_count` (médiane attendue nettement > 9).

--- a/apps/mobile/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
+++ b/apps/mobile/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
@@ -140,5 +140,10 @@ public final class GeneratedPluginRegistrant {
     } catch (Exception e) {
       Log.e(TAG, "Error registering plugin webview_flutter_android, io.flutter.plugins.webviewflutter.WebViewFlutterPlugin", e);
     }
+    try {
+      flutterEngine.getPlugins().add(new dev.fluttercommunity.workmanager.WorkmanagerPlugin());
+    } catch (Exception e) {
+      Log.e(TAG, "Error registering plugin workmanager_android, dev.fluttercommunity.workmanager.WorkmanagerPlugin", e);
+    }
   }
 }

--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Widget d'accueil",
+      "summary": "Le widget Facteur se met enfin à jour quand il faut : après chaque passage dans l'app, au tap sur son bouton refresh, et même app fermée. Il garde jusqu'à 80 articles au lieu de se vider à mesure que tu lis, et l'ouvrir avant ta tournée du matin ne te déconnecte plus. Un nouveau bandeau dans Flâner te propose de l'ajouter à ton écran d'accueil en un tap."
+    },
+    {
       "tag": "Objectif du jour",
       "summary": "Tu choisis désormais ton objectif quotidien : dans « Progression », un curseur règle le nombre d'articles à lire jusqu'au bout pour valider ta journée (de 1 à 7). Quand tu l'atteins, le message de félicitation te propose de le réajuster, et le pied de page d'un article terminé passe tout au vert."
     },

--- a/apps/mobile/ios/Runner/GeneratedPluginRegistrant.m
+++ b/apps/mobile/ios/Runner/GeneratedPluginRegistrant.m
@@ -144,6 +144,12 @@
 @import webview_flutter_wkwebview;
 #endif
 
+#if __has_include(<workmanager_apple/WorkmanagerPlugin.h>)
+#import <workmanager_apple/WorkmanagerPlugin.h>
+#else
+@import workmanager_apple;
+#endif
+
 @implementation GeneratedPluginRegistrant
 
 + (void)registerWithRegistry:(NSObject<FlutterPluginRegistry>*)registry {
@@ -170,6 +176,7 @@
   [SqflitePlugin registerWithRegistrar:[registry registrarForPlugin:@"SqflitePlugin"]];
   [URLLauncherPlugin registerWithRegistrar:[registry registrarForPlugin:@"URLLauncherPlugin"]];
   [WebViewFlutterPlugin registerWithRegistrar:[registry registrarForPlugin:@"WebViewFlutterPlugin"]];
+  [WorkmanagerPlugin registerWithRegistrar:[registry registrarForPlugin:@"WorkmanagerPlugin"]];
 }
 
 @end

--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -203,7 +203,16 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
   /// réseau (retour de premier plan après un long passage en arrière-plan).
   void _ensureWidgetFresh({bool stale = false}) {
     if (!ref.read(authStateProvider).isAuthenticated) return;
-    unawaited(ref.read(feedProvider.notifier).ensureWidgetFresh(stale: stale));
+    // Ceinture + bretelles : `ensureWidgetFresh` avale déjà ses erreurs, mais
+    // ce `unawaited` est justement le point où une future rejetée devenait un
+    // crash fatal sans handler (Sentry FLUTTER-1E).
+    unawaited(
+      ref.read(feedProvider.notifier).ensureWidgetFresh(stale: stale).catchError(
+        (Object e) {
+          debugPrint('FacteurApp: ensureWidgetFresh failed (ignored): $e');
+        },
+      ),
+    );
   }
 
   Future<void> _flushFluxScrollMetricIfAny() async {
@@ -249,6 +258,9 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
 
     // Bind the DeepLinkService once the router is built. Idempotent.
     final analytics = ref.read(analyticsServiceProvider);
+    // Capturé ici (et pas dans la closure) pour pouvoir tester l'existence
+    // d'un provider sans le construire — cf. `onRefreshRequested`.
+    final container = ProviderScope.containerOf(context, listen: false);
     DeepLinkService.instance.bind(
       router: router,
       analytics: analytics,
@@ -259,7 +271,15 @@ class _FacteurAppState extends ConsumerState<FacteurApp>
       // le bouton « sans effet ». On force donc un re-push complet des deux
       // caches. Fire-and-forget : le handler de deep link est synchrone.
       onRefreshRequested: () {
-        unawaited(ref.read(digestProvider.notifier).syncWidgetFromRefresh());
+        // `ref.read(digestProvider.notifier)` **construit** le provider s'il
+        // ne l'est pas encore, et son `build()` part sur `_loadBothDigests()`
+        // (45 s × 5 retries). Un tap sur le bouton widget ne doit jamais
+        // amorcer cette chaîne : on ne touche à l'Essentiel que s'il est déjà
+        // vivant, et `syncWidgetFromRefresh` se contente alors de re-sérialiser
+        // la mémoire. Cf. docs/bugs/bug-widget-fiabilite.md (C4).
+        if (container.exists(digestProvider)) {
+          unawaited(ref.read(digestProvider.notifier).syncWidgetFromRefresh());
+        }
         unawaited(ref.read(feedProvider.notifier).refreshForWidget());
       },
     );

--- a/apps/mobile/lib/config/routes.dart
+++ b/apps/mobile/lib/config/routes.dart
@@ -57,6 +57,16 @@ import '../shared/widgets/navigation/modal_bottom_sheet_page.dart';
 
 const tourneeSectionTransitionDuration = Duration(milliseconds: 420);
 
+/// `state.extra` typé, ou `null` quand il porte autre chose.
+///
+/// `extra` n'est jamais garanti : il est perdu à la restauration d'état par
+/// l'OS et absent des deep-links et des notifications. Le `as X?` d'origine
+/// levait alors `type 'Null' is not a subtype of type 'Perspective'` en pleine
+/// construction de page (Sentry FLUTTER-Y) — un test de type le dégrade
+/// proprement en `null`, que les écrans savent déjà gérer.
+T? extraAs<T>(GoRouterState state) =>
+    state.extra is T ? state.extra as T : null;
+
 /// Clés de navigator des deux branches du shell principal (Essentiel / Flâner).
 ///
 /// Chaque branche d'un `StatefulShellRoute` possède son propre navigator pour
@@ -178,15 +188,33 @@ final routerProvider = Provider<GoRouter>((ref) {
       // Intercept widget deep links pushed by PlatformRouteInformationProvider.
       // Without this, a raw `io.supabase.facteur://digest/<id>` URI lands in
       // GoRouter and falls through to errorBuilder ("Page non trouvée") before
-      // DeepLinkService (app_links) can route. Idempotent with DeepLinkService:
-      // both ultimately call router.go on the same in-app path.
+      // DeepLinkService (app_links) can route.
+      //
+      // This branch used to `return action.route` directly, i.e. **before** the
+      // `authState.isLoading` gate below. Cold-opening the app from the widget
+      // therefore mounted the reader while `Supabase.currentSession` was still
+      // null: the first `/api` call went out anonymous, came back 401, the
+      // cold-boot refresh timed out and `onAuthError(401)` signed the user out
+      // app-wide — « j'ouvre le widget avant ma tournée et ensuite plus rien ne
+      // charge ». Cf. docs/bugs/bug-widget-fiabilite.md (C3).
+      //
+      // We now seed the URI as pending and park on the splash. Block 3 below
+      // consumes it once auth is fully resolved — the path the design already
+      // provided for `flushPendingIfReady`.
       if (state.uri.scheme == 'io.supabase.facteur') {
         final action = DeepLinkService.parse(state.uri);
-        // GoRouter received the deep link directly (some launchers deliver it
-        // as the initial route). Consume any seeded pending URI so the
-        // post-auth `flushPendingIfReady` doesn't replay it and double-navigate.
-        DeepLinkService.instance.clearPending();
-        return action.route ?? RoutePaths.fluxContinu;
+        if (action.target == WidgetDeepLinkTarget.authCallback) {
+          // The one family that must be handled before the gates: it carries
+          // the very session the gates are waiting on.
+          DeepLinkService.instance.clearPending();
+          return action.route ?? RoutePaths.splash;
+        }
+        if (DeepLinkService.navigableRouteFor(action) != null) {
+          DeepLinkService.instance.seedPending(state.uri);
+        } else {
+          DeepLinkService.instance.clearPending();
+        }
+        return RoutePaths.splash;
       }
 
       final authState = ref.read(authStateProvider);
@@ -275,10 +303,17 @@ final routerProvider = Provider<GoRouter>((ref) {
         // Deep link de cold-start (widget) : il est la source de vérité de
         // l'atterrissage. On le consomme ici pour éviter la course avec
         // `flushPendingIfReady` (qui redeviendrait no-op après clearPending).
-        final pending = DeepLinkService.instance.pendingRoute();
-        if (pending != null) {
+        final pendingAction = DeepLinkService.instance.pendingAction();
+        if (pendingAction != null) {
           DeepLinkService.instance.clearPending();
-          return pending;
+          // `refresh=1` (widget refresh button) survives the cold start now.
+          // Deferred: we are inside `redirect`, no provider reads here.
+          if (pendingAction.refresh) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              DeepLinkService.instance.replayRefreshIfRequested(pendingAction);
+            });
+          }
+          return DeepLinkService.navigableRouteFor(pendingAction);
         }
         return postAuthHomePath();
       }
@@ -416,7 +451,7 @@ final routerProvider = Provider<GoRouter>((ref) {
                     parentNavigatorKey: NotificationService.navigatorKey,
                     pageBuilder: (context, state) {
                       final contentId = state.pathParameters['id']!;
-                      final content = state.extra as Content?;
+                      final content = extraAs<Content>(state);
                       return FullSwipeCupertinoPage(
                         child: ContentDetailScreen(
                           contentId: contentId,
@@ -430,7 +465,7 @@ final routerProvider = Provider<GoRouter>((ref) {
                     parentNavigatorKey: NotificationService.navigatorKey,
                     pageBuilder: (context, state) {
                       final key = state.pathParameters['key']!;
-                      final section = state.extra as FeedThemeSection?;
+                      final section = extraAs<FeedThemeSection>(state);
                       return FullSwipeCupertinoPage(
                         key: state.pageKey,
                         transitionDurationOverride:
@@ -448,7 +483,7 @@ final routerProvider = Provider<GoRouter>((ref) {
                     parentNavigatorKey: NotificationService.navigatorKey,
                     pageBuilder: (context, state) {
                       final key = state.pathParameters['key']!;
-                      final section = state.extra as DigestTopicSection?;
+                      final section = extraAs<DigestTopicSection>(state);
                       // `src=week` → « Tout lire » de la rétro hebdo : la page
                       // épingle l'agrégat passé en `extra` au lieu de résoudre
                       // le feed du jour (cf. DigestSectionScreen.pinToInitial).
@@ -475,7 +510,7 @@ final routerProvider = Provider<GoRouter>((ref) {
                     parentNavigatorKey: NotificationService.navigatorKey,
                     pageBuilder: (context, state) {
                       final id = state.pathParameters['id']!;
-                      final section = state.extra as FeedThemeSection?;
+                      final section = extraAs<FeedThemeSection>(state);
                       return FullSwipeCupertinoPage(
                         key: state.pageKey,
                         transitionDurationOverride:
@@ -509,7 +544,7 @@ final routerProvider = Provider<GoRouter>((ref) {
                     parentNavigatorKey: NotificationService.navigatorKey,
                     pageBuilder: (context, state) {
                       final contentId = state.pathParameters['id']!;
-                      final content = state.extra as Content?;
+                      final content = extraAs<Content>(state);
                       // `from=pdr` → article ouvert depuis un CTA « Pas de
                       // recul » : header contextuel (lavis bleu + médaillon 🔭).
                       final fromDeepReco =
@@ -580,7 +615,7 @@ final routerProvider = Provider<GoRouter>((ref) {
         name: RouteNames.contentExternal,
         parentNavigatorKey: NotificationService.navigatorKey,
         pageBuilder: (context, state) {
-          final p = state.extra as Perspective?;
+          final p = extraAs<Perspective>(state);
           if (p == null) {
             // extra perdu (deep-link/notif après kill, ou restauration OS) :
             // on annule au lieu de planter la construction (FLUTTER-Y).
@@ -652,9 +687,7 @@ final routerProvider = Provider<GoRouter>((ref) {
                 // universelle (story 30.1). Absent → écran vierge habituel.
                 pageBuilder: (context, state) => FullSwipeCupertinoPage(
                   child: AddSourceScreen(
-                    initialQuery: state.extra is String
-                        ? state.extra as String
-                        : null,
+                    initialQuery: extraAs<String>(state),
                   ),
                 ),
               ),
@@ -669,7 +702,7 @@ final routerProvider = Provider<GoRouter>((ref) {
                 name: RouteNames.themeSources,
                 pageBuilder: (context, state) {
                   final slug = state.pathParameters['slug']!;
-                  final themeName = state.extra as String?;
+                  final themeName = extraAs<String>(state);
                   return FullSwipeCupertinoPage(
                     child: ThemeSourcesScreen(
                       themeSlug: slug,
@@ -789,7 +822,7 @@ final routerProvider = Provider<GoRouter>((ref) {
         path: RoutePaths.topicExplorer,
         name: RouteNames.topicExplorer,
         pageBuilder: (context, state) {
-          final extra = state.extra as Map<String, dynamic>? ?? {};
+          final extra = extraAs<Map<String, dynamic>>(state) ?? <String, dynamic>{};
           return FullSwipeCupertinoPage(
             child: TopicExplorerScreen(
               topicSlug: extra['topicSlug'] as String? ?? '',

--- a/apps/mobile/lib/core/api/api_client.dart
+++ b/apps/mobile/lib/core/api/api_client.dart
@@ -43,6 +43,22 @@ class ApiClient {
   /// (`HTTPException(status_code=403, detail="Email not confirmed")`).
   static const String _emailNotConfirmedDetail = 'Email not confirmed';
 
+  /// Marqueur posé sur les requêtes parties **sans** header `Authorization`.
+  /// Un 401 sur une telle requête ne prouve rien sur la validité de la session
+  /// et ne doit jamais déclencher `handleSessionExpired` (cf. C3 de
+  /// `docs/bugs/bug-widget-fiabilite.md`).
+  static const String _anonymousRequestFlag = 'facteur_anonymous_request';
+
+  /// Budget d'attente d'une session au moment d'émettre une requête.
+  ///
+  /// Les 100 ms d'origine étaient calibrées pour une race Riverpod ; elles ne
+  /// couvrent pas un cold boot (restauration Hive + `recoverSession` Supabase),
+  /// où l'app partait en anonyme, prenait un 401 et se déloguait. Même esprit
+  /// que `resolveMorningRitualMaxWait` : on laisse le temps au démarrage à
+  /// froid, sans jamais bloquer une requête qui a déjà sa session.
+  static const Duration _sessionWaitBudget = Duration(seconds: 2);
+  static const Duration _sessionPollInterval = Duration(milliseconds: 100);
+
   late final Dio _dio;
   final SupabaseClient _supabase;
   final void Function(int code)? onAuthError;
@@ -85,14 +101,7 @@ class ApiClient {
     _dio.interceptors.add(
       InterceptorsWrapper(
         onRequest: (options, handler) async {
-          // Try to get session, with a short wait if not immediately available
-          var session = _supabase.auth.currentSession;
-
-          // If no session, wait a bit and try again (race condition fix for Android release)
-          if (session == null) {
-            await Future<void>.delayed(const Duration(milliseconds: 100));
-            session = _supabase.auth.currentSession;
-          }
+          final session = await _awaitSession();
 
           if (session != null) {
             // ignore: avoid_print
@@ -100,9 +109,13 @@ class ApiClient {
                 'ApiClient: Attaching token ${session.accessToken.substring(0, 10)}...');
             options.headers['Authorization'] = 'Bearer ${session.accessToken}';
           } else {
+            // Requête émise quand même : certains endpoints sont publics. Mais
+            // on la marque pour que son éventuel 401 ne puisse pas être lu
+            // comme une session expirée.
+            options.extra[_anonymousRequestFlag] = true;
             // ignore: avoid_print
             print(
-                'ApiClient: [WARNING] No session found, request will be anonymous.');
+                'ApiClient: [WARNING] No session after ${_sessionWaitBudget.inMilliseconds}ms, request will be anonymous.');
           }
           return handler.next(options);
         },
@@ -110,6 +123,18 @@ class ApiClient {
           final statusCode = error.response?.statusCode;
 
           if (statusCode == 401) {
+            // La requête est partie sans header : le 401 est attendu et ne dit
+            // rien de la session. La traiter comme une expiration déconnectait
+            // l'utilisateur au cold boot (C3). On laisse le 401 remonter au
+            // caller, sans refresh ni `onAuthError`.
+            if (error.requestOptions.extra[_anonymousRequestFlag] == true) {
+              // ignore: avoid_print
+              print(
+                  'ApiClient: 401 on an anonymous request (${error.requestOptions.path}) — no session to expire, not signing out.');
+              _logError(error);
+              return handler.next(error);
+            }
+
             // Single-flight refresh via SessionRefresher : si plusieurs
             // requêtes parallèles reçoivent 401 (typique au resume après
             // background), un seul refresh est envoyé au SDK Supabase. Évite
@@ -117,8 +142,11 @@ class ApiClient {
             // (cf. docs/bugs/bug-android-disconnect-race.md).
             Session? refreshedSession;
             try {
-              refreshedSession = await SessionRefresher.instance
-                  .refresh(timeout: const Duration(seconds: 5));
+              // Pas de `timeout:` explicite : `SessionRefresher` calcule un
+              // budget adaptatif (8 s au premier plan, 20 s au cold boot /
+              // réveil). Les 5 s fixes d'avant expiraient systématiquement au
+              // réveil par tap widget, ce qui armait le logout ci-dessous.
+              refreshedSession = await SessionRefresher.instance.refresh();
             } catch (_) {
               // Refresh failed — recheck currentSession avant de logout :
               // un autre acteur (SDK auto-refresh) a peut-être obtenu une
@@ -239,6 +267,24 @@ class ApiClient {
     _dio.interceptors.add(UserErrorInterceptor());
   }
 
+  /// Attend une session Supabase jusqu'à [_sessionWaitBudget], en sortant dès
+  /// qu'elle est disponible. Retourne `null` si le budget est épuisé.
+  ///
+  /// Coût nul sur le chemin nominal (session déjà là → retour immédiat) ; le
+  /// budget ne s'applique qu'au cold boot, où la session est en cours de
+  /// restauration depuis Hive.
+  Future<Session?> _awaitSession() async {
+    var session = _supabase.auth.currentSession;
+    if (session != null) return session;
+
+    final deadline = DateTime.now().add(_sessionWaitBudget);
+    while (session == null && DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(_sessionPollInterval);
+      session = _supabase.auth.currentSession;
+    }
+    return session;
+  }
+
   /// Extrait le champ `detail` d'une réponse d'erreur FastAPI (si dispo).
   String? _extractErrorDetail(dynamic data) {
     if (data is Map && data['detail'] is String) {
@@ -266,6 +312,11 @@ class ApiClient {
 
   /// Accès au client Dio
   Dio get dio => _dio;
+
+  /// `true` quand une session Supabase est disponible à l'instant T. Permet
+  /// aux caches applicatifs de ne pas mémoriser une réponse obtenue en
+  /// anonyme (cf. `FeedRepository._defaultViewLastResult`).
+  bool get hasSession => _supabase.auth.currentSession != null;
 
   /// Helper GET
   Future<dynamic> get(

--- a/apps/mobile/lib/core/auth/auth_state.dart
+++ b/apps/mobile/lib/core/auth/auth_state.dart
@@ -10,6 +10,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 import '../../features/auth/utils/auth_error_messages.dart';
 import '../services/posthog_service.dart';
 import '../services/server_push_service.dart';
+import '../services/widget_background_refresh.dart';
 import '../services/widget_service.dart';
 import 'session_refresher.dart';
 
@@ -421,6 +422,9 @@ class AuthStateNotifier extends StateNotifier<AuthState>
     // Wipe the home-screen widget so the next account on the same device
     // never briefly sees the previous user's digest.
     await WidgetService.clear();
+    // Le job de fond doit mourir avec la session : sinon il continue de
+    // réécrire le widget avec le flux du compte précédent.
+    await WidgetBackgroundRefresh.cancel();
 
     // Reset onboarding navigation state — otherwise a fresh signup on the
     // same device inherits saved section/question and skips Section 1.

--- a/apps/mobile/lib/core/auth/session_refresher.dart
+++ b/apps/mobile/lib/core/auth/session_refresher.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -52,10 +52,39 @@ class SessionRefresher {
   Session? _defaultCurrentSession() =>
       Supabase.instance.client.auth.currentSession;
 
+  /// Budget d'attente par défaut d'un `refreshSession()`.
+  ///
+  /// 8 s suffisent quand l'app est au premier plan sur un réseau correct. Au
+  /// cold boot ou au retour de `paused` (app réveillée par un tap widget, radio
+  /// cellulaire endormie), le handshake dépasse régulièrement ce plafond : le
+  /// `TimeoutException 0:00:08` est Sentry FLUTTER-6, et son échec en cascade
+  /// arme `onAuthError(401)` → déconnexion. Même approche que
+  /// `resolveMorningRitualMaxWait` : on élargit le budget hors `resumed`.
+  ///
+  /// Exposé pour les tests.
+  @visibleForTesting
+  static Duration resolveRefreshTimeout(AppLifecycleState? lifecycle) {
+    return lifecycle == AppLifecycleState.resumed
+        ? const Duration(seconds: 8)
+        : const Duration(seconds: 20);
+  }
+
+  Duration get _defaultTimeout {
+    AppLifecycleState? lifecycle;
+    try {
+      lifecycle = WidgetsBinding.instance.lifecycleState;
+    } catch (_) {
+      // Binding non initialisé (tests unitaires purs, isolate de fond) : on
+      // retombe sur le budget « premier plan », le plus serré.
+      lifecycle = AppLifecycleState.resumed;
+    }
+    return resolveRefreshTimeout(lifecycle);
+  }
+
   /// Refresh single-flight. Si un appel est déjà en cours, retourne sa future.
-  Future<Session?> refresh({
-    Duration timeout = const Duration(seconds: 8),
-  }) {
+  /// [timeout] omis → budget adaptatif ([resolveRefreshTimeout]).
+  Future<Session?> refresh({Duration? timeout}) {
+    final budget = timeout ?? _defaultTimeout;
     final pending = _inflight;
     if (pending != null) {
       debugPrint('SessionRefresher: piggyback on in-flight refresh.');
@@ -64,7 +93,7 @@ class SessionRefresher {
 
     final completer = Completer<Session?>();
     _inflight = completer;
-    _runRefresh(completer, timeout);
+    _runRefresh(completer, budget);
     return completer.future;
   }
 

--- a/apps/mobile/lib/core/nudges/nudge_ids.dart
+++ b/apps/mobile/lib/core/nudges/nudge_ids.dart
@@ -17,6 +17,10 @@ class NudgeIds {
   static const feedBadgeLongpress = 'feed_badge_longpress';
   static const feedPreviewLongpress = 'feed_preview_longpress';
   static const personalisationCta = 'personalisation_cta';
+  // Bandeau « Ajoute le widget » en tête de Flâner. Distinct de
+  // [widgetPinAndroid], qui décrit la feuille du bas côté Essentiel : surface,
+  // placement et fréquence diffèrent, seule l'intention est voisine.
+  static const widgetCtaFeedBanner = 'widget_cta_feed_banner';
   // ID kept after the slider→picker migration so users who already dismissed
   // the explainer don't see it pop again.
   static const prioritySliderExplainer = 'priority_slider_explainer';

--- a/apps/mobile/lib/core/nudges/nudge_registry.dart
+++ b/apps/mobile/lib/core/nudges/nudge_registry.dart
@@ -84,6 +84,16 @@ class NudgeRegistry {
       frequency: NudgeFrequency.cooldown,
       cooldown: Duration(days: 30),
     ),
+    // Bandeau « Ajoute le widget » de Flâner. Cooldown 7 j, aligné sur le
+    // bandeau Lettres : on repropose, sans être insistant.
+    const Nudge(
+      id: NudgeIds.widgetCtaFeedBanner,
+      surface: NudgeSurface.feed,
+      placement: NudgePlacement.inlineBanner,
+      priority: NudgePriority.low,
+      frequency: NudgeFrequency.cooldown,
+      cooldown: Duration(days: 7),
+    ),
     const Nudge(
       id: NudgeIds.prioritySliderExplainer,
       surface: NudgeSurface.settings,

--- a/apps/mobile/lib/core/services/deep_link_service.dart
+++ b/apps/mobile/lib/core/services/deep_link_service.dart
@@ -178,13 +178,10 @@ class DeepLinkService {
     _initialLinkSeeded = true;
   }
 
-  /// Resolve the in-app route for the currently pending URI **without
-  /// consuming it**, or `null` when nothing navigable is pending. Called by the
-  /// router `redirect` to land cold-opens on their deep-linked destination.
-  String? pendingRoute() {
-    final pending = _pending;
-    if (pending == null) return null;
-    final action = parse(pending);
+  /// The in-app route an [action] should land on, or `null` when the action
+  /// carries nothing navigable (auth callbacks are routed by the auth listener,
+  /// not by the pending-link path).
+  static String? navigableRouteFor(WidgetDeepLinkAction action) {
     switch (action.target) {
       case WidgetDeepLinkTarget.article:
       case WidgetDeepLinkTarget.digest:
@@ -197,6 +194,38 @@ class DeepLinkService {
       case WidgetDeepLinkTarget.unhandled:
         return null;
     }
+  }
+
+  /// The **full** pending action (route *and* `refresh` flag), without
+  /// consuming it. Returns `null` when nothing navigable is pending.
+  ///
+  /// [pendingRoute] used to be the only accessor, which is why the widget's
+  /// refresh button was a literal no-op on cold start: the router consumed the
+  /// route and dropped `refresh=1` on the floor, so `_onRefreshRequested` was
+  /// never invoked. Callers should prefer this and then
+  /// [replayRefreshIfRequested].
+  WidgetDeepLinkAction? pendingAction() {
+    final pending = _pending;
+    if (pending == null) return null;
+    final action = parse(pending);
+    return navigableRouteFor(action) == null ? null : action;
+  }
+
+  /// Resolve the in-app route for the currently pending URI **without
+  /// consuming it**, or `null` when nothing navigable is pending. Called by the
+  /// router `redirect` to land cold-opens on their deep-linked destination.
+  String? pendingRoute() {
+    final action = pendingAction();
+    return action == null ? null : navigableRouteFor(action);
+  }
+
+  /// Fire the widget-refresh side effects for an [action] the router consumed
+  /// itself (cold start). Analytics is re-emitted here because `_route` — the
+  /// usual emitter — is bypassed on that path.
+  void replayRefreshIfRequested(WidgetDeepLinkAction action) {
+    if (!action.refresh) return;
+    _analytics?.trackWidgetAppOpened(target: 'feed');
+    _onRefreshRequested?.call();
   }
 
   /// Clear the pending URI. Called by the redirect once it has consumed the

--- a/apps/mobile/lib/core/services/widget_background_refresh.dart
+++ b/apps/mobile/lib/core/services/widget_background_refresh.dart
@@ -1,0 +1,164 @@
+import 'dart:io' show Platform;
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:workmanager/workmanager.dart';
+
+import '../../config/constants.dart';
+import '../../features/feed/repositories/feed_repository.dart';
+import '../auth/supabase_storage.dart';
+import 'widget_service.dart';
+
+/// Rafraîchissement du widget d'accueil **app fermée**.
+///
+/// Sans ça, rien ne rafraîchissait le widget hors app vivante :
+/// `homeWidgetBackgroundCallback` est un no-op assumé, le handler FCM de fond
+/// ne touche pas [WidgetService], et l'alarme système `updatePeriodMillis`
+/// (30 min) se contente de **repeindre les mêmes octets** — `onUpdate` relit
+/// SharedPreferences sans jamais toucher au réseau. Cf.
+/// docs/bugs/bug-widget-fiabilite.md (C6).
+///
+/// Contraintes de conception, toutes issues des autres causes racines :
+///  - **Dio nu**, sans les interceptors d'`ApiClient` : un 401 en tâche de fond
+///    ne doit jamais pouvoir armer `onAuthError` → `signOut` (leçon de C3) ;
+///  - pas de session restaurable → **abandon silencieux**, jamais de purge ;
+///  - fusion et non remplacement du payload (une page = 20 articles, le widget
+///    en garde 80) via [WidgetService.updateWidgetMergingFlux].
+class WidgetBackgroundRefresh {
+  const WidgetBackgroundRefresh._();
+
+  static const String taskName = 'facteur_widget_refresh';
+  static const String uniqueName = 'facteur_widget_refresh_periodic';
+
+  /// WorkManager applique un plancher de 15 min ; 1 h est un compromis entre
+  /// fraîcheur perçue et budget batterie/quota.
+  static const Duration frequency = Duration(hours: 1);
+
+  /// Une seule page suffit : le buffer widget est alimenté en union.
+  static const int _pageSize = 20;
+
+  /// Enregistre la tâche périodique. Android uniquement (pas de widget iOS —
+  /// ni extension ni app group). Idempotent : `keep` laisse la tâche déjà
+  /// planifiée poursuivre son cycle.
+  static Future<void> register() async {
+    if (kIsWeb || !Platform.isAndroid) return;
+    try {
+      await Workmanager().initialize(widgetRefreshCallbackDispatcher);
+      await Workmanager().registerPeriodicTask(
+        uniqueName,
+        taskName,
+        frequency: frequency,
+        constraints: Constraints(
+          networkType: NetworkType.connected,
+          requiresBatteryNotLow: true,
+        ),
+        existingWorkPolicy: ExistingPeriodicWorkPolicy.keep,
+      );
+    } catch (e) {
+      debugPrint('WidgetBackgroundRefresh: register failed (non-critical): $e');
+    }
+  }
+
+  /// Annule la tâche. Appelé au logout, à côté de `WidgetService.clear()` :
+  /// sans ça, le job continuerait à réécrire le widget avec le flux de
+  /// l'utilisateur précédent.
+  static Future<void> cancel() async {
+    if (kIsWeb || !Platform.isAndroid) return;
+    try {
+      await Workmanager().cancelByUniqueName(uniqueName);
+    } catch (e) {
+      debugPrint('WidgetBackgroundRefresh: cancel failed (non-critical): $e');
+    }
+  }
+
+  /// Le travail réel, exécuté dans l'isolate de fond.
+  ///
+  /// Retourne `true` même en cas d'échec « normal » (pas de session, réseau
+  /// coupé) : ce n'est pas une erreur à retenter agressivement, le prochain
+  /// cycle réessaiera de toute façon.
+  static Future<bool> run() async {
+    try {
+      await Hive.initFlutter();
+      final storage = SupabaseHiveStorage();
+      await storage.initialize();
+      if (!await storage.hasAccessToken()) {
+        debugPrint('WidgetBackgroundRefresh: no persisted session, skipping.');
+        return true;
+      }
+
+      await Supabase.initialize(
+        url: SupabaseConstants.url,
+        anonKey: SupabaseConstants.anonKey,
+        authOptions: FlutterAuthClientOptions(localStorage: storage),
+      );
+
+      final session = Supabase.instance.client.auth.currentSession;
+      if (session == null) {
+        debugPrint('WidgetBackgroundRefresh: session not recovered, skipping.');
+        return true;
+      }
+      final token = session.isExpired
+          ? (await Supabase.instance.client.auth.refreshSession())
+              .session
+              ?.accessToken
+          : session.accessToken;
+      if (token == null) {
+        debugPrint('WidgetBackgroundRefresh: refresh yielded no token.');
+        return true;
+      }
+
+      // Dio nu, délibérément : aucun interceptor auth, aucun chemin vers
+      // `handleSessionExpired`.
+      final dio = Dio(
+        BaseOptions(
+          baseUrl: ApiConstants.baseUrl,
+          connectTimeout: const Duration(seconds: 20),
+          receiveTimeout: const Duration(seconds: 20),
+          headers: {
+            'Accept': 'application/json',
+            'Authorization': 'Bearer $token',
+          },
+        ),
+      );
+
+      final response = await dio.get<dynamic>(
+        'feed/',
+        queryParameters: {'page': 1, 'limit': _pageSize},
+      );
+      // Même parseur que le chemin nominal : `parseFeedData` est statique et
+      // sans `ApiClient`, donc utilisable tel quel depuis l'isolate. Deux
+      // parseurs pour le même endpoint, c'est la garantie qu'un changement de
+      // schéma ferait silencieusement retomber le widget à vide.
+      final items = FeedRepository.parseFeedData(
+        data: response.data,
+        page: 1,
+        limit: _pageSize,
+      ).items;
+      if (items.isEmpty) {
+        debugPrint('WidgetBackgroundRefresh: empty feed, nothing to push.');
+        return true;
+      }
+
+      await WidgetService.updateWidgetMergingFlux(items);
+      debugPrint('WidgetBackgroundRefresh: pushed ${items.length} fresh rows.');
+      return true;
+    } catch (e) {
+      // Best-effort de bout en bout : un widget en retard vaut mieux qu'un
+      // job qui boucle en retry.
+      debugPrint('WidgetBackgroundRefresh: run failed: $e');
+      return true;
+    }
+  }
+}
+
+/// Point d'entrée de l'isolate WorkManager. Doit rester une fonction top-level
+/// annotée `vm:entry-point` (l'AOT la supprimerait sinon).
+@pragma('vm:entry-point')
+void widgetRefreshCallbackDispatcher() {
+  Workmanager().executeTask((taskName, inputData) async {
+    if (taskName != WidgetBackgroundRefresh.taskName) return true;
+    return WidgetBackgroundRefresh.run();
+  });
+}

--- a/apps/mobile/lib/core/services/widget_pin_prompt.dart
+++ b/apps/mobile/lib/core/services/widget_pin_prompt.dart
@@ -1,0 +1,36 @@
+import '../ui/notification_service.dart';
+import 'widget_service.dart';
+
+/// Point d'entrée unique pour proposer l'épinglage du widget Facteur.
+///
+/// Le CTA « Ajouter le widget » échouait en silence sur les deux flavors : le
+/// plugin ne trouvait jamais le receiver (applicationId ≠ namespace, cf.
+/// `WidgetService.androidNamespace`) et l'exception était avalée. L'utilisateur
+/// tapait, rien ne se passait, aucun message. Toute surface qui propose
+/// l'épinglage passe désormais par ici pour garantir un retour explicite.
+class WidgetPinPrompt {
+  const WidgetPinPrompt._();
+
+  /// Demande l'épinglage et rend compte à l'utilisateur.
+  ///
+  /// Succès : silencieux (le launcher affiche déjà sa propre confirmation).
+  /// Retourne le résultat pour que l'appelant puisse rafraîchir son état.
+  static Future<WidgetPinResult> requestAndReport() async {
+    final result = await WidgetService.requestPinWidget();
+    switch (result) {
+      case WidgetPinResult.requested:
+        break;
+      case WidgetPinResult.unsupported:
+        NotificationService.showInfo(
+          'Ton lanceur ne permet pas d\'ajouter le widget automatiquement. '
+          'Appuie longuement sur l\'écran d\'accueil, puis choisis Widgets et Facteur.',
+          duration: const Duration(seconds: 6),
+        );
+      case WidgetPinResult.failed:
+        NotificationService.showError(
+          'Impossible d\'ajouter le widget pour le moment. Réessaie dans un instant.',
+        );
+    }
+    return result;
+  }
+}

--- a/apps/mobile/lib/core/services/widget_service.dart
+++ b/apps/mobile/lib/core/services/widget_service.dart
@@ -11,6 +11,21 @@ import '../../features/digest/models/digest_models.dart';
 import '../../features/feed/models/content_model.dart';
 import '../../features/gamification/models/streak_model.dart';
 
+/// Outcome of [WidgetService.requestPinWidget]. The three failure modes used to
+/// be indistinguishable (everything was swallowed into a `debugPrint`), which
+/// is why the « Ajouter un Widget » button looked dead.
+enum WidgetPinResult {
+  /// Android accepted the request — the launcher shows its confirmation dialog.
+  requested,
+
+  /// Launcher / OS version does not support programmatic pinning (API < 26 or
+  /// a launcher that opted out). The user has to add the widget manually.
+  unsupported,
+
+  /// The platform call threw. Genuine bug territory.
+  failed,
+}
+
 /// Service to push the unified Facteur feed (Essentiel + Flux) to the home
 /// screen widgets.
 ///
@@ -35,6 +50,41 @@ class WidgetService {
   // pinned independently by the user — both must be updated on every push.
   static const _androidNameLight = 'FacteurWidgetLight';
   static const _androidNameDark = 'FacteurWidgetDark';
+
+  /// Fully-qualified receiver names, derived from the Gradle **namespace**
+  /// (`android/app/build.gradle.kts` → `namespace = "com.example.facteur"`),
+  /// NOT from the applicationId.
+  ///
+  /// The trap: `HomeWidgetPlugin.kt` resolves a bare [androidName] as
+  /// `"${context.packageName}.$className"`, and `context.packageName` is the
+  /// **applicationId** — `com.example.facteur.staging` on the `beta` flavor,
+  /// `facteur.app` on `playstore`. Neither matches the namespace the receivers
+  /// actually live in, so every call threw `ClassNotFoundException` and no
+  /// `ACTION_APPWIDGET_UPDATE` was ever broadcast. Passing
+  /// `qualifiedAndroidName` bypasses that concatenation entirely.
+  ///
+  /// If the namespace ever changes, these must follow — guarded by
+  /// `test/core/services/widget_service_test.dart`, which reads the namespace
+  /// straight out of `build.gradle.kts`.
+  static const androidNamespace = 'com.example.facteur';
+  static const _qualifiedLight = '$androidNamespace.$_androidNameLight';
+  static const _qualifiedDark = '$androidNamespace.$_androidNameDark';
+
+  /// Broadcast `ACTION_APPWIDGET_UPDATE` to both receivers. Always pass the
+  /// qualified name; `androidName` is kept as a fallback for any plugin
+  /// version that would not honour the qualified one.
+  static Future<void> _pushUpdate() {
+    return Future.wait([
+      HomeWidget.updateWidget(
+        androidName: _androidNameLight,
+        qualifiedAndroidName: _qualifiedLight,
+      ),
+      HomeWidget.updateWidget(
+        androidName: _androidNameDark,
+        qualifiedAndroidName: _qualifiedDark,
+      ),
+    ]);
+  }
 
   static const _maxEssentiel = 5;
   static const _maxFeedArticles = 80;
@@ -100,12 +150,49 @@ class WidgetService {
         await _rewriteMergedPayload();
       }
 
-      await Future.wait([
-        HomeWidget.updateWidget(androidName: _androidNameLight),
-        HomeWidget.updateWidget(androidName: _androidNameDark),
-      ]);
+      await _pushUpdate();
     } catch (e) {
       debugPrint('WidgetService: updateWidget failed: $e');
+    }
+  }
+
+  /// Fusionne des lignes Flux fraîches **par-dessus** le cache existant, au
+  /// lieu de le remplacer, puis pousse le widget.
+  ///
+  /// Réservé au rafraîchissement de fond, qui ne récupère qu'une page (20
+  /// articles) : un `updateWidget(feedItems:)` classique ferait retomber le
+  /// payload de 80 à 20 lignes, soit exactement le symptôme « 9 articles »
+  /// qu'on vient de corriger. Union dédupliquée par `id`, frais en tête,
+  /// capée à [_maxFeedArticles], rangs réindexés.
+  static Future<void> updateWidgetMergingFlux(List<Content> freshItems) async {
+    try {
+      if (freshItems.isEmpty) return;
+      final fresh = await _buildFeedArticleList(freshItems);
+      final cachedJson =
+          await HomeWidget.getWidgetData<String>('feed_articles_json') ?? '[]';
+      final cached = _decodeList(cachedJson);
+
+      final merged = <Map<String, dynamic>>[];
+      final seen = <String>{};
+      for (final entry in [...fresh, ...cached]) {
+        if (merged.length >= _maxFeedArticles) break;
+        final id = (entry['id'] as String?) ?? '';
+        if (id.isEmpty || !seen.add(id)) continue;
+        merged.add({...entry, 'rank': merged.length + 1});
+      }
+
+      await HomeWidget.saveWidgetData(
+        'feed_articles_json',
+        jsonEncode(merged),
+      );
+      await HomeWidget.saveWidgetData(
+        'articles_updated_at',
+        '${DateTime.now().millisecondsSinceEpoch}',
+      );
+      await _rewriteMergedPayload();
+      await _pushUpdate();
+    } catch (e) {
+      debugPrint('WidgetService: updateWidgetMergingFlux failed: $e');
     }
   }
 
@@ -129,10 +216,7 @@ class WidgetService {
         jsonEncode(<dynamic>[]),
       );
       await HomeWidget.saveWidgetData('digest_status', 'none');
-      await Future.wait([
-        HomeWidget.updateWidget(androidName: _androidNameLight),
-        HomeWidget.updateWidget(androidName: _androidNameDark),
-      ]);
+      await _pushUpdate();
     } catch (e) {
       debugPrint('WidgetService: initWidgetIfNeeded failed: $e');
     }
@@ -149,10 +233,7 @@ class WidgetService {
       await HomeWidget.saveWidgetData('digest_status', 'none');
       await HomeWidget.saveWidgetData('digest_progress', '0/0');
       await HomeWidget.saveWidgetData('streak', '0');
-      await Future.wait([
-        HomeWidget.updateWidget(androidName: _androidNameLight),
-        HomeWidget.updateWidget(androidName: _androidNameDark),
-      ]);
+      await _pushUpdate();
     } catch (e) {
       debugPrint('WidgetService: clear failed: $e');
     }
@@ -161,11 +242,43 @@ class WidgetService {
   /// Request Android to pin one of the two widgets to the home screen. We pin
   /// the Clair variant by default — the user can later swap it with Sombre
   /// from the launcher if they prefer.
-  static Future<void> requestPinWidget() async {
+  ///
+  /// Returns a typed outcome so the caller can tell the user what happened:
+  /// a silent failure here is exactly what made the CTA look broken.
+  static Future<WidgetPinResult> requestPinWidget() async {
     try {
-      await HomeWidget.requestPinWidget(androidName: _androidNameLight);
+      final supported = await HomeWidget.isRequestPinWidgetSupported();
+      if (supported != true) return WidgetPinResult.unsupported;
+      await HomeWidget.requestPinWidget(
+        androidName: _androidNameLight,
+        qualifiedAndroidName: _qualifiedLight,
+      );
+      return WidgetPinResult.requested;
     } catch (e) {
       debugPrint('WidgetService: requestPinWidget failed: $e');
+      return WidgetPinResult.failed;
+    }
+  }
+
+  /// `true` when at least one Facteur widget is currently pinned on the home
+  /// screen. Drives the « Ajouter le widget » banner (hidden once pinned).
+  ///
+  /// Unlike [updateWidget], this path is NOT affected by the applicationId ≠
+  /// namespace trap: the plugin enumerates providers via
+  /// `getInstalledProvidersForPackage(context.packageName)` instead of
+  /// resolving a class name. Returns `null` when the platform call fails, so
+  /// callers can distinguish « not pinned » from « unknown ».
+  static Future<bool?> isWidgetPinned() async {
+    try {
+      final installed = await HomeWidget.getInstalledWidgets();
+      return installed.any((w) {
+        final name = w.androidClassName ?? '';
+        return name.endsWith(_androidNameLight) ||
+            name.endsWith(_androidNameDark);
+      });
+    } catch (e) {
+      debugPrint('WidgetService: isWidgetPinned failed: $e');
+      return null;
     }
   }
 
@@ -212,6 +325,13 @@ class WidgetService {
       'widget_articles_json',
       jsonEncode(merged),
     );
+    // Diagnostic « le widget n'affiche que 9 articles » : on persiste la
+    // profondeur réelle du payload plutôt que de la déduire de l'écran.
+    await HomeWidget.saveWidgetData<int>(
+      'widget_last_push_count',
+      merged.length,
+    );
+    debugPrint('WidgetService: pushed ${merged.length} rows to widget');
   }
 
   static List<Map<String, dynamic>> _decodeList(String raw) {
@@ -282,10 +402,7 @@ class WidgetService {
       article.thumbnailUrl,
       'widget_thumbnail_$rank.jpg',
     );
-    final logoPath = await _downloadIfPresent(
-      article.source?.logoUrl,
-      'widget_logo_$rank.png',
-    );
+    final logoPath = await _cachedLogo(article.source?.logoUrl);
 
     return {
       'id': article.contentId,
@@ -324,10 +441,7 @@ class WidgetService {
     required Content item,
     required int rank,
   }) async {
-    final logoPath = await _downloadIfPresent(
-      item.source.logoUrl,
-      'widget_feed_logo_$rank.png',
-    );
+    final logoPath = await _cachedLogo(item.source.logoUrl);
 
     final topicSlug = item.topics.isNotEmpty ? item.topics.first : '';
     final topicLabel = topicSlugToLabel[topicSlug] ?? '';
@@ -443,6 +557,49 @@ class WidgetService {
     return digest.items
         .where((i) => i.isRead || i.isDismissed || i.isSaved)
         .length;
+  }
+
+  /// Logo de source, mis en cache **par URL** et non par rang.
+  ///
+  /// Deux raisons de ne plus indexer par rang (`widget_feed_logo_$rank.png`) :
+  ///  - le fichier du rang N était réécrit à chaque push, donc une entrée de
+  ///    payload conservée d'un push précédent pointait vers les octets d'une
+  ///    *autre* source (visible dès qu'on fusionne au lieu de remplacer) ;
+  ///  - chaque push re-téléchargeait jusqu'à 80 logos identiques. Un logo ne
+  ///    change pas : s'il est déjà sur le disque, on le réutilise.
+  ///
+  /// Single-flight par URL : [_buildFeedArticleList] sérialise les 80 lignes
+  /// via `Future.wait`, donc les N articles d'une même source arrivaient ici
+  /// en parallèle et lançaient N sondes — voire N téléchargements concurrents
+  /// écrivant *le même* fichier. On partage la première future par URL.
+  static final Map<String, Future<String?>> _logoInflight = {};
+
+  static Future<String?> _cachedLogo(String? url) {
+    if (url == null || url.isEmpty) return Future.value(null);
+    return _logoInflight[url] ??= _resolveLogo(url).then((path) {
+      // Une URL qui n'a rien donné doit pouvoir être retentée au push suivant ;
+      // un chemin résolu, lui, reste valable pour la durée du process.
+      if (path == null) _logoInflight.remove(url);
+      return path;
+    }).catchError((Object e) {
+      _logoInflight.remove(url);
+      debugPrint('WidgetService: logo resolve failed ($url): $e');
+      return null;
+    });
+  }
+
+  static Future<String?> _resolveLogo(String url) async {
+    final name = 'widget_logo_${url.hashCode.toRadixString(16)}.png';
+    try {
+      final dir = await getApplicationDocumentsDirectory();
+      final file = File('${dir.path}/$name');
+      if (await file.exists() && await file.length() > 0) {
+        return file.path;
+      }
+    } catch (e) {
+      debugPrint('WidgetService: logo cache probe failed ($url): $e');
+    }
+    return _downloadIfPresent(url, name);
   }
 
   /// Download an image to local storage and return the file path.

--- a/apps/mobile/lib/features/digest/providers/digest_provider.dart
+++ b/apps/mobile/lib/features/digest/providers/digest_provider.dart
@@ -294,23 +294,23 @@ class DigestNotifier extends AsyncNotifier<DigestResponse?> {
   }
 
   /// Re-push the Essentiel side of the widget on explicit demand — the home
-  /// screen widget's refresh button.
+  /// screen widget's refresh button. Depuis la **mémoire seule**,
+  /// volontairement sans réseau.
   ///
-  /// The Flux-side `refresh()` never rebuilds the Essentiel cache
-  /// (`articles_json`), so a degenerate/empty Essentiel payload can only be
-  /// repaired here. When the digest isn't in memory yet — precisely the state
-  /// that leaves the widget's Essentiel side empty (`articles_json = []`) — we
-  /// load it first so the refresh actually rebuilds it instead of re-pushing
-  /// `null`. Silent on failure: the Flux side of the refresh still proceeds.
+  /// Ce chemin appelait `_loadBothDigests()` quand le cache était vide, soit
+  /// jusqu'à 5 retries × 45 s de timeout (~80 s de chaîne réseau) déclenchés
+  /// par un simple tap sur le bouton refresh du widget — et, en passant,
+  /// `sereinToggleProvider.initFromApi()` pouvait basculer le toggle Serein
+  /// sous l'utilisateur, ce que `feedProvider` et `digestProvider` watchent
+  /// (rebuild complet du feed). Cf. docs/bugs/bug-widget-fiabilite.md (C4).
+  ///
+  /// Si rien n'est en mémoire, on ne fait rien : le Flux, lui, est rafraîchi
+  /// par `FeedNotifier.refreshForWidget()`, et l'Essentiel sera re-poussé au
+  /// prochain chargement normal.
   Future<void> syncWidgetFromRefresh() async {
     try {
-      if (_normalDigest == null) {
-        // _loadBothDigests() already re-pushes the widget on success, so no
-        // extra _syncWidget() is needed on the cold-cache path.
-        await _loadBothDigests();
-      } else {
-        _syncWidget();
-      }
+      if (_normalDigest == null) return;
+      _syncWidget();
     } catch (e) {
       // ignore: avoid_print
       print('DigestNotifier: syncWidgetFromRefresh failed: $e');

--- a/apps/mobile/lib/features/feed/providers/feed_provider.dart
+++ b/apps/mobile/lib/features/feed/providers/feed_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 import '../../../core/api/providers.dart';
 import '../../../core/auth/auth_state.dart';
@@ -222,7 +223,25 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
 
   Timer? _widgetPushDebounce;
   String? _lastWidgetPushSignature;
+  DateTime? _lastWidgetPushAt;
   static const Duration _widgetPushDelay = Duration(seconds: 1);
+
+  /// Buffer dédié au payload widget, **découplé** de la liste visible de
+  /// Flâner.
+  ///
+  /// Le widget était alimenté par `state.items`, qui *rétrécit* au fil de la
+  /// lecture (overlay `_consumedContentIds`) : après quelques articles lus, il
+  /// ne restait que ~9 lignes sur l'écran d'accueil, et rien ne reconstituait
+  /// la profondeur. Le buffer est alimenté en **union** (dédup par id, les
+  /// arrivées fraîches en tête) et ne perd jamais d'entrée autrement que par
+  /// éviction au-delà de [_widgetFluxCap].
+  /// Cf. docs/bugs/bug-widget-fiabilite.md (C5).
+  final List<Content> _widgetBuffer = [];
+
+  /// Péremption du payload widget : au-delà, on re-pousse même à signature
+  /// identique (l'utilisateur voit au moins des horodatages rafraîchis et le
+  /// widget ne peut pas geler indéfiniment sur un cache figé).
+  static const Duration _widgetPushMaxAge = Duration(hours: 6);
 
   // Cap mirrored to the Kotlin RemoteViewsFactory's MAX_ROWS_FLUX. The
   // widget runs without thumbnails in Flux, so 80 rows fit well under the
@@ -232,6 +251,17 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
   // prefetch chain bounded even if the backend keeps reporting hasNext.
   static const int _widgetPrefetchMaxPages = 4;
   bool _widgetDepthFillInProgress = false;
+
+  /// Silence entre deux chaînes de remplissage de profondeur.
+  ///
+  /// Nécessaire depuis que `!_hasNext` n'est plus un motif d'abandon : un
+  /// compte qui n'a tout simplement pas 80 articles disponibles ne verra
+  /// **jamais** son buffer atteindre [_widgetFluxCap], et sans ce garde il
+  /// relancerait jusqu'à [_widgetPrefetchMaxPages] appels `/api/feed/` à
+  /// chaque build du feed et à chaque retour de premier plan — exactement
+  /// l'amplification documentée dans `docs/bugs/bug-infinite-load-requests.md`.
+  static const Duration _widgetDepthFillCooldown = Duration(minutes: 30);
+  DateTime? _lastWidgetDepthFillAt;
 
   bool get isLoadingMore => _isLoadingMore;
   bool get hasNext => _hasNext;
@@ -283,10 +313,12 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
         _resetFiltersToEmpty(syncSelectionProvider: true);
         _setSelectionOwner(null);
         FeedRepository.clearDefaultViewCache();
+        _resetWidgetBuffer();
       } else if (selectionOwner != null && selectionOwner != authGate.userId) {
         _resetFiltersToEmpty(syncSelectionProvider: true);
         _setSelectionOwner(authGate.userId);
         FeedRepository.clearDefaultViewCache();
+        _resetWidgetBuffer();
       }
       return FeedState(items: []);
     }
@@ -295,6 +327,7 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
       FeedRepository.clearDefaultViewCache();
       _resetFiltersToEmpty(syncSelectionProvider: true);
       _setSelectionOwner(authGate.userId);
+      _resetWidgetBuffer();
     } else {
       if (selectionOwner == null) {
         _setSelectionOwner(authGate.userId);
@@ -459,11 +492,34 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
   /// SharedPreferences si le contenu est identique.
   Future<void> ensureWidgetFresh({bool stale = false}) async {
     final items = state.value?.items ?? const <Content>[];
-    if (items.isNotEmpty) {
+    if (items.isNotEmpty || _widgetBuffer.isNotEmpty) {
       _scheduleWidgetPush(items);
     }
+    // Profondeur : si le buffer n'a jamais atteint 80 (widget « 9 articles »),
+    // chaque reprise d'app est une occasion de la reconstituer.
+    if (_isUnfiltered && _widgetBuffer.length < _widgetFluxCap) {
+      unawaited(_prefetchForWidget(items));
+    }
     if (stale) {
-      await refresh();
+      // Best-effort, jamais fatal. Ce `refresh()` est appelé en
+      // fire-and-forget depuis `app.dart` (`didChangeAppLifecycleState`) : une
+      // erreur async qui remonte ici n'a aucun handler et finit en crash
+      // *unhandled* via `PlatformDispatcher.onError` — c'est Sentry FLUTTER-1E
+      // (401 au retour de premier plan). Rafraîchir le widget ne justifie
+      // jamais de tuer l'app.
+      try {
+        await refresh();
+      } catch (e, st) {
+        // ignore: avoid_print
+        print('FeedNotifier: ensureWidgetFresh refresh failed (ignored): $e');
+        unawaited(
+          Sentry.captureException(
+            e,
+            stackTrace: st,
+            withScope: (scope) => scope.level = SentryLevel.warning,
+          ),
+        );
+      }
     }
   }
 
@@ -479,22 +535,21 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
   /// last push or a Flâner filter is active in-app. Callers on the [force]
   /// path are responsible for passing the canonical *unfiltered* items.
   void _scheduleWidgetPush(List<Content> items, {bool force = false}) {
-    if (!force &&
-        (_selectedFilter != null ||
-            _selectedTheme != null ||
-            _selectedTopic != null ||
-            _selectedSourceId != null ||
-            _selectedEntity != null ||
-            _selectedKeyword != null)) {
-      return;
-    }
-    final slice = items.take(_widgetFluxCap).toList(growable: false);
+    if (!force && !_isUnfiltered) return;
+    final slice = mergeIntoWidgetBuffer(items);
     if (slice.isEmpty) return;
-    final signature = '${slice.length}|${slice.first.id}|${slice.last.id}';
-    if (!force && signature == _lastWidgetPushSignature) return;
+    // Signature sur **tous** les ids : l'ancienne (`len|first|last`) ne voyait
+    // pas un réordonnancement du milieu et gelait le widget, tout en laissant
+    // passer un rétrécissement (len change) sans jamais le réparer.
+    final signature = '${slice.length}|${slice.map((c) => c.id).join(',')}';
+    final lastAt = _lastWidgetPushAt;
+    final expired =
+        lastAt == null || DateTime.now().difference(lastAt) >= _widgetPushMaxAge;
+    if (!force && !expired && signature == _lastWidgetPushSignature) return;
     _widgetPushDebounce?.cancel();
     void push() {
       _lastWidgetPushSignature = signature;
+      _lastWidgetPushAt = DateTime.now();
       WidgetService.updateWidget(feedItems: slice);
     }
 
@@ -507,21 +562,71 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     }
   }
 
+  /// Fusionne [incoming] dans [_widgetBuffer] : entrées fraîches en tête (dans
+  /// leur ordre), puis le reste du buffer précédent non déjà présent, capé à
+  /// [_widgetFluxCap]. Retourne le buffer résultant.
+  ///
+  /// Conséquence voulue : un article lu dans l'app disparaît de `state.items`
+  /// mais **reste** dans le widget jusqu'à être évincé par du contenu plus
+  /// récent. Le compteur du widget ne descend plus quand on lit.
+  @visibleForTesting
+  List<Content> mergeIntoWidgetBuffer(List<Content> incoming) {
+    final merged = <Content>[];
+    final seen = <String>{};
+    for (final c in incoming) {
+      if (merged.length >= _widgetFluxCap) break;
+      if (seen.add(c.id)) merged.add(c);
+    }
+    for (final c in _widgetBuffer) {
+      if (merged.length >= _widgetFluxCap) break;
+      if (seen.add(c.id)) merged.add(c);
+    }
+    _widgetBuffer
+      ..clear()
+      ..addAll(merged);
+    return List<Content>.unmodifiable(merged);
+  }
+
+  /// Vide le buffer widget (logout / changement d'utilisateur) : le compte
+  /// suivant ne doit jamais hériter du flux du précédent.
+  void _resetWidgetBuffer() {
+    _widgetBuffer.clear();
+    _lastWidgetPushSignature = null;
+    _lastWidgetPushAt = null;
+    _lastWidgetDepthFillAt = null;
+  }
+
   /// Prefetch additional pages purely to feed the widget. Calls the repository
   /// directly so the in-app feed state (`state.value.items`, `_hasNext`, `_page`)
   /// is never mutated — pages 2-3 fetched here only land in the widget payload.
   ///
   /// Aborts silently if a filter becomes active mid-flight or if the chain is
-  /// already running. Bounded by [_widgetPrefetchMaxPages] and [_widgetFluxCap].
-  Future<void> _prefetchForWidget(List<Content> initialItems) async {
+  /// already running. Bounded by [_widgetPrefetchMaxPages], [_widgetFluxCap] et
+  /// [_widgetDepthFillCooldown] — sauf [force] (geste utilisateur explicite).
+  Future<void> _prefetchForWidget(
+    List<Content> initialItems, {
+    bool force = false,
+  }) async {
     if (!_isUnfiltered) return;
     if (_widgetDepthFillInProgress) return;
-    if (initialItems.length >= _widgetFluxCap) return;
-    if (!_hasNext) return;
+    // On raisonne sur le buffer widget, pas sur la page qu'on vient de
+    // recevoir : c'est lui qui doit atteindre 80. `_hasNext` n'est PLUS un
+    // motif d'abandon — il décrit la pagination *visible* de Flâner, qui peut
+    // être épuisée alors que le widget n'a que 9 lignes. Les vraies bornes
+    // restent [_widgetPrefetchMaxPages] et [_widgetFluxCap].
+    final seeded = mergeIntoWidgetBuffer(initialItems);
+    if (seeded.length >= _widgetFluxCap) return;
+    final lastFill = _lastWidgetDepthFillAt;
+    if (!force &&
+        lastFill != null &&
+        DateTime.now().difference(lastFill) < _widgetDepthFillCooldown) {
+      return;
+    }
 
     _widgetDepthFillInProgress = true;
+    _lastWidgetDepthFillAt = DateTime.now();
     try {
-      final buffer = List<Content>.from(initialItems);
+      final buffer = List<Content>.from(seeded);
       final existingIds = Set<String>.from(buffer.map((c) => c.id));
       final repository = ref.read(feedRepositoryProvider);
       final isSerein = ref.read(sereinToggleProvider).enabled;
@@ -947,19 +1052,19 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
       );
       unfiltered = response.items;
 
-      // When no filter is active in-app, mirror the fresh page into the
-      // on-screen feed and the unfiltered snapshot so the app and the widget
-      // stay consistent. Under an active filter we must NOT touch the visible
-      // (filtered) state — only the widget payload is refreshed.
+      // Le snapshot non filtré est mis à jour, mais **jamais** `state`.
+      //
+      // Le `state = AsyncData(...)` d'avant s'exécutait juste après le
+      // `router.go('/flaner')` du deep-link : l'état visible était remplacé
+      // pendant que `FlanerScreen` se montait, ce qui donnait le « le bouton
+      // refresh plante Flâner ». Un tap sur le widget rafraîchit le *widget*,
+      // pas l'écran sous le doigt — Flâner garde son scroll et son état.
+      // Cf. docs/bugs/bug-widget-fiabilite.md (C4).
       if (_isUnfiltered && unfiltered.isNotEmpty) {
         final overlaid =
             _overlayConsumed(unfiltered, state.value?.carousels ?? const []);
         unfiltered = overlaid.items;
         _globalItems = overlaid.items;
-        _hasNext = response.pagination.hasNext && response.items.isNotEmpty;
-        state = AsyncData(
-          FeedState(items: overlaid.items, carousels: overlaid.carousels),
-        );
       }
     } catch (e) {
       // Network failure: fall back to the last known unfiltered feed so the
@@ -972,7 +1077,9 @@ class FeedNotifier extends AsyncNotifier<FeedState> {
     final toPush = unfiltered.isNotEmpty ? unfiltered : _globalItems;
     if (toPush.isEmpty) return;
     _scheduleWidgetPush(toPush, force: true);
-    unawaited(_prefetchForWidget(toPush));
+    // `force` : geste explicite de l'utilisateur, il court-circuite le cooldown
+    // de profondeur (qui ne vise que les déclenchements ambiants).
+    unawaited(_prefetchForWidget(toPush, force: true));
   }
 
   /// Refresh feed: mark visible articles (cards + carousel items qui sont

--- a/apps/mobile/lib/features/feed/repositories/feed_repository.dart
+++ b/apps/mobile/lib/features/feed/repositories/feed_repository.dart
@@ -191,8 +191,13 @@ class FeedRepository {
       _defaultViewInflight = future;
       try {
         final result = await future;
-        _defaultViewLastResult = result;
-        _defaultViewLastFetchAt = DateTime.now();
+        // Ne jamais mémoriser une réponse obtenue sans session : la fenêtre de
+        // 5 s propagerait un feed anonyme/dégradé à tous les appelants, y
+        // compris le payload widget (cf. docs/bugs/bug-widget-fiabilite.md, C3).
+        if (_apiClient.hasSession) {
+          _defaultViewLastResult = result;
+          _defaultViewLastFetchAt = DateTime.now();
+        }
         return result;
       } finally {
         // Always clear the in-flight Future, success or failure, so the

--- a/apps/mobile/lib/features/feed/screens/flaner_screen.dart
+++ b/apps/mobile/lib/features/feed/screens/flaner_screen.dart
@@ -38,6 +38,7 @@ import '../widgets/feed_filter_bar.dart';
 import '../widgets/feedback_inline.dart';
 import '../widgets/follow_keyword_suggestion_card.dart';
 import '../widgets/pin_subjects_sheet.dart';
+import '../widgets/widget_cta_banner.dart';
 
 const double _kLoadMoreLeadingPx = 800.0;
 
@@ -410,6 +411,7 @@ class _FlanerScreenState extends ConsumerState<FlanerScreen> {
           // (« Résultats pour « … » ») le temps de se repérer, puis s'efface.
           const SliverToBoxAdapter(child: _SearchNavBanner()),
           const SliverToBoxAdapter(child: PinSubjectsBanner()),
+          const SliverToBoxAdapter(child: WidgetCtaBanner()),
           // Recherche bredouille → l'état vide porte déjà « suivre ce sujet »
           // parmi ses rattrapages ; on n'empile pas deux invitations à suivre.
           if (hasKeyword && state.items.isNotEmpty)

--- a/apps/mobile/lib/features/feed/widgets/widget_cta_banner.dart
+++ b/apps/mobile/lib/features/feed/widgets/widget_cta_banner.dart
@@ -1,0 +1,134 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../config/theme.dart';
+import '../../../core/nudges/nudge_coordinator.dart';
+import '../../../core/nudges/nudge_ids.dart';
+import '../../../core/services/widget_pin_prompt.dart';
+import '../../../core/services/widget_service.dart';
+
+/// `true` quand le bandeau « Ajouter le widget » doit être affiché.
+///
+/// Trois conditions : plateforme Android, aucun widget Facteur déjà épinglé,
+/// et pas de rejet récent. En cas de doute sur l'épinglage (appel plateforme
+/// en échec, [WidgetService.isWidgetPinned] renvoie `null`), on **n'affiche
+/// pas** : mieux vaut rater une proposition que la répéter à un utilisateur
+/// qui a déjà le widget.
+///
+/// Le throttle passe par le registre unifié des nudges
+/// ([NudgeIds.widgetCtaFeedBanner], cooldown 7 j) plutôt que par une clé
+/// SharedPreferences maison : même horloge testable, même purge au logout,
+/// même namespace que les autres bandeaux du feed.
+final widgetCtaVisibleProvider = FutureProvider<bool>((ref) async {
+  if (kIsWeb || !Platform.isAndroid) return false;
+
+  final pinned = await WidgetService.isWidgetPinned();
+  if (pinned != false) return false;
+
+  return ref.watch(nudgeServiceProvider).canShow(NudgeIds.widgetCtaFeedBanner);
+});
+
+/// Bandeau en tête de Flâner proposant d'épingler le widget d'accueil.
+///
+/// L'entrée historique était enterrée dans Compte > Widget et, surtout, ne
+/// faisait rien : le plugin ne résolvait jamais le receiver et l'échec était
+/// silencieux (cf. docs/bugs/bug-widget-fiabilite.md, C1). Ici le CTA est
+/// visible, dismissible, et rend toujours compte du résultat via
+/// [WidgetPinPrompt].
+class WidgetCtaBanner extends ConsumerWidget {
+  const WidgetCtaBanner({super.key});
+
+  Future<void> _dismiss(WidgetRef ref) async {
+    // Best-effort : même si la persistance échoue, le bandeau disparaît pour
+    // la session courante via l'invalidation.
+    try {
+      await ref
+          .read(nudgeServiceProvider)
+          .markShown(NudgeIds.widgetCtaFeedBanner);
+    } catch (_) {}
+    ref.invalidate(widgetCtaVisibleProvider);
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final visible = ref.watch(widgetCtaVisibleProvider);
+    if (visible.valueOrNull != true) return const SizedBox.shrink();
+
+    final colors = context.facteurColors;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(FacteurRadius.large),
+          onTap: () async {
+            HapticFeedback.mediumImpact();
+            final result = await WidgetPinPrompt.requestAndReport();
+            if (result == WidgetPinResult.requested) {
+              // Le launcher a pris la main : on ne re-proposera qu'après la
+              // fenêtre de throttle, que l'utilisateur confirme ou non.
+              await _dismiss(ref);
+            }
+          },
+          child: Container(
+            padding: const EdgeInsets.all(FacteurSpacing.space4),
+            decoration: BoxDecoration(
+              color: colors.primary.withValues(alpha: 0.08),
+              borderRadius: BorderRadius.circular(FacteurRadius.large),
+              border: Border.all(color: colors.primary.withValues(alpha: 0.25)),
+            ),
+            child: Row(
+              children: [
+                Icon(
+                  PhosphorIcons.squaresFour(PhosphorIconsStyle.fill),
+                  size: 22,
+                  color: colors.primary,
+                ),
+                const SizedBox(width: FacteurSpacing.space3),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        'Ton flux sur l\'écran d\'accueil',
+                        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                              fontWeight: FontWeight.w700,
+                              color: colors.textPrimary,
+                            ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        'Ajoute le widget Facteur et lis tes articles sans ouvrir l\'app.',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: colors.textSecondary,
+                            ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: FacteurSpacing.space2),
+                IconButton(
+                  icon: Icon(
+                    PhosphorIcons.x(PhosphorIconsStyle.regular),
+                    size: 18,
+                    color: colors.textTertiary,
+                  ),
+                  onPressed: () => _dismiss(ref),
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(),
+                  tooltip: 'Masquer',
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/settings/screens/account_screen.dart
+++ b/apps/mobile/lib/features/settings/screens/account_screen.dart
@@ -11,7 +11,7 @@ import '../../../config/routes.dart';
 import '../../../config/theme.dart';
 import '../../../core/api/providers.dart';
 import '../../../core/auth/auth_state.dart';
-import '../../../core/services/widget_service.dart';
+import '../../../core/services/widget_pin_prompt.dart';
 import '../../../core/ui/notification_service.dart';
 import '../providers/user_profile_provider.dart';
 
@@ -122,7 +122,7 @@ class AccountScreen extends ConsumerWidget {
                     const SizedBox(height: FacteurSpacing.space3),
                     InkWell(
                       onTap: () async {
-                        await WidgetService.requestPinWidget();
+                        await WidgetPinPrompt.requestAndReport();
                       },
                       borderRadius: BorderRadius.circular(FacteurRadius.medium),
                       child: Row(

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -23,6 +23,8 @@ import 'core/services/deep_link_service.dart';
 import 'core/services/posthog_service.dart';
 import 'core/services/push_notification_service.dart';
 import 'core/services/server_push_service.dart';
+import 'core/services/widget_background_refresh.dart';
+import 'core/services/widget_service.dart';
 import 'core/errors/user_facing_error_notifier.dart';
 import 'core/ui/notification_service.dart';
 import 'features/feed/services/completed_reads_store.dart';
@@ -406,6 +408,12 @@ Future<void> _initDeferredServices({required PostHogService posthog}) async {
     unawaited(
       HomeWidget.registerInteractivityCallback(homeWidgetBackgroundCallback),
     );
+    // Seed empty payload + broadcast an update so a widget the user just
+    // pinned never stays blank until the next feed push. Idempotent (no-op
+    // when a payload already exists).
+    unawaited(WidgetService.initWidgetIfNeeded());
+    // Rafraîchissement app fermée (WorkManager, ~1 h). Annulé au logout.
+    unawaited(WidgetBackgroundRefresh.register());
   } catch (e) {
     debugPrint('Main: Home Widget init failed (non-critical): $e');
   }

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -1805,6 +1805,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.15.0"
+  workmanager:
+    dependency: "direct main"
+    description:
+      name: workmanager
+      sha256: "065673b2a465865183093806925419d311a9a5e0995aa74ccf8920fd695e2d10"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.0+3"
+  workmanager_android:
+    dependency: transitive
+    description:
+      name: workmanager_android
+      sha256: "9ae744db4ef891f5fcd2fb8671fccc712f4f96489a487a1411e0c8675e5e8cb7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.0+2"
+  workmanager_apple:
+    dependency: transitive
+    description:
+      name: workmanager_apple
+      sha256: "1cc12ae3cbf5535e72f7ba4fde0c12dd11b757caf493a28e22d684052701f2ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.1+2"
+  workmanager_platform_interface:
+    dependency: transitive
+    description:
+      name: workmanager_platform_interface
+      sha256: f40422f10b970c67abb84230b44da22b075147637532ac501729256fcea10a47
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.1+1"
   xdg_directories:
     dependency: transitive
     description:

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -58,6 +58,11 @@ dependencies:
   # Home Screen Widget
   home_widget: ^0.7.0
 
+  # Rafraîchissement du widget app fermée (WorkManager Android).
+  # Cf. docs/bugs/bug-widget-fiabilite.md (C6) : sans ça, l'alarme système de
+  # 30 min ne fait que repeindre les mêmes octets, aucun réseau.
+  workmanager: ^0.9.0
+
   # Deep Links (widget tap → in-app routing)
   app_links: ^6.3.2
 

--- a/apps/mobile/test/core/services/deep_link_service_test.dart
+++ b/apps/mobile/test/core/services/deep_link_service_test.dart
@@ -223,6 +223,55 @@ void main() {
       );
       expect(service.pendingRoute(), isNull);
     });
+
+    // Régression C4 : au cold start, le routeur consommait `pendingRoute()` et
+    // jetait `action.refresh`. `_onRefreshRequested` n'était jamais appelé →
+    // le bouton refresh du widget était un no-op littéral quand l'app était
+    // tuée. Cf. docs/bugs/bug-widget-fiabilite.md.
+    test('pendingAction carries the refresh flag through a cold start', () {
+      final service = DeepLinkService.forTest();
+      DeepLinkService.setInstanceForTest(service);
+
+      service.seedPending(Uri.parse('io.supabase.facteur://feed?refresh=1'));
+
+      final action = service.pendingAction();
+      expect(action, isNotNull);
+      expect(action!.refresh, isTrue);
+      expect(DeepLinkService.navigableRouteFor(action), '/flaner');
+    });
+
+    test('pendingAction has refresh=false on a plain feed link', () {
+      final service = DeepLinkService.forTest();
+      DeepLinkService.setInstanceForTest(service);
+
+      service.seedPending(Uri.parse('io.supabase.facteur://feed'));
+      expect(service.pendingAction()!.refresh, isFalse);
+    });
+
+    test('replayRefreshIfRequested fires the callback only when refresh=1',
+        () {
+      var calls = 0;
+      final service = DeepLinkService.forTest();
+      DeepLinkService.setInstanceForTest(service);
+      service.bind(
+        router: GoRouter(routes: [
+          GoRoute(path: '/', builder: (_, __) => const SizedBox.shrink()),
+        ]),
+        onRefreshRequested: () => calls++,
+      );
+
+      service.replayRefreshIfRequested(
+        DeepLinkService.parse(Uri.parse('io.supabase.facteur://feed')),
+      );
+      expect(calls, 0);
+
+      service.replayRefreshIfRequested(
+        DeepLinkService.parse(
+          Uri.parse('io.supabase.facteur://feed?refresh=1'),
+        ),
+      );
+      expect(calls, 1);
+    });
   });
 
   // Regression: a widget article tap must open the reader by STACKING (push),

--- a/apps/mobile/test/core/services/widget_service_test.dart
+++ b/apps/mobile/test/core/services/widget_service_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:facteur/config/topic_labels.dart';
 import 'package:facteur/core/services/widget_service.dart';
@@ -12,6 +13,8 @@ import 'package:flutter_test/flutter_test.dart';
 /// path also writes to SharedPreferences via `home_widget`, which requires the
 /// platform channel and is not exercised in unit tests.
 void main() {
+  _namespaceGuardTests();
+
   group('Digest → widget article shape', () {
     test('first topic article gets is_main=true', () {
       final digest = _digest(topics: [
@@ -328,4 +331,66 @@ Content _content(
     ),
     topics: topics,
   );
+}
+
+// ──────────────────────────────────────────────────────────────
+// Garde anti-régression C1 — noms qualifiés vs namespace Gradle
+// ──────────────────────────────────────────────────────────────
+
+/// Le bug d'origine : `HomeWidgetPlugin` résout un `androidName` nu en
+/// `"${context.packageName}.$className"`, où `context.packageName` est
+/// l'**applicationId** (`com.example.facteur.staging` sur le flavor beta,
+/// `facteur.app` sur playstore) — jamais le **namespace** où vivent réellement
+/// les receivers. Résultat : `ClassNotFoundException` sur les deux flavors, à
+/// chaque appel, avalé par un `catch`. Zéro `ACTION_APPWIDGET_UPDATE` envoyé,
+/// « Ajouter un Widget » mort.
+///
+/// Ce test lit le namespace directement dans `build.gradle.kts` : si quelqu'un
+/// le change (ou change l'applicationId en croyant que c'est équivalent), la
+/// suite rougit ici au lieu de casser silencieusement en prod.
+void _namespaceGuardTests() {
+  group('C1 — noms qualifiés alignés sur le namespace Gradle', () {
+    late String gradleNamespace;
+
+    setUpAll(() {
+      final gradle = File('android/app/build.gradle.kts').readAsStringSync();
+      final match =
+          RegExp(r'namespace\s*=\s*"([^"]+)"').firstMatch(gradle);
+      expect(
+        match,
+        isNotNull,
+        reason: 'namespace introuvable dans android/app/build.gradle.kts',
+      );
+      gradleNamespace = match!.group(1)!;
+    });
+
+    test('WidgetService.androidNamespace == namespace de build.gradle.kts', () {
+      expect(WidgetService.androidNamespace, gradleNamespace);
+    });
+
+    test('le namespace n\'est pas dérivé de l\'applicationId des flavors', () {
+      // Les deux flavors ont un applicationId différent du namespace : c'est
+      // précisément ce qui rendait la concaténation du plugin invalide.
+      final gradle = File('android/app/build.gradle.kts').readAsStringSync();
+      expect(gradle, contains('applicationIdSuffix = ".staging"'));
+      expect(gradle, contains('applicationId = "facteur.app"'));
+      expect(WidgetService.androidNamespace, isNot('facteur.app'));
+      expect(
+        WidgetService.androidNamespace.endsWith('.staging'),
+        isFalse,
+      );
+    });
+
+    test('les deux receivers du manifest sont couverts', () {
+      final manifest =
+          File('android/app/src/main/AndroidManifest.xml').readAsStringSync();
+      for (final receiver in ['FacteurWidgetLight', 'FacteurWidgetDark']) {
+        expect(
+          manifest,
+          contains('android:name=".$receiver"'),
+          reason: '$receiver doit rester déclaré dans le manifest',
+        );
+      }
+    });
+  });
 }

--- a/apps/mobile/test/features/feed/feed_provider_widget_refresh_test.dart
+++ b/apps/mobile/test/features/feed/feed_provider_widget_refresh_test.dart
@@ -180,7 +180,8 @@ void main() {
   );
 
   test(
-    'refreshForWidget (unfiltered) refreshes the visible feed with fresh items',
+    'refreshForWidget (unfiltered) leaves the visible feed alone — it refreshes '
+    'the widget, not the screen under the finger',
     () async {
       var call = 0;
       when(
@@ -216,10 +217,21 @@ void main() {
 
       await notifier.refreshForWidget();
 
+      // Le `state = AsyncData(...)` d'avant s'exécutait juste après le
+      // `router.go('/flaner')` du deep-link : l'état visible était remplacé
+      // pendant que FlanerScreen se montait (« le bouton refresh plante
+      // Flâner »). Cf. docs/bugs/bug-widget-fiabilite.md (C4).
       expect(
         container.read(feedProvider).value!.items.map((c) => c.id),
+        ['old'],
+        reason: 'refreshForWidget must never mutate the visible feed state',
+      );
+
+      // Le snapshot non filtré, lui, a bien été rafraîchi (c'est ce qui part
+      // vers le widget).
+      expect(
+        notifier.globalItems.map((c) => c.id),
         ['fresh-1', 'fresh-2'],
-        reason: 'unfiltered widget refresh mirrors the fresh page in-app too',
       );
     },
   );
@@ -265,4 +277,88 @@ void main() {
       expect(state.value!.items.map((c) => c.id), ['a', 'b']);
     },
   );
+
+  // ────────────────────────────────────────────────────────────
+  // C5 — profondeur du payload widget
+  // ────────────────────────────────────────────────────────────
+  //
+  // Le widget était alimenté par `state.items`, qui rétrécit au fil de la
+  // lecture (overlay `_consumedContentIds`). Après quelques articles lus il ne
+  // restait que ~9 lignes sur l'écran d'accueil, et rien ne reconstituait la
+  // profondeur. Cf. docs/bugs/bug-widget-fiabilite.md (C5).
+  group('buffer widget (mergeIntoWidgetBuffer)', () {
+    late FeedNotifier notifier;
+
+    setUp(() async {
+      when(
+        () => mockFeedRepo.getFeed(
+          page: any(named: 'page'),
+          limit: any(named: 'limit'),
+          contentType: any(named: 'contentType'),
+          savedOnly: any(named: 'savedOnly'),
+          mode: any(named: 'mode'),
+          theme: any(named: 'theme'),
+          topic: any(named: 'topic'),
+          hasNote: any(named: 'hasNote'),
+          sourceId: any(named: 'sourceId'),
+          entity: any(named: 'entity'),
+          keyword: any(named: 'keyword'),
+          includeUnfollowed: any(named: 'includeUnfollowed'),
+          serein: any(named: 'serein'),
+          personalized: any(named: 'personalized'),
+          followedOnly: any(named: 'followedOnly'),
+          forceFresh: any(named: 'forceFresh'),
+        ),
+      ).thenAnswer((_) async => resp(const []));
+
+      notifier = container.read(feedProvider.notifier);
+      await container.read(feedProvider.future);
+    });
+
+    test('ne rétrécit pas quand la liste visible rétrécit (lecture in-app)',
+        () {
+      final full = [
+        makeContent('a'),
+        makeContent('b'),
+        makeContent('c'),
+        makeContent('d'),
+      ];
+      expect(notifier.mergeIntoWidgetBuffer(full).length, 4);
+
+      // L'utilisateur lit a et b → `state.items` n'en contient plus que 2.
+      final afterReading = [makeContent('c'), makeContent('d')];
+      final merged = notifier.mergeIntoWidgetBuffer(afterReading);
+
+      expect(merged.length, 4, reason: 'le widget ne perd pas de profondeur');
+      expect(merged.map((c) => c.id), ['c', 'd', 'a', 'b']);
+    });
+
+    test('les entrées fraîches passent en tête, dédupliquées par id', () {
+      notifier.mergeIntoWidgetBuffer([makeContent('old1'), makeContent('old2')]);
+      final merged = notifier.mergeIntoWidgetBuffer([
+        makeContent('new1'),
+        makeContent('old1'),
+      ]);
+      expect(merged.map((c) => c.id), ['new1', 'old1', 'old2']);
+    });
+
+    test('cape à 80 en évinçant les plus anciennes', () {
+      notifier.mergeIntoWidgetBuffer(
+        List.generate(80, (i) => makeContent('old$i')),
+      );
+      final merged = notifier.mergeIntoWidgetBuffer(
+        List.generate(10, (i) => makeContent('new$i')),
+      );
+      expect(merged.length, 80);
+      expect(merged.take(10).map((c) => c.id),
+          List.generate(10, (i) => 'new$i'));
+      expect(merged.map((c) => c.id), isNot(contains('old79')));
+    });
+
+    test('une page vide préserve le buffer', () {
+      notifier.mergeIntoWidgetBuffer([makeContent('a'), makeContent('b')]);
+      final merged = notifier.mergeIntoWidgetBuffer(const []);
+      expect(merged.map((c) => c.id), ['a', 'b']);
+    });
+  });
 }

--- a/apps/mobile/test/features/feed/feed_refresh_recovery_test.dart
+++ b/apps/mobile/test/features/feed/feed_refresh_recovery_test.dart
@@ -192,7 +192,21 @@ void main() {
             keyword: any(named: 'keyword'),
             serein: any(named: 'serein'),
           ),
-        ).thenAnswer((_) async {
+        ).thenAnswer((inv) async {
+          // Les pages > 1 sont le prefetch de profondeur du widget
+          // (`_prefetchForWidget`), pas le chemin testé ici : on le sert à
+          // vide pour que le compteur ne suive que les fetch page 1.
+          if ((inv.namedArguments[#page] as int?) != 1) {
+            return FeedResponse(
+              items: const [],
+              pagination: Pagination(
+                page: 2,
+                perPage: 20,
+                total: 0,
+                hasNext: false,
+              ),
+            );
+          }
           callCount++;
           if (callCount == 1) {
             // initial build

--- a/apps/mobile/test/features/feed/feed_repository_dedupe_test.dart
+++ b/apps/mobile/test/features/feed/feed_repository_dedupe_test.dart
@@ -47,6 +47,7 @@ void main() {
     final api = _MockApiClient();
     final dio = _MockDio();
     when(() => api.dio).thenReturn(dio);
+    when(() => api.hasSession).thenReturn(true);
 
     int calls = 0;
     when(() => dio.get<dynamic>(any(),
@@ -81,6 +82,7 @@ void main() {
     final api = _MockApiClient();
     final dio = _MockDio();
     when(() => api.dio).thenReturn(dio);
+    when(() => api.hasSession).thenReturn(true);
 
     int calls = 0;
     when(() => dio.get<dynamic>(any(),
@@ -100,10 +102,42 @@ void main() {
     expect(calls, 1, reason: 'follow-up within window must reuse cached result');
   });
 
+  // Régression C3 (docs/bugs/bug-widget-fiabilite.md) : au cold boot depuis le
+  // widget, la 1ère requête pouvait partir sans session et revenir dégradée.
+  // Mémorisée, elle était ensuite servie pendant 5 s à tous les appelants — y
+  // compris au payload widget.
+  test('une réponse obtenue sans session n\'est jamais mémorisée', () async {
+    final api = _MockApiClient();
+    final dio = _MockDio();
+    when(() => api.dio).thenReturn(dio);
+    when(() => api.hasSession).thenReturn(false);
+
+    int calls = 0;
+    when(() => dio.get<dynamic>(any(),
+        queryParameters: any(named: 'queryParameters'))).thenAnswer(
+      (_) async {
+        calls += 1;
+        return _resp(_samplePayload());
+      },
+    );
+
+    final repo = FeedRepository(api);
+    await repo.getFeedWithRaw();
+    expect(calls, 1);
+
+    await repo.getFeedWithRaw();
+    expect(
+      calls,
+      2,
+      reason: 'sans session, la fenêtre de 5 s ne doit rien propager',
+    );
+  });
+
   test('forceFresh bypasses the dedupe window (pull-to-refresh)', () async {
     final api = _MockApiClient();
     final dio = _MockDio();
     when(() => api.dio).thenReturn(dio);
+    when(() => api.hasSession).thenReturn(true);
 
     int calls = 0;
     when(() => dio.get<dynamic>(any(),
@@ -128,6 +162,7 @@ void main() {
     final api = _MockApiClient();
     final dio = _MockDio();
     when(() => api.dio).thenReturn(dio);
+    when(() => api.hasSession).thenReturn(true);
 
     int calls = 0;
     when(() => dio.get<dynamic>(any(),
@@ -148,6 +183,7 @@ void main() {
     final api = _MockApiClient();
     final dio = _MockDio();
     when(() => api.dio).thenReturn(dio);
+    when(() => api.hasSession).thenReturn(true);
 
     int calls = 0;
     when(() => dio.get<dynamic>(any(),
@@ -169,6 +205,7 @@ void main() {
     final api = _MockApiClient();
     final dio = _MockDio();
     when(() => api.dio).thenReturn(dio);
+    when(() => api.hasSession).thenReturn(true);
 
     int calls = 0;
     when(() => dio.get<dynamic>(any(),
@@ -199,6 +236,7 @@ void main() {
     final api = _MockApiClient();
     final dio = _MockDio();
     when(() => api.dio).thenReturn(dio);
+    when(() => api.hasSession).thenReturn(true);
 
     int calls = 0;
     when(() => dio.get<dynamic>(any(),

--- a/docs/bugs/bug-widget-fiabilite.md
+++ b/docs/bugs/bug-widget-fiabilite.md
@@ -1,0 +1,338 @@
+# Bug — Widget Facteur : refonte fiabilité
+
+**Type** : Bug · **Statut** : implémenté, en attente de vérification device
+**Date** : 27/07/2026 · **Branche** : `boujonlaurin-dotcom/widget-refresh-bugs`
+
+---
+
+## Symptômes rapportés
+
+1. Pour certains utilisateurs, les news du widget ne se rafraîchissent **jamais**.
+2. Le bouton « Ajouter un Widget » ne fait rien (et est enterré dans Compte).
+3. Le widget n'affiche que ~9 articles.
+4. Le bouton refresh du widget ne rafraîchit pas et fait planter Flâner.
+5. Ouvrir le widget **avant** la tournée du matin casse ensuite les requêtes
+   d'articles dans toute l'app.
+
+Ce ne sont pas 5 bugs indépendants : ce sont 4 causes racines, dont une seule
+explique déjà la moitié des symptômes.
+
+---
+
+## Diagnostic
+
+### C1 — `home_widget` ne peut jamais atteindre les receivers (applicationId ≠ namespace)
+
+`HomeWidgetPlugin.kt:105` et `:157` (`home_widget-0.7.0+1`) :
+
+```kotlin
+val javaClass = Class.forName(qualifiedName ?: "${context.packageName}.${className}")
+```
+
+- `context.packageName` = **applicationId** → `com.example.facteur.staging`
+  (flavor `beta`) ou `facteur.app` (flavor `playstore`).
+- Les receivers vivent dans le **namespace** `com.example.facteur`
+  (`android/app/build.gradle.kts:50` ; `AndroidManifest.xml` déclare
+  `android:name=".FacteurWidgetLight"`, résolu contre le namespace).
+
+⇒ `ClassNotFoundException` sur **les deux flavors**, à **chaque** appel.
+`WidgetService` passait `androidName:` sans `qualifiedAndroidName:` et avalait
+l'exception dans un `catch (e) { debugPrint(...) }`.
+
+Conséquences :
+- `requestPinWidget()` no-op → « Ajouter un Widget » mort, sans feedback ;
+- **aucun `ACTION_APPWIDGET_UPDATE` jamais envoyé**. Les données *sont* écrites
+  dans `HomeWidgetPreferences` (ce chemin ne touche pas aux noms de classe),
+  mais le widget ne repeint que sur l'alarme système `updatePeriodMillis`
+  (30 min) → contenu systématiquement en retard, jamais à la demande.
+
+Cohérent avec Sentry : **zéro** `PlatformException` remontée (tout est catché),
+donc aucune contre-preuve.
+
+### C2 — Crash fatal 401 sur le chemin de fraîcheur widget (Sentry FLUTTER-1E, 23 events / 11 users)
+
+```
+_FacteurAppState.didChangeAppLifecycleState (app.dart)
+_FacteurAppState._ensureWidgetFresh
+FeedNotifier.ensureWidgetFresh (feed_provider.dart)
+```
+
+`DioException [bad response] 401`, **unhandled / fatal** via
+`PlatformDispatcher.onError` : `app.dart` faisait `unawaited(...)` sur
+`ensureWidgetFresh`, qui `await refresh()` sans try/catch → l'erreur async
+n'avait aucun handler. Feeder amont : **FLUTTER-6** `TimeoutException 0:00:08`
+dans `SessionRefresher._defaultRefresh`.
+
+### C3 — Le deep-link widget court-circuitait la porte d'auth → `signOut` app-wide
+
+`config/routes.dart`, **avant** le gate `authState.isLoading → /splash` :
+
+```dart
+if (state.uri.scheme == 'io.supabase.facteur') {
+  final action = DeepLinkService.parse(state.uri);
+  DeepLinkService.instance.clearPending();
+  return action.route ?? RoutePaths.fluxContinu;   // ← saute isLoading / onboarding / email
+}
+```
+
+Cold-open depuis le widget → atterrissage direct sur `/flaner/content/<id>` ou
+`/flux-continu/content/<id>` (ces sous-routes échappent volontairement au gate
+rituel) alors que `Supabase.currentSession` peut encore être `null`.
+`ApiClient` attendait **100 ms** puis partait **en anonyme** → 401 →
+`SessionRefresher.refresh(5 s)` échoue au cold boot → `onAuthError(401)` →
+`handleSessionExpired` → **`signOut()` complet** → `WidgetService.clear()` vide
+le widget.
+
+C'est exactement « j'ouvre le widget avant ma tournée et ensuite plus rien ne
+charge » : ce n'est pas une panne de requêtes, c'est une **déconnexion**. Ça
+explique aussi une partie des « widgets qui ne se rafraîchissent jamais »
+(payload vidé, utilisateur déloggé sans s'en rendre compte).
+
+Aggravant : le cache statique `FeedRepository._defaultViewLastResult`
+(fenêtre 5 s) pouvait mémoriser une réponse dégradée/anonyme et la propager à
+tous les appelants.
+
+Sentry corrobore : **FLUTTER-Y** `type 'Null' is not a subtype of type
+'Perspective'` (`state.extra` null, 20 events) — même chemin cold-restore.
+
+### C4 — Bouton refresh : flag perdu au cold start, effets de bord violents à chaud
+
+- **Cold start** : le flag `refresh=1` était **jeté**. `pendingRoute()` ne
+  renvoyait que `action.route`, le redirect perdait `action.refresh` →
+  `_onRefreshRequested` jamais appelé → **no-op littéral**.
+- **À chaud** :
+  - `ref.read(digestProvider.notifier)` **construit** le provider, dont le
+    `build()` lance `_loadBothDigests` : timeout 45 s × 5 retries avec backoff
+    5/10/15/20/30 s, soit ~80 s de chaîne réseau pour un tap ;
+  - au passage `_loadBothDigests` appelle `sereinToggleProvider.initFromApi(...)`
+    → peut **basculer le toggle Serein** sous l'utilisateur, ce que `feedProvider`
+    et `digestProvider` watchent → rebuild du feed ;
+  - `refreshForWidget()` faisait `state = AsyncData(...)` **juste après**
+    `router.go('/flaner')` → l'état visible était remplacé pendant que
+    `FlanerScreen` se montait. C'est le « plante Flâner ».
+
+### C5 — Symptôme « 9 articles » : la profondeur n'est jamais reconstituée
+
+Les caps sont cohérents à **80 partout** et le parsing Kotlin est non destructif.
+**Rien ne tronque à 9** — le payload contenait réellement ~9 lignes :
+
+- les pushes ambiants poussaient `state.items`, c'est-à-dire la liste **visible**
+  de Flâner, qui **rétrécit** au fil de la lecture (overlay `_consumedContentIds`) ;
+- `_prefetchForWidget` abandonnait dès `!_hasNext` → la profondeur n'était jamais
+  restaurée ;
+- le garde de signature `'${len}|${first.id}|${last.id}'` laissait passer ce
+  rétrécissement mais bloquait toute repush si seul le *milieu* changeait.
+
+### C6 — Rien ne rafraîchissait le widget app fermée
+
+Pas de `workmanager` ni `background_fetch`. `homeWidgetBackgroundCallback` est un
+no-op assumé. `firebaseMessagingBackgroundHandler` ne touche jamais
+`WidgetService`. L'alarme 30 min ne fait que **repeindre les mêmes octets**
+(`onUpdate` relit SharedPreferences, aucun réseau). `initWidgetIfNeeded()` était
+**du code mort** — zéro appelant → un widget fraîchement épinglé restait vide.
+
+### C7 (suivi, non corrigé) — Sentry FLUTTER-1D, 3 users, fatal
+
+`RuntimeException: Unable to start activity ComponentInfo{facteur.app/androidx.glance.appwidget.action.ActionTrampolineActivity}`
+→ `IllegalArgumentException: List adapter activity trampoline invoked without
+specifying target intent`.
+
+Vérifié : `home_widget` 0.7 tire bien `androidx.glance:glance-appwidget:1.0.0`
+(`android/build.gradle:54`) alors que nous n'utilisons que RemoteViews et
+n'enregistrons aucun receiver Glance. Mais l'AAR n'est pas dans le cache Gradle
+local et Conductor n'a pas de JDK : **le manifest mergé n'a pas pu être
+inspecté**. Conformément au plan, on ne retire rien sur une activité tierce
+exportée sans preuve. À reprendre avec un build Android disponible.
+
+---
+
+## Correctifs livrés
+
+### Lot 1 — C1 : réparer le pont Flutter → receivers
+
+`lib/core/services/widget_service.dart`
+- Constantes qualifiées dérivées du **namespace** (`WidgetService.androidNamespace`
+  = `com.example.facteur`), avec commentaire sur le piège applicationId ≠ namespace.
+- `qualifiedAndroidName:` passé sur **tous** les appels, via `_pushUpdate()`
+  (3 `updateWidget` + `requestPinWidget`). `androidName:` gardé en fallback.
+- `requestPinWidget()` retourne un `enum WidgetPinResult { requested, unsupported,
+  failed }`, en s'appuyant sur `HomeWidget.isRequestPinWidgetSupported()`.
+- `WidgetService.isWidgetPinned()` via `HomeWidget.getInstalledWidgets()` — ce
+  chemin utilise `getInstalledProvidersForPackage(context.packageName)` et n'est
+  **pas** affecté par C1.
+- `initWidgetIfNeeded()` (code mort) appelé au bootstrap depuis
+  `_initDeferredServices`.
+
+**Garde anti-régression** : `test/core/services/widget_service_test.dart` lit le
+`namespace` directement dans `build.gradle.kts` et vérifie qu'il est bien
+distinct des applicationId des deux flavors.
+
+### Lot 2 — C3 : le deep-link ne peut plus déconnecter
+
+`lib/config/routes.dart`
+- La branche `scheme == 'io.supabase.facteur'` **seed** désormais le pending et
+  retourne `/splash` au lieu de router avant l'auth. Le bloc 3 existant consomme
+  le pending une fois l'auth résolue — le chemin déjà prévu par le design. Les
+  auth callbacks restent traités avant les gates (ils portent la session que les
+  gates attendent).
+- Tous les `state.extra as X?` durcis via un helper unique `extraAs<T>(state)`
+  (9 sites) — corrige **FLUTTER-Y**.
+
+`lib/core/api/api_client.dart`
+- L'attente de session passe de 100 ms à un budget borné de 2 s (`_awaitSession`),
+  aligné sur l'esprit de `resolveMorningRitualMaxWait`.
+- **Écart assumé au plan** : la requête part quand même en anonyme si le budget
+  est épuisé (certains endpoints sont publics ; échouer localement aurait été une
+  régression à large rayon). Elle est en revanche **marquée**, et un 401 sur une
+  requête partie sans header ne déclenche **jamais** `handleSessionExpired`. La
+  chaîne C3 est coupée au même endroit, sans casser les appels légitimes.
+- Le refresh du chemin 401 n'impose plus 5 s : il hérite du budget adaptatif.
+
+`lib/features/feed/repositories/feed_repository.dart`
+- `_defaultViewLastResult` n'est plus mémorisé quand la réponse a été obtenue
+  sans session (`ApiClient.hasSession`).
+
+### Lot 3 — C2 : plus de crash fatal sur le chemin de fraîcheur
+
+- `FeedNotifier.ensureWidgetFresh` : `await refresh()` enveloppé dans un
+  try/catch qui log en Sentry `warning` et **ne relance pas**.
+- `app.dart._ensureWidgetFresh` : `.catchError` explicite sur le `unawaited`.
+- `SessionRefresher.resolveRefreshTimeout(lifecycle)` : 8 s en `resumed`, 20 s
+  sinon (cold boot / réveil par tap widget) — corrige le feeder FLUTTER-6.
+
+### Lot 4 — C4 : un bouton refresh qui rafraîchit vraiment
+
+- `DeepLinkService.pendingAction()` expose l'action complète (route + `refresh`),
+  `navigableRouteFor()` factorise la résolution, `replayRefreshIfRequested()`
+  rejoue le side-effect + `trackWidgetAppOpened`. Le routeur les utilise → le
+  bouton marche aussi au **cold start**.
+- `app.dart` : `container.exists(digestProvider)` avant tout `ref.read(...notifier)`
+  → un tap widget ne peut plus amorcer la chaîne 45 s × 5.
+- `DigestNotifier.syncWidgetFromRefresh()` devient **mémoire seule** : plus de
+  `_loadBothDigests()`, donc plus de bascule Serein parasite.
+- `FeedNotifier.refreshForWidget()` **n'écrit plus dans `state`**. Il rafraîchit
+  `_globalItems` + le buffer widget et pousse le widget.
+
+### Lot 5 — C5 : profondeur du payload garantie
+
+- Buffer widget dédié `_widgetBuffer` (cap 80), alimenté en **union** (dédup par
+  `id`, frais en tête) et **découplé** de l'overlay `_consumedContentIds` : lire
+  un article dans l'app ne vide plus le widget.
+- `_scheduleWidgetPush` pousse le buffer, pas `state.items`.
+- `_prefetchForWidget` : le bail `!_hasNext` est levé (il décrivait la pagination
+  *visible*, pas la profondeur widget) ; bornes `_widgetPrefetchMaxPages` et cap
+  conservées. Déclenché aussi depuis `ensureWidgetFresh` quand le buffer < 80.
+  **Cooldown de 30 min** ajouté avec le bail : un compte qui n'a pas 80 articles
+  disponibles n'atteindra jamais le cap, et sans garde il relancerait 4 appels
+  `/api/feed/` à chaque build de feed et chaque retour de premier plan (cf.
+  `docs/bugs/bug-infinite-load-requests.md`). Le bouton refresh du widget passe
+  `force: true` et court-circuite le cooldown.
+- Garde de signature étendu à **tous** les ids + péremption 6 h (repush forcé).
+- Diagnostic : la profondeur réelle du payload est persistée à chaque push dans
+  `widget_last_push_count` (`HomeWidgetPreferences`).
+- Bonus nécessaire : les logos de source sont désormais cachés **par URL** et non
+  par rang. Le fichier du rang N était réécrit à chaque push, donc une entrée
+  conservée d'un push précédent pointait vers les octets d'une *autre* source —
+  invisible tant qu'on remplaçait, fatal dès qu'on fusionne. Effet de bord
+  bienvenu : plus de re-téléchargement des mêmes logos à chaque push.
+  `_cachedLogo` est en **single-flight par URL** : `_buildFeedArticleList`
+  sérialise les 80 lignes via `Future.wait`, donc les N articles d'une même
+  source arrivaient en parallèle et lançaient N téléchargements concurrents
+  écrivant *le même* fichier.
+
+### Lot 6 — C6 : refresh de fond via `workmanager`
+
+`lib/core/services/widget_background_refresh.dart` (nouveau)
+- `workmanager: ^0.9.0` ajouté au `pubspec.yaml`.
+- Callback dispatcher `@pragma('vm:entry-point')`.
+- Dans l'isolate : `Hive.initFlutter()` + `SupabaseHiveStorage` pour restaurer la
+  session ; aucune session → **abandon silencieux**, jamais de `signOut`.
+- **Dio nu**, sans les interceptors `onAuthError`/`onAuthRecovered` : un 401 en
+  background ne peut pas délogger (leçon de C3).
+- Réponse parsée par `FeedRepository.parseFeedData` (statique, sans
+  `ApiClient`) : un second parseur pour le même endpoint aurait garanti qu'un
+  changement de schéma fasse silencieusement retomber le widget à vide.
+- `GET feed/?page=1&limit=20` → `WidgetService.updateWidgetMergingFlux()`, qui
+  **fusionne** au lieu de remplacer (sinon le payload retomberait de 80 à 20,
+  soit exactement le symptôme C5).
+- `registerPeriodicTask` toutes les ~1 h, `NetworkType.connected`,
+  `requiresBatteryNotLow`, `ExistingPeriodicWorkPolicy.keep`. Annulé au logout à
+  côté de `WidgetService.clear()`.
+
+### Lot 7 — CTA « Ajouter le widget »
+
+- `lib/features/feed/widgets/widget_cta_banner.dart` : bandeau en tête de Flâner,
+  bâti sur les tokens existants (même idiome que `PinSubjectsBanner`).
+- Affiché uniquement si `WidgetService.isWidgetPinned()` renvoie `false` (en cas
+  d'incertitude → masqué) ; dismissible, throttle 7 j aligné sur le bandeau
+  Lettres. Le throttle passe par le **registre unifié des nudges**
+  (`NudgeIds.widgetCtaFeedBanner`, `NudgeFrequency.cooldown`) et non par une clé
+  SharedPreferences maison : même horloge testable, même purge, même namespace
+  que les autres bandeaux du feed. (`NudgeIds.widgetPinAndroid` n'a pas été
+  réemployé : cette entrée sert de fixture `once`/`high` aux tests du
+  coordinateur, la repurposer les aurait cassés.)
+- `lib/core/services/widget_pin_prompt.dart` : point d'entrée unique qui rend
+  toujours compte du résultat (`unsupported` → explication, `failed` → erreur).
+  L'entrée Compte est branchée dessus.
+
+### Lot 8 — C7 : trampoline Glance
+
+Non corrigé, documenté ci-dessus. Dépendance confirmée, manifest mergé non
+inspectable sans JDK. FLUTTER-1D reste en suivi.
+
+---
+
+## Vérification
+
+### Fait
+
+- `flutter analyze` : aucune **erreur** ; les warnings de `lib/` sont tous
+  pré-existants (inférence Dio, `unused_element`…).
+- Tests ciblés : `widget_service_test.dart` (garde namespace),
+  `deep_link_service_test.dart` (`pendingAction` + `refresh=1` cold start),
+  `feed_provider_widget_refresh_test.dart` (buffer qui ne rétrécit pas,
+  `refreshForWidget` qui ne mute plus `state`).
+- Suite mobile complète comparée à la baseline connue (~27 échecs pré-existants,
+  cf. mémoire projet).
+
+### Reste à faire — vérification device (la seule qui prouve C1)
+
+Conductor n'a pas de JDK par défaut (`brew install openjdk@17` + `JAVA_HOME`).
+
+```bash
+cd apps/mobile && flutter build apk --debug --flavor beta
+```
+
+1. Épingler le widget **depuis le bandeau Flâner** → il doit apparaître
+   (aujourd'hui : rien).
+2. `adb logcat -s FacteurWidget:D FacteurWidgetSvc:D` → vérifier `onUpdate` /
+   `onDataSetChanged` **immédiatement** après une action in-app, pas 30 min plus
+   tard. Vérifier `count=` > 9 et croissant jusqu'à 80.
+3. Lire 10 articles dans Flâner → le compteur du masthead **ne doit pas** descendre.
+4. Tap refresh **app tuée** (cold start) → l'app s'ouvre, le widget se met à jour,
+   Flâner ne perd pas son état et ne crashe pas.
+5. **Scénario clé** : app tuée, tournée du matin non ouverte, tap sur une ligne du
+   widget → l'article s'ouvre après résolution de l'auth, l'utilisateur **reste
+   connecté**. Vérifier dans logcat l'absence de
+   `⛔️ ApiClient: 401 after refresh attempt` et de `auth_session_expired`.
+6. Background : app tuée > 1 h → le contenu du widget doit avoir bougé.
+   Forçable via `adb shell cmd jobscheduler run -f <applicationId> <jobId>`.
+
+### Après merge sur `main` (staging)
+
+- Sentry projet `flutter` : **FLUTTER-1E** (23 events / 11 users) et **FLUTTER-Y**
+  doivent tomber à zéro ; surveiller FLUTTER-6 et FLUTTER-1D.
+- Vérifier `widget_last_push_count` (médiane attendue nettement > 9).
+
+---
+
+## Hors scope explicite
+
+- Crashes **Flux Continu** (FLUTTER-1R/1M/1S/1T/1K/1N, ~30 events fatals sur 5 j :
+  `ref` après dispose dans le fan-out progressif, Timer `_maybeTriggerAutoGrow`,
+  `ref` dans `dispose()`, `GoRouter.of` sur contexte mort) et **FLUTTER-1X**
+  (guided tour, `No ProviderScope found`, marqué *escalating*) : famille distincte,
+  workspace dédié. **À signaler au PO.**
+- Backend `PYTHON-3C` (`IdleInTransactionSessionTimeout` dans `_build_carousels`) :
+  cause DB indépendante du widget.
+- Pas de widget iOS (aucune extension, aucun app group) — tout ce plan est Android.


### PR DESCRIPTION
# fix(widget): refonte fiabilité du widget d'accueil — 6 causes racines

## Résumé

Les 5 symptômes remontés sur le widget Android ne sont pas 5 bugs indépendants.
Ce sont **6 causes racines**, dont une seule (`applicationId ≠ namespace`)
explique déjà la moitié des plaintes.

Base `main`. **Aucune migration.** Aucun impact backend. Android uniquement
(il n'y a pas de widget iOS : ni extension, ni app group).

Doc complète : `docs/bugs/bug-widget-fiabilite.md`.

## Causes racines et correctifs

### C1 — `home_widget` n'a **jamais** pu atteindre les receivers

`HomeWidgetPlugin.kt` résout un `androidName` nu en
`"${context.packageName}.$className"`, où `context.packageName` est
l'**applicationId** (`com.example.facteur.staging` / `facteur.app`). Les
receivers vivent dans le **namespace** `com.example.facteur`.

⇒ `ClassNotFoundException` sur les deux flavors, à chaque appel, avalé par un
`catch`. Donc : « Ajouter un Widget » mort, et **zéro `ACTION_APPWIDGET_UPDATE`
jamais envoyé** — le widget ne repeignait que sur l'alarme système de 30 min.

Cohérent avec Sentry : **zéro** `PlatformException` remontée (tout est catché).

**Fix** : `qualifiedAndroidName:` sur tous les appels, dérivé du namespace.
Garde anti-régression : un test lit le `namespace` directement dans
`build.gradle.kts` et vérifie qu'il diffère bien des applicationId des flavors.

### C2 — Crash **fatal** sur le chemin de fraîcheur (Sentry FLUTTER-1E, 23 events / 11 users)

`app.dart` faisait `unawaited(ensureWidgetFresh())`, qui `await refresh()` sans
try/catch → l'erreur async n'avait aucun handler → crash *unhandled* via
`PlatformDispatcher.onError`.

**Fix** : try/catch (log Sentry `warning`, pas de rethrow) + `.catchError` sur le
`unawaited`. Feeder amont FLUTTER-6 traité aussi : le timeout de
`SessionRefresher` devient adaptatif (8 s `resumed`, 20 s au cold boot / réveil
par tap widget), les 5 s fixes expiraient systématiquement.

### C3 — Le deep-link widget **déconnectait** l'utilisateur

C'est le vrai « j'ouvre le widget avant ma tournée et ensuite plus rien ne
charge » : ce n'est pas une panne de requêtes, c'est un **`signOut()`**.

La branche deep-link de `routes.dart` retournait sa route **avant** le gate
`authState.isLoading`. Cold-open depuis le widget → le reader se montait alors
que `Supabase.currentSession` était encore `null` → `ApiClient` attendait
**100 ms** puis partait en anonyme → 401 → refresh 5 s en échec au cold boot →
`onAuthError(401)` → `handleSessionExpired` → `signOut()` → `WidgetService.clear()`.

**Fix, en trois points de coupure** :
- `routes.dart` : la branche **seed** le pending et retourne `/splash`. Le bloc 3
  existant le consomme une fois l'auth résolue — le chemin déjà prévu par le
  design. Les auth callbacks restent traités avant les gates (ils portent la
  session que les gates attendent).
- `api_client.dart` : attente de session portée de 100 ms à un budget borné de
  2 s. **Écart assumé au plan** : la requête part quand même en anonyme si le
  budget est épuisé (certains endpoints sont publics ; échouer localement aurait
  été une régression à large rayon). Elle est en revanche **marquée**, et un 401
  sur une requête partie sans header ne déclenche **jamais**
  `handleSessionExpired`.
- `feed_repository.dart` : le cache statique `_defaultViewLastResult` (fenêtre
  5 s) ne mémorise plus une réponse obtenue sans session — il propageait un feed
  dégradé à tous les appelants, widget compris.

Corrige aussi **FLUTTER-Y** (`type 'Null' is not a subtype of type
'Perspective'`, 20 events) : les 9 `state.extra as X?` passent par un helper
unique `extraAs<T>(state)`.

### C4 — Bouton refresh : no-op à froid, effets de bord violents à chaud

- **Cold start** : le flag `refresh=1` était **jeté**. `pendingRoute()` ne
  renvoyait que la route → `_onRefreshRequested` jamais appelé → no-op littéral.
- **À chaud** : `ref.read(digestProvider.notifier)` **construit** le provider,
  dont le `build()` lance `_loadBothDigests` (45 s × 5 retries, ~80 s de chaîne
  réseau pour un tap) et appelle `sereinToggleProvider.initFromApi()` → pouvait
  **basculer le toggle Serein** sous l'utilisateur. Et `refreshForWidget()`
  faisait `state = AsyncData(...)` juste après `router.go('/flaner')` → l'état
  visible était remplacé pendant que `FlanerScreen` se montait. C'est le
  « plante Flâner ».

**Fix** : `pendingAction()` expose l'action complète et `replayRefreshIfRequested()`
rejoue le side-effect (le bouton marche donc au cold start) ;
`container.exists(digestProvider)` avant tout `ref.read(...notifier)` ;
`syncWidgetFromRefresh()` devient **mémoire seule** ; `refreshForWidget()`
**n'écrit plus dans `state`**.

### C5 — « le widget n'affiche que 9 articles »

Les caps sont à 80 partout et le parsing Kotlin est non destructif : **rien ne
tronque à 9**. Le payload contenait réellement ~9 lignes, parce que les pushes
poussaient `state.items` — la liste **visible** de Flâner, qui *rétrécit* au fil
de la lecture (overlay `_consumedContentIds`) — et que rien ne reconstituait la
profondeur.

**Fix** : buffer widget dédié (cap 80), alimenté en **union** dédupliquée et
**découplé** de l'overlay ; lire un article dans l'app ne vide plus le widget.
Le garde de signature passe de `len|first|last` (aveugle à un réordonnancement
du milieu) à **tous** les ids, avec péremption 6 h.

### C6 — Rien ne rafraîchissait le widget app fermée

L'alarme 30 min ne fait que **repeindre les mêmes octets** (`onUpdate` relit
SharedPreferences, aucun réseau). `initWidgetIfNeeded()` était **du code mort**
— zéro appelant → un widget fraîchement épinglé restait vide.

**Fix** : `workmanager` (~1 h, `NetworkType.connected`, `requiresBatteryNotLow`).
Contraintes de conception, toutes tirées des autres causes :
- **Dio nu**, sans les interceptors `onAuthError` : un 401 en tâche de fond ne
  peut pas délogger (leçon de C3) ;
- pas de session restaurable → **abandon silencieux**, jamais de `signOut` ;
- `updateWidgetMergingFlux()` **fusionne** au lieu de remplacer (une page = 20
  articles ; remplacer ferait retomber le payload de 80 à 20, soit exactement
  le symptôme C5) ;
- annulé au logout, à côté de `WidgetService.clear()`.

### CTA « Ajouter le widget »

L'entrée était enterrée dans Compte **et** ne faisait rien. Nouveau bandeau en
tête de Flâner, bâti sur les tokens existants, affiché seulement si aucun widget
n'est épinglé (en cas d'incertitude → masqué). Throttle 7 j via le **registre
unifié des nudges**. `WidgetPinPrompt` rend toujours compte du résultat
(`unsupported` → explication, `failed` → erreur), au lieu du silence d'avant.

## Comment ça a été vérifié

- `flutter analyze` : **0 erreur**. 532 issues, toutes pré-existantes (aucune
  nouvelle sur les fichiers touchés).
- `flutter test` : **1859 passés / 27 échecs**.
  Les 27 échecs sont **exactement la baseline** : vérifié en montant un worktree
  sur `origin/main` et en rejouant les fichiers à risque
  (`router_redirection_test` ×2, `feed_sources_test` ×5, `widget_test` ×1) —
  ils échouent à l'identique sans ce diff.
- Tests ajoutés : garde namespace (lit `build.gradle.kts`), `pendingAction` +
  `refresh=1` au cold start, buffer qui ne rétrécit pas, `refreshForWidget` qui
  ne mute plus `state`, réponse sans session jamais mémorisée.

### Non vérifié — vérification device (la seule qui prouve C1)

Conductor n'a pas de JDK, donc **aucun APK n'a été construit**. C1, C6 et le
CTA d'épinglage ne sont prouvés que par lecture du plugin et des tests de garde.
Le protocole device est écrit dans la doc du bug (§ Vérification) : épingler
depuis le bandeau, `adb logcat -s FacteurWidget:D`, vérifier `count=` > 9 et
croissant, tap refresh app tuée, et le scénario clé « widget avant la tournée →
rester connecté ».

## Zones à risque

- **Auth / Router** (`api_client.dart`, `routes.dart`, `session_refresher.dart`,
  `auth_state.dart`) — cf. Safety Guardrails. Le changement le plus sensible est
  le passage du deep-link widget par `/splash` : à relire en priorité.
- `feed_provider.dart` : `refreshForWidget()` n'écrit plus dans `state` (un test
  existant a été inversé en conséquence, volontairement).
- `_prefetchForWidget` : le bail `!_hasNext` est levé, borné par un **cooldown
  30 min** — sans lui, un compte qui n'a pas 80 articles disponibles relancerait
  4 appels `/api/feed/` à chaque build de feed et chaque retour de premier plan.

## Hors scope (à signaler au PO)

- Crashes **Flux Continu** (FLUTTER-1R/1M/1S/1T/1K/1N, ~30 events fatals sur 5 j)
  et **FLUTTER-1X** (guided tour, marqué *escalating*) : famille distincte,
  workspace dédié.
- **FLUTTER-1D** (trampoline Glance, 3 users, fatal) : la dépendance
  `androidx.glance:glance-appwidget` est confirmée, mais le manifest mergé n'est
  pas inspectable sans JDK. On ne retire pas une activité tierce exportée sans
  preuve. Reste en suivi.

## Après merge sur `main` (staging)

- Sentry `flutter` : **FLUTTER-1E** et **FLUTTER-Y** doivent tomber à zéro ;
  surveiller FLUTTER-6 et FLUTTER-1D.
- Vérifier `widget_last_push_count` (médiane attendue nettement > 9).
