### PR TITLE
feat(tournée): « Actus du jour » en première section par défaut (nouveaux users)

### DIFF
--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -2407,22 +2407,27 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
             !favoriteKeySet.contains(sectionKey(section)))
           sectionKey(section),
     ];
-    // Ordre par défaut unifié (normal & serein) : on démarre la Tournée par les
-    // favoris utilisateur (thèmes/sources/veille — le signal d'intérêt le plus
-    // fort), puis les sections suggérées « Choisie pour vous » (Story 22.3),
-    // puis les Actus du jour, puis Bonnes Nouvelles. En mode serein ce sont les
-    // contenus serein qui peuplent ces mêmes sections (fetch serein) ; seul
-    // l'ordre reste constant. Un ordre personnalisé (`customized`) reste
-    // prioritaire via `applyOrder`.
+    // Ordre par défaut unifié (normal & serein). Pour les comptes **non
+    // personnalisés** (tous les nouveaux utilisateurs), on démarre la Tournée
+    // par les Actus du jour — la section éditoriale cœur du rituel — puis les
+    // favoris utilisateur (thèmes/sources/veille), puis les suggestions
+    // « Choisie pour vous » (Story 22.3), puis Bonnes Nouvelles. La Grille
+    // s'épingle juste après les Actus (plus bas) → 2ᵉ position par défaut.
+    // Un compte **personnalisé** garde l'ordre historique (favoris d'abord,
+    // Actus après) : `applyOrder` réapplique ensuite l'arrangement manuel
+    // sticky à partir de cette base, laissant son comportement inchangé.
+    // En mode serein ce sont les contenus serein qui peuplent ces mêmes
+    // sections (fetch serein) ; seul l'ordre reste constant.
     // La Grille n'est PAS réordonnable par l'utilisateur (cf. modal « Mes
     // favoris ») : on l'exclut d'`applyOrder` et on l'épingle juste après les
     // Actus plus bas. Sinon, comme sa clé est absente de `order` (compte
     // personnalisé), `applyOrder` la reléguerait en fin de liste → coupée par
     // le cap → la Grille disparaîtrait. Régression corrigée par hotfix.
     final defaultKeys = <String>[
+      if (!customized) kTourneeActusKey,
       ...favoriteKeys,
       ...suggestedKeys,
-      kTourneeActusKey,
+      if (customized) kTourneeActusKey,
       kTourneeBonnesKey,
     ];
     final availableKeys = [

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_tournee_order_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_tournee_order_test.dart
@@ -359,7 +359,8 @@ void main() {
 
   group('éditorial + Grille dans la liste unifiée', () {
     test(
-      'ordre normal par défaut : favoris puis Actus (+ Grille slot) puis Bonnes',
+      'ordre normal par défaut (compte non personnalisé) : Actus en tête '
+      '(+ Grille slot) puis favoris puis Bonnes',
       () async {
         stubDigest();
         stubFeed(
@@ -379,16 +380,16 @@ void main() {
 
         final state = await settle(container);
 
-        // Ordre par défaut demandé : favoris utilisateur, puis Actus du jour,
-        // puis Bonnes Nouvelles.
+        // Ordre par défaut pour tous les nouveaux utilisateurs : Actus du jour
+        // en première section, puis favoris, puis Bonnes Nouvelles.
         expect(state.sections.map(sectionKey).toList(), [
-          'theme:society',
           kTourneeActusKey,
+          'theme:society',
           kTourneeBonnesKey,
         ]);
         expect(
           state.grilleSlotIndex,
-          2,
+          1,
           reason: 'La Grille est rendue juste après Actus (ici en 2e position)',
         );
       },
@@ -430,8 +431,10 @@ void main() {
 
       final state = await settle(container);
 
-      // 8 thèmes + Actus + Grille + Bonnes = 11 items ≤ cap 13 → tout tient.
+      // Actus en tête (compte non personnalisé), puis 8 thèmes, puis Bonnes.
+      // + Grille = 11 items ≤ cap 13 → tout tient.
       expect(state.sections.map(sectionKey).toList(), [
+        kTourneeActusKey,
         'theme:society',
         'theme:culture',
         'theme:economy',
@@ -440,10 +443,9 @@ void main() {
         'theme:science',
         'theme:environment',
         'theme:international',
-        kTourneeActusKey,
         kTourneeBonnesKey,
       ]);
-      expect(state.grilleSlotIndex, 9);
+      expect(state.grilleSlotIndex, 1);
       expect(
         state.sections.map(sectionKey),
         contains(kTourneeBonnesKey),
@@ -473,10 +475,10 @@ void main() {
     });
 
     test(
-      'mode serène par défaut : même ordre que normal (favoris, Actus, Bonnes)',
+      'mode serène par défaut : même ordre que normal (Actus, favoris, Bonnes)',
       () async {
         // Plan QA onboarding — le mode serein garde l'ordre par défaut demandé
-        // (favoris → Actus → Bonnes), avec les contenus serein. Plus de Bonnes
+        // (Actus → favoris → Bonnes), avec les contenus serein. Plus de Bonnes
         // remontées en tête.
         stubDigest();
         stubFeed(
@@ -498,11 +500,11 @@ void main() {
         final state = await settle(container);
 
         expect(state.sections.map(sectionKey).toList(), [
-          'theme:society',
           kTourneeActusKey,
+          'theme:society',
           kTourneeBonnesKey,
         ]);
-        expect(state.grilleSlotIndex, 2);
+        expect(state.grilleSlotIndex, 1);
       },
     );
 


### PR DESCRIPTION
## Quoi

L'ordre par défaut de la **Tournée du jour** place désormais la section
**« Actus du jour »** (`kTourneeActusKey`) en **première position** pour tous les
comptes **non personnalisés** (= tous les nouveaux utilisateurs). Auparavant elle
arrivait après les favoris (thèmes/sources/veille) et les suggestions.

Ordre par défaut (nouvel utilisateur) :
`Actus du jour → [Grille] → favoris → « Choisie pour vous » → Bonnes Nouvelles`.

## Pourquoi

Demande PO : les Actus du jour sont la section éditoriale cœur du rituel
quotidien et doivent ouvrir la Tournée par défaut.

## Comment

- `flux_continu_provider.dart` — `_orderedTourneeKeys` : `defaultKeys` place
  `kTourneeActusKey` en tête **si le compte n'est pas `customized`** ; les comptes
  ayant déjà composé leur Tournée conservent l'ordre historique (Actus après les
  favoris), qui reste ensuite piloté par leur arrangement manuel sticky
  (`applyOrder`). Comportement des comptes personnalisés **inchangé à l'octet**.
- La Grille reste épinglée juste après les Actus (invariant `actusIndex + 1`)
  → 2ᵉ position par défaut.
- 100 % mobile, **aucune migration**, aucun changement backend (l'ordre des
  sections est entièrement client-side).

## Comment ça a été vérifié

- [x] `flutter analyze` : 0 erreur (fichiers touchés « No issues found »).
- [x] `flutter test test/features/flux_continu/` : **475 tests OK** (3 tests
  d'ordre par défaut mis à jour + le cas `customized` qui valide le
  non-changement du chemin personnalisé).
- [x] Suite complète : 1877 OK / 30 échecs = **baseline pré-existante**
  (flakiness d'état partagé SharedPreferences/Hive ; le seul test flux_continu
  rouge en run complet **passe en isolation**).
- [x] `/simplify` passé (ternaire dupliqué → littéral unique avec collection-`if`).

## Zones à risque

- `flux_continu_provider.dart` (`_orderedTourneeKeys`) — ordre de la Tournée.
  Chemin `customized` volontairement laissé identique pour ne pas perturber les
  utilisateurs existants.