### PR TITLE
fix(onboarding): carrousel sujets — clavier, hitbox chips & clarté sous-titre

### DIFF
--- a/apps/mobile/lib/features/onboarding/onboarding_strings.dart
+++ b/apps/mobile/lib/features/onboarding/onboarding_strings.dart
@@ -307,6 +307,8 @@ class OnboardingStrings {
       'Indique quels sujets tu veux le plus voir apparaitre dans ton feed.';
   static const String addCustomTopicHint = 'Ajouter un sujet';
   static const String maxCustomTopicsReached = 'Maximum 3 sujets par thème';
+  static const String customTopicAddedHint =
+      'Vous permettra de mettre en avant le sujet dans vos actus, et de définir des alertes si vous le souhaitez !';
 
   // Finalize
   static const String finalizeTitle = 'Ton essentiel est prêt.';

--- a/apps/mobile/lib/features/onboarding/screens/questions/subtopics_question.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/subtopics_question.dart
@@ -219,14 +219,7 @@ class _SubtopicsQuestionState extends ConsumerState<SubtopicsQuestion> {
 
           const SizedBox(height: FacteurSpacing.space3),
 
-          Text(
-            OnboardingStrings.subtopicsSubtitle,
-            style: Theme.of(context)
-                .textTheme
-                .bodyMedium
-                ?.copyWith(color: colors.textSecondary),
-            textAlign: TextAlign.center,
-          ),
+          _buildSubtitle(colors),
 
           const SizedBox(height: FacteurSpacing.space4),
 
@@ -243,6 +236,10 @@ class _SubtopicsQuestionState extends ConsumerState<SubtopicsQuestion> {
                 ? PageView.builder(
                     controller: _pageController,
                     onPageChanged: (i) {
+                      // Relâche tout focus résiduel (ex : champ de l'EntityAddSheet
+                      // fermée) pour éviter que le clavier ne remonte au changement
+                      // de carte.
+                      FocusManager.instance.primaryFocus?.unfocus();
                       HapticFeedback.selectionClick();
                       setState(() {
                         _currentTheme = i;
@@ -347,6 +344,38 @@ class _SubtopicsQuestionState extends ConsumerState<SubtopicsQuestion> {
     );
   }
 
+  /// Sous-titre avec « le plus » en gras : un utilisateur n'avait pas compris que
+  /// ne pas cocher un sujet l'excluait. On garde `subtopicsSubtitle` comme source
+  /// de vérité et on met en emphase le segment à l'exécution.
+  Widget _buildSubtitle(FacteurColors colors) {
+    const subtitle = OnboardingStrings.subtopicsSubtitle;
+    const emphasis = 'le plus';
+    final base = Theme.of(context)
+        .textTheme
+        .bodyMedium
+        ?.copyWith(color: colors.textSecondary);
+    final index = subtitle.indexOf(emphasis);
+
+    if (index < 0) {
+      return Text(subtitle, style: base, textAlign: TextAlign.center);
+    }
+
+    return Text.rich(
+      TextSpan(
+        style: base,
+        children: [
+          TextSpan(text: subtitle.substring(0, index)),
+          TextSpan(
+            text: emphasis,
+            style: const TextStyle(fontWeight: FontWeight.w700),
+          ),
+          TextSpan(text: subtitle.substring(index + emphasis.length)),
+        ],
+      ),
+      textAlign: TextAlign.center,
+    );
+  }
+
   ThemeOption _resolveTheme(String slug) {
     return AvailableThemes.all.firstWhere(
       (t) => t.slug == slug,
@@ -431,6 +460,7 @@ class _SubtopicsQuestionState extends ConsumerState<SubtopicsQuestion> {
   /// Joue un bref état « validé » sur la carte courante (scale/opacité +
   /// check vert) puis enchaîne le scroll vers le thème suivant.
   Future<void> _validateAndGoToNextPage() async {
+    FocusManager.instance.primaryFocus?.unfocus();
     setState(() => _isValidatingCurrentPage = true);
     HapticFeedback.selectionClick();
     await Future.delayed(const Duration(milliseconds: 250));
@@ -586,6 +616,13 @@ class _SubtopicsQuestionState extends ConsumerState<SubtopicsQuestion> {
                       ))
                   .toList(),
             ),
+            const SizedBox(height: FacteurSpacing.space2),
+            Text(
+              OnboardingStrings.customTopicAddedHint,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: colors.textTertiary,
+                  ),
+            ),
           ],
 
           const SizedBox(height: FacteurSpacing.space2),
@@ -594,6 +631,7 @@ class _SubtopicsQuestionState extends ConsumerState<SubtopicsQuestion> {
           // valide + confirme + persiste le sujet au moment de l'ajout.
           if (canAddMore)
             GestureDetector(
+              behavior: HitTestBehavior.opaque,
               onTap: () => _openAddSheet(theme.slug),
               child: Container(
                 padding:
@@ -645,13 +683,14 @@ class _EntityChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
+      behavior: HitTestBehavior.opaque,
       onTap: () {
         HapticFeedback.selectionClick();
         onTap();
       },
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 150),
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
         decoration: BoxDecoration(
           color: isSelected
               ? themeColor.withOpacity(0.1)

--- a/apps/mobile/lib/features/onboarding/widgets/theme_with_subtopics.dart
+++ b/apps/mobile/lib/features/onboarding/widgets/theme_with_subtopics.dart
@@ -180,13 +180,14 @@ class SubtopicChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
+      behavior: HitTestBehavior.opaque,
       onTap: () {
         HapticFeedback.selectionClick();
         onTap();
       },
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 150),
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
         decoration: BoxDecoration(
           color: isSelected
               ? themeColor.withOpacity(0.1)


### PR DESCRIPTION
## Quoi
Fixes UX sur le carrousel de sujets de l'onboarding : le clavier ne remonte plus au changement de carte, les chips/bouton d'ajout ont une hitbox plus large, et le sous-titre clarifie que ne pas cocher un sujet l'exclut.

## Pourquoi
- Un utilisateur n'avait pas compris que ne pas cocher un sujet l'excluait → emphase « le plus » + hint sous les sujets custom.
- Le clavier de l'EntityAddSheet remontait de façon résiduelle au swipe entre cartes.
- Les zones tactiles des chips étaient trop étroites (padding vertical + HitTestBehavior.opaque).

## Comment ça a été vérifié
- [x] flutter analyze (aucune nouvelle issue — deprecations/unused pré-existants)
- [x] flutter test test/features/onboarding/ → 85 tests OK
- [x] /simplify passé (diff propre, pas de helper partagé à réutiliser)

## Zones à risque
UI onboarding uniquement (subtopics_question.dart, theme_with_subtopics.dart, onboarding_strings.dart). Aucun backend, aucune migration.