### PR TITLE
feat(landing): Google Analytics 4 avec consentement RGPD

### DIFF
--- a/apps/landing/public/blog-soiree-prelancement.html
+++ b/apps/landing/public/blog-soiree-prelancement.html
@@ -121,6 +121,7 @@
     </footer>
 
     <script src="/js/event.js?v=3"></script>
+    <script src="/js/consent.js?v=1"></script>
 
 </body>
 

--- a/apps/landing/public/blog.html
+++ b/apps/landing/public/blog.html
@@ -76,6 +76,7 @@
         </div>
     </footer>
 
+    <script src="/js/consent.js?v=1"></script>
 </body>
 
 </html>

--- a/apps/landing/public/checkout-redirect.html
+++ b/apps/landing/public/checkout-redirect.html
@@ -74,6 +74,7 @@
             document.getElementById('fallback').hidden = false;
         })();
     </script>
+    <script src="/js/consent.js?v=1"></script>
 </body>
 
 </html>

--- a/apps/landing/public/conditions-utilisation.html
+++ b/apps/landing/public/conditions-utilisation.html
@@ -143,6 +143,7 @@
             </div>
         </section>
     </main>
+    <script src="/js/consent.js?v=1"></script>
 </body>
 
 </html>

--- a/apps/landing/public/css/consent.css
+++ b/apps/landing/public/css/consent.css
@@ -1,0 +1,74 @@
+/* Facteur Landing Page — Bandeau de consentement cookies */
+
+#consent-banner {
+    position: fixed;
+    left: var(--space-sm);
+    right: var(--space-sm);
+    bottom: var(--space-sm);
+    z-index: 9999;
+    max-width: 640px;
+    margin: 0 auto;
+    background: var(--color-dark-bg);
+    color: var(--color-dark-text);
+    border-radius: var(--radius-md);
+    padding: var(--space-sm) var(--space-md);
+    box-shadow: var(--shadow-card-hover);
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-xs) var(--space-sm);
+    font-family: system-ui, -apple-system, sans-serif;
+    font-size: 0.9rem;
+    line-height: 1.45;
+}
+
+#consent-banner p {
+    margin: 0;
+    flex: 1 1 260px;
+}
+
+#consent-banner a {
+    color: inherit;
+    text-decoration: underline;
+}
+
+#consent-banner .consent-banner__actions {
+    display: flex;
+    gap: var(--space-xs);
+    flex: 0 0 auto;
+}
+
+#consent-banner button {
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: var(--space-xs) var(--space-sm);
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+#consent-refuse {
+    background: transparent;
+    color: var(--color-dark-text);
+    border: 1px solid rgba(240, 236, 230, 0.4);
+}
+
+#consent-accept {
+    background: var(--color-dark-text);
+    color: var(--color-dark-bg);
+}
+
+@media (max-width: 480px) {
+    #consent-banner {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    #consent-banner p {
+        flex: initial;
+    }
+
+    #consent-banner .consent-banner__actions {
+        justify-content: flex-end;
+    }
+}

--- a/apps/landing/public/founder.html
+++ b/apps/landing/public/founder.html
@@ -72,6 +72,7 @@
     </main>
 
     <script src="/js/checkout.js"></script>
+    <script src="/js/consent.js?v=1"></script>
 </body>
 
 </html>

--- a/apps/landing/public/grille.html
+++ b/apps/landing/public/grille.html
@@ -136,6 +136,7 @@
             tryOpen();
         });
     </script>
+    <script src="/js/consent.js?v=1"></script>
 </body>
 
 </html>

--- a/apps/landing/public/index.html
+++ b/apps/landing/public/index.html
@@ -736,6 +736,7 @@
     </div>
 
     <script src="/js/main.js?v=3"></script>
+    <script src="/js/consent.js?v=1"></script>
 </body>
 
 </html>

--- a/apps/landing/public/js/checkout.js
+++ b/apps/landing/public/js/checkout.js
@@ -54,6 +54,9 @@
                 })
                 .then(function (data) {
                     if (data && data.checkout_url) {
+                        if (typeof gtag === 'function') {
+                            gtag('event', 'generate_lead', { offering: offering });
+                        }
                         window.location.href = data.checkout_url;
                     } else {
                         throw new Error('Réponse invalide');

--- a/apps/landing/public/js/consent.js
+++ b/apps/landing/public/js/consent.js
@@ -1,0 +1,91 @@
+/* Facteur Landing Page — Consentement cookies (Google Consent Mode v2)
+ *
+ * Source unique pour le stub gtag/dataLayer, le bandeau de consentement et
+ * le chargement de GA4. Chargé sur chaque page via un seul <script> — pas de
+ * markup ni de stub dupliqués par page (risque de drift entre 11 copies).
+ */
+(function () {
+    'use strict';
+
+    var STORAGE_KEY = 'ga_consent_choice';
+    var GA_MEASUREMENT_ID = 'G-LJ2QT4846J';
+
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    window.gtag = gtag;
+
+    gtag('consent', 'default', {
+        analytics_storage: 'denied',
+        ad_storage: 'denied',
+        ad_user_data: 'denied',
+        ad_personalization: 'denied'
+    });
+
+    var gaLoaded = false;
+
+    function loadGA() {
+        if (gaLoaded) return;
+        gaLoaded = true;
+        gtag('consent', 'update', { analytics_storage: 'granted' });
+        var script = document.createElement('script');
+        script.async = true;
+        script.src = 'https://www.googletagmanager.com/gtag/js?id=' + GA_MEASUREMENT_ID;
+        document.head.appendChild(script);
+        gtag('js', new Date());
+        gtag('config', GA_MEASUREMENT_ID, { anonymize_ip: true });
+    }
+
+    var stored = null;
+    try {
+        stored = window.localStorage.getItem(STORAGE_KEY);
+    } catch (e) {
+        stored = null;
+    }
+
+    if (stored === 'granted') {
+        loadGA();
+        return;
+    }
+    if (stored === 'denied') {
+        return;
+    }
+
+    function renderBanner() {
+        var link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = '/css/consent.css?v=1';
+        document.head.appendChild(link);
+
+        var banner = document.createElement('div');
+        banner.id = 'consent-banner';
+        banner.innerHTML =
+            '<p>Nous utilisons Google Analytics pour mesurer l’audience du site. ' +
+            'Ces cookies ne sont déposés qu’avec ton accord. ' +
+            '<a href="/politique-confidentialite.html">En savoir plus</a></p>' +
+            '<div class="consent-banner__actions">' +
+            '<button type="button" id="consent-refuse">Refuser</button>' +
+            '<button type="button" id="consent-accept">Accepter</button>' +
+            '</div>';
+        document.body.appendChild(banner);
+
+        function choose(choice) {
+            try {
+                window.localStorage.setItem(STORAGE_KEY, choice);
+            } catch (e) {
+                // localStorage indisponible (navigation privée) : le choix ne sera pas persisté,
+                // le bandeau réapparaîtra au prochain chargement.
+            }
+            if (choice === 'granted') loadGA();
+            banner.remove();
+        }
+
+        document.getElementById('consent-accept').addEventListener('click', function () { choose('granted'); });
+        document.getElementById('consent-refuse').addEventListener('click', function () { choose('denied'); });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', renderBanner);
+    } else {
+        renderBanner();
+    }
+})();

--- a/apps/landing/public/methodologie.html
+++ b/apps/landing/public/methodologie.html
@@ -649,6 +649,7 @@
 </footer>
 
 <script src="js/methodologie.js?v=2"></script>
+<script src="js/consent.js?v=1"></script>
 </body>
 
 </html>

--- a/apps/landing/public/politique-confidentialite.html
+++ b/apps/landing/public/politique-confidentialite.html
@@ -56,6 +56,11 @@
                     </header>
 
                     <div class="legal-document__content">
+                        <!-- Section ajoutée manuellement (hors template Termly) : à conserver si le
+                             contenu ci-dessous est régénéré/re-collé depuis Termly. -->
+                        <h2>Cookies et outils de mesure d'audience</h2>
+                        <p>Nous utilisons <strong>Google Analytics</strong> (Google LLC) pour mesurer la fréquentation du site et comprendre d'où viennent nos visiteurs (canaux d'acquisition). Cet outil dépose des cookies (<code>_ga</code>, <code>_ga_*</code>) uniquement après ton accord explicite, donné via le bandeau affiché lors de ta première visite. Tu peux à tout moment refuser ou retirer ton consentement en effaçant les données de navigation stockées par ce site dans ton navigateur.</p>
+                        <p>Les données collectées (pages consultées, provenance du trafic, appareil utilisé) sont conservées 14 mois et traitées par Google conformément à sa propre <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">politique de confidentialité</a>. La base légale de ce traitement est ton consentement (art. 6.1.a du RGPD), que tu peux retirer à tout moment.</p>
 <style>
   [data-custom-class='body'], [data-custom-class='body'] * {
           background: transparent !important;
@@ -116,6 +121,7 @@ word-break: break-word !important;
             </div>
         </section>
     </main>
+    <script src="/js/consent.js?v=1"></script>
 </body>
 
 </html>

--- a/apps/landing/public/premium.html
+++ b/apps/landing/public/premium.html
@@ -91,6 +91,7 @@
     </main>
 
     <script src="/js/checkout.js"></script>
+    <script src="/js/consent.js?v=1"></script>
 </body>
 
 </html>

--- a/apps/landing/public/supprimer-mon-compte.html
+++ b/apps/landing/public/supprimer-mon-compte.html
@@ -129,6 +129,7 @@
             </p>
         </div>
     </main>
+    <script src="/js/consent.js?v=1"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Quoi

Branche Google Analytics 4 sur les 11 pages du site landing (`facteur.app`), avec un bandeau de consentement (Google Consent Mode v2, deny-all par défaut tant que le visiteur n'a pas choisi).

## Pourquoi

Suivre l'audience du site (visites, provenance des visiteurs, clics vers les stores) sans déposer de cookies analytiques avant consentement explicite (RGPD).

## Ce qui a été fait

- **Propriété GA4 créée** : `Facteur - Landing Web` (séparée de la propriété Firebase existante `facteur-c30dc`, qui reste dédiée à l'app mobile), flux Web sur `https://facteur.app`, Measurement ID `G-LJ2QT4846J`.
- **Enhanced Measurement** vérifié actif (page views, scrolls, **outbound clicks** — couvre déjà les liens App Store/Play Store sur `grille.html` et les futurs liens stores sur `index.html`, form interactions, video engagement, file downloads).
- **Bandeau de consentement** : stocké en `localStorage` (`ga_consent_choice`), GA ne charge qu'après acceptation explicite. Refus = aucune requête envoyée à Google.
- **1 event de conversion** : `generate_lead` (nom recommandé GA4) déclenché dans `checkout.js` juste avant la redirection vers RevenueCat, avec le paramètre `offering` (`founder`/`default`).
- **Attribution WhatsApp/liens externes** : via convention `utm_source/medium/campaign` sur les liens partagés (déjà supportée par `checkout.js`, captée nativement par GA4).
- **Section RGPD ajoutée** à `politique-confidentialite.html` (cookies `_ga`/`_ga_*`, base légale, durée de conservation).

Le stub gtag + le markup du bandeau — initialement dupliqués mot pour mot sur les 11 pages — sont centralisés dans `consent.js` (CSS et markup injectés uniquement si le choix n'est pas encore stocké, donc pas de coût pour les visiteurs ayant déjà décidé). Chaque page n'a plus qu'un seul `<script src="/js/consent.js">`.

## Comment ça a été vérifié

- [x] `node --check` sur `consent.js` et `checkout.js` — syntaxe OK
- [x] Playwright CLI (viewport mobile 390x844) sur `index.html` servi en local :
  - Bandeau affiché par défaut (aucun choix stocké)
  - **Accepter** → requête `google-analytics.com/g/collect` avec `tid=G-LJ2QT4846J`, `en=page_view`, statut 204 ; `ga_consent_choice=granted` en localStorage
  - **Refuser** → aucune requête GA envoyée ; `ga_consent_choice=denied`
  - Aucune erreur console sur l'ensemble du scénario
- [x] Re-testé après la refonte consent.js (consolidation) : comportement identique, CSS des design tokens appliqué (`position: fixed` calculé correctement)
- [x] `/simplify` : 4 agents (reuse/simplification/efficiency/altitude) — dédup du stub/markup 11×, réutilisation des tokens `style.css`, CSS non bloquant

## Zones à risque

- Aucun backend/mobile touché — site statique uniquement (`apps/landing/public/**`).
- Le Measurement ID `G-LJ2QT4846J` est en dur dans `consent.js` (source unique, pas de secret sensible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)