### PR TITLE
fix(sources): anti double-tap sur le bouton d'ajout manuel

### DIFF
--- a/apps/mobile/lib/features/sources/widgets/source_add_panel.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_add_panel.dart
@@ -86,7 +86,19 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
   bool _expanded = false;
   bool _sourceAdded = false;
   final Set<String> _addedSourceIds = {};
+  // Ajouts en cours (clé stable par résultat) : désactive le bouton pendant
+  // l'appel réseau pour bloquer les double-taps.
+  final Set<String> _addingKeys = {};
   String? _lastAddedName;
+
+  /// Clé d'identité stable d'un résultat, valable pour une source catalogue
+  /// (sourceId) comme pour une URL custom (feedUrl/url) — le sourceId étant
+  /// null pour les ajouts manuels.
+  String _resultKey(SmartSearchResult r) {
+    final id = r.sourceId;
+    if (id != null && id.isNotEmpty && id != 'null') return id;
+    return r.feedUrl.isNotEmpty ? r.feedUrl : r.url;
+  }
   late final TextEditingController _searchController;
   late final FocusNode _searchFocusNode;
   bool _searchActive = false;
@@ -205,6 +217,11 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
   }
 
   Future<void> _addSource(SmartSearchResult result) async {
+    final key = _resultKey(result);
+    // Anti double-tap : un ajout déjà en cours pour ce résultat bloque les
+    // clics répétés (le PO avait créé la source 4 fois).
+    if (_addingKeys.contains(key)) return;
+    setState(() => _addingKeys.add(key));
     try {
       final sourceId = result.sourceId;
       final hasCatalogId =
@@ -212,7 +229,7 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
 
       if (widget.veilleMode) {
         setState(() {
-          if (hasCatalogId) _addedSourceIds.add(sourceId);
+          _addedSourceIds.add(key);
           _sourceAdded = true;
           _lastAddedName = result.name;
         });
@@ -227,7 +244,7 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
       if (hasCatalogId) {
         await repository.trustSource(sourceId);
         setState(() {
-          _addedSourceIds.add(sourceId);
+          _addedSourceIds.add(key);
           _sourceAdded = true;
           _lastAddedName = result.name;
         });
@@ -238,6 +255,7 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
         }
         await repository.addCustomSource(result.feedUrl, name: result.name);
         setState(() {
+          _addedSourceIds.add(key);
           _sourceAdded = true;
           _lastAddedName = result.name;
         });
@@ -298,6 +316,8 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
       if (mounted) {
         NotificationService.showError('Erreur lors de l\'ajout : $e');
       }
+    } finally {
+      if (mounted) setState(() => _addingKeys.remove(key));
     }
   }
 
@@ -663,10 +683,12 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
         ),
         const SizedBox(height: 12),
         ...results.map((result) {
+          final key = _resultKey(result);
           final id = result.sourceId;
           final isAdded =
-              _addedSourceIds.contains(id) ||
+              _addedSourceIds.contains(key) ||
               (id != null && followedIds.contains(id));
+          final isAdding = _addingKeys.contains(key);
           // E3 — la carte bascule en preuve « Connecté » à l'ajout pour
           // l'onboarding (inlineProof) et pour une correspondance vérifiée
           // dans le panneau normal. Jamais en veilleMode : le sheet Veille
@@ -676,6 +698,7 @@ class _SourceAddPanelState extends ConsumerState<SourceAddPanel> {
           return SourceResultCard(
             result: result,
             isAdded: isAdded,
+            isAdding: isAdding,
             showProof: showProof,
             onAdd: () => _addSource(result),
             onPreview: () => _previewSource(result),

--- a/apps/mobile/lib/features/sources/widgets/source_result_card.dart
+++ b/apps/mobile/lib/features/sources/widgets/source_result_card.dart
@@ -12,6 +12,10 @@ class SourceResultCard extends StatelessWidget {
   final VoidCallback onPreview;
   final bool isAdded;
 
+  /// Ajout en cours : le bouton affiche un spinner et devient non cliquable
+  /// (empêche les double-taps le temps de l'appel réseau).
+  final bool isAdding;
+
   /// Mode preuve (onboarding) : à l'ajout, la carte se transforme en bloc
   /// « Connecté » avec les derniers articles, au lieu d'ouvrir la modal.
   final bool showProof;
@@ -22,6 +26,7 @@ class SourceResultCard extends StatelessWidget {
     required this.onAdd,
     required this.onPreview,
     this.isAdded = false,
+    this.isAdding = false,
     this.showProof = false,
   });
 
@@ -286,21 +291,33 @@ class SourceResultCard extends StatelessWidget {
                       ),
                     )
                   : ElevatedButton(
-                      onPressed: onAdd,
+                      onPressed: isAdding ? null : onAdd,
                       style: ElevatedButton.styleFrom(
                         padding: const EdgeInsets.symmetric(vertical: 12),
                         backgroundColor: colors.primary,
                         foregroundColor: colors.textPrimary,
+                        disabledBackgroundColor:
+                            colors.primary.withValues(alpha: 0.6),
                         elevation: 0,
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(8),
                         ),
                       ),
-                      child: Text(
-                        _addCtaLabel(),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
+                      child: isAdding
+                          ? SizedBox(
+                              width: 18,
+                              height: 18,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                valueColor: AlwaysStoppedAnimation<Color>(
+                                    colors.textPrimary),
+                              ),
+                            )
+                          : Text(
+                              _addCtaLabel(),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
                     ),
             ),
           ],


### PR DESCRIPTION
## Quoi

Le bouton « Ajouter » d'un résultat de recherche de source pouvait être tapé plusieurs fois pendant l'appel réseau. On ajoute une garde anti double-tap (clé d'identité stable par résultat dans un `Set _addingKeys`) et un retour visuel : spinner + bouton désactivé le temps de l'appel.

## Pourquoi

Le PO avait créé la même source **4 fois** en tapant rapidement le bouton — chaque tap relançait `trustSource` / `addCustomSource`. La garde bloque les taps répétés tant qu'un ajout est en cours pour ce résultat. Bonus : les ajouts manuels (custom URL, `sourceId` null) sont désormais aussi marqués « ajoutés » dans la carte via la clé `feedUrl/url`.

## Comment ça a été vérifié

- [x] `flutter test` ciblé sources widgets — 23 tests OK (`source_result_card_test`, `source_add_panel_test`, `source_add_panel_initial_query_test`)
- [x] `flutter analyze` sur les 2 fichiers — 0 issue
- [x] Suite complète `flutter test` — 1877 pass / 30 fail, les 30 échecs = baseline pré-existante hors périmètre (auth, custom_topics, feed, settings, veille…), aucun dans `sources/widgets`
- [x] `/simplify` passé (candidat de dédup écarté : cassait la promotion non-null de Dart)
- [ ] Playwright non lancé (session non-interactive ; états couverts au niveau widget)

## Zones à risque

`source_add_panel.dart` (`_addSource`, clé d'identité) + `source_result_card.dart` (nouveau param `isAdding`). UI mobile only, aucun changement backend, aucune migration.