### PR TITLE
fix(serein): sujet de fond décide la sérénité + choix onboarding gelé

### DIFF
--- a/apps/mobile/lib/features/digest/providers/serein_toggle_provider.dart
+++ b/apps/mobile/lib/features/digest/providers/serein_toggle_provider.dart
@@ -100,11 +100,14 @@ class SereinToggleNotifier extends StateNotifier<SereinToggleState> {
   }
 
   /// Persist the onboarding "serein" choice locally so it survives the very
-  /// first cold start (before /digest/both is ever hit). The server already
-  /// persisted it via save_onboarding, so this only writes the local mirror and
-  /// does not mark the reconciliation done — a later server sync still applies.
+  /// first cold start (before /digest/both is ever hit). This is an explicit
+  /// user choice, so it also freezes any later server reconciliation (like
+  /// [toggle]): the first /digest/both after onboarding must never overwrite it
+  /// with a preference the server may not have committed yet (the
+  /// save_onboarding purge→reinsert window, or a delayed read).
   void commitFromOnboarding(bool enabled) {
     state = state.copyWith(enabled: enabled, isLoading: false);
+    _serverReconciled = true;
     _persistLocal(enabled);
   }
 

--- a/apps/mobile/test/features/digest/serein_toggle_provider_test.dart
+++ b/apps/mobile/test/features/digest/serein_toggle_provider_test.dart
@@ -214,15 +214,17 @@ void main() {
       expect(Hive.box<dynamic>('settings').get(_key('userA')), isTrue);
     });
 
-    test('ne marque pas reconciled → une sync serveur peut encore corriger', () {
+    test('gèle la réconciliation → un /digest/both tardif ne l\'écrase pas', () {
+      // Régression issue 2 : le 1er /digest/both après l'onboarding peut lire
+      // une préférence pas encore commitée durablement (fenêtre purge→réinsert
+      // de save_onboarding). Le choix onboarding, explicite, doit tenir.
       final container = _container(_FakeAuthNotifier('userA'));
       final notifier = container.read(sereinToggleProvider.notifier);
 
       notifier.commitFromOnboarding(true);
-      // La préférence serveur fait autorité pour la réconciliation.
-      notifier.initFromApi(false);
+      notifier.initFromApi(false); // sync tardive lisant une valeur périmée
 
-      expect(container.read(sereinToggleProvider).enabled, isFalse);
+      expect(container.read(sereinToggleProvider).enabled, isTrue);
     });
   });
 

--- a/packages/api/app/services/ml/classification_service.py
+++ b/packages/api/app/services/ml/classification_service.py
@@ -268,6 +268,7 @@ serene = false : tout sujet susceptible de provoquer de l'anxiété chez le lect
 - Tensions géopolitiques, menaces nucléaires, sanctions
 - Maltraitance, violences conjugales, pédocriminalité
 Règle : si le sujet principal de l'article est anxiogène, même partiellement, marque false.
+Un cadrage positif (solidarité, tourisme, entraide, hommage) d'un sujet de fond anxiogène NE le rend PAS serene : c'est le sujet de fond qui décide.
 En cas de doute, marque false.
 
 ## ENTITÉS NOMMÉES
@@ -319,7 +320,7 @@ MISTRAL_API_URL = "https://api.mistral.ai/v1/chat/completions"
 # (PAS `cache_control`) : route les requêtes partageant le même gros préfixe
 # système vers le même cache → tokens de prompt re-facturés moins cher. Une clé
 # par prompt système stable ; bumper le suffixe `-vN` si le prompt change.
-CLASSIFICATION_CACHE_KEY = "facteur-classif-v1"
+CLASSIFICATION_CACHE_KEY = "facteur-classif-v2"
 ENTITY_CACHE_KEY = "facteur-entities-v1"
 
 ENTITY_SYSTEM_PROMPT = """\

--- a/packages/api/tests/ml/test_classification_service.py
+++ b/packages/api/tests/ml/test_classification_service.py
@@ -15,12 +15,27 @@ import pytest
 from app.services.ml.classification_service import (
     CLASSIFICATION_CACHE_KEY,
     CLASSIFICATION_MODEL,
+    CLASSIFICATION_SYSTEM_PROMPT,
     ENTITY_CACHE_KEY,
     ENTITY_SYSTEM_PROMPT,
     VALID_TOPIC_SLUGS,
     ClassificationService,
     _clean_text,
 )
+
+
+class TestSerenityPrompt:
+    """Guards for the serenity classification rule (issue 1: positive framing of
+    an anxiogenic base topic must not flip it to serene)."""
+
+    def test_positive_framing_rule_present(self):
+        """The system prompt states the base topic decides, not the framing."""
+        assert "c'est le sujet de fond qui décide" in CLASSIFICATION_SYSTEM_PROMPT
+        assert "cadrage positif" in CLASSIFICATION_SYSTEM_PROMPT
+
+    def test_cache_key_bumped_with_prompt(self):
+        """A system-prompt change must bump the Mistral prompt cache key."""
+        assert CLASSIFICATION_CACHE_KEY == "facteur-classif-v2"
 
 
 class TestCleanText:


### PR DESCRIPTION
## Quoi

Deux fixes du mode serein ("Bonnes nouvelles") :
- **Backend** : un cadrage positif (solidarité, tourisme, entraide, hommage) d'un sujet de fond anxiogène pouvait faire basculer l'article en `serene`. Règle explicite ajoutée au prompt de classification ("c'est le sujet de fond qui décide") + clé de cache Mistral bumpée `v1`→`v2`.
- **Mobile** : le 1er `/digest/both` après l'onboarding pouvait écraser le choix serein de l'utilisateur en lisant une préférence pas encore commitée durablement (fenêtre purge→réinsert de `save_onboarding`). `commitFromOnboarding` gèle désormais la réconciliation serveur (`_serverReconciled = true`), exactement comme `toggle()`.

## Pourquoi

Le mode serein était perçu comme cassé : des articles anxiogènes fuitaient malgré un cadrage positif, et le choix fait à l'onboarding pouvait sauter au premier chargement du digest.

## Comment ça a été vérifié

- [x] pytest `tests/ml/test_classification_service.py` — 46 passed (garde règle prompt + garde bump clé cache)
- [x] flutter test `serein_toggle_provider_test.dart` — 16 passed (garde régression : sync tardive n'écrase pas le choix onboarding)
- [x] flutter analyze — aucun nouveau warning (seul `unawaited_futures` préexistant sur `HapticFeedback`)
- [x] /simplify — diff déjà propre (réutilise l'idiome de gel de `toggle()`)

## Zones à risque

- `classification_service.py` : bump de clé de cache Mistral (invalidation attendue du cache de préfixe).
- `serein_toggle_provider.dart` : logique de réconciliation onboarding ↔ serveur.