### PR TITLE
feat(tournee): réordonner la Tournée par drag des onglets du header (story 9.10)

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,10 +1,18 @@
 {
   "unreleased": [
     {
+      "tag": "Ma Tournée",
+      "summary": "Réorganise ta tournée sans quitter ta lecture : maintiens un onglet du bandeau en haut de l'écran, puis fais-le glisser à sa nouvelle place. Ton Essentiel reste en tête, le Mot du jour et la citation gardent la leur."
+    },
+    {
       "tag": "Nous soutenir",
       "summary": "L'offre de soutien met désormais en avant le geste plutôt qu'un tarif : plus de montant affiché, un cadrage « soutiens une info libre, sans pub ni actionnaire »."
+    },
+    {
       "tag": "Ma Tournée",
       "summary": "Tes sources favorites ne manquent plus à l'appel : leur section apparaît dès l'ouverture, même après une réinstallation ou sur un nouvel appareil. Et pendant que ta tournée se prépare, les blocs en attente respirent et l'annoncent clairement."
+    },
+    {
       "tag": "Widget d'accueil",
       "summary": "Le widget Facteur se met enfin à jour quand il faut : après chaque passage dans l'app, au tap sur son bouton refresh, et même app fermée. Il garde jusqu'à 80 articles au lieu de se vider à mesure que tu lis, et l'ouvrir avant ta tournée du matin ne te déconnecte plus. Un nouveau bandeau dans Flâner te propose de l'ajouter à ton écran d'accueil en un tap."
     },

--- a/apps/mobile/lib/features/flux_continu/providers/tournee_order_prefs_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/tournee_order_prefs_provider.dart
@@ -73,6 +73,22 @@ const String kTourneeGrilleKey = 'grille';
 /// Clé de la veille (singleton à V1) — alignée sur la branche `'veille'` de `sectionKey`.
 const String kTourneeVeilleKey = 'veille';
 
+/// `true` ssi [key] désigne une section **réordonnable** de la Tournée, au sens
+/// « l'utilisateur peut la déplacer ». Source unique de vérité partagée par la
+/// sheet « Composer ma Tournée » et le drag des onglets du header sticky.
+///
+/// Sont exclus :
+/// - `essentiel_v3` (carte hi-fi héros, toujours 1ʳᵉ),
+/// - `grille` (Mot du jour, épinglé après les Actus par `grilleSlotIndex`),
+/// - `alerts` et tout onglet virtuel (Citation, Fin de tournée, « Pour toi »),
+/// - `topic:` (sujets personnalisés — Flâner uniquement, hors Tournée).
+bool isTourneeReorderableKey(String key) =>
+    key == kTourneeActusKey ||
+    key == kTourneeBonnesKey ||
+    key == kTourneeVeilleKey ||
+    key.startsWith('theme:') ||
+    key.startsWith('source:');
+
 /// État de l'ordre Tournée : la liste ordonnée de clés + les clés masquées +
 /// le flag « Tournée customisée » (cf. doc de la library).
 class TourneeOrderState {

--- a/apps/mobile/lib/features/flux_continu/providers/tournee_reorder_persistence.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/tournee_reorder_persistence.dart
@@ -1,0 +1,161 @@
+/// Persistance partagée d'un réordre de la Tournée du jour.
+///
+/// Deux points d'entrée utilisateur produisent le **même** effet : la sheet
+/// « Composer ma Tournée » (`manage_favorites_sheet.dart`) et le drag des
+/// onglets du header sticky (`flux_continu_screen.dart`). Ce fichier porte la
+/// séquence canonique — garde d'appartenance → `markCustomized()` →
+/// `setOrder(mergeVisibleReorder(...))` → sync serveur thèmes/sources — pour
+/// qu'aucun des deux chemins ne dérive de l'autre.
+library;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../feed/providers/tab_order_prefs_provider.dart'
+    show mergeVisibleReorder;
+import '../../my_interests/models/user_interests_state.dart';
+import '../../my_interests/models/user_sources_state.dart';
+import '../../my_interests/providers/user_interests_provider.dart';
+import '../../my_interests/providers/user_sources_state_provider.dart';
+import 'tournee_order_prefs_provider.dart' hide applyOrder;
+
+/// Remappe un réordre d'onglets du header vers la nouvelle séquence des clés
+/// d'ordre. [orderKeys] est la liste des `StickyTab.orderKey` dans l'ordre
+/// affiché (`null` = onglet figé) ; [oldIndex]/[newIndex] sont les index bruts
+/// de `ReorderableListView` (`newIndex` exprimé dans l'espace d'insertion,
+/// c.-à-d. avant retrait de l'élément déplacé).
+///
+/// La cible est **clampée** entre le premier et le dernier emplacement
+/// réordonnable : le héros Essentiel reste infranchissable en tête, Citation et
+/// Fin de tournée en queue. Les onglets figés *intérieurs* (Mot du jour,
+/// « Pour toi ») peuvent être traversés — ils se ré-épinglent à leur slot au
+/// rebuild suivant.
+///
+/// Retourne `null` quand le mouvement est impossible ou sans effet (onglet figé
+/// saisi, index hors bornes, moins de deux onglets déplaçables, position
+/// inchangée) — l'appelant ne doit alors rien persister.
+List<String>? reorderTourneeTabKeys(
+  List<String?> orderKeys,
+  int oldIndex,
+  int newIndex,
+) {
+  if (oldIndex < 0 || oldIndex >= orderKeys.length) return null;
+  if (orderKeys[oldIndex] == null) return null;
+
+  final moved = orderKeys[oldIndex];
+  final rest = [...orderKeys]..removeAt(oldIndex);
+  // Bornes d'insertion dans `rest` : après le préfixe figé, avant le suffixe
+  // figé. Calculées post-retrait pour rester valides quel que soit oldIndex.
+  var lo = 0;
+  while (lo < rest.length && rest[lo] == null) {
+    lo++;
+  }
+  var hi = rest.length;
+  while (hi > lo && rest[hi - 1] == null) {
+    hi--;
+  }
+  if (lo >= hi) return null; // aucun autre onglet déplaçable.
+
+  final target = (newIndex > oldIndex ? newIndex - 1 : newIndex).clamp(lo, hi);
+  if (target == oldIndex) return null;
+  rest.insert(target, moved);
+  return [
+    for (final k in rest)
+      if (k != null) k,
+  ];
+}
+
+/// Garde-fou des réordres : ne pas réécrire l'ordre tant que les données
+/// d'appartenance (intérêts + sources) ne sont pas chargées — sinon un favori
+/// non matérialisé serait élagué de l'ordre (cf. `mergeVisibleReorder`).
+bool tourneeMembershipDataReady(WidgetRef ref) =>
+    ref.read(userInterestsProvider).valueOrNull != null &&
+    ref.read(userSourcesStateProvider).valueOrNull != null;
+
+/// Applique et persiste un réordre de la Tournée décrit par la séquence des
+/// clés **effectivement rendues** ([visibleOrderedKeys], dans leur nouvel
+/// ordre). No-op si les données d'appartenance ne sont pas prêtes.
+///
+/// Le réordre est non destructif : toute clé de l'ordre absente de
+/// [visibleOrderedKeys] (tuile non matérialisée, clé masquée, ou onglet figé
+/// comme `grille`) est préservée à sa position absolue.
+Future<void> persistTourneeEssentielReorder(
+  WidgetRef ref,
+  List<String> visibleOrderedKeys,
+) async {
+  if (!tourneeMembershipDataReady(ref)) return;
+
+  final notifier = ref.read(tourneeOrderPrefsProvider.notifier);
+  await notifier.markCustomized();
+  final prevOrder = ref.read(tourneeOrderPrefsProvider).order;
+  await notifier.setOrder(mergeVisibleReorder(prevOrder, visibleOrderedKeys));
+
+  final themeRefs = <FavoriteRef>[
+    for (final key in visibleOrderedKeys)
+      if (key.startsWith('theme:'))
+        ThemeFavoriteRef(slug: key.substring('theme:'.length)),
+  ];
+  final sourceIds = [
+    for (final key in visibleOrderedKeys)
+      if (key.startsWith('source:')) key.substring('source:'.length),
+  ];
+  await Future.wait([
+    syncTourneeThemePositions(ref, themeRefs),
+    syncSourcePositionsMerged(ref, sourceIds, essentiel: true),
+  ]);
+}
+
+/// Réordonne les `ThemeFavoriteRef` serveur en préservant veille/custom-topics.
+Future<void> syncTourneeThemePositions(
+  WidgetRef ref,
+  List<FavoriteRef> themeRefs,
+) async {
+  final interests = ref.read(userInterestsProvider).valueOrNull;
+  if (interests == null) return;
+  final themeSlots = interests.favorites.whereType<ThemeFavoriteRef>().length;
+  if (themeRefs.length != themeSlots) return;
+  var i = 0;
+  final merged = [
+    for (final f in interests.favorites)
+      f is ThemeFavoriteRef ? themeRefs[i++] : f,
+  ];
+  try {
+    await ref.read(userInterestsProvider.notifier).reorderFavorites(merged);
+  } catch (_) {
+    // best-effort.
+  }
+}
+
+/// Réassigne les positions serveur des sources favorites **sans jamais perdre**
+/// celles de l'autre section : `reorderFavorites` remplace toute la liste, donc
+/// on fusionne le sous-ensemble réordonné avec l'autre mode.
+Future<void> syncSourcePositionsMerged(
+  WidgetRef ref,
+  List<String> reorderedIds, {
+  required bool essentiel,
+}) async {
+  final sourcesState = ref.read(userSourcesStateProvider).valueOrNull;
+  if (sourcesState == null) return;
+  final tournee = ref.read(tourneeOrderPrefsProvider);
+  bool isEssentiel(String id) => tournee.sourceIsEssentiel(id);
+  final reorderedSet = reorderedIds.toSet();
+  final others = [
+    for (final f in [
+      ...sourcesState.favorites,
+    ]..sort((a, b) => a.position.compareTo(b.position)))
+      if ((essentiel ? !isEssentiel(f.sourceId) : isEssentiel(f.sourceId)) &&
+          !reorderedSet.contains(f.sourceId))
+        f.sourceId,
+  ];
+  final fullIds = essentiel
+      ? [...reorderedIds, ...others]
+      : [...others, ...reorderedIds];
+  final refs = [
+    for (var i = 0; i < fullIds.length; i++)
+      SourceFavoriteRef(sourceId: fullIds[i], position: i),
+  ];
+  try {
+    await ref.read(userSourcesStateProvider.notifier).reorderFavorites(refs);
+  } catch (_) {
+    // best-effort : l'ordre prefs reste appliqué.
+  }
+}

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -16,6 +16,7 @@ import 'package:go_router/go_router.dart';
 import 'package:haptic_feedback/haptic_feedback.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
 import '../../../config/routes.dart';
@@ -54,7 +55,9 @@ import '../providers/pending_feed_section_provider.dart';
 import '../providers/personalisation_cta_provider.dart';
 import '../providers/selected_edition_date_provider.dart';
 import '../providers/tournee_order_prefs_provider.dart'
-    show tourneeOrderPrefsProvider;
+    show isTourneeReorderableKey, tourneeOrderPrefsProvider;
+import '../providers/tournee_reorder_persistence.dart'
+    show persistTourneeEssentielReorder, reorderTourneeTabKeys;
 import '../services/auto_grow_nudge_scheduler.dart';
 import '../services/tournee_progress_service.dart'
     show TourneeProgressService;
@@ -85,6 +88,9 @@ const double _kStickyThreshold = 60.0;
 /// track (4) + refresh strip (2). **Must mirror the real sticky bar height** —
 /// it feeds the snap framing AND the fit budget ([usableViewportHeightProvider]).
 const double _kStickyBarHeight = 50.0;
+
+/// Flag one-shot du hint « maintiens un onglet pour réorganiser ta tournée ».
+const String _kDragHintSeenKey = 'tournee_header_drag_hint_seen_v1';
 
 /// px. Anti-crop safety inset for section-top snap anchors. Each snap `top` is
 /// pulled up by this much so a section poses a hair **below** the sticky header
@@ -276,6 +282,16 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
   // [_syncStickyEntries]).
   final List<GlobalKey> _stickyEntryKeys = [];
 
+  /// Derniers descripteurs d'onglets produits par [_syncStickyEntries], alignés
+  /// sur [_stickyEntryKeys]. Sert de référentiel au remappage index → clé
+  /// d'ordre lors d'un réordre par drag ([_onHeaderReorder]).
+  List<StickyTab> _stickyTabs = const [];
+
+  /// Un onglet du header est soulevé. Gèle l'auto-align de la rangée et le
+  /// suivi de section active : sans ça, un scroll résiduel recentrerait les
+  /// onglets sous le doigt en plein drag.
+  bool _headerDragging = false;
+
   /// Sliver « Grille du jour » (carte d'entrée de La Grille). Son insertion est
   /// pilotée par `FluxContinuState.grilleSlotIndex`. Wrappé dans un
   /// `KeyedSubtree(_grilleKey)` pour exposer la carte au suivi sticky.
@@ -357,6 +373,17 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
   DateTime? _lastPullHintAt;
   Timer? _pullHintTimer;
 
+  // Hint one-shot « maintiens un onglet pour réorganiser ». Affiché à la 1ʳᵉ
+  // révélation du header sticky comportant au moins deux onglets déplaçables,
+  // puis jamais plus (flag SharedPreferences). Rendu en overlay sous la barre
+  // sticky, donc sans impact sur `_kStickyBarHeight` ni sur les budgets de fit.
+  bool _showDragHint = false;
+
+  /// Pessimiste tant que les prefs ne sont pas lues : pas de hint sur un cold
+  /// boot où l'utilisateur l'a déjà vu.
+  bool _dragHintSeen = true;
+  Timer? _dragHintTimer;
+
   /// Story 9.8 — horodatages du dernier passage en arrière-plan et du dernier
   /// refresh au foreground, pour le cooldown anti-refresh-intempestif
   /// (cf. [shouldRefreshEssentielOnForeground]).
@@ -414,6 +441,40 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
       const Duration(seconds: 60),
       (_) => unawaited(_maybeTriggerAutoGrow()),
     );
+    unawaited(_loadDragHintSeen());
+  }
+
+  Future<void> _loadDragHintSeen() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      if (!mounted) return;
+      _dragHintSeen = prefs.getBool(_kDragHintSeenKey) ?? false;
+    } catch (_) {
+      // Pas de prefs (tests sans mock) → on reste silencieux.
+    }
+  }
+
+  /// Révèle une fois le hint de réorganisation, si le header expose au moins
+  /// deux onglets déplaçables. Marque le flag immédiatement (avant l'écriture
+  /// asynchrone) pour ne jamais le montrer deux fois dans la même session.
+  void _maybeShowDragHint() {
+    if (_dragHintSeen || _showDragHint) return;
+    var reorderable = 0;
+    for (final t in _stickyTabs) {
+      if (t.orderKey != null) reorderable++;
+    }
+    if (reorderable < 2) return;
+    _dragHintSeen = true;
+    unawaited(
+      SharedPreferences.getInstance()
+          .then((prefs) => prefs.setBool(_kDragHintSeenKey, true))
+          .catchError((Object _) => false),
+    );
+    setState(() => _showDragHint = true);
+    _dragHintTimer?.cancel();
+    _dragHintTimer = Timer(const Duration(milliseconds: 2400), () {
+      if (mounted) setState(() => _showDragHint = false);
+    });
   }
 
   @override
@@ -429,6 +490,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
     _activeIndex.dispose();
     _tallSections.dispose();
     _pullHintTimer?.cancel();
+    _dragHintTimer?.cancel();
     _autoGrowTimer?.cancel();
     super.dispose();
   }
@@ -459,6 +521,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
     final showSticky = currentScroll > _kStickyThreshold;
     if (_stickyVisible.value != showSticky) {
       _stickyVisible.value = showSticky;
+      if (showSticky) _maybeShowDragHint();
     }
     _updateActiveSection();
 
@@ -502,6 +565,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
 
   void _updateActiveSection() {
     if (_stickyEntryKeys.isEmpty) return;
+    if (_headerDragging) return;
     // Active = sticky entry that occupies the most visible area below the
     // sticky bar. The previous heuristic ("last section whose top has crossed
     // stickyBar + 200px lookahead") switched late on long sections because it
@@ -730,6 +794,9 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
   }
 
   void _alignTabsToActive(int index) {
+    // Gelé pendant un drag d'onglet : l'auto-align se battrait avec
+    // l'auto-scroll aux bords du `ReorderableListView`.
+    if (_headerDragging) return;
     if (!_tabsScroll.hasClients) return;
     void doScroll() {
       if (!_tabsScroll.hasClients) return;
@@ -1444,6 +1511,9 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
                 tabs: stickyTabs,
                 onTapTab: _scrollToSection,
                 tabsController: _tabsScroll,
+                onReorder: _onHeaderReorder,
+                onDragStart: () => _headerDragging = true,
+                onDragEnd: () => _headerDragging = false,
               ),
             // Pull-to-refresh discoverability pill.
             Positioned(
@@ -1461,6 +1531,24 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
                 ),
               ),
             ),
+            // Hint one-shot de réorganisation, posé sous la barre sticky (en
+            // overlay : ne consomme aucune hauteur de layout).
+            if (!isSkeleton && !isPastEdition)
+              Positioned(
+                top: 0,
+                left: 0,
+                right: 0,
+                child: SafeArea(
+                  bottom: false,
+                  child: IgnorePointer(
+                    child: AnimatedOpacity(
+                      duration: const Duration(milliseconds: 280),
+                      opacity: _showDragHint ? 1.0 : 0.0,
+                      child: const _HeaderDragHint(),
+                    ),
+                  ),
+                ),
+              ),
           ],
         ),
       ),
@@ -1503,9 +1591,16 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
         add(_grilleKey, _motDuJourTab);
       }
       final section = state.sections[i];
+      final key = sectionKey(section);
       add(
         _sectionKeys[i],
-        StickyTab(label: section.label, accent: section.accent),
+        StickyTab(
+          label: section.label,
+          accent: section.accent,
+          // Seules les vraies sections de la Tournée sont déplaçables ; le
+          // héros Essentiel, les alertes et les sujets Flâner restent figés.
+          orderKey: isTourneeReorderableKey(key) ? key : null,
+        ),
       );
       // Destination de snap dédiée juste après le hero (entrée virtuelle,
       // sans section réelle — retourne -1 dans _sectionIndexForStickyIndex).
@@ -1524,7 +1619,22 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
     _stickyEntryKeys
       ..clear()
       ..addAll(keys);
+    _stickyTabs = tabs;
     return tabs;
+  }
+
+  /// Réordre déclenché par le drag d'un onglet du header. Le remappage
+  /// index → clé (et la contrainte des zones figées) vit dans
+  /// [reorderTourneeTabKeys] ; la persistance est celle, partagée, de la sheet
+  /// « Composer ma Tournée ».
+  void _onHeaderReorder(int oldIndex, int newIndex) {
+    final visibleKeys = reorderTourneeTabKeys(
+      [for (final t in _stickyTabs) t.orderKey],
+      oldIndex,
+      newIndex,
+    );
+    if (visibleKeys == null) return;
+    unawaited(persistTourneeEssentielReorder(ref, visibleKeys));
   }
 
   Widget _buildContent(BuildContext context, FluxContinuState state) {
@@ -2410,6 +2520,9 @@ class _StickyHostOverlay extends StatelessWidget {
   final List<StickyTab> tabs;
   final ValueChanged<int> onTapTab;
   final ScrollController tabsController;
+  final void Function(int oldIndex, int newIndex) onReorder;
+  final VoidCallback onDragStart;
+  final VoidCallback onDragEnd;
 
   const _StickyHostOverlay({
     required this.stickyVisible,
@@ -2417,6 +2530,9 @@ class _StickyHostOverlay extends StatelessWidget {
     required this.tabs,
     required this.onTapTab,
     required this.tabsController,
+    required this.onReorder,
+    required this.onDragStart,
+    required this.onDragEnd,
   });
 
   @override
@@ -2442,9 +2558,61 @@ class _StickyHostOverlay extends StatelessWidget {
               onTapTab: onTapTab,
               tabsController: tabsController,
               showFilterBar: false,
+              onReorder: onReorder,
+              onDragStart: onDragStart,
+              onDragEnd: onDragEnd,
             ),
           );
         },
+      ),
+    );
+  }
+}
+
+/// Pill de découvrabilité du réordre par drag des onglets. Rendue une seule
+/// fois (cf. [_kDragHintSeenKey]), juste sous la barre sticky.
+class _HeaderDragHint extends StatelessWidget {
+  const _HeaderDragHint();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    return Padding(
+      padding: const EdgeInsets.only(top: _kStickyBarHeight + 10),
+      child: Center(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+          decoration: BoxDecoration(
+            color: colors.textPrimary.withValues(alpha: 0.92),
+            borderRadius: BorderRadius.circular(FacteurRadius.full),
+            boxShadow: const [
+              BoxShadow(
+                color: Color.fromRGBO(0, 0, 0, 0.18),
+                blurRadius: 12,
+                offset: Offset(0, 3),
+              ),
+            ],
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                PhosphorIcons.handGrabbing(PhosphorIconsStyle.bold),
+                size: 14,
+                color: colors.backgroundPrimary,
+              ),
+              const SizedBox(width: 8),
+              Text(
+                'Maintiens un onglet pour réorganiser ta tournée',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: colors.backgroundPrimary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -459,11 +459,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
   /// asynchrone) pour ne jamais le montrer deux fois dans la même session.
   void _maybeShowDragHint() {
     if (_dragHintSeen || _showDragHint) return;
-    var reorderable = 0;
-    for (final t in _stickyTabs) {
-      if (t.orderKey != null) reorderable++;
-    }
-    if (reorderable < 2) return;
+    if (!stickyTabsAllowReorder(_stickyTabs)) return;
     _dragHintSeen = true;
     unawaited(
       SharedPreferences.getInstance()
@@ -2569,6 +2565,58 @@ class _StickyHostOverlay extends StatelessWidget {
   }
 }
 
+/// Chrome partagée des pills de découvrabilité (drag des onglets,
+/// pull-to-refresh) : capsule pleine à coins ronds + ombre douce, icône +
+/// libellé. Seuls la couleur de fond/ombre, l'icône et le texte varient.
+class _HintPill extends StatelessWidget {
+  final Widget icon;
+  final String label;
+  final Color background;
+  final Color foreground;
+  final Color shadowColor;
+
+  const _HintPill({
+    required this.icon,
+    required this.label,
+    required this.background,
+    required this.foreground,
+    required this.shadowColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(FacteurRadius.full),
+        boxShadow: [
+          BoxShadow(
+            color: shadowColor,
+            blurRadius: 12,
+            offset: const Offset(0, 3),
+          ),
+        ],
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          icon,
+          const SizedBox(width: 8),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 12,
+              color: foreground,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 /// Pill de découvrabilité du réordre par drag des onglets. Rendue une seule
 /// fois (cf. [_kDragHintSeenKey]), juste sous la barre sticky.
 class _HeaderDragHint extends StatelessWidget {
@@ -2580,38 +2628,16 @@ class _HeaderDragHint extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.only(top: _kStickyBarHeight + 10),
       child: Center(
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
-          decoration: BoxDecoration(
-            color: colors.textPrimary.withValues(alpha: 0.92),
-            borderRadius: BorderRadius.circular(FacteurRadius.full),
-            boxShadow: const [
-              BoxShadow(
-                color: Color.fromRGBO(0, 0, 0, 0.18),
-                blurRadius: 12,
-                offset: Offset(0, 3),
-              ),
-            ],
+        child: _HintPill(
+          icon: Icon(
+            PhosphorIcons.handGrabbing(PhosphorIconsStyle.bold),
+            size: 14,
+            color: colors.backgroundPrimary,
           ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(
-                PhosphorIcons.handGrabbing(PhosphorIconsStyle.bold),
-                size: 14,
-                color: colors.backgroundPrimary,
-              ),
-              const SizedBox(width: 8),
-              Text(
-                'Maintiens un onglet pour réorganiser ta tournée',
-                style: TextStyle(
-                  fontSize: 12,
-                  color: colors.backgroundPrimary,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
-          ),
+          label: 'Maintiens un onglet pour réorganiser ta tournée',
+          background: colors.textPrimary.withValues(alpha: 0.92),
+          foreground: colors.backgroundPrimary,
+          shadowColor: const Color.fromRGBO(0, 0, 0, 0.18),
         ),
       ),
     );
@@ -2663,49 +2689,27 @@ class _PullToRefreshHintState extends State<_PullToRefreshHint>
     return Padding(
       padding: const EdgeInsets.only(top: 80),
       child: Center(
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
-          decoration: BoxDecoration(
-            color: colors.primary.withValues(alpha: 0.95),
-            borderRadius: BorderRadius.circular(FacteurRadius.full),
-            boxShadow: [
-              BoxShadow(
-                color: colors.primary.withValues(alpha: 0.25),
-                blurRadius: 12,
-                offset: const Offset(0, 3),
-              ),
-            ],
+        child: _HintPill(
+          icon: AnimatedBuilder(
+            animation: _bounceController,
+            builder: (context, child) {
+              final t = _bounceController.value;
+              final offset = math.sin(t * math.pi * 2) * 3.0;
+              return Transform.translate(
+                offset: Offset(0, offset),
+                child: child,
+              );
+            },
+            child: Icon(
+              PhosphorIcons.arrowDown(PhosphorIconsStyle.bold),
+              size: 14,
+              color: Colors.white,
+            ),
           ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              AnimatedBuilder(
-                animation: _bounceController,
-                builder: (context, child) {
-                  final t = _bounceController.value;
-                  final offset = math.sin(t * math.pi * 2) * 3.0;
-                  return Transform.translate(
-                    offset: Offset(0, offset),
-                    child: child,
-                  );
-                },
-                child: Icon(
-                  PhosphorIcons.arrowDown(PhosphorIconsStyle.bold),
-                  size: 14,
-                  color: Colors.white,
-                ),
-              ),
-              const SizedBox(width: 8),
-              const Text(
-                'Tirer pour rafraîchir',
-                style: TextStyle(
-                  fontSize: 12,
-                  color: Colors.white,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
-          ),
+          label: 'Tirer pour rafraîchir',
+          background: colors.primary.withValues(alpha: 0.95),
+          foreground: Colors.white,
+          shadowColor: colors.primary.withValues(alpha: 0.25),
         ),
       ),
     );

--- a/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/manage_favorites_sheet.dart
@@ -14,7 +14,6 @@ import '../../digest/providers/serein_toggle_provider.dart';
 import '../../feed/providers/tab_order_prefs_provider.dart';
 import '../../feed/widgets/favorite_topic_tabs.dart' show kMaxFavoriteTabs;
 import '../../my_interests/models/user_interests_state.dart';
-import '../../my_interests/models/user_sources_state.dart';
 import '../../my_interests/providers/user_interests_provider.dart';
 import '../../my_interests/providers/user_sources_state_provider.dart';
 import '../../sources/models/source_model.dart';
@@ -25,6 +24,7 @@ import '../../veille/providers/veille_active_config_provider.dart';
 import '../../veille/providers/veille_themes_provider.dart';
 import '../providers/flux_continu_provider.dart' show fluxContinuProvider;
 import '../providers/tournee_order_prefs_provider.dart' hide applyOrder;
+import '../providers/tournee_reorder_persistence.dart';
 import '../providers/tournee_smart_arrangement_provider.dart';
 import '../utils/theme_color_mapping.dart';
 import 'choice_tile.dart';
@@ -373,35 +373,15 @@ class _ManageFavoritesContentState
   /// Garde-fou des réordres : ne pas réécrire l'ordre tant que les données
   /// d'appartenance (intérêts + sources) ne sont pas chargées — sinon un favori
   /// non matérialisé serait élagué de l'ordre (cf. `mergeVisibleReorder`).
-  bool get _membershipDataReady =>
-      ref.read(userInterestsProvider).valueOrNull != null &&
-      ref.read(userSourcesStateProvider).valueOrNull != null;
+  bool get _membershipDataReady => tourneeMembershipDataReady(ref);
 
-  Future<void> _persistEssentielReorder(List<_FavItem> ordered) async {
-    if (!_membershipDataReady) return;
-
-    // Réordre non destructif : on ne permute que les clés rendues ; toute clé
-    // d'ordre non rendue cette frame (catalogue en cours, source absente du
-    // catalogue, clé masquée) est préservée à sa position. Seul `_onRemove`
-    // retire une clé.
-    final prevOrder = ref.read(tourneeOrderPrefsProvider).order;
-    final renderedKeys = ordered.map((e) => e.key).toList();
-    await ref
-        .read(tourneeOrderPrefsProvider.notifier)
-        .setOrder(mergeVisibleReorder(prevOrder, renderedKeys));
-    final themeRefs = <FavoriteRef>[
-      for (final e in ordered)
-        if (e.kind == _FavKind.theme) ThemeFavoriteRef(slug: e.id),
-    ];
-    final sourceIds = [
-      for (final e in ordered)
-        if (e.kind == _FavKind.source) e.id,
-    ];
-    await Future.wait([
-      _syncThemePositions(themeRefs),
-      _syncSourcePositionsMerged(sourceIds, essentiel: true),
-    ]);
-  }
+  /// Délègue au helper partagé — même séquence que le drag des onglets du
+  /// header sticky (cf. `tournee_reorder_persistence.dart`), zéro duplication.
+  Future<void> _persistEssentielReorder(List<_FavItem> ordered) =>
+      persistTourneeEssentielReorder(
+        ref,
+        [for (final e in ordered) e.key],
+      );
 
   Future<void> _persistFlanerReorder(List<_FavItem> ordered) async {
     // Même garde-fou + réordre non destructif que côté Essentiel (cf.
@@ -424,26 +404,8 @@ class _ManageFavoritesContentState
     ];
     await Future.wait([
       _syncTopicPositions(topicIds),
-      _syncSourcePositionsMerged(sourceIds, essentiel: false),
+      syncSourcePositionsMerged(ref, sourceIds, essentiel: false),
     ]);
-  }
-
-  /// Réordonne les `ThemeFavoriteRef` serveur en préservant veille/custom-topics.
-  Future<void> _syncThemePositions(List<FavoriteRef> themeRefs) async {
-    final interests = ref.read(userInterestsProvider).valueOrNull;
-    if (interests == null) return;
-    final themeSlots = interests.favorites.whereType<ThemeFavoriteRef>().length;
-    if (themeRefs.length != themeSlots) return;
-    var i = 0;
-    final merged = [
-      for (final f in interests.favorites)
-        f is ThemeFavoriteRef ? themeRefs[i++] : f,
-    ];
-    try {
-      await ref.read(userInterestsProvider.notifier).reorderFavorites(merged);
-    } catch (_) {
-      // best-effort.
-    }
   }
 
   /// Réordonne les `CustomTopicFavoriteRef` serveur en préservant thèmes/veille.
@@ -464,40 +426,6 @@ class _ManageFavoritesContentState
       await ref.read(userInterestsProvider.notifier).reorderFavorites(merged);
     } catch (_) {
       // best-effort.
-    }
-  }
-
-  /// Réassigne les positions serveur des sources favorites **sans jamais
-  /// perdre** celles de l'autre section : `reorderFavorites` remplace toute la
-  /// liste, donc on fusionne le sous-ensemble réordonné avec l'autre mode.
-  Future<void> _syncSourcePositionsMerged(
-    List<String> reorderedIds, {
-    required bool essentiel,
-  }) async {
-    final sourcesState = ref.read(userSourcesStateProvider).valueOrNull;
-    if (sourcesState == null) return;
-    final tournee = ref.read(tourneeOrderPrefsProvider);
-    bool isEssentiel(String id) => tournee.sourceIsEssentiel(id);
-    final reorderedSet = reorderedIds.toSet();
-    final others = [
-      for (final f in [
-        ...sourcesState.favorites,
-      ]..sort((a, b) => a.position.compareTo(b.position)))
-        if ((essentiel ? !isEssentiel(f.sourceId) : isEssentiel(f.sourceId)) &&
-            !reorderedSet.contains(f.sourceId))
-          f.sourceId,
-    ];
-    final fullIds = essentiel
-        ? [...reorderedIds, ...others]
-        : [...others, ...reorderedIds];
-    final refs = [
-      for (var i = 0; i < fullIds.length; i++)
-        SourceFavoriteRef(sourceId: fullIds[i], position: i),
-    ];
-    try {
-      await ref.read(userSourcesStateProvider.notifier).reorderFavorites(refs);
-    } catch (_) {
-      // best-effort : l'ordre prefs reste appliqué.
     }
   }
 

--- a/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
@@ -29,6 +29,19 @@ class StickyTab {
   const StickyTab({required this.label, required this.accent, this.orderKey});
 }
 
+/// Le réordre par drag n'a de sens qu'avec **≥2 onglets déplaçables** (sinon le
+/// seul onglet mobile n'a nulle part où aller, et le clamp le renverrait en
+/// queue). Source unique de vérité de cette règle, partagée par la rangée
+/// d'onglets ([_TabsRowState._reorderEnabled]) et la découvrabilité du geste
+/// côté écran (le hint one-shot). Court-circuite au 2ᵉ onglet réordonnable.
+bool stickyTabsAllowReorder(Iterable<StickyTab> tabs) {
+  var count = 0;
+  for (final t in tabs) {
+    if (t.orderKey != null && ++count >= 2) return true;
+  }
+  return false;
+}
+
 /// Sticky tab bar revealed once the user scrolls past the AppBar threshold.
 ///
 /// Layout per V6 maquette :
@@ -195,16 +208,8 @@ class _TabsRowState extends State<_TabsRow> {
   /// Un onglet est soulevé. Pilote l'atténuation des zones figées.
   bool _dragging = false;
 
-  /// Un réordre n'a de sens qu'avec ≥2 onglets déplaçables (sinon le seul
-  /// onglet mobile n'a nulle part où aller, et le clamp le renverrait en queue).
-  bool get _reorderEnabled {
-    if (widget.onReorder == null) return false;
-    var count = 0;
-    for (final t in widget.tabs) {
-      if (t.orderKey != null && ++count >= 2) return true;
-    }
-    return false;
-  }
+  bool get _reorderEnabled =>
+      widget.onReorder != null && stickyTabsAllowReorder(widget.tabs);
 
   void _setDragging(bool value) {
     if (_dragging == value) return;

--- a/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/sticky_tab_bar.dart
@@ -1,6 +1,8 @@
 import 'dart:math' as math;
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 
@@ -17,7 +19,14 @@ class StickyTab {
   final String label;
   final Color accent;
 
-  const StickyTab({required this.label, required this.accent});
+  /// Clé d'ordre Tournée (`theme:`/`source:`/`essentiel`/`bonnes`/`veille`)
+  /// quand l'onglet correspond à une section **réordonnable** ; `null` sinon
+  /// (carte héros Essentiel, Mot du jour, Citation, Fin de tournée, « Pour
+  /// toi », alertes). Non-null ⇒ l'onglet peut être soulevé au long-press dans
+  /// le header et sert de clé pour la persistance de l'ordre.
+  final String? orderKey;
+
+  const StickyTab({required this.label, required this.accent, this.orderKey});
 }
 
 /// Sticky tab bar revealed once the user scrolls past the AppBar threshold.
@@ -42,6 +51,17 @@ class StickyTabBar extends StatelessWidget {
   final ScrollController? tabsController;
   final bool showFilterBar;
 
+  /// Réordre par drag long-press d'un onglet. `null` ⇒ rangée non réordonnable
+  /// (comportement historique). Reçoit les index bruts de
+  /// `ReorderableListView` (`newIndex` exprimé dans l'espace d'insertion) ; le
+  /// remappage vers les clés d'ordre est fait par l'appelant.
+  final void Function(int oldIndex, int newIndex)? onReorder;
+
+  /// Bornes du drag, pour geler l'auto-align et le suivi de section actif tant
+  /// qu'un onglet est soulevé.
+  final VoidCallback? onDragStart;
+  final VoidCallback? onDragEnd;
+
   const StickyTabBar({
     super.key,
     required this.tabs,
@@ -49,6 +69,9 @@ class StickyTabBar extends StatelessWidget {
     required this.onTapTab,
     this.tabsController,
     this.showFilterBar = false,
+    this.onReorder,
+    this.onDragStart,
+    this.onDragEnd,
   });
 
   @override
@@ -67,6 +90,9 @@ class StickyTabBar extends StatelessWidget {
             activeIndex: activeIndex,
             onTapTab: onTapTab,
             controller: tabsController,
+            onReorder: onReorder,
+            onDragStart: onDragStart,
+            onDragEnd: onDragEnd,
           ),
           SizedBox(
             height: 4,
@@ -136,42 +162,192 @@ class _FeedRefreshIndicatorStrip extends ConsumerWidget {
   }
 }
 
-class _TabsRow extends StatelessWidget {
+/// Rangée d'onglets horizontale. Quand [onReorder] est fourni **et** qu'au
+/// moins deux onglets portent une `orderKey`, la rangée devient un
+/// `ReorderableListView` horizontal : un long-press (~900 ms) sur un onglet
+/// réordonnable le soulève, le glissement le repositionne. Les onglets figés
+/// (héros, Mot du jour, Citation, Fin de tournée) ne portent pas de listener de
+/// drag — ils sont donc non saisissables « gratuitement » et servent de bornes.
+class _TabsRow extends StatefulWidget {
   final List<StickyTab> tabs;
   final int activeIndex;
   final ValueChanged<int> onTapTab;
   final ScrollController? controller;
+  final void Function(int oldIndex, int newIndex)? onReorder;
+  final VoidCallback? onDragStart;
+  final VoidCallback? onDragEnd;
 
   const _TabsRow({
     required this.tabs,
     required this.activeIndex,
     required this.onTapTab,
     this.controller,
+    this.onReorder,
+    this.onDragStart,
+    this.onDragEnd,
   });
 
   @override
+  State<_TabsRow> createState() => _TabsRowState();
+}
+
+class _TabsRowState extends State<_TabsRow> {
+  /// Un onglet est soulevé. Pilote l'atténuation des zones figées.
+  bool _dragging = false;
+
+  /// Un réordre n'a de sens qu'avec ≥2 onglets déplaçables (sinon le seul
+  /// onglet mobile n'a nulle part où aller, et le clamp le renverrait en queue).
+  bool get _reorderEnabled {
+    if (widget.onReorder == null) return false;
+    var count = 0;
+    for (final t in widget.tabs) {
+      if (t.orderKey != null && ++count >= 2) return true;
+    }
+    return false;
+  }
+
+  void _setDragging(bool value) {
+    if (_dragging == value) return;
+    setState(() => _dragging = value);
+  }
+
+  @override
   Widget build(BuildContext context) {
+    // Compaction « cartes ≤ écran » : rangée d'onglets 48→44 (sync avec
+    // `_kStickyBarHeight` côté écran, qui alimente budget de fit ET snap).
+    const height = 44.0;
+    // Padding latéral 12 - 1 : l'espacement inter-onglets (ex-`separatorBuilder`
+    // de 2px) est désormais porté par chaque item (1px de chaque côté), car
+    // `ReorderableListView` n'accepte pas de séparateurs.
+    const padding = EdgeInsets.fromLTRB(11, 2, 11, 6);
+
+    if (!_reorderEnabled) {
+      return SizedBox(
+        height: height,
+        child: ListView.builder(
+          controller: widget.controller,
+          scrollDirection: Axis.horizontal,
+          padding: padding,
+          itemCount: widget.tabs.length,
+          itemBuilder: (context, i) => _buildTab(i, draggable: false),
+        ),
+      );
+    }
+
     return SizedBox(
-      // Compaction « cartes ≤ écran » : rangée d'onglets 48→44 (sync avec
-      // `_kStickyBarHeight` côté écran, qui alimente budget de fit ET snap).
-      height: 44,
-      child: ListView.separated(
-        controller: controller,
+      height: height,
+      child: ReorderableListView.builder(
+        scrollController: widget.controller,
         scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.fromLTRB(12, 2, 12, 6),
-        itemCount: tabs.length,
-        separatorBuilder: (_, __) => const SizedBox(width: 2),
-        itemBuilder: (context, i) {
-          return _Tab(
-            tab: tabs[i],
-            isActive: i == activeIndex,
-            isDone: i < activeIndex,
-            onTap: () => onTapTab(i),
-          );
+        padding: padding,
+        // Les poignées par défaut rendraient *tous* les onglets déplaçables ;
+        // on pose le listener nous-mêmes, uniquement sur les réordonnables.
+        buildDefaultDragHandles: false,
+        proxyDecorator: _proxyDecorator,
+        itemCount: widget.tabs.length,
+        onReorderStart: (_) {
+          HapticFeedback.mediumImpact();
+          _setDragging(true);
+          widget.onDragStart?.call();
         },
+        onReorderEnd: (_) {
+          HapticFeedback.selectionClick();
+          _setDragging(false);
+          widget.onDragEnd?.call();
+        },
+        onReorder: (oldIndex, newIndex) =>
+            widget.onReorder!(oldIndex, newIndex),
+        itemBuilder: (context, i) => _buildTab(i, draggable: true),
       ),
     );
   }
+
+  Widget _buildTab(int i, {required bool draggable}) {
+    final tab = widget.tabs[i];
+    final reorderable = draggable && tab.orderKey != null;
+    Widget child = Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 1),
+      child: _Tab(
+        tab: tab,
+        isActive: i == widget.activeIndex,
+        isDone: i < widget.activeIndex,
+        onTap: () => widget.onTapTab(i),
+      ),
+    );
+    if (_dragging && !reorderable) {
+      // Zones figées atténuées pendant le drag : lisible sans icône cadenas
+      // (minimalisme du « moment de fermeture »).
+      child = Opacity(opacity: 0.5, child: child);
+    }
+    return KeyedSubtree(
+      // Clé stable : la clé d'ordre pour les réordonnables (invariante au
+      // déplacement), la position + le libellé pour les onglets figés.
+      key: ValueKey(tab.orderKey ?? 'fixed:$i:${tab.label}'),
+      child: reorderable
+          ? _LongPressReorderListener(index: i, child: child)
+          : child,
+    );
+  }
+
+  /// Proxy « soulevé » : léger agrandissement + ombre portée + fond opaque,
+  /// pour que l'onglet se détache du backdrop parchemin pendant le drag.
+  Widget _proxyDecorator(Widget child, int index, Animation<double> animation) {
+    final colors = context.facteurColors;
+    return AnimatedBuilder(
+      animation: animation,
+      builder: (context, inner) {
+        // Mêmes courbe / amplitude que le `_DragProxy` de la sheet
+        // « Composer ma Tournée » : le soulèvement se lit pareil aux deux
+        // points d'entrée.
+        final t = Curves.easeInOut.transform(animation.value.clamp(0.0, 1.0));
+        return Transform.scale(
+          scale: 1 + 0.03 * t,
+          child: Container(
+            decoration: BoxDecoration(
+              color: Color.lerp(
+                Colors.transparent,
+                colors.backgroundPrimary,
+                t,
+              ),
+              borderRadius: const BorderRadius.all(
+                Radius.circular(FacteurRadius.small),
+              ),
+              boxShadow: [
+                BoxShadow(
+                  color: Color.fromRGBO(0, 0, 0, 0.18 * t),
+                  blurRadius: 12 * t,
+                  offset: Offset(0, 4 * t),
+                ),
+              ],
+            ),
+            // Le proxy est rendu dans l'Overlay, hors de l'arbre Material de
+            // la page : sans ce Material, l'InkWell de `_Tab` casse.
+            child: Material(type: MaterialType.transparency, child: inner),
+          ),
+        );
+      },
+      child: child,
+    );
+  }
+}
+
+/// `ReorderableDragStartListener` à délai long (~900 ms) : le défaut de
+/// `ReorderableDelayedDragStartListener` est de 500 ms et non paramétrable, ce
+/// qui entre en concurrence avec le scroll horizontal de la rangée. Le
+/// `DelayedMultiDragGestureRecognizer` annule aussi au moindre mouvement
+/// pendant le hold ⇒ un swipe reste un scroll, un tap reste une navigation.
+class _LongPressReorderListener extends ReorderableDragStartListener {
+  const _LongPressReorderListener({
+    required super.child,
+    required super.index,
+  });
+
+  @override
+  MultiDragGestureRecognizer createRecognizer() =>
+      DelayedMultiDragGestureRecognizer(
+        debugOwner: this,
+        delay: const Duration(milliseconds: 900),
+      );
 }
 
 class _Tab extends StatelessWidget {

--- a/apps/mobile/test/features/flux_continu/providers/tournee_reorder_remap_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/tournee_reorder_remap_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/flux_continu/providers/tournee_order_prefs_provider.dart';
+import 'package:facteur/features/flux_continu/providers/tournee_reorder_persistence.dart';
+
+/// Rangée type de la Tournée : héros figé, puis sections réordonnables, avec la
+/// Grille épinglée au milieu, et Citation / Fin de tournée figées en queue.
+const _row = <String?>[
+  null, // essentiel_v3 (héros)
+  'essentiel', // Actus du jour
+  null, // grille (Mot du jour)
+  'theme:tech',
+  'source:42',
+  'bonnes',
+  null, // citation
+  null, // fin de tournée
+];
+
+void main() {
+  group('isTourneeReorderableKey', () {
+    test('accepte les sections réellement déplaçables', () {
+      expect(isTourneeReorderableKey(kTourneeActusKey), isTrue);
+      expect(isTourneeReorderableKey(kTourneeBonnesKey), isTrue);
+      expect(isTourneeReorderableKey(kTourneeVeilleKey), isTrue);
+      expect(isTourneeReorderableKey(tourneeThemeKey('tech')), isTrue);
+      expect(isTourneeReorderableKey(tourneeSourceKey('42')), isTrue);
+    });
+
+    test('refuse héros, Grille, alertes et sujets Flâner', () {
+      expect(isTourneeReorderableKey('essentiel_v3'), isFalse);
+      expect(isTourneeReorderableKey(kTourneeGrilleKey), isFalse);
+      expect(isTourneeReorderableKey('alerts'), isFalse);
+      expect(isTourneeReorderableKey('topic:abc'), isFalse);
+    });
+  });
+
+  group('reorderTourneeTabKeys', () {
+    test('déplace une section vers la gauche', () {
+      // 'bonnes' (index 5) déposé juste avant 'theme:tech' (insertion à 3).
+      expect(
+        reorderTourneeTabKeys(_row, 5, 3),
+        ['essentiel', 'bonnes', 'theme:tech', 'source:42'],
+      );
+    });
+
+    test('déplace une section vers la droite (espace d\'insertion)', () {
+      // 'essentiel' (index 1) déposé après 'source:42' (insertion à 5).
+      expect(
+        reorderTourneeTabKeys(_row, 1, 5),
+        ['theme:tech', 'source:42', 'essentiel', 'bonnes'],
+      );
+    });
+
+    test('clampe un drop au-delà du héros au premier slot réordonnable', () {
+      expect(
+        reorderTourneeTabKeys(_row, 3, 0),
+        ['theme:tech', 'essentiel', 'source:42', 'bonnes'],
+      );
+    });
+
+    test('clampe un drop au-delà de la queue figée au dernier slot', () {
+      expect(
+        reorderTourneeTabKeys(_row, 1, 8),
+        ['theme:tech', 'source:42', 'bonnes', 'essentiel'],
+      );
+    });
+
+    test('refuse la saisie d\'un onglet figé', () {
+      expect(reorderTourneeTabKeys(_row, 0, 4), isNull);
+      expect(reorderTourneeTabKeys(_row, 2, 5), isNull);
+    });
+
+    test('no-op si la position ne change pas ou si l\'index est hors bornes',
+        () {
+      expect(reorderTourneeTabKeys(_row, 3, 3), isNull);
+      expect(reorderTourneeTabKeys(_row, 42, 1), isNull);
+      expect(reorderTourneeTabKeys(_row, -1, 1), isNull);
+    });
+
+    test('no-op avec un seul onglet déplaçable', () {
+      expect(reorderTourneeTabKeys(const [null, 'essentiel', null], 1, 3),
+          isNull);
+    });
+  });
+}

--- a/apps/mobile/test/features/flux_continu/widgets/sticky_tab_bar_reorder_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/sticky_tab_bar_reorder_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/flux_continu/widgets/sticky_tab_bar.dart';
+
+/// Rangée type : héros figé en tête, trois sections déplaçables, Citation figée
+/// en queue (cf. `_syncStickyEntries`).
+const _tabs = [
+  StickyTab(label: 'Ton Essentiel', accent: Color(0xFFB0470A)),
+  StickyTab(
+    label: 'Actus',
+    accent: Color(0xFFB0470A),
+    orderKey: 'essentiel',
+  ),
+  StickyTab(label: 'Tech', accent: Color(0xFF2C3E50), orderKey: 'theme:tech'),
+  StickyTab(
+    label: 'Bonnes nouvelles',
+    accent: Color(0xFF2E7D32),
+    orderKey: 'bonnes',
+  ),
+  StickyTab(label: 'Citation du jour', accent: Color(0xFFB8A898)),
+];
+
+Widget _wrap(Widget child) => ProviderScope(
+      child: MaterialApp(
+        theme: ThemeData(extensions: [FacteurPalettes.light]),
+        home: Scaffold(
+          body: Align(alignment: Alignment.topCenter, child: child),
+        ),
+      ),
+    );
+
+/// Simule un long-press (au-delà du délai de 900 ms du recognizer) suivi d'un
+/// glissement horizontal de [dx] pixels sur l'onglet [label].
+Future<void> _longPressDrag(
+  WidgetTester tester,
+  String label,
+  double dx,
+) async {
+  final gesture = await tester.startGesture(tester.getCenter(find.text(label)));
+  await tester.pump(const Duration(milliseconds: 1100));
+  // Déplacement fractionné : le proxy suit le doigt et la liste recalcule la
+  // position de drop à chaque frame.
+  for (var i = 0; i < 5; i++) {
+    await gesture.moveBy(Offset(dx / 5, 0));
+    await tester.pump(const Duration(milliseconds: 16));
+  }
+  await gesture.up();
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  group('StickyTabBar — réordre par drag', () {
+    testWidgets('un long-press-drag sur une section déplaçable réordonne',
+        (tester) async {
+      final calls = <List<int>>[];
+      await tester.pumpWidget(_wrap(
+        StickyTabBar(
+          tabs: _tabs,
+          activeIndex: 0,
+          onTapTab: (_) {},
+          onReorder: (o, n) => calls.add([o, n]),
+        ),
+      ));
+
+      await _longPressDrag(tester, 'Tech', -160);
+
+      expect(calls, isNotEmpty, reason: 'le drag doit produire un réordre');
+      expect(calls.single[0], 2, reason: 'index saisi = celui de « Tech »');
+      expect(calls.single[1], lessThan(2),
+          reason: 'un drag vers la gauche remonte l\'onglet');
+    });
+
+    testWidgets('un onglet figé n\'est pas saisissable', (tester) async {
+      final calls = <List<int>>[];
+      await tester.pumpWidget(_wrap(
+        StickyTabBar(
+          tabs: _tabs,
+          activeIndex: 0,
+          onTapTab: (_) {},
+          onReorder: (o, n) => calls.add([o, n]),
+        ),
+      ));
+
+      await _longPressDrag(tester, 'Ton Essentiel', 200);
+      await _longPressDrag(tester, 'Citation du jour', -200);
+
+      expect(calls, isEmpty);
+    });
+
+    testWidgets('un tap court navigue toujours (le drag ne vole pas le geste)',
+        (tester) async {
+      var tapped = -1;
+      final calls = <List<int>>[];
+      await tester.pumpWidget(_wrap(
+        StickyTabBar(
+          tabs: _tabs,
+          activeIndex: 0,
+          onTapTab: (i) => tapped = i,
+          onReorder: (o, n) => calls.add([o, n]),
+        ),
+      ));
+
+      await tester.tap(find.text('Tech'));
+      await tester.pumpAndSettle();
+
+      expect(tapped, 2);
+      expect(calls, isEmpty);
+    });
+
+    testWidgets('sans callback de réordre, la rangée reste une simple liste',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        StickyTabBar(tabs: _tabs, activeIndex: 0, onTapTab: (_) {}),
+      ));
+      expect(find.byType(ReorderableListView), findsNothing);
+      expect(find.text('Tech'), findsOneWidget);
+    });
+
+    testWidgets('un seul onglet déplaçable ⇒ pas de réordre possible',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        StickyTabBar(
+          tabs: const [
+            StickyTab(label: 'Ton Essentiel', accent: Color(0xFFB0470A)),
+            StickyTab(
+              label: 'Actus',
+              accent: Color(0xFFB0470A),
+              orderKey: 'essentiel',
+            ),
+          ],
+          activeIndex: 0,
+          onTapTab: (_) {},
+          onReorder: (_, __) {},
+        ),
+      ));
+      expect(find.byType(ReorderableListView), findsNothing);
+    });
+  });
+}

--- a/docs/stories/core/9.10.reorder-tournee-tabs-header.md
+++ b/docs/stories/core/9.10.reorder-tournee-tabs-header.md
@@ -1,0 +1,113 @@
+# Story 9.10 — Réordonner la Tournée du jour par drag des onglets du header
+
+**Type** : Feature · **Statut** : implémentée, en attente review · **Épic** : 9 (l'Essentiel / Tournée du jour)
+
+## Contexte
+
+L'ordre des sections de la « Tournée du jour » se réglait uniquement via la sheet
+« Composer ma Tournée » (`manage_favorites_sheet.dart`). Cette story ajoute un
+raccourci : un **long-press (~900 ms) sur un onglet de la barre sticky** le
+soulève et permet de le glisser pour le repositionner.
+
+Décisions PO :
+
+- Feature prod-ready (contraintes fines, feedback soigné), pas un spike.
+- **Coexiste** avec la sheet (drag rapide dans le header + sheet pour le réglage
+  fin Essentiel/Flâner).
+- **Seules les vraies sections réordonnables sont déplaçables** : thèmes,
+  sources, veille, Actus du jour, Bonnes Nouvelles. Le héros Essentiel reste
+  1ᵉʳ ; Mot du jour (Grille), Citation et Fin de tournée restent figés.
+
+## Implémentation
+
+### A. Persistance factorisée (zéro duplication)
+
+Nouveau `providers/tournee_reorder_persistence.dart` :
+
+- `persistTourneeEssentielReorder(ref, visibleOrderedKeys)` — séquence canonique
+  garde `tourneeMembershipDataReady` → `markCustomized()` →
+  `setOrder(mergeVisibleReorder(prev, visible))` → sync serveur thèmes/sources.
+- `syncTourneeThemePositions` / `syncSourcePositionsMerged` — déplacés depuis la
+  sheet, inchangés fonctionnellement.
+- `reorderTourneeTabKeys(orderKeys, oldIndex, newIndex)` — **fonction pure** de
+  remappage index → clés, avec le clamp des zones figées. Testée isolément.
+
+`manage_favorites_sheet._persistEssentielReorder` devient un wrapper de 3 lignes
+qui délègue au helper.
+
+> ⚠️ Seul écart de comportement côté sheet : un réordre appelle désormais
+> `markCustomized()` (il ne le faisait pas). C'est cohérent avec les autres
+> mutations (ajout/retrait) et évite qu'un compte neuf qui réordonne se fasse
+> ré-injecter les thèmes canoniques au reload.
+
+### B. Réordonnabilité portée par le descripteur
+
+- `StickyTab.orderKey` (`String?`) : non-null ⇒ onglet déplaçable, valeur = clé
+  d'ordre `tournee_order_v1`.
+- `isTourneeReorderableKey(String)` dans `tournee_order_prefs_provider.dart` —
+  source unique de vérité (`theme:` / `source:` / `essentiel` / `bonnes` /
+  `veille` ; exclut `essentiel_v3`, `grille`, `alerts`, `topic:`).
+- `_syncStickyEntries` renseigne `orderKey` depuis `sectionKey(section)`.
+
+### C. Geste
+
+`_TabsRow` devient un `ReorderableListView.builder` horizontal partageant le
+`_tabsScroll` existant (arbitrage scroll/tap/drag et auto-scroll aux bords
+natifs), avec `buildDefaultDragHandles: false` : seules les vraies sections
+portent un `_LongPressReorderListener` (recognizer
+`DelayedMultiDragGestureRecognizer(delay: 900ms)` — le défaut de 500 ms de
+`ReorderableDelayedDragStartListener` n'est pas paramétrable et entre en
+concurrence avec le scroll horizontal). Les onglets figés n'ont pas de listener
+⇒ non saisissables « gratuitement », et servent de bornes de drop.
+
+Repli : si `onReorder` est absent ou s'il y a moins de 2 onglets déplaçables, la
+rangée reste une `ListView` simple (comportement historique).
+
+### D. Contrainte de drop
+
+`reorderTourneeTabKeys` clampe la cible entre le premier et le dernier
+emplacement réordonnable *calculés après retrait de l'élément déplacé* ⇒ héros
+infranchissable en tête, Citation / Fin de tournée en queue. Les onglets figés
+**intérieurs** (Mot du jour, « Pour toi ») peuvent être traversés : ils se
+ré-épinglent à leur slot au rebuild suivant (petit « settle » visuel documenté,
+accepté).
+
+### E. Gel pendant le drag
+
+`_headerDragging` (posé par `onDragStart` / `onDragEnd`) coupe
+`_alignTabsToActive` et `_updateActiveSection` : sans ça l'auto-align se battrait
+avec l'auto-scroll aux bords du `ReorderableListView`.
+
+### F. Feedback & découvrabilité
+
+- Haptiques : `mediumImpact` au soulèvement, `selectionClick` au dépôt (comme la
+  sheet).
+- Proxy soulevé : `Transform.scale(1.03)` + fond opaque + ombre portée, animés
+  sur la courbe de drag.
+- Zones figées atténuées (opacité 0.5) pendant le drag ; pas d'icône cadenas
+  (minimalisme).
+- Hint one-shot `_HeaderDragHint` : flag SharedPreferences
+  `tournee_header_drag_hint_seen_v1`, pill « Maintiens un onglet pour réorganiser
+  ta tournée », affichée à la 1ʳᵉ révélation du sticky avec ≥2 onglets
+  déplaçables, auto-dismiss 2,4 s. **Rendue en overlay** (Positioned dans le
+  Stack de l'écran) et non dans la Column du sticky, pour ne consommer aucune
+  hauteur de layout et ne pas désaligner `_kStickyBarHeight` (budget fit + snap).
+
+## Fichiers
+
+| Fichier | Nature |
+|---|---|
+| `lib/features/flux_continu/providers/tournee_reorder_persistence.dart` | **nouveau** — persistance partagée + remappage pur |
+| `lib/features/flux_continu/providers/tournee_order_prefs_provider.dart` | `isTourneeReorderableKey` |
+| `lib/features/flux_continu/widgets/sticky_tab_bar.dart` | `StickyTab.orderKey`, `ReorderableListView`, recognizer, proxy, dimming |
+| `lib/features/flux_continu/screens/flux_continu_screen.dart` | wiring `orderKey`, `_headerDragging`, `_onHeaderReorder`, hint one-shot |
+| `lib/features/flux_continu/widgets/manage_favorites_sheet.dart` | délègue au helper (−90 lignes) |
+| `test/features/flux_continu/providers/tournee_reorder_remap_test.dart` | **nouveau** — 9 tests purs (prédicat + remappage/clamp) |
+| `test/features/flux_continu/widgets/sticky_tab_bar_reorder_test.dart` | **nouveau** — 5 tests widget (drag, onglets figés, tap, replis) |
+
+## Vérification
+
+- `flutter analyze` : 0 error / 0 warning (les 527 `info` sont des dépréciations
+  pré-existantes hors périmètre).
+- `flutter test` : 14 nouveaux tests verts ; les tests `StickyTabBar` existants
+  restent verts ; pas de régression au-delà de la baseline mobile connue.


### PR DESCRIPTION
## Quoi

Ajoute un raccourci de réorganisation de la **Tournée du jour** : un **long-press (~900 ms) sur un onglet de la barre sticky** le soulève et permet de le glisser pour le repositionner. Coexiste avec la sheet « Composer ma Tournée » (drag rapide dans le header + sheet pour le réglage fin Essentiel/Flâner).

Seules les vraies sections réordonnables sont déplaçables (thèmes, sources, veille, Actus du jour, Bonnes Nouvelles) ; le héros Essentiel reste 1ᵉʳ, Mot du jour / Citation / Fin de tournée restent figés et servent de bornes de drop.

## Pourquoi

L'ordre des sections ne se réglait qu'via la sheet. Story 9.10 (Épic 9 — l'Essentiel / Tournée du jour) : décision PO d'un geste prod-ready, découvrable, cohérent avec le reste des mutations d'ordre.

## Comment ça a été implémenté (points saillants)

- **Persistance factorisée** : nouveau `tournee_reorder_persistence.dart` (`persistTourneeEssentielReorder` + `reorderTourneeTabKeys` pur/testé) ; `manage_favorites_sheet` délègue désormais (−~90 lignes). Réutilise `mergeVisibleReorder` existant.
- **Réordonnabilité portée par le descripteur** `StickyTab.orderKey`, prédicat unique `isTourneeReorderableKey`.
- **Geste** : `ReorderableListView` horizontal partageant le `_tabsScroll`, recognizer `DelayedMultiDragGestureRecognizer(900ms)`, gel de l'auto-align pendant le drag.
- **Simplify** : `stickyTabsAllowReorder()` (source unique du seuil ≥2 onglets) + `_HintPill` partagée entre le hint de réordre et le hint pull-to-refresh.

## Comment ça a été vérifié

- [x] `flutter test` — suite complète `+1894 -27` = **baseline mobile connue**, aucune régression dans flux_continu / sticky / reorder / tournee
- [x] 14 nouveaux tests verts (9 remap pur + clamp, 5 widget drag/figé/tap/replis)
- [x] `flutter analyze` — 0 nouvel error/warning sur les fichiers touchés
- [x] `/simplify` passé (2 dédups appliquées, behavior-preserving)
- [ ] Playwright / QA web — **skippé** (décision PO) : geste sur canvas CanvasKit déjà couvert par les tests widget

## Zones à risque

- `manage_favorites_sheet.dart` : refactor de la persistance + **nouvel appel `markCustomized()` au réordre** (seul écart de comportement, volontaire — évite la ré-injection des thèmes canoniques au reload).
- Arbitrage scroll / tap / drag dans le header sticky (`sticky_tab_bar.dart`).

## Suivi recommandé (hors PR)

- Le hint one-shot utilise un flag SharedPreferences dédié plutôt que le `nudgeCoordinatorProvider` : il échappe au budget/cooldown des nudges. Migration à évaluer si collision constatée.
- `isTourneeReorderableKey` et la liste réordonnable de la sheet restent deux énumérations parallèles (SSOT nominal) : converger si dérive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
