### PR TITLE
feat(api): cache feed observable, correct et ciblé (PR 2)

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,109 +1,158 @@
-# feat(feedback): invitation « un café en visio » visible, humaine et actionnable (story 13.3)
+# feat(api): cache feed observable, correct et ciblé (PR 2)
 
-Base `main`. **Aucune migration.**
+Base `main`. **Aucune migration.** Backend-only (0 fichier mobile).
 
-L'invitation à un call qualitatif (Epic 13) ne convertissait pas : **jamais vue**,
-**lien de booking mort**, ton froid, et une carte de clôture qui dépassait l'écran.
-Cette PR la remet en état de marche.
+## Résumé
 
-## Ce qui n'allait pas (vérifié dans le code)
+PR 2 du plan « Accélérer et fiabiliser l'écran Essentiel ». L'écran Essentiel est
+lent : chaque cold-open fait un fan-out de 10 à 14 `GET /api/feed?personalized=true`,
+chacun payant le pipeline de scoring complet sur 1 seul worker uvicorn.
 
-| # | Symptôme | Cause racine |
-|---|---|---|
-| 1 | Invitation jamais vue | Le teaser vivait dans la **toute dernière boîte de la page** (`ClosingCardV18.secondary`), sous le vote emoji et sous `DailyCompletionRecap`. Il fallait scroller jusqu'au bout **puis** taper pour révéler la modale. |
-| 2 | 0 RDV pris | `ExternalLinks.calendlyUrl` était un placeholder jamais remplacé, avec son `TODO(laurin)`. Lien mort. |
-| 3 | Ton froid | Avatar = `CircleAvatar('👋')`, copy signée « Laurin » seul, ask à « 15 min ». |
-| 4 | Carte trop haute | La résolution de l'invite ajoutait Divider + teaser (~+90 px) dans une boîte déjà chargée → hors budget `section_fit`. |
-| 5 | Deux boutons redondants | « 15 min, je suis curieux » et « J'ai un truc précis à te dire » appelaient **tous les deux** `_accept`. |
-| 6 | Compteur d'affichages faussé | `markInviteShown()` partait au **build** de la carte de clôture : le cap `MAX_SHOWS=2` se consommait sur des affichages que personne n'avait vus. |
+Un cache existait (`app/services/feed_cache.py`, clé `(user, variant)`, TTL 60 s)
+mais était **neutralisé en pratique** : `invalidate(user_id)` purge *tous* les
+variants du user, et l'écriture dominante est `POST /contents/{id}/status` en
+`SEEN`, émise **à chaque scroll**. Scroller trois articles vidait le cache des
+~12 sections de la Tournée.
 
-## Ce que fait la PR
+Doc : `docs/maintenance/maintenance-essentiel-loading-speed.md` (décisions +
+protocole de vérification staging).
 
-**Placement (le vrai fix du #1).** L'invitation quitte la carte de clôture et
-devient une entrée slim (`CallInviteEntry`) ancrée **2 sections avant la fin** de
-la Tournée : `inviteTargetIndex = max(1, sections.length - 3)`, jamais sur le hero
-Essentiel. Elle est rendue **dans le `KeyedSubtree` de sa section** (pattern de
-`MyInterestsIntro`) : un sliver autonome serait orphelin entre deux ancres de snap.
-Le micro-vote emoji, lui, reste en fin de Tournée (c'est une note *sur* la tournée).
+PR 1 (`#1017`, mergée) a traité le volet mobile « Sources favorites toujours
+rendues + attente lisible ».
 
-**Auto-déploiement une fois.** À la première exposition **réellement visible**
-(`VisibilityDetector` ≥ 50 %, pas au build), la modale s'ouvre seule, gardée par
-`NudgeIds.feedbackCallAutoModal` (`frequency: once`). Ensuite, seule l'entrée
-inline subsiste et le tap la rouvre. `markInviteShown()` migre sur cette même
-garde de visibilité (fix #6).
+## 1. Observabilité — la baseline, à lire avant de toucher au TTL
 
-**Modale humaine.** `FounderCollage` (nos deux vraies photos) + tampon
-« TON AVIS COMPTE » + copy dans le ton « Nous soutenir », signée « Django &
-Laurin, tes facteurs ». Ask ramené de 15 min à « un café en visio, 5 minutes ».
-Toute la copy vit dans un `FeedbackCallCopy` unique (modèle `SoutienCopy`), zéro
-em-dash. Titre unique tous segments, deux corps seulement (`active` vs
-« Tu ouvres parfois Facteur » pour `low_active`/`returning`).
+- `app/routers/feed.py` : un log structlog `feed_request` par requête —
+  `cache=hit|miss|bypass`, `variant_class=default|personalized|none`,
+  `duration_ms`, `items`. Avant, `feed_total` n'était émis que par
+  `_compute_feed` : **un hit ne produisait aucun log**, le hit rate était
+  invisible. `items` seulement sur miss/bypass (le compter sur un hit imposerait
+  un `json.loads` du payload sur le chemin rapide).
+- `app/main.py` : `GET /api/health/feed-cache`, calqué sur `/api/health/pool`,
+  avec deux écarts assumés :
+  - **gate par header `X-Health-Token`** (`hmac.compare_digest`) quand
+    `HEALTH_METRICS_TOKEN` est configuré — nouveau champ `health_metrics_token`
+    dans `Settings` (`app/config.py`), à côté de `admin_api_token`. `size` est un
+    proxy du nombre d'users actifs. Sans le secret (staging), l'endpoint reste
+    **ouvert** : fail-open assumé, à l'inverse de `require_admin_token` qui est
+    fail-closed ;
+  - `uptime_seconds` ajouté à `stats()` : les compteurs sont cumulatifs depuis le
+    boot, donc le hit rate se lisse et masquerait une régression. La lecture se
+    fait sur le **delta de deux échantillons**.
 
-**Trois sorties nettes** (fin du #5) : « Prendre un café » (`accepted` + ouverture
-du **vrai** lien Google Agenda), « Plus tard » (`declined`, snooze 21 j), et
-**« On l'a déjà fait »** (`already_done`, nouveau statut terminal côté backend).
-Après une sortie, `inviteStatusProvider` est invalidé : l'entrée disparaît tout de
-suite au lieu de laisser traîner un CTA qu'on vient d'écarter.
+## 2. Correction préalable : les générations (bug pré-existant)
 
-**Carte de clôture compactée** (#4) : le départ de l'invitation libère ~125 px, et
-le micro-vote est resserré (emoji 30 → 24, gaps et paddings réduits) pour ~45 px de
-plus. `FeedbackClosingCard` redevient un `StatelessWidget` ; le tampon dupliqué
-entre carte et modale est extrait en `FeedbackStamp`.
+Sous le lock single-flight, `_compute_feed` prend 1,5 à 5 s puis `put()` écrivait
+**inconditionnellement**. Une `invalidate` arrivant dans cette fenêtre était
+écrasée : **un article masqué pouvait réapparaître** jusqu'à expiration du TTL.
 
-**Funnel analytics** (il n'y en avait aucun) : `feedback_invite_shown` /
-`_opened` (origin `auto`|`tap`) / `_booked` / `_snoozed` / `_already_done`, avec
-`segment`, en `_logEvent` + `_capturePostHog`.
+Le bug existait déjà, mais l'invalidation ciblée l'aggraverait (elle inspecte le
+payload *en cache*, l'ancien, alors que le payload en cours de calcul contient
+l'article ⇒ faux négatif systématique dans la fenêtre) et un TTL plus long
+multiplierait la durée du symptôme. Corrigé **avant** de scoper.
 
-## Backend
+`generation(user_id)` renvoie `(compteur du user, compteur global)` — le second
+sert aux invalidations cross-user, dont le rayon d'action inclut des users sans
+entrée en cache. Le endpoint le capture juste avant `_compute_feed` et le repasse
+à `put()`, qui droppe l'écriture si le couple a bougé. Un compteur global seul
+aurait laissé l'écriture d'un user annuler le `put()` en vol de tous les autres,
+soit en permanence avec le SEEN à chaque scroll.
 
-Nouvelle action terminale `already_done` dans `submit_invite_action`, ajoutée au
-set des statuts terminaux de `get_invite_status`, autorisée par le pattern du
-schéma. Gating inchangé (`classify_segment`, `SNOOZE_DAYS`, `MAX_SHOWS`) : le
-problème n'était pas le gating.
+## 3. Invalidation content-scoped, limitée aux sites prouvés sûrs
 
-**Aucune migration Alembic** : `FeedbackInvite.status` est un `String(20)` libre,
-pas une enum PG. 1 head, inchangé.
+`invalidate_content(user_id, content_id)` ne purge que les variants du user
+**dont le payload mentionne l'id** (scan d'octets, ~50 µs pour 12 variants).
 
-## Vérification
+> Pourquoi un scan d'octets plutôt qu'un `frozenset` d'ids capturé au `put()` :
+> le set exigerait un walk qui connaît le schéma (`items`, `carousels[].items`,
+> `clusters[]…`) et **manquerait silencieusement** les items imbriqués ⇒ faux
+> négatifs, donc contenu périmé servi après écriture. Le scan est agnostique du
+> schéma et son seul mode d'échec est le faux positif (une purge en trop,
+> inoffensive). Le risque réel, une évolution de sérialisation qui casserait le
+> match en silence, est épinglé par `test_cached_payload_item_ids_match_str_uuid`.
 
-- `pytest tests/test_feedback_router.py` → **22 passed** (2 tests ajoutés :
-  `already_done` terminal côté GET et côté POST, sans snooze résiduel).
-- Suite backend complète : 1996 passed. Le 1 failed + 554 errors sont tous des
-  `OperationalError`/`InterfaceError` sur `localhost:54322` (DB de test locale
-  éteinte), faux négatif documenté, aucun lié à cette story.
-- `ruff check` / `ruff format` OK sur les 4 fichiers Python touchés.
-- `flutter analyze` → **0 erreur**. `flutter test` → **1857 passed / 27 failed**,
-  soit exactement la baseline pré-existante du repo. Run ciblé
-  `feedback` + `flux_continu` + `soutien` → **496 passed**, aucun échec.
-- 14 tests sur la feature, dont 4 nouveaux sur `CallInviteEntry` (non éligible =
-  rien rendu ; entrée + `markInviteShown` sur visibilité ; auto-ouverture **une
-  seule fois** ; tap rouvre).
-- Passe `simplify` : `_trackFeedbackInvite` prend un `extra` (les 4 wrappers
-  d'event redeviennent des one-liners) et les 3 sorties passent par un seul
-  `trackFeedbackInviteAction(action)` piloté par la table
-  action → event ; `TERMINAL_ACTIONS` / `TERMINAL_STATUSES` remplacent les
-  tuples de statuts recopiés dans le routeur ; `entryCta` fusionné dans
-  `ctaBook`. Tests re-passés après coup.
+**Le point critique, c'est le périmètre.** Vérifié dans `content_service.py` :
+like, save, hide, note upsert et la transition CONSUMED mutent
+`UserSubtopic.weight` et `UserEntityAffinity.affinity`, qui alimentent le scoring
+de *toutes* les sections. Les scoper laisserait un **classement** périmé partout.
+On ne les touche pas.
 
-### Gotcha noté pour la suite
+| Site | Après |
+|---|---|
+| `update_content_status` **sans** transition consumed (SEEN au scroll) | `invalidate_content` ← **le gain principal** |
+| `impress_content` (n'écrit que `manually_impressed`/`last_impressed_at`) | `invalidate_content` |
+| `unsave_content` / `unhide_content` (aucun poids ajusté) | `invalidate_content` |
+| `delete_note` — **n'invalidait rien** | `invalidate_content` (bug fix) |
+| like/unlike, save, hide, feedback, status→CONSUMED | `invalidate()` inchangé |
+| `upsert_note` — **n'invalidait rien**, or il boost les poids | `invalidate()` (bug fix) |
+| `report_not_serene` — **n'invalidait rien**, et `is_serene=False` est un flip **global cross-user** | `invalidate_content_global` (bug fix) |
+| les 27 autres sites (mute, follow, prefs, custom topics, refresh…) | inchangés |
 
-`addPostFrameCallback` posé **depuis** le callback de `VisibilityDetector` ne se
-rejoue jamais (aucune frame supplémentaire n'est planifiée) : rien ne partait, y
-compris en test. `Future.microtask` sort de la passe de rendu sans dépendre d'une
-frame.
+Deux garde-fous notables :
 
-### Reste à faire avant merge
+- **Ne pas purger `_locks` dans `invalidate*`** : retirer un `Lock` détenu par
+  des waiters casserait le single-flight, soit le thundering herd que ce cache
+  existe pour éviter. Gardé par `test_invalidate_keeps_locks_alive`.
+- Faux négatif résiduel borné par le TTL : le payload caché est une tranche
+  top-N ; une action sur un article hors-tranche ne purge pas la variante, ce qui
+  est correct puisqu'il n'était pas affiché.
 
-**Non joué faute d'environnement** (Docker indisponible sur la machine, donc pas
-de DB de test locale sur `localhost:54322` ni d'API locale à interroger) :
+## Décisions documentées (ce qui ne change PAS)
 
-- `uvicorn` + `curl` sur `POST /feedback/invite/action {"action":"already_done"}`
-  puis `GET /feedback/invite`. Couvert en tests unitaires (2 tests dédiés), pas
-  en bout-en-bout HTTP.
-- Passe Playwright (`facteur-qa-web`, 390x844) : entrée visible sans scroller
-  jusqu'au bout, auto-ouverture unique, photos rendues, ouverture du lien Google
-  Agenda, carte de clôture sans overflow. Scénarios détaillés dans
-  `.context/qa-handoff.md` → lancer `/validate-feature` depuis une machine avec
-  Docker.
+- **`--workers 2` : non.** Le cache est in-process et `invalidate` est
+  process-local : avec 2 workers, un `POST /hide` traité par le worker A ne purge
+  pas le cache du worker B ⇒ l'article masqué réapparaît. Idem
+  `_analysis_cache` / `_perspectives_cache`. Condition de réouverture :
+  invalidation partagée (Redis pub/sub). Et si le besoin est du parallélisme CPU,
+  la vraie réponse est de sortir le scoring du chemin requête.
+- **`FEED_CACHE_PERSONALIZED_TTL_SECONDS=300` : hors PR.** Étape ops Railway, à
+  faire **après** lecture du hit rate réel. Défaut code inchangé à 60 s.
+- `degraded_fallback` dans `FeedResponse` : abandonné (champ additif sans
+  consommateur UI ; le log `feed_request` couvre le besoin).
+- `profile_feed_latency.py` : pas réécrit — il bypasse le endpoint *et* le cache.
 
-Story : `docs/stories/core/13.3.invitation-feedback-humaine.story.md`
+## Tests
+
+- `tests/services/test_feed_cache.py` : +18 unitaires — invalidation ciblée /
+  globale, générations (stale droppé, per-user, bump même sans purge), garde
+  anti-régression sur `_locks`, `uptime_seconds`.
+- `tests/routers/test_feed_cache_invalidation_sites.py` (nouveau) : épingle
+  **quels endpoints purgent tout et lesquels ciblent**, plus l'invariant de
+  sérialisation dont dépend le scan d'octets.
+- `tests/test_health_feed_cache.py` (nouveau) : métriques exposées, fail-open
+  sans secret, 404 avec secret configuré.
+- `tests/test_feed_personalized_cache.py` : +3 sur le log `feed_request`
+  (miss→hit, classe default, bypass paginé).
+- Suite complète backend : **2648 passed, 18 skipped, 2 xfailed**.
+- `ruff check` + `ruff format --check` OK sur les fichiers touchés ;
+  `alembic heads` = 1 head (`sa02_alerts_v2`).
+- Smoke live `uvicorn` : `/api/health/feed-cache` → 200 sans secret,
+  `uptime_seconds` croissant sur deux échantillons ; avec `HEALTH_METRICS_TOKEN`
+  posé → 404 sans header, 404 avec mauvais token, 200 avec le bon.
+
+## Vérification sur staging (après déploiement)
+
+1. Deux lectures de `/api/health/feed-cache` encadrant une ouverture d'app → hit
+   rate sur le **delta**.
+2. `grep 'feed_request'` dans les logs Railway sur 5 min d'usage réel.
+3. **Scroller 3 articles puis rouvrir la Tournée < 60 s** → sections servies du
+   cache. C'est le scénario que cette PR débloque.
+4. `hide` un article visible + pull-to-refresh immédiat → il ne revient pas (test
+   des générations).
+5. Deux comptes en mode serein : A signale non-serein, B pull-to-refresh →
+   l'article disparaît chez B.
+
+Puis seulement : poser `FEED_CACHE_PERSONALIZED_TTL_SECONDS=300` et re-mesurer.
+
+## Suivi post-merge (hors PR)
+
+- `HEALTH_METRICS_TOKEN` n'est pas configuré sur Railway : l'endpoint sera
+  **ouvert** sur staging (fail-open documenté). À décider avant que `production`
+  n'avance.
+- PR 3 (SWR client par section) : périmètre réel et ses **trois bloquants**
+  (reseed nu qui détruirait l'hydratation, sections source non hydratées,
+  `_dismissedIds` en mémoire seule) documentés en fin de doc maintenance.
+
+## Hors périmètre
+
+Aucun changement mobile, aucune migration DB, aucun changement de TTL.

--- a/docs/maintenance/maintenance-essentiel-loading-speed.md
+++ b/docs/maintenance/maintenance-essentiel-loading-speed.md
@@ -1,0 +1,232 @@
+# Maintenance : vitesse de chargement de l'Essentiel (Tournée du jour)
+
+**Date :** 2026-07-29
+**Classification :** MAINTENANCE
+**Branche :** `boujonlaurin-dotcom/essentiel-loading-speed`
+
+---
+
+## Problème
+
+L'écran Essentiel est lent à l'ouverture. Chaque cold-open déclenche un fan-out
+client de 10 à 14 `GET /api/feed?personalized=true` (une par section), chacun
+payant le pipeline de scoring complet sur **1 seul worker uvicorn**.
+
+Un cache applicatif existe pourtant (`app/services/feed_cache.py`, clé
+`(user, variant)`, TTL 60 s pour les variantes personnalisées) — mais il était
+**neutralisé en pratique** :
+
+- `invalidate(user_id)` purge *tous* les variants du user, et il était appelé
+  depuis 36 sites d'écriture ;
+- or l'écriture dominante est `POST /contents/{id}/status` en `SEEN`, émise **à
+  chaque scroll**.
+
+Autrement dit : scroller trois articles suffisait à annihiler le cache des
+~12 sections de la Tournée, donc le cache ne servait quasiment jamais.
+
+---
+
+## Découpage
+
+| PR | Périmètre | État |
+|---|---|---|
+| PR 1 (`e8c9fbaa`) | Sections « Sources favorites » toujours rendues + attente lisible (shimmer) | mergée |
+| **PR 2 (ce doc)** | Backend : cache feed observable, correct sous écriture concurrente, et invalidation ciblée | cette PR |
+| PR 3 | SWR client par section (hydratation) — voir « Périmètre réel de PR 3 » plus bas | à faire |
+
+PR 2 et PR 3 restent séparées : zéro fichier et zéro test en commun, cycles de
+validation disjoints (backend = redéploiement Railway 2 min ; mobile = QA device
+réel puis build), et surtout **la mesure doit précéder le jugement** — il faut
+lire le hit rate réel sur staging avant de décider du TTL et de l'ampleur du
+volet client.
+
+---
+
+## Ce que fait PR 2
+
+### 1. Observabilité (la baseline)
+
+- **`app/routers/feed.py`** — un log structlog `feed_request` par requête :
+  `cache=hit|miss|bypass`, `variant_class=default|personalized|none`,
+  `duration_ms`, `items`. Avant, `feed_total` n'était émis que par
+  `_compute_feed` : **un hit ne produisait aucun log**, le hit rate était
+  invisible. `items` n'est renseigné que sur miss/bypass (le compter sur un hit
+  imposerait un `json.loads` du payload sur le chemin rapide).
+  `variant_class` seulement, pas le variant complet : bruit.
+- **`app/main.py`** — `GET /api/health/feed-cache`, calqué sur
+  `/api/health/pool`, avec deux écarts assumés :
+  - **gate par header `X-Health-Token`** (comparaison `hmac.compare_digest`)
+    quand le secret `HEALTH_METRICS_TOKEN` est configuré — déclaré comme
+    `health_metrics_token` dans `Settings` (`app/config.py`), à côté de
+    `admin_api_token`. `size` est un proxy du nombre d'users actifs. Sans le
+    secret (staging), l'endpoint reste ouvert : fail-**open** assumé, à
+    l'inverse de `require_admin_token` qui est fail-closed ;
+  - `uptime_seconds` ajouté à `stats()` : les compteurs sont cumulatifs depuis
+    le boot, donc le hit rate se lisse et masquerait une régression. La QA prend
+    **deux échantillons et calcule le delta**.
+
+### 2. Correction : les générations (bug pré-existant)
+
+Sous le lock single-flight, `_compute_feed` prend 1,5 à 5 s puis `put()`
+écrivait **inconditionnellement**. Une `invalidate` arrivant dans cette fenêtre
+était écrasée ⇒ **un article masqué pouvait réapparaître** jusqu'à expiration du
+TTL.
+
+Le bug existait déjà, mais l'invalidation ciblée l'aggraverait (elle inspecte le
+payload *en cache*, l'ancien, alors que le payload *en cours de calcul* contient
+l'article ⇒ faux négatif systématique dans la fenêtre), et un TTL plus long
+multiplierait la durée du symptôme.
+
+Fix : `generation(user_id)` renvoie le couple `(compteur du user, compteur
+global)` — le second sert aux invalidations cross-user, dont le rayon d'action
+inclut des users sans entrée en cache. Le endpoint le capture **juste avant**
+`_compute_feed` et le repasse à `put()`, qui droppe l'écriture si le couple a
+bougé. Un compteur global seul aurait laissé l'écriture d'un user annuler le
+`put()` en vol de tous les autres — soit, avec le SEEN à chaque scroll, en
+permanence.
+
+### 3. Invalidation content-scoped, limitée aux sites prouvés sûrs
+
+`FeedPageCache.invalidate_content(user_id, content_id)` ne purge que les
+variants du user **dont le payload contient l'id**.
+
+> **Pourquoi un scan d'octets plutôt qu'un `frozenset` d'ids capturé au `put()`**
+> — le set exigerait un walk qui connaît le schéma (`items`,
+> `carousels[].items`, `clusters[]…`) et **manquerait silencieusement** les items
+> imbriqués ⇒ faux négatifs (contenu périmé servi après écriture). Le scan est
+> agnostique du schéma, son seul mode d'échec est le faux positif (une purge en
+> trop, inoffensive), et il coûte ~50 µs pour 12 variants. Le risque réel (une
+> évolution de sérialisation qui casserait le match en silence) est couvert par
+> `test_cached_payload_item_ids_match_str_uuid`, qui épingle l'invariant : les
+> ids apparaissent verbatim dans le payload caché.
+
+**Périmètre — le point critique.** Vérifié dans `content_service.py` :
+**like (l. 476), save (l. 514), hide (l. 562), note upsert (l. 646) et la
+transition CONSUMED (l. 187) mutent `UserSubtopic.weight` et
+`UserEntityAffinity.affinity`**, qui alimentent le scoring de *toutes* les
+sections. Les scoper laisserait un **classement** périmé partout. On ne les
+touche donc pas.
+
+| Site | Après |
+|---|---|
+| `update_content_status` **sans** transition consumed (SEEN au scroll) | `invalidate_content` ← **le gain principal** |
+| `impress_content` (n'écrit que `manually_impressed`/`last_impressed_at`) | `invalidate_content` |
+| `unsave_content` (`set_save_status(False)` ⇒ aucun poids ajusté) | `invalidate_content` |
+| `unhide_content` (`unset_hide_status` ⇒ idem) | `invalidate_content` |
+| `delete_note` — **n'invalidait rien** | `invalidate_content` (bug fix) |
+| like/unlike, save, hide, feedback, status→CONSUMED | `invalidate()` inchangé |
+| `upsert_note` — **n'invalidait rien** | `invalidate()` (bug fix ; il boost les poids) |
+| `report_not_serene` — **n'invalidait rien**, et le flip `is_serene=False` est **global cross-user** | `invalidate_content_global(content_id)` (bug fix) |
+| les 27 autres sites (mute, follow, prefs, custom topics, refresh…) | inchangés |
+
+`update_content_status` avait déjà le discriminant en main : il renvoie
+`(updated_status, transitioned_to_consumed)`.
+
+**Faux négatif résiduel, borné par le TTL** : le payload caché est une tranche
+top-N ; une action sur un article hors-tranche ne purge pas la variante — ce qui
+est correct, cet article n'était pas affiché.
+
+**Ne pas purger `_locks` dans `invalidate*`** : retirer un `Lock` détenu par des
+waiters casserait le single-flight (le thundering herd que ce cache existe pour
+éviter). C'est écrit en commentaire dans le code et gardé par
+`test_invalidate_keeps_locks_alive`.
+
+Aucune migration DB.
+
+---
+
+## Décisions : ce qui ne change PAS, et pourquoi
+
+### `--workers 2` : non — décision de correction, pas de perf
+
+Le cache est in-process et `invalidate` est process-local : avec 2 workers, un
+`POST /hide` traité par le worker A ne purge pas le cache du worker B ⇒
+**l'article masqué réapparaît**. Idem pour `_analysis_cache` /
+`_perspectives_cache` (`contents.py`). C'est incompatible avec la stratégie même
+qu'on renforce ici.
+
+**Condition de réouverture** : une invalidation partagée (Redis pub/sub). Et si
+le besoin est du parallélisme CPU pour le scoring, la vraie réponse est de sortir
+le scoring du chemin requête, pas d'ajouter des workers.
+
+*Décidé le 2026-07-29.*
+
+### `FEED_CACHE_PERSONALIZED_TTL_SECONDS=300` : hors PR
+
+Étape ops Railway staging, à faire **après** lecture du hit rate réel, et jamais
+avant que les générations soient déployées. Le défaut code reste 60 s.
+Réversible sans build.
+
+### `degraded_fallback` dans `FeedResponse` : abandonné
+
+Le fallback timeout→curé ne concerne que la vue par défaut, pas les sections. Un
+champ de schéma additif sans consommateur UI est du poids mort ; le log
+`feed_request` couvre le besoin d'observabilité.
+
+### `profile_feed_latency.py` : pas réécrit
+
+Il bypasse le endpoint *et* le cache (et contient un `NameError`,
+`briefing_rows`) — il ne peut pas mesurer ce qu'on change. Le log `feed_request`
+et `/api/health/feed-cache` sont les instruments.
+
+---
+
+## Vérification sur staging (après déploiement)
+
+1. Deux lectures de `/api/health/feed-cache` encadrant une ouverture d'app →
+   hit rate calculé **sur le delta**, pas sur le cumul.
+2. `grep 'feed_request'` dans les logs Railway sur 5 min d'usage réel.
+3. **Scroller 3 articles puis rouvrir la Tournée < 60 s** → les sections doivent
+   être servies du cache (c'est le scénario que cette PR débloque).
+4. `hide` un article visible dans une section + pull-to-refresh immédiat → il ne
+   revient **pas** (test des générations, cas intermittent d'aujourd'hui).
+5. `like` un article → cœur toujours plein après aller-retour d'onglet.
+6. Deux comptes en mode serein : A signale non-serein, B pull-to-refresh →
+   l'article disparaît chez B.
+
+Puis seulement : poser `FEED_CACHE_PERSONALIZED_TTL_SECONDS=300` sur staging et
+re-mesurer.
+
+---
+
+## Suite : périmètre réel de PR 3 (SWR client par section)
+
+Le SWR client par section reste le vrai gain **perçu** : aujourd'hui, à une
+réouverture in-day, `_buildStateFromPayload(fetchThemes: false)` seed des
+**coquilles vides** et retourne sans fan-out — le digest est instantané, les
+12 sections restent vides jusqu'à la fin du fan-out complet.
+
+Mais trois bloquants la précèdent, tous vérifiés dans le code
+(`apps/mobile/lib/providers/flux_continu_provider.dart` sauf mention) :
+
+- **Le reseed nu détruirait l'hydratation, visiblement.**
+  `_buildStateFromPayload` fait `_themes = _shellThemeSections(...)` (pas
+  `_reseedShells`) + `_resolvedSectionKeys.clear()`, et `sectionTask` appelle
+  `emit()` **inconditionnellement**, hors de la garde `emitProgressive`.
+  Aujourd'hui inoffensif (coquilles → coquilles) ; avec l'hydratation, c'est un
+  flash contenu → vide → contenu sur toute la page. Le commentaire en place
+  promet déjà l'inverse : **le code ne tient pas ce que son commentaire dit**.
+  À corriger en commit séparé, *avant* toute hydratation (corrige aussi le
+  pull-to-refresh).
+- **Les sections source ne s'hydrateraient pas.** Le chemin `fetchThemes: false`
+  retourne **avant** `_ensureSourceCatalog` ; `userSourcesProvider` est lazy ⇒
+  `if (src == null) continue`. Idem pour les custom topics (label) et la veille
+  (`veilleActiveConfigProvider` non résolu ⇒ section absente). Il faut persister
+  l'en-tête minimal (label, logo) à côté du raw.
+- **Un article balayé réapparaîtrait.** `_dismissedIds` est en mémoire seule.
+  Invisible aujourd'hui ; avec l'hydratation, c'est le pire ressenti possible.
+  À persister par jour.
+
+Points à ne pas redécouvrir :
+
+- ne **pas** hydrater `_resolvedSectionKeys` (pilote `demote`/`underfilled` ⇒
+  saut d'ordre des sections au boot) ;
+- ne **pas** hydrater les suggestions « Choisie pour vous » (`onEmpty` retire la
+  coquille ⇒ disparition sous le doigt) ;
+- `getVeilleFeedItems` (`flux_continu_repository.dart`) **avale les
+  DioException** et renvoie un feed vide ⇒ on persisterait une section vide
+  comme légitime ;
+- le snapshot passerait de ~80 KB à ~600 KB, or `patchContentConsumed` fait
+  decode + walk + encode du **snapshot entier sur le thread UI au retour de
+  WebView** (`read_sync_service.dart`) ⇒ éclater en clés Hive `section:<key>`
+  plutôt qu'un map imbriqué.

--- a/packages/api/app/config.py
+++ b/packages/api/app/config.py
@@ -112,6 +112,13 @@ class Settings(BaseSettings):
     # Admin endpoints shared secret (Story 14.1)
     admin_api_token: str = ""
 
+    # Health-metrics shared secret (header `X-Health-Token`). Fail-**open**
+    # when empty, unlike `admin_api_token` : les sondes santé doivent rester
+    # lisibles sur staging sans configuration. Le poser en prod ferme les
+    # endpoints dont la réponse est un proxy d'activité utilisateur
+    # (`/api/health/feed-cache` : `size` ≈ nombre d'users actifs).
+    health_metrics_token: str = ""
+
     # YouTube Data API v3
     youtube_api_key: str = ""
 

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -1,6 +1,7 @@
 """Point d'entrée de l'API Facteur."""
 
 import asyncio
+import hmac
 import logging
 import os
 import socket
@@ -31,7 +32,7 @@ _STARTUP_CATCHUP_LOCK = asyncio.Lock()
 
 import sentry_sdk
 import structlog
-from fastapi import Depends, FastAPI, Request
+from fastapi import Depends, FastAPI, Header, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
@@ -709,6 +710,43 @@ async def pool_metrics() -> dict[str, Any]:
         )
 
     logger.info("pool_metrics_probed", **metrics)
+    return metrics
+
+
+@app.get("/api/health/feed-cache", tags=["Health"])
+async def feed_cache_metrics(
+    x_health_token: str | None = Header(default=None, alias="X-Health-Token"),
+) -> dict[str, Any]:
+    """
+    Métriques du cache `/api/feed/` — mesure du hit rate sans infra externe.
+
+    Le cache in-process (`app.services.feed_cache`) est ce qui évite de
+    rejouer le pipeline de scoring sur les ~12 appels `personalized=true` du
+    cold-open. Cet endpoint expose ses compteurs pour vérifier, après un
+    changement d'invalidation ou de TTL, que le hit rate bouge dans le bon
+    sens.
+
+    Les compteurs sont **cumulatifs depuis le boot** : lire `hit_rate` seul
+    lisse la mesure et masquerait une régression. Prendre deux échantillons
+    et calculer le delta — `uptime_seconds` fournit la base de temps.
+
+    Contrairement à `/api/health/pool`, cet endpoint est **gated** quand
+    `HEALTH_METRICS_TOKEN` est configuré : `size` est un proxy du nombre
+    d'utilisateurs actifs. Sans le secret (staging), il reste ouvert —
+    fail-open assumé, à l'inverse de `require_admin_token`.
+    """
+    from app.services.feed_cache import FEED_CACHE
+
+    # Relu à chaque requête (comme `require_admin_token`) plutôt que depuis le
+    # `settings` de module : le secret peut être posé sans redéployer.
+    expected = get_settings().health_metrics_token
+    if expected and not (
+        x_health_token and hmac.compare_digest(x_health_token, expected)
+    ):
+        raise HTTPException(status_code=404, detail="Not Found")
+
+    metrics: dict[str, Any] = FEED_CACHE.stats()
+    logger.info("feed_cache_metrics_probed", **metrics)
     return metrics
 
 

--- a/packages/api/app/routers/contents.py
+++ b/packages/api/app/routers/contents.py
@@ -80,7 +80,15 @@ async def update_content_status(
     )
 
     await db.commit()
-    FEED_CACHE.invalidate(user_uuid)
+    # SEEN (émis à chaque scroll) ne change que l'état d'affichage de cet
+    # article : purger les ~12 sections de la Tournée à chaque scroll vidait
+    # le cache en continu. La transition CONSUMED, elle, ajuste les poids
+    # subtopics/entités (cf. `content_service.update_content_status`) donc
+    # rebat le classement partout ⇒ purge complète.
+    if transitioned_to_consumed:
+        FEED_CACHE.invalidate(user_uuid)
+    else:
+        FEED_CACHE.invalidate_content(user_uuid, content_id)
     return {
         "status": "ok",
         "current_status": updated_status.status,
@@ -130,7 +138,9 @@ async def unsave_content(
     )
 
     await db.commit()
-    FEED_CACHE.invalidate(user_uuid)
+    # `set_save_status(False)` n'ajuste aucun poids (le boost n'est appliqué
+    # qu'au save).
+    FEED_CACHE.invalidate_content(user_uuid, content_id)
     return {"status": "ok", "is_saved": False}
 
 
@@ -228,7 +238,9 @@ async def unhide_content(
     await service.unset_hide_status(user_id=user_uuid, content_id=content_id)
 
     await db.commit()
-    FEED_CACHE.invalidate(user_uuid)
+    # `unset_hide_status` ne touche pas aux poids (le malus n'est appliqué
+    # qu'au hide).
+    FEED_CACHE.invalidate_content(user_uuid, content_id)
     return {"status": "ok", "is_hidden": False}
 
 
@@ -283,6 +295,10 @@ async def report_not_serene(
         )
         raise HTTPException(status_code=500, detail="Failed to record serene report")
 
+    # `is_serene=False` est un flip global sur le Content : sans purge
+    # cross-user, les sections serein des *autres* comptes continuaient à
+    # servir l'article signalé. N'invalidait rien jusqu'ici.
+    FEED_CACHE.invalidate_content_global(content_id)
     return {"status": "ok"}
 
 
@@ -325,7 +341,9 @@ async def impress_content(
     )
     await db.execute(stmt)
     await db.commit()
-    FEED_CACHE.invalidate(user_uuid)
+    # N'écrit que `manually_impressed` / `last_impressed_at` : signal par
+    # article, pas un ajustement de poids.
+    FEED_CACHE.invalidate_content(user_uuid, content_id)
     return {"status": "ok", "manually_impressed": True}
 
 
@@ -352,6 +370,10 @@ async def upsert_note(
         raise HTTPException(status_code=422, detail=str(e))
 
     await db.commit()
+    # `upsert_note` auto-sauvegarde ET booste les poids subtopics/entités
+    # (même delta que le bookmark) ⇒ le classement change partout.
+    # N'invalidait rien jusqu'ici.
+    FEED_CACHE.invalidate(user_uuid)
     return NoteResponse(
         note_text=result.note_text,
         note_updated_at=result.note_updated_at,
@@ -374,6 +396,9 @@ async def delete_note(
         raise HTTPException(status_code=404, detail="Status not found")
 
     await db.commit()
+    # Efface `note_text` sur cette ligne, sans retirer les poids boostés au
+    # upsert ⇒ seul cet article change. N'invalidait rien jusqu'ici.
+    FEED_CACHE.invalidate_content(user_uuid, content_id)
     return {"status": "ok"}
 
 

--- a/packages/api/app/routers/feed.py
+++ b/packages/api/app/routers/feed.py
@@ -1,5 +1,6 @@
 import json
 import re
+import time
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
@@ -252,8 +253,15 @@ async def get_personalized_feed(
     composite `(user, variant)` (TTL `FEED_CACHE_PERSONALIZED_TTL_SECONDS`,
     60s), avec le même pattern single-flight. Coupe le recompute du pipeline
     piliers sur les ~10 appels parallèles du cold-open.
+
+    Chaque requête émet un log `feed_request` (hit/miss/bypass + durée) —
+    `feed_total` n'était émis que par `_compute_feed`, donc jamais sur un
+    hit : le hit rate était invisible. `items` n'est renseigné que sur
+    miss/bypass, où la réponse est déjà désérialisée ; le compter sur un hit
+    imposerait un `json.loads` du payload sur le chemin rapide.
     """
     user_uuid = UUID(current_user_id)
+    started_at = time.perf_counter()
 
     # Resolve cache eligibility + the key variant. `variant is None` ⇒ the
     # default page-1 view (R5). A non-None variant ⇒ a personalized Tournée
@@ -302,10 +310,28 @@ async def get_personalized_feed(
             limit=limit,
         )
 
+    # La classe seulement : le variant complet (thème, topic, source, limit)
+    # est du bruit à ce volume.
+    variant_class = (
+        "none"
+        if not cache_eligible
+        else ("default" if cache_variant is None else "personalized")
+    )
+
+    def _emit(cache: str, items: int | None = None) -> None:
+        logger.info(
+            "feed_request",
+            cache=cache,
+            variant_class=variant_class,
+            duration_ms=round((time.perf_counter() - started_at) * 1000, 1),
+            items=items,
+        )
+
     if cache_eligible:
         # Fast path: cached and fresh → no DB work, no Pydantic.
         cached = FEED_CACHE.get(user_uuid, cache_variant)
         if cached is not None:
+            _emit("hit")
             return Response(content=cached, media_type="application/json")
 
         # Single-flight: serialize concurrent first-misses for the same
@@ -314,7 +340,12 @@ async def get_personalized_feed(
         async with FEED_CACHE.lock(user_uuid, cache_variant):
             cached = FEED_CACHE.get(user_uuid, cache_variant)
             if cached is not None:
+                _emit("hit")
                 return Response(content=cached, media_type="application/json")
+            # Capturée juste AVANT le compute (1,5-5 s) : une invalidation
+            # arrivant dans cette fenêtre change la génération et le `put`
+            # est droppé, au lieu de ressusciter le payload évincé.
+            generation = FEED_CACHE.generation(user_uuid)
             response = await _compute_feed(
                 db=db,
                 user_uuid=user_uuid,
@@ -335,7 +366,8 @@ async def get_personalized_feed(
                 followed_only=followed_only,
             )
             payload = json.dumps(response.model_dump(mode="json")).encode("utf-8")
-            FEED_CACHE.put(user_uuid, payload, cache_variant)
+            FEED_CACHE.put(user_uuid, payload, cache_variant, generation=generation)
+            _emit("miss", len(response.items))
             return Response(content=payload, media_type="application/json")
 
     response = await _compute_feed(
@@ -357,6 +389,7 @@ async def get_personalized_feed(
         personalized=personalized,
         followed_only=followed_only,
     )
+    _emit("bypass", len(response.items))
     return response
 
 

--- a/packages/api/app/services/content_service.py
+++ b/packages/api/app/services/content_service.py
@@ -271,6 +271,13 @@ class ContentService:
         """
         Ajuste les poids des sous-thèmes utilisateur en fonction d'un signal explicite.
         Réutilisé par like (+0.15) et bookmark (+0.05).
+
+        ⚠️ Ces poids alimentent le scoring de **toutes** les sections du feed.
+        Tout endpoint dont le chemin arrive ici doit donc appeler
+        `FEED_CACHE.invalidate(user_id)` (purge complète) et surtout pas
+        `invalidate_content` — un classement périmé subsisterait partout
+        ailleurs. Le partage des rôles est épinglé par
+        `tests/routers/test_feed_cache_invalidation_sites.py`.
         """
         from sqlalchemy.orm import selectinload
 

--- a/packages/api/app/services/feed_cache.py
+++ b/packages/api/app/services/feed_cache.py
@@ -39,6 +39,23 @@ Design
   `FEED_CACHE.invalidate(user_id)`, which purges **all** variants for that
   user (default + every personalized section). Stale-but-correct is
   acceptable for passive reads (blink); inconsistent-after-write is not.
+- **Content-scoped eviction** — a write that changes *one article's* display
+  state without touching the ranking inputs (`UserSubtopic.weight`,
+  `UserEntityAffinity.affinity`) calls `invalidate_content(user_id,
+  content_id)` instead: only the variants whose payload mentions that id are
+  purged. This is what keeps the cache alive under the dominant write,
+  `POST /contents/{id}/status` in `SEEN` (fired on every scroll) — a full
+  `invalidate` there annihilated the ~12 Tournée sections after three
+  scrolled articles. Writes that *do* adjust weights (like, save, hide,
+  feedback, note upsert, the CONSUMED transition) keep the full purge: a
+  scoped one would leave a stale **ranking** everywhere else.
+- **Generations** — `put()` from a compute that started before an
+  invalidation is dropped instead of resurrecting the evicted payload.
+  `_compute_feed` takes 1.5-5 s under the single-flight lock; an
+  `invalidate` landing inside that window used to be overwritten by the
+  unconditional `put()`, so a hidden article could reappear until the TTL
+  expired. Callers capture `generation(user_id)` **before** computing and
+  hand it back to `put()`.
 - **Default-view key scope** = the *default* mobile view only:
   `offset == 0` + `limit == 20` + no filter (mode/theme/topic/source/entity
   /keyword) + `serein == False` + `saved_only == False` + not personalized.
@@ -118,9 +135,18 @@ class FeedPageCache:
         )
         self._entries: dict[_CacheKey, _Entry] = {}
         self._locks: dict[_CacheKey, asyncio.Lock] = {}
+        # Monotonic invalidation counters. Per-user + one global (bumped by
+        # `invalidate_content_global`, whose blast radius is every user —
+        # including users with no entry yet, hence not expressible per-user).
+        # A global-only counter would let any user's write drop every *other*
+        # user's in-flight `put()`, which the per-scroll SEEN write would fire
+        # constantly — exactly the cache defeat this change removes.
+        self._generations: dict[UUID, int] = {}
+        self._global_generation = 0
         self._hits = 0
         self._misses = 0
         self._invalidations = 0
+        self._started_at = time.monotonic()
         self._last_flush_at = time.monotonic()
 
     @property
@@ -182,14 +208,30 @@ class FeedPageCache:
         self._maybe_flush_telemetry(now)
         return entry.payload
 
-    def put(self, user_id: UUID, payload: bytes, variant: str | None = None) -> None:
+    def generation(self, user_id: UUID) -> tuple[int, int]:
+        """Current invalidation generation for `user_id`, as `(per_user,
+        global)`. Capture it **before** a long compute and hand it to
+        `put()`. Cf. *Generations* in the module docstring."""
+        return (self._generations.get(user_id, 0), self._global_generation)
+
+    def put(
+        self,
+        user_id: UUID,
+        payload: bytes,
+        variant: str | None = None,
+        *,
+        generation: tuple[int, int] | None = None,
+    ) -> None:
         """Store `payload` for `(user_id, variant)` with the variant's TTL.
 
-        No-op when the relevant TTL class is disabled (default view when
-        `FEED_CACHE_TTL_SECONDS=0`, personalized when
-        `FEED_CACHE_PERSONALIZED_TTL_SECONDS=0`)."""
+        No-op when the relevant TTL class is disabled, or when `generation`
+        is stale — the entry was invalidated while the caller was computing
+        this payload. Only test seeding omits `generation`; every production
+        caller passes one."""
         ttl = self._ttl_for(variant)
         if ttl <= 0:
+            return
+        if generation is not None and generation != self.generation(user_id):
             return
         self._entries[(user_id, variant)] = _Entry(
             expires_at=time.monotonic() + ttl,
@@ -199,16 +241,62 @@ class FeedPageCache:
     def invalidate(self, user_id: UUID) -> None:
         """Drop **all** cached variants for `user_id` (default + personalized).
 
-        Called by every write endpoint. A single call counts as one
-        invalidation regardless of how many variants it purged."""
-        keys = [key for key in self._entries if key[0] == user_id]
+        Called by every write endpoint that can change the *ranking*."""
+        self._purge(user_id=user_id)
+
+    def invalidate_content(self, user_id: UUID, content_id: UUID) -> None:
+        """Drop only the variants of `user_id` whose payload mentions
+        `content_id` — for writes that change one article's display state
+        without touching the ranking. Cf. *Content-scoped eviction* in the
+        module docstring."""
+        self._purge(user_id=user_id, needle=str(content_id).encode())
+
+    def invalidate_content_global(self, content_id: UUID) -> None:
+        """Drop the variants of **every** user whose payload mentions
+        `content_id`.
+
+        For writes whose effect is cross-user: `report_not_serene` flips
+        `Content.is_serene=False` for everyone, so purging only the reporter
+        would keep serving the article to the other users' serein sections.
+
+        Unlike `invalidate_content`, the scan is not narrowed to one user, so
+        it costs ~13 µs per cached entry across the whole cache (~16 ms at
+        100 DAU). Acceptable because the trigger is a rare user report; if
+        that ever changes, narrow it to serein variants."""
+        self._purge(needle=str(content_id).encode())
+
+    def _purge(
+        self, *, user_id: UUID | None = None, needle: bytes | None = None
+    ) -> None:
+        """Drop the entries matching both optional narrowings and bump the
+        matching generation. One call == one counted invalidation, and only
+        when it purged something.
+
+        `_locks` is deliberately left untouched: dropping a `Lock` that
+        in-flight waiters hold would let a later request create a fresh one
+        and break single-flight — the thundering herd this cache exists to
+        prevent. Pinned by `test_invalidate_keeps_locks_alive`."""
+        keys = [
+            key
+            for key, entry in self._entries.items()
+            if (user_id is None or key[0] == user_id)
+            and (needle is None or needle in entry.payload)
+        ]
         for key in keys:
             del self._entries[key]
+        # Bumped even when nothing was purged: the entry being invalidated may
+        # be mid-compute (cache miss ⇒ no entry to scan), and that `put()` is
+        # exactly what must be dropped.
+        if user_id is None:
+            self._global_generation += 1
+        else:
+            self._generations[user_id] = self._generations.get(user_id, 0) + 1
         if keys:
             self._invalidations += 1
 
     def stats(self) -> dict[str, int | float]:
-        """Snapshot for tests / health endpoint."""
+        """Snapshot for tests / health endpoint. `uptime_seconds` is the time
+        base for reading the cumulative counters as a delta."""
         total = self._hits + self._misses
         return {
             "hits": self._hits,
@@ -218,6 +306,7 @@ class FeedPageCache:
             "hit_rate": (self._hits / total) if total else 0.0,
             "ttl_seconds": self._ttl,
             "personalized_ttl_seconds": self._personalized_ttl,
+            "uptime_seconds": round(time.monotonic() - self._started_at, 1),
         }
 
     def reset_stats(self) -> None:
@@ -225,12 +314,20 @@ class FeedPageCache:
         self._hits = 0
         self._misses = 0
         self._invalidations = 0
+        self._started_at = time.monotonic()
         self._last_flush_at = time.monotonic()
 
     def clear(self) -> None:
-        """Test helper."""
+        """Test helper.
+
+        Also resets generations: the singleton survives across tests, so a
+        counter left high by one test would silently drop the `put()` of the
+        next one (heisenbug on test order). Safe here only because no
+        compute is in flight between tests."""
         self._entries.clear()
         self._locks.clear()
+        self._generations.clear()
+        self._global_generation = 0
 
     def _maybe_flush_telemetry(self, now: float) -> None:
         if now - self._last_flush_at < 60.0:

--- a/packages/api/tests/conftest.py
+++ b/packages/api/tests/conftest.py
@@ -1,6 +1,7 @@
 """Test configuration and fixtures for API tests."""
 
 from contextlib import asynccontextmanager
+from datetime import UTC
 from uuid import uuid4
 
 import pytest
@@ -43,12 +44,77 @@ def _reset_feed_cache():
     # an explicit reset a test that populates it for `user_uuid=X` can
     # silently feed its cached payload to the next test that reuses the
     # same UUID (heisenbugs). Clearing before AND after also guards
-    # against test-ordering flakes.
+    # against test-ordering flakes. `clear()` also resets the invalidation
+    # generations — a counter left high by one test would silently drop the
+    # next test's `put()`.
     FEED_CACHE.clear()
     FEED_CACHE.reset_stats()
     yield
     FEED_CACHE.clear()
     FEED_CACHE.reset_stats()
+
+
+@pytest.fixture
+def feed_cache_payload():
+    """Build a cached-feed payload mentioning the given content ids.
+
+    `FeedPageCache.invalidate_content` matches by scanning the serialized
+    payload for `str(content_id)`, so the shape of this string *is* the
+    contract under test — hence one definition shared by the unit tests
+    (`tests/services/test_feed_cache.py`) and the endpoint tests
+    (`tests/routers/test_feed_cache_invalidation_sites.py`) rather than a
+    copy in each. The real serialization is pinned separately by
+    `test_cached_payload_item_ids_match_str_uuid`.
+    """
+
+    def _build(*content_ids) -> bytes:
+        items = ", ".join(f'{{"id": "{cid}"}}' for cid in content_ids)
+        return f'{{"items": [{items}]}}'.encode()
+
+    return _build
+
+
+@pytest.fixture
+def feed_response_factory():
+    """Build a minimal real `FeedResponse` (n items, one source).
+
+    `FeedResponse` / `FeedItemResponse` are required-field-heavy, so one
+    factory keeps the log tests and the serialization-invariant test from
+    breaking apart when a field is added.
+    """
+    from datetime import datetime
+
+    from app.models.enums import ContentType
+    from app.schemas.content import SourceMini
+    from app.schemas.feed import FeedItemResponse, FeedResponse, PaginationMeta
+
+    def _build(*, items: int = 3, content_ids: list | None = None):
+        ids = (
+            content_ids if content_ids is not None else [uuid4() for _ in range(items)]
+        )
+        source = SourceMini(
+            id=uuid4(), name="Test Source", logo_url=None, type="article", theme="tech"
+        )
+        return FeedResponse(
+            items=[
+                FeedItemResponse(
+                    id=content_id,
+                    title=f"Article {i}",
+                    url=f"https://example.com/{i}",
+                    thumbnail_url=None,
+                    content_type=ContentType.ARTICLE,
+                    duration_seconds=None,
+                    published_at=datetime(2026, 6, 1, 12, 0, tzinfo=UTC),
+                    source=source,
+                )
+                for i, content_id in enumerate(ids)
+            ],
+            pagination=PaginationMeta(
+                page=1, per_page=12, total=len(ids), has_next=False
+            ),
+        )
+
+    return _build
 
 
 @pytest.fixture(autouse=True)

--- a/packages/api/tests/routers/test_feed_cache_invalidation_sites.py
+++ b/packages/api/tests/routers/test_feed_cache_invalidation_sites.py
@@ -1,0 +1,333 @@
+"""Which write endpoints purge the whole feed cache, and which purge one article.
+
+The filet that was missing. `POST /contents/{id}/status` in SEEN is fired on
+every scroll, and it used to call `FEED_CACHE.invalidate()` — scrolling three
+articles annihilated the ~12 cached Tournée sections, so the cache never paid
+off at cold-open. Scoping it to the touched article is the whole point of the
+change; the tests below pin both halves of the rule:
+
+- **Targeted** (`invalidate_content`) — writes that only change one article's
+  display state.
+- **Full** (`invalidate`) — writes that adjust `UserSubtopic.weight` /
+  `UserEntityAffinity.affinity`, i.e. rebalance the **ranking** of every
+  section. Scoping those would leave a stale order everywhere else, which is
+  why the "stays full" cases below are explicit guards against a future
+  over-optimisation.
+"""
+
+import json
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.database import get_db
+from app.dependencies import get_current_user_id
+from app.main import app
+from app.models.content import Content
+from app.models.enums import ContentType, SourceType
+from app.models.source import Source
+from app.models.user import UserProfile
+from app.services.feed_cache import FEED_CACHE
+
+BASE_DT = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+
+# Two cached sections: one that displays the article being written to, one
+# that does not. A targeted invalidation must purge only the first.
+MATCHING_VARIANT = "p|t=tech|tp=None|s=None|sr=0|l=12"
+OTHER_VARIANT = "p|t=science|tp=None|s=None|sr=0|l=12"
+
+
+@pytest_asyncio.fixture
+async def user_id() -> UUID:
+    return uuid4()
+
+
+@pytest_asyncio.fixture
+async def auth_client(db_session, user_id):
+    async def _fake_user():
+        return str(user_id)
+
+    async def _fake_db():
+        yield db_session
+
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+    transport = ASGITransport(app=app)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+
+@pytest_asyncio.fixture
+async def article(db_session, user_id) -> Content:
+    # `user_interests` FKs to `user_profiles`; the weight-adjusting writes
+    # below insert into it.
+    db_session.add(UserProfile(user_id=user_id))
+    source = Source(
+        id=uuid4(),
+        name="Test Source",
+        url="https://example.com",
+        feed_url=f"https://example.com/feed-{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="tech",
+        is_active=True,
+        is_curated=True,
+    )
+    db_session.add(source)
+    await db_session.flush()
+    content = Content(
+        id=uuid4(),
+        source_id=source.id,
+        title="Un article",
+        url=f"https://example.com/{uuid4()}",
+        published_at=BASE_DT - timedelta(hours=2),
+        content_type=ContentType.ARTICLE,
+        guid=str(uuid4()),
+        is_serene=True,
+    )
+    db_session.add(content)
+    await db_session.commit()
+    # Tests and endpoints share one session (the `get_db` override). Left in
+    # the identity map, `session.get(Content, ...)` inside
+    # `_adjust_subtopic_weights` would return this instance without applying
+    # its `selectinload(Content.source)`, and reading `content.source` would
+    # then lazy-load outside a greenlet. Production gets a fresh session per
+    # request; expunging reproduces that.
+    db_session.expunge_all()
+    return content
+
+
+@pytest.fixture
+def seed_cache(feed_cache_payload):
+    """Cache two sections for a user: one showing the article, one not."""
+
+    def _seed(user_id: UUID, content_id: UUID) -> None:
+        FEED_CACHE.put(
+            user_id, feed_cache_payload(content_id), variant=MATCHING_VARIANT
+        )
+        FEED_CACHE.put(user_id, feed_cache_payload(uuid4()), variant=OTHER_VARIANT)
+
+    return _seed
+
+
+def _assert_targeted(user_id: UUID) -> None:
+    assert FEED_CACHE.get(user_id, variant=MATCHING_VARIANT) is None
+    assert FEED_CACHE.get(user_id, variant=OTHER_VARIANT) is not None
+
+
+def _assert_full(user_id: UUID) -> None:
+    assert FEED_CACHE.get(user_id, variant=MATCHING_VARIANT) is None
+    assert FEED_CACHE.get(user_id, variant=OTHER_VARIANT) is None
+
+
+# --- Targeted: display-state-only writes -----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_seen_status_purges_only_matching_sections(
+    auth_client, article, user_id, seed_cache
+):
+    """The dominant write — emitted on every scroll."""
+    seed_cache(user_id, article.id)
+
+    resp = await auth_client.post(
+        f"/api/contents/{article.id}/status", json={"status": "seen"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["transitioned_to_consumed"] is False
+    _assert_targeted(user_id)
+
+
+@pytest.mark.asyncio
+async def test_impress_purges_only_matching_sections(
+    auth_client, article, user_id, seed_cache
+):
+    seed_cache(user_id, article.id)
+
+    resp = await auth_client.post(f"/api/contents/{article.id}/impress")
+
+    assert resp.status_code == 200, resp.text
+    _assert_targeted(user_id)
+
+
+@pytest.mark.asyncio
+async def test_unsave_purges_only_matching_sections(
+    auth_client, article, user_id, seed_cache
+):
+    await auth_client.post(f"/api/contents/{article.id}/save")
+    seed_cache(user_id, article.id)
+
+    resp = await auth_client.delete(f"/api/contents/{article.id}/save")
+
+    assert resp.status_code == 200, resp.text
+    _assert_targeted(user_id)
+
+
+@pytest.mark.asyncio
+async def test_unhide_purges_only_matching_sections(
+    auth_client, article, user_id, seed_cache
+):
+    await auth_client.post(f"/api/contents/{article.id}/hide")
+    seed_cache(user_id, article.id)
+
+    resp = await auth_client.delete(f"/api/contents/{article.id}/hide")
+
+    assert resp.status_code == 200, resp.text
+    _assert_targeted(user_id)
+
+
+@pytest.mark.asyncio
+async def test_note_delete_purges_only_matching_sections(
+    auth_client, article, user_id, seed_cache
+):
+    """Erasing `note_text` does not undo the weights boosted at upsert."""
+    await auth_client.put(
+        f"/api/contents/{article.id}/note", json={"note_text": "ma note"}
+    )
+    seed_cache(user_id, article.id)
+
+    resp = await auth_client.delete(f"/api/contents/{article.id}/note")
+
+    assert resp.status_code == 200, resp.text
+    _assert_targeted(user_id)
+
+
+# --- Full: ranking-affecting writes ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_consumed_status_purges_everything(
+    auth_client, article, user_id, seed_cache
+):
+    """The CONSUMED transition adjusts subtopic weights + entity affinity."""
+    seed_cache(user_id, article.id)
+
+    resp = await auth_client.post(
+        f"/api/contents/{article.id}/status",
+        json={"status": "consumed", "time_spent_seconds": 60},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["transitioned_to_consumed"] is True
+    _assert_full(user_id)
+
+
+@pytest.mark.asyncio
+async def test_like_stays_full(auth_client, article, user_id, seed_cache):
+    seed_cache(user_id, article.id)
+
+    resp = await auth_client.post(f"/api/contents/{article.id}/like")
+
+    assert resp.status_code == 200, resp.text
+    _assert_full(user_id)
+
+
+@pytest.mark.asyncio
+async def test_save_stays_full(auth_client, article, user_id, seed_cache):
+    seed_cache(user_id, article.id)
+
+    resp = await auth_client.post(f"/api/contents/{article.id}/save")
+
+    assert resp.status_code == 200, resp.text
+    _assert_full(user_id)
+
+
+@pytest.mark.asyncio
+async def test_hide_stays_full(auth_client, article, user_id, seed_cache):
+    seed_cache(user_id, article.id)
+
+    resp = await auth_client.post(f"/api/contents/{article.id}/hide")
+
+    assert resp.status_code == 200, resp.text
+    _assert_full(user_id)
+
+
+@pytest_asyncio.fixture
+async def article_feedback_table(db_session):
+    """`article_feedback` is Alembic-only — it is not registered in
+    `Base.metadata`, so conftest's `create_all` never creates it and
+    `POST /feedback` would 500 on an undefined relation.
+
+    Created on the test's own connection, so the DDL rolls back with the
+    surrounding transaction. Imported lazily: at module scope it would land
+    in `Base.metadata` before the session-scoped `create_tables` runs and
+    silently change the schema of the whole suite.
+    """
+    from app.models.article_feedback import ArticleFeedback
+
+    conn = await db_session.connection()
+    await conn.run_sync(ArticleFeedback.__table__.create, checkfirst=True)
+
+
+@pytest.mark.asyncio
+async def test_feedback_stays_full(
+    auth_client, article, user_id, seed_cache, article_feedback_table
+):
+    seed_cache(user_id, article.id)
+
+    resp = await auth_client.post(
+        f"/api/contents/{article.id}/feedback", json={"sentiment": "positive"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    _assert_full(user_id)
+
+
+@pytest.mark.asyncio
+async def test_note_upsert_purges_everything(auth_client, article, user_id, seed_cache):
+    """Boosts subtopic weights like a bookmark. Invalidated nothing before."""
+    seed_cache(user_id, article.id)
+
+    resp = await auth_client.put(
+        f"/api/contents/{article.id}/note", json={"note_text": "ma note"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    _assert_full(user_id)
+
+
+# --- Cross-user ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_report_not_serene_purges_every_user(
+    auth_client, article, user_id, seed_cache
+):
+    """`is_serene=False` is a global flip on the Content — purging only the
+    reporter would keep serving the article to the other users."""
+    other_user = uuid4()
+    seed_cache(user_id, article.id)
+    seed_cache(other_user, article.id)
+
+    resp = await auth_client.post(f"/api/contents/{article.id}/report-not-serene")
+
+    assert resp.status_code == 200, resp.text
+    _assert_targeted(user_id)
+    _assert_targeted(other_user)
+
+
+# --- The invariant the byte scan rests on ----------------------------------
+
+
+def test_cached_payload_item_ids_match_str_uuid(feed_response_factory):
+    """`invalidate_content` scans the serialized payload for `str(content_id)`.
+
+    Pin the serialization it depends on: a change that stopped emitting ids
+    verbatim (compression, int ids, a binary codec) would silently turn every
+    scoped invalidation into a no-op — stale content served after a write,
+    with no test failing. This is that test.
+    """
+    content_id = uuid4()
+    response = feed_response_factory(content_ids=[content_id])
+
+    # Exactly the serialization `get_personalized_feed` caches.
+    payload = json.dumps(response.model_dump(mode="json")).encode("utf-8")
+
+    assert str(content_id).encode() in payload

--- a/packages/api/tests/services/test_feed_cache.py
+++ b/packages/api/tests/services/test_feed_cache.py
@@ -281,3 +281,171 @@ def test_personalized_variant_uses_personalized_ttl(
     # Past the personalized TTL.
     fake_now[0] += 20.0
     assert cache.get(user, variant="p|theme=tech") is None
+
+
+# --- Content-scoped invalidation ------------------------------------------
+
+
+def test_invalidate_content_purges_only_matching_variants(
+    cache: FeedPageCache, feed_cache_payload
+) -> None:
+    user = uuid4()
+    target, other = uuid4(), uuid4()
+    cache.put(user, feed_cache_payload(target, other), variant="p|theme=tech")
+    cache.put(user, feed_cache_payload(other), variant="p|theme=science")
+    cache.put(user, feed_cache_payload(target), variant=None)
+
+    cache.invalidate_content(user, target)
+
+    assert cache.get(user, variant="p|theme=tech") is None
+    assert cache.get(user, variant=None) is None
+    assert cache.get(user, variant="p|theme=science") == feed_cache_payload(other)
+    assert cache.stats()["invalidations"] == 1
+
+
+def test_invalidate_content_unknown_id_is_noop(
+    cache: FeedPageCache, feed_cache_payload
+) -> None:
+    """No variant mentions the id ⇒ nothing purged, nothing counted."""
+    user = uuid4()
+    kept = feed_cache_payload(uuid4())
+    cache.put(user, kept, variant="p|theme=tech")
+
+    cache.invalidate_content(user, uuid4())
+
+    assert cache.get(user, variant="p|theme=tech") == kept
+    assert cache.stats()["invalidations"] == 0
+
+
+def test_invalidate_content_does_not_touch_other_users(
+    cache: FeedPageCache, feed_cache_payload
+) -> None:
+    a, b = uuid4(), uuid4()
+    target = uuid4()
+    cache.put(a, feed_cache_payload(target), variant="p|theme=tech")
+    cache.put(b, feed_cache_payload(target), variant="p|theme=tech")
+
+    cache.invalidate_content(a, target)
+
+    assert cache.get(a, variant="p|theme=tech") is None
+    assert cache.get(b, variant="p|theme=tech") == feed_cache_payload(target)
+
+
+def test_invalidate_content_global_purges_every_user(
+    cache: FeedPageCache, feed_cache_payload
+) -> None:
+    """`report_not_serene` flips `is_serene` for everyone — so must the purge."""
+    a, b, c = uuid4(), uuid4(), uuid4()
+    target = uuid4()
+    cache.put(a, feed_cache_payload(target), variant="p|sr=1")
+    cache.put(b, feed_cache_payload(target), variant="p|sr=1")
+    kept = feed_cache_payload(uuid4())
+    cache.put(c, kept, variant="p|sr=1")
+
+    cache.invalidate_content_global(target)
+
+    assert cache.get(a, variant="p|sr=1") is None
+    assert cache.get(b, variant="p|sr=1") is None
+    assert cache.get(c, variant="p|sr=1") == kept
+    assert cache.stats()["invalidations"] == 1
+
+
+# --- Generations (write-during-compute) ------------------------------------
+
+
+def test_put_with_stale_generation_is_dropped(cache: FeedPageCache) -> None:
+    """The bug this fixes: a 1.5-5 s compute whose `put` lands after an
+    invalidation used to resurrect the evicted payload — a hidden article
+    reappearing until the TTL expired."""
+    user = uuid4()
+    generation = cache.generation(user)
+
+    cache.invalidate(user)  # write lands mid-compute
+    cache.put(user, b"stale", variant="p|theme=tech", generation=generation)
+
+    assert cache.get(user, variant="p|theme=tech") is None
+
+
+def test_put_with_current_generation_is_stored(cache: FeedPageCache) -> None:
+    user = uuid4()
+    generation = cache.generation(user)
+    cache.put(user, b"fresh", variant="p|theme=tech", generation=generation)
+    assert cache.get(user, variant="p|theme=tech") == b"fresh"
+
+
+def test_put_without_generation_is_unconditional(cache: FeedPageCache) -> None:
+    """Omitting the generation keeps the unconditional write — only test
+    seeding does that; the endpoint always passes one."""
+    user = uuid4()
+    cache.invalidate(user)
+    cache.put(user, b"x", variant="p|theme=tech")
+    assert cache.get(user, variant="p|theme=tech") == b"x"
+
+
+def test_content_scoped_invalidation_also_bumps_generation(
+    cache: FeedPageCache,
+) -> None:
+    """Even when it purges nothing: on a cache miss there is no entry to scan,
+    yet the in-flight compute holds the pre-write payload."""
+    user = uuid4()
+    generation = cache.generation(user)
+
+    cache.invalidate_content(user, uuid4())  # nothing cached to purge
+    cache.put(user, b"stale", variant="p|theme=tech", generation=generation)
+
+    assert cache.get(user, variant="p|theme=tech") is None
+
+
+def test_global_invalidation_bumps_generation_for_unknown_users(
+    cache: FeedPageCache,
+) -> None:
+    """A user with no cached entry still has their in-flight compute dropped."""
+    user = uuid4()
+    generation = cache.generation(user)
+
+    cache.invalidate_content_global(uuid4())
+    cache.put(user, b"stale", variant="p|sr=1", generation=generation)
+
+    assert cache.get(user, variant="p|sr=1") is None
+
+
+def test_generations_are_per_user(cache: FeedPageCache) -> None:
+    """One user's write must not drop another user's in-flight compute."""
+    a, b = uuid4(), uuid4()
+    generation_b = cache.generation(b)
+
+    cache.invalidate(a)
+    cache.put(b, b"fresh", variant="p|theme=tech", generation=generation_b)
+
+    assert cache.get(b, variant="p|theme=tech") == b"fresh"
+
+
+def test_clear_resets_generations(cache: FeedPageCache) -> None:
+    """The singleton survives across tests; a counter left high would silently
+    drop the next test's `put`."""
+    user = uuid4()
+    cache.invalidate(user)
+    cache.clear()
+    assert cache.generation(user) == (0, 0)
+
+
+# --- Single-flight guards --------------------------------------------------
+
+
+def test_invalidate_keeps_locks_alive(cache: FeedPageCache) -> None:
+    """Anti-regression: dropping a held `Lock` would let a later request
+    create a fresh one and break single-flight (thundering herd)."""
+    user = uuid4()
+    lock = cache.lock(user, variant="p|theme=tech")
+    cache.put(user, b"x", variant="p|theme=tech")
+
+    cache.invalidate(user)
+    cache.invalidate_content(user, uuid4())
+    cache.invalidate_content_global(uuid4())
+
+    assert cache.lock(user, variant="p|theme=tech") is lock
+
+
+def test_stats_exposes_uptime(cache: FeedPageCache) -> None:
+    """Counters are cumulative — readers need a time base to take a delta."""
+    assert cache.stats()["uptime_seconds"] >= 0.0

--- a/packages/api/tests/test_feed_personalized_cache.py
+++ b/packages/api/tests/test_feed_personalized_cache.py
@@ -1,7 +1,14 @@
 """Unit tests for the personalized-section cache eligibility + variant key
-(app-load slowdown fix). Pure predicate functions — no DB / app needed."""
+(app-load slowdown fix), plus the per-request `feed_request` log."""
 
 from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+import structlog
+from httpx import ASGITransport, AsyncClient
 
 from app.models.enums import ContentType, FeedFilterMode
 from app.routers.feed import (
@@ -130,3 +137,92 @@ def test_variant_is_never_none() -> None:
         theme=None, topic=None, source_id="src", serein=True, limit=12
     )
     assert isinstance(v, str) and v
+
+
+# --- `feed_request` log ----------------------------------------------------
+#
+# `feed_total` is emitted by `_compute_feed`, so a cache hit used to produce
+# no log line at all — the hit rate was invisible and no decision on TTL or
+# invalidation scope could be grounded. These tests pin the one line every
+# request now emits.
+
+
+@pytest_asyncio.fixture
+async def feed_client(monkeypatch, feed_response_factory):
+    """Client hitting `/api/feed/` with the recommendation pipeline stubbed.
+
+    The log is what's under test, not the pipeline — stubbing `_compute_feed`
+    keeps these tests DB-free and fast.
+    """
+    from app.database import get_db
+    from app.dependencies import get_current_user_id
+    from app.main import app
+
+    async def _fake_compute(**_kwargs):
+        return feed_response_factory(items=3)
+
+    monkeypatch.setattr("app.routers.feed._compute_feed", _fake_compute)
+
+    user_id = uuid4()
+
+    async def _fake_user():
+        return str(user_id)
+
+    async def _fake_db():
+        yield None
+
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as ac:
+            yield ac
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+
+def _feed_requests(logs: list[dict]) -> list[dict]:
+    return [entry for entry in logs if entry.get("event") == "feed_request"]
+
+
+@pytest.mark.asyncio
+async def test_logs_miss_then_hit_on_personalized_section(feed_client) -> None:
+    url = "/api/feed/?personalized=true&theme=tech&limit=12"
+
+    with structlog.testing.capture_logs() as logs:
+        assert (await feed_client.get(url)).status_code == 200
+        assert (await feed_client.get(url)).status_code == 200
+
+    miss, hit = _feed_requests(logs)
+    assert miss["cache"] == "miss"
+    assert miss["variant_class"] == "personalized"
+    assert miss["items"] == 3
+    assert miss["duration_ms"] >= 0
+    assert hit["cache"] == "hit"
+    assert hit["variant_class"] == "personalized"
+
+
+@pytest.mark.asyncio
+async def test_logs_default_view_class(feed_client) -> None:
+    with structlog.testing.capture_logs() as logs:
+        assert (await feed_client.get("/api/feed/?limit=20")).status_code == 200
+
+    (entry,) = _feed_requests(logs)
+    assert entry["cache"] == "miss"
+    assert entry["variant_class"] == "default"
+
+
+@pytest.mark.asyncio
+async def test_logs_bypass_for_non_cacheable_view(feed_client) -> None:
+    """Paginated fetches skip the cache entirely — they must still be counted,
+    else the hit rate reads as better than it is."""
+    with structlog.testing.capture_logs() as logs:
+        resp = await feed_client.get("/api/feed/?offset=20&limit=20")
+        assert resp.status_code == 200
+
+    (entry,) = _feed_requests(logs)
+    assert entry["cache"] == "bypass"
+    assert entry["variant_class"] == "none"
+    assert entry["items"] == 3

--- a/packages/api/tests/test_health_feed_cache.py
+++ b/packages/api/tests/test_health_feed_cache.py
@@ -1,0 +1,78 @@
+"""Tests for /api/health/feed-cache — feed cache observability endpoint.
+
+Mirror of `test_health_pool.py`. Without it, a cache hit emitted no signal
+at all: impossible to tell whether an invalidation or TTL change improved
+anything. The endpoint must:
+- Expose the counters dashboards/QA depend on, including `uptime_seconds`
+  (the counters are cumulative — a reader needs a time base for the delta).
+- Stay open when `HEALTH_METRICS_TOKEN` is unset (staging).
+- 404 without the token when it is set (`size` proxies active users).
+"""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.config import get_settings
+from app.main import app
+
+
+@pytest.fixture(autouse=True)
+def _clear_settings_cache():
+    """`get_settings` is `lru_cache`d — without this the first test's env
+    leaks into the others."""
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+async def _get(headers: dict[str, str] | None = None):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        return await ac.get("/api/health/feed-cache", headers=headers or {})
+
+
+@pytest.mark.asyncio
+async def test_feed_cache_endpoint_returns_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("HEALTH_METRICS_TOKEN", raising=False)
+
+    resp = await _get()
+
+    assert resp.status_code == 200, f"got {resp.status_code}: {resp.text[:200]}"
+    body = resp.json()
+    for field in (
+        "hits",
+        "misses",
+        "invalidations",
+        "size",
+        "hit_rate",
+        "ttl_seconds",
+        "personalized_ttl_seconds",
+        "uptime_seconds",
+    ):
+        assert field in body, field
+    assert body["uptime_seconds"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_feed_cache_endpoint_is_open_without_token_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Staging has no `HEALTH_METRICS_TOKEN` — a stray header must not gate it."""
+    monkeypatch.delenv("HEALTH_METRICS_TOKEN", raising=False)
+
+    resp = await _get({"X-Health-Token": "whatever"})
+
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_feed_cache_endpoint_requires_token_when_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HEALTH_METRICS_TOKEN", "s3cret")
+
+    assert (await _get()).status_code == 404
+    assert (await _get({"X-Health-Token": "wrong"})).status_code == 404
+    assert (await _get({"X-Health-Token": "s3cret"})).status_code == 200


### PR DESCRIPTION
# feat(api): cache feed observable, correct et ciblé (PR 2)

Base `main`. **Aucune migration.** Backend-only (0 fichier mobile).

## Résumé

PR 2 du plan « Accélérer et fiabiliser l'écran Essentiel ». L'écran Essentiel est
lent : chaque cold-open fait un fan-out de 10 à 14 `GET /api/feed?personalized=true`,
chacun payant le pipeline de scoring complet sur 1 seul worker uvicorn.

Un cache existait (`app/services/feed_cache.py`, clé `(user, variant)`, TTL 60 s)
mais était **neutralisé en pratique** : `invalidate(user_id)` purge *tous* les
variants du user, et l'écriture dominante est `POST /contents/{id}/status` en
`SEEN`, émise **à chaque scroll**. Scroller trois articles vidait le cache des
~12 sections de la Tournée.

Doc : `docs/maintenance/maintenance-essentiel-loading-speed.md` (décisions +
protocole de vérification staging).

PR 1 (`#1017`, mergée) a traité le volet mobile « Sources favorites toujours
rendues + attente lisible ».

## 1. Observabilité — la baseline, à lire avant de toucher au TTL

- `app/routers/feed.py` : un log structlog `feed_request` par requête —
  `cache=hit|miss|bypass`, `variant_class=default|personalized|none`,
  `duration_ms`, `items`. Avant, `feed_total` n'était émis que par
  `_compute_feed` : **un hit ne produisait aucun log**, le hit rate était
  invisible. `items` seulement sur miss/bypass (le compter sur un hit imposerait
  un `json.loads` du payload sur le chemin rapide).
- `app/main.py` : `GET /api/health/feed-cache`, calqué sur `/api/health/pool`,
  avec deux écarts assumés :
  - **gate par header `X-Health-Token`** (`hmac.compare_digest`) quand
    `HEALTH_METRICS_TOKEN` est configuré — nouveau champ `health_metrics_token`
    dans `Settings` (`app/config.py`), à côté de `admin_api_token`. `size` est un
    proxy du nombre d'users actifs. Sans le secret (staging), l'endpoint reste
    **ouvert** : fail-open assumé, à l'inverse de `require_admin_token` qui est
    fail-closed ;
  - `uptime_seconds` ajouté à `stats()` : les compteurs sont cumulatifs depuis le
    boot, donc le hit rate se lisse et masquerait une régression. La lecture se
    fait sur le **delta de deux échantillons**.

## 2. Correction préalable : les générations (bug pré-existant)

Sous le lock single-flight, `_compute_feed` prend 1,5 à 5 s puis `put()` écrivait
**inconditionnellement**. Une `invalidate` arrivant dans cette fenêtre était
écrasée : **un article masqué pouvait réapparaître** jusqu'à expiration du TTL.

Le bug existait déjà, mais l'invalidation ciblée l'aggraverait (elle inspecte le
payload *en cache*, l'ancien, alors que le payload en cours de calcul contient
l'article ⇒ faux négatif systématique dans la fenêtre) et un TTL plus long
multiplierait la durée du symptôme. Corrigé **avant** de scoper.

`generation(user_id)` renvoie `(compteur du user, compteur global)` — le second
sert aux invalidations cross-user, dont le rayon d'action inclut des users sans
entrée en cache. Le endpoint le capture juste avant `_compute_feed` et le repasse
à `put()`, qui droppe l'écriture si le couple a bougé. Un compteur global seul
aurait laissé l'écriture d'un user annuler le `put()` en vol de tous les autres,
soit en permanence avec le SEEN à chaque scroll.

## 3. Invalidation content-scoped, limitée aux sites prouvés sûrs

`invalidate_content(user_id, content_id)` ne purge que les variants du user
**dont le payload mentionne l'id** (scan d'octets, ~50 µs pour 12 variants).

> Pourquoi un scan d'octets plutôt qu'un `frozenset` d'ids capturé au `put()` :
> le set exigerait un walk qui connaît le schéma (`items`, `carousels[].items`,
> `clusters[]…`) et **manquerait silencieusement** les items imbriqués ⇒ faux
> négatifs, donc contenu périmé servi après écriture. Le scan est agnostique du
> schéma et son seul mode d'échec est le faux positif (une purge en trop,
> inoffensive). Le risque réel, une évolution de sérialisation qui casserait le
> match en silence, est épinglé par `test_cached_payload_item_ids_match_str_uuid`.

**Le point critique, c'est le périmètre.** Vérifié dans `content_service.py` :
like, save, hide, note upsert et la transition CONSUMED mutent
`UserSubtopic.weight` et `UserEntityAffinity.affinity`, qui alimentent le scoring
de *toutes* les sections. Les scoper laisserait un **classement** périmé partout.
On ne les touche pas.

| Site | Après |
|---|---|
| `update_content_status` **sans** transition consumed (SEEN au scroll) | `invalidate_content` ← **le gain principal** |
| `impress_content` (n'écrit que `manually_impressed`/`last_impressed_at`) | `invalidate_content` |
| `unsave_content` / `unhide_content` (aucun poids ajusté) | `invalidate_content` |
| `delete_note` — **n'invalidait rien** | `invalidate_content` (bug fix) |
| like/unlike, save, hide, feedback, status→CONSUMED | `invalidate()` inchangé |
| `upsert_note` — **n'invalidait rien**, or il boost les poids | `invalidate()` (bug fix) |
| `report_not_serene` — **n'invalidait rien**, et `is_serene=False` est un flip **global cross-user** | `invalidate_content_global` (bug fix) |
| les 27 autres sites (mute, follow, prefs, custom topics, refresh…) | inchangés |

Deux garde-fous notables :

- **Ne pas purger `_locks` dans `invalidate*`** : retirer un `Lock` détenu par
  des waiters casserait le single-flight, soit le thundering herd que ce cache
  existe pour éviter. Gardé par `test_invalidate_keeps_locks_alive`.
- Faux négatif résiduel borné par le TTL : le payload caché est une tranche
  top-N ; une action sur un article hors-tranche ne purge pas la variante, ce qui
  est correct puisqu'il n'était pas affiché.

## Décisions documentées (ce qui ne change PAS)

- **`--workers 2` : non.** Le cache est in-process et `invalidate` est
  process-local : avec 2 workers, un `POST /hide` traité par le worker A ne purge
  pas le cache du worker B ⇒ l'article masqué réapparaît. Idem
  `_analysis_cache` / `_perspectives_cache`. Condition de réouverture :
  invalidation partagée (Redis pub/sub). Et si le besoin est du parallélisme CPU,
  la vraie réponse est de sortir le scoring du chemin requête.
- **`FEED_CACHE_PERSONALIZED_TTL_SECONDS=300` : hors PR.** Étape ops Railway, à
  faire **après** lecture du hit rate réel. Défaut code inchangé à 60 s.
- `degraded_fallback` dans `FeedResponse` : abandonné (champ additif sans
  consommateur UI ; le log `feed_request` couvre le besoin).
- `profile_feed_latency.py` : pas réécrit — il bypasse le endpoint *et* le cache.

## Tests

- `tests/services/test_feed_cache.py` : +18 unitaires — invalidation ciblée /
  globale, générations (stale droppé, per-user, bump même sans purge), garde
  anti-régression sur `_locks`, `uptime_seconds`.
- `tests/routers/test_feed_cache_invalidation_sites.py` (nouveau) : épingle
  **quels endpoints purgent tout et lesquels ciblent**, plus l'invariant de
  sérialisation dont dépend le scan d'octets.
- `tests/test_health_feed_cache.py` (nouveau) : métriques exposées, fail-open
  sans secret, 404 avec secret configuré.
- `tests/test_feed_personalized_cache.py` : +3 sur le log `feed_request`
  (miss→hit, classe default, bypass paginé).
- Suite complète backend : **2648 passed, 18 skipped, 2 xfailed**.
- `ruff check` + `ruff format --check` OK sur les fichiers touchés ;
  `alembic heads` = 1 head (`sa02_alerts_v2`).
- Smoke live `uvicorn` : `/api/health/feed-cache` → 200 sans secret,
  `uptime_seconds` croissant sur deux échantillons ; avec `HEALTH_METRICS_TOKEN`
  posé → 404 sans header, 404 avec mauvais token, 200 avec le bon.

## Vérification sur staging (après déploiement)

1. Deux lectures de `/api/health/feed-cache` encadrant une ouverture d'app → hit
   rate sur le **delta**.
2. `grep 'feed_request'` dans les logs Railway sur 5 min d'usage réel.
3. **Scroller 3 articles puis rouvrir la Tournée < 60 s** → sections servies du
   cache. C'est le scénario que cette PR débloque.
4. `hide` un article visible + pull-to-refresh immédiat → il ne revient pas (test
   des générations).
5. Deux comptes en mode serein : A signale non-serein, B pull-to-refresh →
   l'article disparaît chez B.

Puis seulement : poser `FEED_CACHE_PERSONALIZED_TTL_SECONDS=300` et re-mesurer.

## Suivi post-merge (hors PR)

- `HEALTH_METRICS_TOKEN` n'est pas configuré sur Railway : l'endpoint sera
  **ouvert** sur staging (fail-open documenté). À décider avant que `production`
  n'avance.
- PR 3 (SWR client par section) : périmètre réel et ses **trois bloquants**
  (reseed nu qui détruirait l'hydratation, sections source non hydratées,
  `_dismissedIds` en mémoire seule) documentés en fin de doc maintenance.

## Hors périmètre

Aucun changement mobile, aucune migration DB, aucun changement de TTL.
