### PR TITLE
revert(flux-continu): annule le retuning du ressort de snap (garde « passer à la suite »)

### DIFF
--- a/apps/mobile/lib/features/flux_continu/utils/section_snap.dart
+++ b/apps/mobile/lib/features/flux_continu/utils/section_snap.dart
@@ -26,15 +26,6 @@ const double kSectionEdgeMargin = 160.0;
 /// rewind (more sections stay snapped on the way up); lower ⇒ easier to escape.
 const double kFastUpwardVelocity = 1400.0;
 
-/// px/s. Seuil « geste rapide » **en descente**. En dessous, un scroll qui
-/// atterrit dans l'intérieur d'une section plus haute que l'écran reste en
-/// lecture libre (on suit le doigt). Au-dessus, l'intention lue est « passer à
-/// la suite » : le snap reprend la main et vise le **haut de la section
-/// suivante**, en ignorant le point de repos intermédiaire (bas de la carte
-/// courante) — sinon une carte longue exige deux gestes. Plus haut ⇒ plus
-/// difficile de sauter une carte longue ; plus bas ⇒ snap plus mordant.
-const double kFastDownwardVelocity = 900.0;
-
 // ── Réglages du ressort de snap (le « grain » du switch vers une section) ──
 // Le snap est un [ScrollSpringSimulation] : on tune ces 3 leviers à l'œil pour
 // le rendre à la fois smooth ET net. Repères :
@@ -42,23 +33,19 @@ const double kFastDownwardVelocity = 900.0;
 /// La **force / vitesse** du tir vers la cible. Plus haut ⇒ snap plus rapide et
 /// « net » (claque vers la section) ; plus bas ⇒ plus lent et mou. C'est le
 /// premier levier pour la « vitesse de switch ».
-const double kSnapStiffness = 900.0;
+const double kSnapStiffness = 700.0;
 
 /// L'**amortissement**. Plus haut ⇒ aucune oscillation, arrivée « posée » et
 /// smooth (mais trop haut = traînant) ; plus bas ⇒ vif, voire un léger rebond.
 /// À monter avec [kSnapStiffness] pour rester net sans wobble.
-/// Baissé à 36 (ex-40) pour retirer un peu d'« amorti » en fin de geste : le
-/// système reste **suramorti** (`c² = 1296 > 4mk = 108`, aucun wobble), mais la
-/// racine lente passe de ≈ 17.7 s⁻¹ à ≈ 25.5 s⁻¹. Ne pas descendre sous ≈ 30
-/// avec cette raideur : en dessous on entre en zone de rebond.
-const double kSnapDamping = 36.0;
+const double kSnapDamping = 40.0;
 
 /// L'**inertie** de la masse animée. Plus haut ⇒ démarrage plus pesant / lent ;
 /// plus bas ⇒ réaction plus immédiate. À laisser ≈ 0.5 sauf besoin précis.
 const double kSnapMass = 0.03;
 
-/// Ressort de pose du snap, assemblé depuis les 3 leviers ci-dessus. Pose
-/// visible (~180-250ms) sans wobble — le snap fait partie de la décélération
+/// Ressort de pose du snap, assemblé depuis les 3 leviers ci-dessus. Visible
+/// « pose » (~250-350ms) sans wobble — le snap fait partie de la décélération
 /// du fling, pas d'une seconde animation.
 const SpringDescription kSnapSpring = SpringDescription(
   mass: kSnapMass,
@@ -79,9 +66,7 @@ typedef SectionFrame = ({double top, double bottom});
 ///
 /// The feel: the reader is **free** while a section fully fills the viewport
 /// (its top is above the sticky header *and* its bottom is below the footer —
-/// no edge shows) **and** their gesture is slow: a downward fling past
-/// [kFastDownwardVelocity] reads as "passer à la suite" and snaps to the next
-/// section top. Once an edge crosses into the viewport the scroll **snaps**,
+/// no edge shows). Once an edge crosses into the viewport the scroll **snaps**,
 /// with a hard **one-step cap**: whatever the fling's strength, the commit
 /// target is always the frame **adjacent to the finger-lift position**
 /// ([currentPixels]) in the travel direction — never bracketed around where the
@@ -134,20 +119,12 @@ double? resolveSnapTarget({
   final freeUpwardEscape = dir < 0 && velocity.abs() >= kFastUpwardVelocity;
   if (freeUpwardEscape) return null;
 
-  // DOWN-only "passer à la suite": a vigorous downward fling reads as an intent
-  // to leave the current section, even a tall one. It disables the free-reading
-  // gate below and targets section **tops** only — so a card taller than the
-  // screen is cleared in a single gesture instead of two. See
-  // [kFastDownwardVelocity].
-  final isFastDown = dir > 0 && velocity.abs() >= kFastDownwardVelocity;
-
   // Free reading: the landing rests inside a section that fully fills the
   // viewport (a tall section's open interior). No edge shows ⇒ leave it free —
-  // but only on a *slow* descent/idle (`dir >= 0 && !isFastDown`). On a slow
-  // upward scroll we fall through to the snap logic so the section above
-  // re-frames under the header instead of drifting (the fix for the "too
-  // permissive" rewind).
-  if (dir >= 0 && !isFastDown) {
+  // but only on descent/idle (`dir >= 0`). On a slow upward scroll we fall
+  // through to the snap logic so the section above re-frames under the header
+  // instead of drifting (the fix for the "too permissive" rewind).
+  if (dir >= 0) {
     for (final f in frames) {
       if (f.bottom > f.top + kSnapEpsilon &&
           naturalLanding > f.top + kSnapEpsilon &&
@@ -160,18 +137,6 @@ double? resolveSnapTarget({
   // Every framing offset is a snap point: each section top, plus the bottom of
   // each tall section (rest on its last cards). Sorted ascending.
   final points = snapPointsOf(frames);
-
-  // Geste rapide en descente : viser le **haut de la section suivante**, en
-  // ignorant le point de repos intermédiaire (bas de la section courante) —
-  // sinon une carte plus haute que l'écran exige deux gestes. Placé avant le
-  // deadband : un fling ≥ [kFastDownwardVelocity] dépasse de toute façon la
-  // marge, et la règle reste lisible sans en dépendre. Toujours **un cran**,
-  // mesuré en sections au lieu de frames.
-  if (isFastDown) {
-    final tops = [for (final f in frames) f.top]..sort();
-    final next = _firstStrictlyAfter(tops, currentPixels);
-    return _commit(next ?? _nearest(points, currentPixels), currentPixels);
-  }
 
   // Deadband (« marge »): how far the fling's inertia carries past the lift
   // point. A small overshoot — or no direction at all — re-frames the section

--- a/apps/mobile/lib/features/flux_continu/utils/section_snap.dart
+++ b/apps/mobile/lib/features/flux_continu/utils/section_snap.dart
@@ -26,6 +26,15 @@ const double kSectionEdgeMargin = 160.0;
 /// rewind (more sections stay snapped on the way up); lower ⇒ easier to escape.
 const double kFastUpwardVelocity = 1400.0;
 
+/// px/s. Seuil « geste rapide » **en descente**. En dessous, un scroll qui
+/// atterrit dans l'intérieur d'une section plus haute que l'écran reste en
+/// lecture libre (on suit le doigt). Au-dessus, l'intention lue est « passer à
+/// la suite » : le snap reprend la main et vise le **haut de la section
+/// suivante**, en ignorant le point de repos intermédiaire (bas de la carte
+/// courante) — sinon une carte longue exige deux gestes. Plus haut ⇒ plus
+/// difficile de sauter une carte longue ; plus bas ⇒ snap plus mordant.
+const double kFastDownwardVelocity = 900.0;
+
 // ── Réglages du ressort de snap (le « grain » du switch vers une section) ──
 // Le snap est un [ScrollSpringSimulation] : on tune ces 3 leviers à l'œil pour
 // le rendre à la fois smooth ET net. Repères :
@@ -66,7 +75,9 @@ typedef SectionFrame = ({double top, double bottom});
 ///
 /// The feel: the reader is **free** while a section fully fills the viewport
 /// (its top is above the sticky header *and* its bottom is below the footer —
-/// no edge shows). Once an edge crosses into the viewport the scroll **snaps**,
+/// no edge shows) **and** their gesture is slow: a downward fling past
+/// [kFastDownwardVelocity] reads as "passer à la suite" and snaps to the next
+/// section top. Once an edge crosses into the viewport the scroll **snaps**,
 /// with a hard **one-step cap**: whatever the fling's strength, the commit
 /// target is always the frame **adjacent to the finger-lift position**
 /// ([currentPixels]) in the travel direction — never bracketed around where the
@@ -119,12 +130,20 @@ double? resolveSnapTarget({
   final freeUpwardEscape = dir < 0 && velocity.abs() >= kFastUpwardVelocity;
   if (freeUpwardEscape) return null;
 
+  // DOWN-only "passer à la suite": a vigorous downward fling reads as an intent
+  // to leave the current section, even a tall one. It disables the free-reading
+  // gate below and targets section **tops** only — so a card taller than the
+  // screen is cleared in a single gesture instead of two. See
+  // [kFastDownwardVelocity].
+  final isFastDown = dir > 0 && velocity.abs() >= kFastDownwardVelocity;
+
   // Free reading: the landing rests inside a section that fully fills the
   // viewport (a tall section's open interior). No edge shows ⇒ leave it free —
-  // but only on descent/idle (`dir >= 0`). On a slow upward scroll we fall
-  // through to the snap logic so the section above re-frames under the header
-  // instead of drifting (the fix for the "too permissive" rewind).
-  if (dir >= 0) {
+  // but only on a *slow* descent/idle (`dir >= 0 && !isFastDown`). On a slow
+  // upward scroll we fall through to the snap logic so the section above
+  // re-frames under the header instead of drifting (the fix for the "too
+  // permissive" rewind).
+  if (dir >= 0 && !isFastDown) {
     for (final f in frames) {
       if (f.bottom > f.top + kSnapEpsilon &&
           naturalLanding > f.top + kSnapEpsilon &&
@@ -137,6 +156,18 @@ double? resolveSnapTarget({
   // Every framing offset is a snap point: each section top, plus the bottom of
   // each tall section (rest on its last cards). Sorted ascending.
   final points = snapPointsOf(frames);
+
+  // Geste rapide en descente : viser le **haut de la section suivante**, en
+  // ignorant le point de repos intermédiaire (bas de la section courante) —
+  // sinon une carte plus haute que l'écran exige deux gestes. Placé avant le
+  // deadband : un fling ≥ [kFastDownwardVelocity] dépasse de toute façon la
+  // marge, et la règle reste lisible sans en dépendre. Toujours **un cran**,
+  // mesuré en sections au lieu de frames.
+  if (isFastDown) {
+    final tops = [for (final f in frames) f.top]..sort();
+    final next = _firstStrictlyAfter(tops, currentPixels);
+    return _commit(next ?? _nearest(points, currentPixels), currentPixels);
+  }
 
   // Deadband (« marge »): how far the fling's inertia carries past the lift
   // point. A small overshoot — or no direction at all — re-frames the section

--- a/apps/mobile/test/features/flux_continu/utils/section_snap_test.dart
+++ b/apps/mobile/test/features/flux_continu/utils/section_snap_test.dart
@@ -210,101 +210,18 @@ void main() {
     });
 
     test(
-        'a moderate fling from inside a tall section stops at its bottom '
-        '(one step)', () {
-      // Lift inside the (300, 600) interior, landing past the section but
-      // BELOW kFastDownwardVelocity. The cap advances to the section's own
-      // bottom frame (600), not beyond (a *fast* fling skips it — see the
-      // fast-descent group).
+        'a hard fling from inside a tall section stops at its bottom (one step)',
+        () {
+      // Lift inside the (300, 600) interior, huge landing past the section.
+      // The cap advances to the section's own bottom frame (600), not beyond.
       final target = resolveSnapTarget(
         currentPixels: 320,
         naturalLanding: 5000,
-        velocity: kFastDownwardVelocity - 1,
-        scrollDirection: 1, // down, sub-threshold
+        velocity: 9000,
+        scrollDirection: 1, // down
         frames: frames,
       );
       expect(target, 600.0);
-    });
-
-    // --- Task: fast DOWNWARD fling clears a tall section in one gesture -----
-
-    test('a slow descent inside a tall section stays free (non-regression)',
-        () {
-      // Landing at 450 inside the (300,600) interior with a velocity under
-      // kFastDownwardVelocity ⇒ free reading, exactly as before.
-      final target = resolveSnapTarget(
-        currentPixels: 430,
-        naturalLanding: 450,
-        velocity: kFastDownwardVelocity - 1,
-        scrollDirection: 1,
-        frames: frames,
-      );
-      expect(target, isNull);
-    });
-
-    test('a fast descent inside a tall section snaps to the NEXT section top',
-        () {
-      // Same landing, but past the threshold: the intent reads as "passer à la
-      // suite" ⇒ target the next section top (1200), never the current
-      // section's bottom (600) — otherwise a long card needs two gestures.
-      final target = resolveSnapTarget(
-        currentPixels: 430,
-        naturalLanding: 450,
-        velocity: 2000,
-        scrollDirection: 1,
-        frames: frames,
-      );
-      expect(target, 1200.0);
-    });
-
-    test('a fast descent from a tall section bottom targets the next top', () {
-      final target = resolveSnapTarget(
-        currentPixels: 600,
-        naturalLanding: 5000,
-        velocity: 2000,
-        scrollDirection: 1,
-        frames: frames,
-      );
-      expect(target, 1200.0);
-    });
-
-    test('the fast-descent target is a different section ⇒ haptic fires', () {
-      // frameIndexOfTarget must differ from the active section (index 1, the
-      // tall one) so the screen fires exactly one settle haptic.
-      final target = resolveSnapTarget(
-        currentPixels: 430,
-        naturalLanding: 450,
-        velocity: 2000,
-        scrollDirection: 1,
-        frames: frames,
-      );
-      expect(frameIndexOfTarget(frames, target!), isNot(1));
-    });
-
-    test('a fast descent past the last section falls back to the nearest frame',
-        () {
-      // No section top after the lift point (already on the finale) ⇒ fall back
-      // to the nearest snap point rather than returning a runaway target.
-      final target = resolveSnapTarget(
-        currentPixels: 1250,
-        naturalLanding: 9000,
-        velocity: 3000,
-        scrollDirection: 1,
-        frames: frames,
-      );
-      expect(target, 1200.0);
-    });
-
-    test('a fast UPWARD fling is unaffected by the downward threshold', () {
-      // kFastDownwardVelocity is DOWN-only: the up escape still wins.
-      final target = resolveSnapTarget(
-        currentPixels: 430,
-        naturalLanding: 450,
-        velocity: -kFastUpwardVelocity - 100,
-        scrollDirection: -1,
-        frames: frames,
-      );
-      expect(target, isNull);
     });
 
     // --- Directional one-step commits --------------------------------------

--- a/apps/mobile/test/features/flux_continu/utils/section_snap_test.dart
+++ b/apps/mobile/test/features/flux_continu/utils/section_snap_test.dart
@@ -210,18 +210,101 @@ void main() {
     });
 
     test(
-        'a hard fling from inside a tall section stops at its bottom (one step)',
-        () {
-      // Lift inside the (300, 600) interior, huge landing past the section.
-      // The cap advances to the section's own bottom frame (600), not beyond.
+        'a moderate fling from inside a tall section stops at its bottom '
+        '(one step)', () {
+      // Lift inside the (300, 600) interior, landing past the section but
+      // BELOW kFastDownwardVelocity. The cap advances to the section's own
+      // bottom frame (600), not beyond (a *fast* fling skips it — see the
+      // fast-descent group).
       final target = resolveSnapTarget(
         currentPixels: 320,
         naturalLanding: 5000,
-        velocity: 9000,
-        scrollDirection: 1, // down
+        velocity: kFastDownwardVelocity - 1,
+        scrollDirection: 1, // down, sub-threshold
         frames: frames,
       );
       expect(target, 600.0);
+    });
+
+    // --- Task: fast DOWNWARD fling clears a tall section in one gesture -----
+
+    test('a slow descent inside a tall section stays free (non-regression)',
+        () {
+      // Landing at 450 inside the (300,600) interior with a velocity under
+      // kFastDownwardVelocity ⇒ free reading, exactly as before.
+      final target = resolveSnapTarget(
+        currentPixels: 430,
+        naturalLanding: 450,
+        velocity: kFastDownwardVelocity - 1,
+        scrollDirection: 1,
+        frames: frames,
+      );
+      expect(target, isNull);
+    });
+
+    test('a fast descent inside a tall section snaps to the NEXT section top',
+        () {
+      // Same landing, but past the threshold: the intent reads as "passer à la
+      // suite" ⇒ target the next section top (1200), never the current
+      // section's bottom (600) — otherwise a long card needs two gestures.
+      final target = resolveSnapTarget(
+        currentPixels: 430,
+        naturalLanding: 450,
+        velocity: 2000,
+        scrollDirection: 1,
+        frames: frames,
+      );
+      expect(target, 1200.0);
+    });
+
+    test('a fast descent from a tall section bottom targets the next top', () {
+      final target = resolveSnapTarget(
+        currentPixels: 600,
+        naturalLanding: 5000,
+        velocity: 2000,
+        scrollDirection: 1,
+        frames: frames,
+      );
+      expect(target, 1200.0);
+    });
+
+    test('the fast-descent target is a different section ⇒ haptic fires', () {
+      // frameIndexOfTarget must differ from the active section (index 1, the
+      // tall one) so the screen fires exactly one settle haptic.
+      final target = resolveSnapTarget(
+        currentPixels: 430,
+        naturalLanding: 450,
+        velocity: 2000,
+        scrollDirection: 1,
+        frames: frames,
+      );
+      expect(frameIndexOfTarget(frames, target!), isNot(1));
+    });
+
+    test('a fast descent past the last section falls back to the nearest frame',
+        () {
+      // No section top after the lift point (already on the finale) ⇒ fall back
+      // to the nearest snap point rather than returning a runaway target.
+      final target = resolveSnapTarget(
+        currentPixels: 1250,
+        naturalLanding: 9000,
+        velocity: 3000,
+        scrollDirection: 1,
+        frames: frames,
+      );
+      expect(target, 1200.0);
+    });
+
+    test('a fast UPWARD fling is unaffected by the downward threshold', () {
+      // kFastDownwardVelocity is DOWN-only: the up escape still wins.
+      final target = resolveSnapTarget(
+        currentPixels: 430,
+        naturalLanding: 450,
+        velocity: -kFastUpwardVelocity - 100,
+        scrollDirection: -1,
+        frames: frames,
+      );
+      expect(target, isNull);
     });
 
     // --- Directional one-step commits --------------------------------------


### PR DESCRIPTION
## What

Revert du seul **retuning du ressort de snap** introduit par la PR #1012 : `kSnapStiffness` 900→700 et `kSnapDamping` 36→40 (pose ~250-350ms). La logique « passer à la suite » sur fling rapide en descente (`kFastDownwardVelocity`) est **conservée**, ainsi que le CTA « Tout lire (N+) ».

## Why

La sensation d'amortissement / vitesse du snap retunée a été jugée désagréable après test E2E ; on revient au grain d'origine du ressort. Le comportement « passer à la suite » est gardé car apprécié.

## Type

- [x] Maintenance / Refactor

## Checklist

- [x] Mobile-only — 36 tests `section_snap_test.dart` verts localement

## Staging

- [x] Mobile-only, pas de migration