### PR TITLE
feat(onboarding): garde-fou fraîcheur des sources recommandées + fix fuite du gate pépites

### DIFF
--- a/packages/api/app/routers/sources.py
+++ b/packages/api/app/routers/sources.py
@@ -69,6 +69,7 @@ from app.services.source_alert_producer import (
     ALERT_CAP,
     count_active_alerts,
 )
+from app.services.source_freshness import freshness_verdicts
 from app.services.source_recommendation_gate import (
     is_quality_catalog,
     passes_safety_gate,
@@ -283,6 +284,34 @@ def _source_matches_theme(slug: str):
         | (Source.secondary_themes.any(slug))
         | (Source.coverage_themes.any(slug))
     )
+
+
+# Borne du fetch élargi des surfaces poussées par thème : on récupère large
+# (au-delà de `limit`) pour pouvoir écarter les feeds morts et déclasser les
+# cadences lentes avant de couper. Large devant le nombre de sources par thème.
+_FRESHNESS_SCAN_LIMIT = 40
+
+
+async def _apply_freshness(
+    db: AsyncSession, sources: list[Source], limit: int
+) -> list[Source]:
+    """Filtre les feeds morts et déclasse les sources lentes, puis coupe à `limit`.
+
+    Ordre : sources fraîches d'abord, puis déclassées (cadence lente sans article
+    récent), chaque groupe conservant l'ordre alphabétique d'entrée. Les sources
+    exclues (feed considéré mort, cf. `source_freshness`) ne sont jamais renvoyées.
+    """
+    if not sources:
+        return []
+    verdicts = await freshness_verdicts(db, sources)
+    fresh: list[Source] = []
+    downgraded: list[Source] = []
+    for s in sources:
+        verdict = verdicts[s.id]
+        if verdict.excluded:
+            continue
+        (downgraded if verdict.downgraded else fresh).append(s)
+    return (fresh + downgraded)[:limit]
 
 
 def _source_to_response(
@@ -511,6 +540,11 @@ async def get_sources_by_theme(
     groups: list[ThemeSourceGroup] = []
     total = 0
 
+    # Fenêtre de fetch élargie : on récupère plus large que `limit` pour pouvoir
+    # écarter les feeds morts (0 article récent) et déclasser les cadences lentes
+    # via `source_freshness`, avant de couper à `limit`.
+    scan_limit = min(limit * 4, _FRESHNESS_SCAN_LIMIT)
+
     # Curées
     stmt_curated = (
         select(Source)
@@ -518,10 +552,10 @@ async def get_sources_by_theme(
         .where(Source.is_curated.is_(True))
         .where(_source_matches_theme(slug))
         .order_by(Source.name)
-        .limit(limit)
+        .limit(scan_limit)
     )
     result = await db.execute(stmt_curated)
-    curated_sources = result.scalars().all()
+    curated_sources = await _apply_freshness(db, result.scalars().all(), limit)
     curated_responses = [
         _source_to_response(s, trusted_ids=trusted_ids) for s in curated_sources
     ]
@@ -539,10 +573,12 @@ async def get_sources_by_theme(
             .where(Source.is_curated.is_(False))
             .where(_source_matches_theme(slug))
             .order_by(Source.name)
-            .limit(remaining)
+            .limit(scan_limit)
         )
         result = await db.execute(stmt_candidates)
-        candidate_sources = result.scalars().all()
+        candidate_sources = await _apply_freshness(
+            db, result.scalars().all(), remaining
+        )
         candidate_responses = [
             _source_to_response(s, trusted_ids=trusted_ids) for s in candidate_sources
         ]
@@ -645,10 +681,13 @@ async def suggest_sources_for_theme(
     pepite_sources = await pepite_service.get_theme_pepite_sources(
         slug, exclude_ids=trusted_ids
     )
+    pepite_verdicts = await freshness_verdicts(db, pepite_sources)
     for s in pepite_sources:
         if len(suggestions) >= cap:
             break
         if not passes_safety_gate(s):
+            continue
+        if pepite_verdicts[s.id].excluded:
             continue
         suggestions.append(
             ThemeSuggestionItem(
@@ -669,12 +708,16 @@ async def suggest_sources_for_theme(
             .limit(_QUALITY_CATALOG_SCAN_LIMIT)
         )
         result = await db.execute(stmt_catalog)
-        for s in result.scalars().all():
+        catalog_sources = result.scalars().all()
+        catalog_verdicts = await freshness_verdicts(db, catalog_sources)
+        for s in catalog_sources:
             if len(suggestions) >= cap:
                 break
             if s.id in trusted_ids or s.id in seen_ids:
                 continue
             if not is_quality_catalog(s):
+                continue
+            if catalog_verdicts[s.id].excluded:
                 continue
             suggestions.append(
                 ThemeSuggestionItem(

--- a/packages/api/app/services/pepite_service.py
+++ b/packages/api/app/services/pepite_service.py
@@ -21,6 +21,8 @@ from app.services.premium_curated_sources import (
     PREMIUM_CURATED_MAP,
     is_paywalled_source,
 )
+from app.services.source_freshness import freshness_verdicts
+from app.services.source_recommendation_gate import passes_safety_gate
 
 logger = structlog.get_logger()
 
@@ -145,16 +147,27 @@ class PepiteService:
         result = await self.db.execute(query)
         rows = result.all()
 
+        # Gate de sécurité : une pépite ne doit jamais être poussée si sa
+        # fiabilité est basse/inconnue ou son positionnement alternatif — même
+        # depuis le carrousel (cohérence avec le footer « Étoffer »).
+        rows = [row for row in rows if passes_safety_gate(row[0])]
+
+        # Fraîcheur : écarte les feeds morts, déclasse les cadences lentes sans
+        # article récent (cf. source_freshness).
+        verdicts = await freshness_verdicts(self.db, [row[0] for row in rows])
+        rows = [row for row in rows if not verdicts[row[0].id].excluded]
+
         def _match_score(source: Source) -> int:
             if not source.pepite_for_themes or not interest_slugs:
                 return 0
             return len(set(source.pepite_for_themes) & interest_slugs)
 
-        # Tri prioritaire : (1) source avec logo (les cartes sans logo
-        # sont moins "vendeuses" visuellement), (2) match thème user,
-        # (3) nb de followers.
+        # Tri prioritaire : (1) source fraîche avant source déclassée, (2) source
+        # avec logo (cartes sans logo moins "vendeuses"), (3) match thème user,
+        # (4) nb de followers.
         rows.sort(
             key=lambda row: (
+                0 if verdicts[row[0].id].downgraded else 1,
                 1 if row[0].logo_url else 0,
                 _match_score(row[0]),
                 row[1] or 0,

--- a/packages/api/app/services/source_freshness.py
+++ b/packages/api/app/services/source_freshness.py
@@ -1,0 +1,143 @@
+"""Fraîcheur des sources — garde-fou des recommandations POUSSÉES.
+
+Une source curée / pépite qui n'a plus publié depuis longtemps (feed cassé,
+jamais ingéré, ou média en sommeil) ne doit pas remonter en tête des
+recommandations d'onboarding. Ce module lit la date du **dernier article** de
+chaque source et la classe selon une règle **cadence-aware** — car un flux RSS
+d'actualité et une chaîne YouTube n'ont pas le même rythme naturel.
+
+Règle (knobs PO centralisés ici) :
+- `type = article` (RSS/news, cadence rapide) : rien publié depuis
+  `FRESH_WINDOW_DAYS` ⇒ **exclue** des surfaces poussées (feed considéré mort).
+- `type ∈ {podcast, youtube, reddit}` (cadence lente) : exclue seulement si rien
+  publié depuis `SLOW_WINDOW_DAYS` (réellement morte) ; sinon **conservée mais
+  déclassée** (triée après les sources fraîches) tant qu'elle n'a rien publié
+  sur `FRESH_WINDOW_DAYS`.
+
+Perf : on ne **compte pas** les articles (une source active en a des milliers) —
+on lit seulement la date du dernier article via un sous-select **corrélé**
+`ORDER BY published_at DESC LIMIT 1` par source. L'index
+`ix_contents_source_published` (source_id, published_at) résout ça en un backward
+index-scan (≈1 ligne/source), soit ~30 ms pour 40 sources. On évite volontairement
+le pattern `func.max(published_at) GROUP BY source_id` (utilisé ailleurs, ex.
+`veille.py`, `source_service._load_articles_30d`) : mesuré à ~2,8 s ici car il
+scanne **toutes** les entrées d'index des sources actives avant d'agréger, alors
+que la corrélée s'arrête au premier tuple. Matérialiser `last_article_at` sur
+`sources` via un job reste un follow-up possible.
+"""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.content import Content
+from app.models.enums import SourceType
+from app.models.source import Source
+
+# Fenêtre « fraîche » — un flux d'actualité doit avoir publié dans ce délai.
+FRESH_WINDOW_DAYS = 30
+# Fenêtre « en vie » pour les cadences lentes (podcast / vidéo) — au-delà de ce
+# silence, même une source lente est considérée morte.
+SLOW_WINDOW_DAYS = 90
+
+# Types à cadence lente : un silence de 30 j n'y signifie pas un feed cassé.
+SLOW_CADENCE_TYPES: frozenset[SourceType] = frozenset(
+    {SourceType.PODCAST, SourceType.YOUTUBE, SourceType.REDDIT}
+)
+
+
+@dataclass(frozen=True)
+class FreshnessVerdict:
+    """Verdict de fraîcheur appliqué à une source poussée."""
+
+    excluded: bool  # à retirer des surfaces poussées (feed mort)
+    downgraded: bool  # à conserver mais reléguer en fin de liste
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _as_utc(dt: datetime) -> datetime:
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
+
+
+def _source_type(source: Source) -> SourceType:
+    raw = source.type
+    if isinstance(raw, SourceType):
+        return raw
+    try:
+        return SourceType(raw)
+    except (ValueError, TypeError):
+        # Défaut prudent : traité comme un flux rapide (règle la plus stricte).
+        return SourceType.ARTICLE
+
+
+def classify(source: Source, last_published_at: datetime | None) -> FreshnessVerdict:
+    """Classe une source d'après la date de son dernier article.
+
+    `last_published_at=None` signifie « aucun article » (feed jamais ingéré ou
+    vidé) — traité comme le silence le plus total.
+    """
+    now = _now()
+    fresh = last_published_at is not None and _as_utc(
+        last_published_at
+    ) > now - timedelta(days=FRESH_WINDOW_DAYS)
+    if fresh:
+        return FreshnessVerdict(excluded=False, downgraded=False)
+
+    alive = last_published_at is not None and _as_utc(
+        last_published_at
+    ) > now - timedelta(days=SLOW_WINDOW_DAYS)
+    if _source_type(source) in SLOW_CADENCE_TYPES:
+        # Cadence lente : morte seulement si silence total sur la fenêtre large.
+        if alive:
+            return FreshnessVerdict(excluded=False, downgraded=True)
+        return FreshnessVerdict(excluded=True, downgraded=False)
+
+    # Flux rapide sans article récent : feed considéré mort.
+    return FreshnessVerdict(excluded=True, downgraded=False)
+
+
+async def fetch_last_published(
+    db: AsyncSession, source_ids: list[UUID]
+) -> dict[UUID, datetime]:
+    """Date du dernier article par source, pour un lot d'IDs.
+
+    Une seule requête : un sous-select corrélé `ORDER BY published_at DESC
+    LIMIT 1` par source (backward index-scan sur `ix_contents_source_published`).
+    Les sources sans article ne figurent pas dans le dict retourné (⇒ traitées
+    comme silence total par [classify]).
+    """
+    if not source_ids:
+        return {}
+
+    last_pub = (
+        select(Content.published_at)
+        .where(Content.source_id == Source.id)
+        .order_by(Content.published_at.desc())
+        .limit(1)
+        .correlate(Source)
+        .scalar_subquery()
+    )
+    stmt = select(Source.id, last_pub.label("last_pub")).where(
+        Source.id.in_(source_ids)
+    )
+    result = await db.execute(stmt)
+    return {row[0]: row[1] for row in result.all() if row[1] is not None}
+
+
+async def freshness_verdicts(
+    db: AsyncSession, sources: list[Source]
+) -> dict[UUID, FreshnessVerdict]:
+    """Verdict de fraîcheur par source, en un seul aller-retour DB.
+
+    Compose `fetch_last_published` (dernier article) + `classify` (règle
+    cadence-aware) pour tout un lot. Seam unique des surfaces poussées : chaque
+    appelant applique ensuite sa propre politique (exclure, déclasser, trier).
+    """
+    last_pub = await fetch_last_published(db, [s.id for s in sources])
+    return {s.id: classify(s, last_pub.get(s.id)) for s in sources}

--- a/packages/api/tests/routers/test_by_theme_freshness.py
+++ b/packages/api/tests/routers/test_by_theme_freshness.py
@@ -1,0 +1,113 @@
+"""Tests fraîcheur de GET /api/sources/by-theme/{slug} — écran onboarding.
+
+Verrouille le garde-fou de fraîcheur du levier prioritaire :
+- un flux `article` sans article récent (feed mort) est écarté des Curées ;
+- une source `article` fraîche est conservée ;
+- une source à cadence lente (`podcast`/`youtube`) silencieuse sur 30 j mais
+  active sur 90 j est conservée mais **déclassée** (après les fraîches).
+"""
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.database import get_db
+from app.dependencies import get_current_user_id
+from app.main import app
+from app.models.content import Content
+from app.models.enums import (
+    BiasStance,
+    ContentType,
+    ReliabilityScore,
+    SourceType,
+)
+from app.models.source import Source
+
+
+def _source(name, *, source_type=SourceType.ARTICLE, theme="tech"):
+    slug = name.lower().replace(" ", "")
+    return Source(
+        id=uuid4(),
+        name=name,
+        url=f"https://{slug}.example.com",
+        feed_url=f"https://{slug}.example.com/feed-{uuid4()}.xml",
+        type=source_type,
+        theme=theme,
+        is_active=True,
+        is_curated=True,
+        bias_stance=BiasStance.CENTER,
+        reliability_score=ReliabilityScore.HIGH,
+    )
+
+
+def _article(source, *, days_ago):
+    return Content(
+        id=uuid4(),
+        source_id=source.id,
+        title=f"Article {source.name}",
+        url=f"{source.url}/a-{uuid4()}",
+        published_at=datetime.now(UTC) - timedelta(days=days_ago),
+        content_type=ContentType.ARTICLE,
+        guid=str(uuid4()),
+    )
+
+
+@pytest_asyncio.fixture
+async def client(db_session):
+    async def _fake_user():
+        return str(uuid4())
+
+    async def _fake_db():
+        yield db_session
+
+    app.dependency_overrides[get_current_user_id] = _fake_user
+    app.dependency_overrides[get_db] = _fake_db
+    transport = ASGITransport(app=app)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+        app.dependency_overrides.pop(get_db, None)
+
+
+def _curated_names(body):
+    for group in body["groups"]:
+        if group["label"] == "Curées":
+            return [s["name"] for s in group["sources"]]
+    return []
+
+
+@pytest.mark.asyncio
+async def test_dead_article_feed_excluded(client, db_session):
+    alive = _source("Alive")
+    dead = _source("Dead")
+    db_session.add_all([alive, dead])
+    await db_session.flush()
+    db_session.add(_article(alive, days_ago=1))  # dead : aucun article
+    await db_session.commit()
+
+    resp = await client.get("/api/sources/by-theme/tech")
+    assert resp.status_code == 200
+    names = _curated_names(resp.json())
+    assert "Alive" in names
+    assert "Dead" not in names
+
+
+@pytest.mark.asyncio
+async def test_slow_source_kept_but_downgraded(client, db_session):
+    fresh = _source("Fresh Article")
+    slow = _source("Slow Podcast", source_type=SourceType.PODCAST)
+    db_session.add_all([fresh, slow])
+    await db_session.flush()
+    db_session.add(_article(fresh, days_ago=2))
+    db_session.add(_article(slow, days_ago=45))  # silencieux 30j, actif 90j
+    await db_session.commit()
+
+    resp = await client.get("/api/sources/by-theme/tech")
+    assert resp.status_code == 200
+    names = _curated_names(resp.json())
+    assert names.index("Fresh Article") < names.index("Slow Podcast")

--- a/packages/api/tests/routers/test_suggest_for_theme.py
+++ b/packages/api/tests/routers/test_suggest_for_theme.py
@@ -5,6 +5,7 @@ garde-fou éditorial (exclusion fiabilité basse/inconnue + biais alternatif des
 tiers poussés), l'exclusion des sources déjà suivies, le thème vide et l'auth.
 """
 
+from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 import pytest
@@ -14,8 +15,33 @@ from httpx import ASGITransport, AsyncClient
 from app.database import get_db
 from app.dependencies import get_current_user_id
 from app.main import app
-from app.models.enums import BiasStance, InterestState, ReliabilityScore, SourceType
+from app.models.content import Content
+from app.models.enums import (
+    BiasStance,
+    ContentType,
+    InterestState,
+    ReliabilityScore,
+    SourceType,
+)
 from app.models.source import Source, UserSource
+
+
+def _recent_article(source: Source) -> Content:
+    """Article récent (aujourd'hui) rattaché à `source`.
+
+    Nécessaire pour que la source passe le filtre de fraîcheur des surfaces
+    poussées (cf. `source_freshness`) : sans article récent, un flux `article`
+    est traité comme mort et écarté.
+    """
+    return Content(
+        id=uuid4(),
+        source_id=source.id,
+        title=f"Article récent {source.name}",
+        url=f"{source.url}/article-{uuid4()}",
+        published_at=datetime.now(UTC) - timedelta(days=1),
+        content_type=ContentType.ARTICLE,
+        guid=str(uuid4()),
+    )
 
 
 def _make_source(
@@ -86,6 +112,8 @@ async def test_tier_mapping_pepite_then_catalog(auth_ctx, db_session):
     )
     catalog = _make_source("Le Monde", theme="tech")
     db_session.add_all([pepite, catalog])
+    await db_session.flush()
+    db_session.add_all([_recent_article(pepite), _recent_article(catalog)])
     await db_session.commit()
 
     resp = await client.get("/api/sources/suggest-for-theme/tech")
@@ -133,6 +161,7 @@ async def test_excludes_followed_sources(auth_ctx, db_session):
     fresh = _make_source("Nouvelle", theme="tech")
     db_session.add_all([followed, fresh])
     await db_session.flush()
+    db_session.add_all([_recent_article(followed), _recent_article(fresh)])
     db_session.add(
         UserSource(
             user_id=user_id,
@@ -169,6 +198,8 @@ async def test_secondary_theme_source_is_eligible(auth_ctx, db_session):
     client, _ = auth_ctx
     src = _make_source("Secondaire", theme="economy", secondary_themes=["tech"])
     db_session.add(src)
+    await db_session.flush()
+    db_session.add(_recent_article(src))
     await db_session.commit()
 
     resp = await client.get("/api/sources/suggest-for-theme/tech")

--- a/packages/api/tests/services/test_pepite_service.py
+++ b/packages/api/tests/services/test_pepite_service.py
@@ -14,7 +14,7 @@ from uuid import uuid4
 
 import pytest
 
-from app.models.enums import SourceType
+from app.models.enums import BiasStance, ReliabilityScore, SourceType
 from app.services.pepite_service import (
     DISMISS_COOL_DOWN_DAYS,
     RATE_LIMIT_HOURS,
@@ -33,12 +33,15 @@ def _mk_source(
     is_curated=True,
     pepite_for_themes=None,
     source_id=None,
+    source_type=SourceType.ARTICLE,
+    reliability_score=ReliabilityScore.HIGH,
+    bias_stance=BiasStance.CENTER,
 ):
     return SimpleNamespace(
         id=source_id or uuid4(),
         name=name,
         url=f"https://{name.lower().replace(' ', '')}.example.com",
-        type=SourceType.ARTICLE,
+        type=source_type,
         theme=theme,
         description=None,
         logo_url=None,
@@ -46,8 +49,8 @@ def _mk_source(
         is_active=True,
         is_pepite_recommendation=True,
         pepite_for_themes=pepite_for_themes,
-        bias_stance=SimpleNamespace(value="unknown"),
-        reliability_score=SimpleNamespace(value="unknown"),
+        bias_stance=bias_stance,
+        reliability_score=reliability_score,
         bias_origin=SimpleNamespace(value="unknown"),
         secondary_themes=None,
         granular_topics=None,
@@ -56,6 +59,18 @@ def _mk_source(
         score_rigor=None,
         score_ux=None,
     )
+
+
+def _freshness_result(*sources, days_ago=1):
+    """MagicMock result for `fetch_last_published`.
+
+    Chaque source reçoit un dernier article à `days_ago` jours (fraîche par
+    défaut). Une source absente ⇒ aucun article ⇒ feed mort pour `classify`.
+    """
+    result = MagicMock()
+    last = _now() - timedelta(days=days_ago)
+    result.all.return_value = [(s.id, last) for s in sources]
+    return result
 
 
 class TestRateLimitPredicate:
@@ -188,7 +203,12 @@ class TestSelection:
         sources_result = MagicMock()
         sources_result.all.return_value = [(src, 0)]
         session.execute = AsyncMock(
-            side_effect=[followed_result, interests_result, sources_result]
+            side_effect=[
+                followed_result,
+                interests_result,
+                sources_result,
+                _freshness_result(src),
+            ]
         )
 
         service = PepiteService(session)
@@ -226,7 +246,12 @@ class TestSelection:
         sources_result.all.return_value = [(visible, 3)]
 
         session.execute = AsyncMock(
-            side_effect=[followed_result, interests_result, sources_result]
+            side_effect=[
+                followed_result,
+                interests_result,
+                sources_result,
+                _freshness_result(visible),
+            ]
         )
 
         service = PepiteService(session)
@@ -258,7 +283,12 @@ class TestSelection:
         sources_result.all.return_value = [(no_match, 10), (match, 1)]
 
         session.execute = AsyncMock(
-            side_effect=[followed_result, interests_result, sources_result]
+            side_effect=[
+                followed_result,
+                interests_result,
+                sources_result,
+                _freshness_result(no_match, match),
+            ]
         )
 
         service = PepiteService(session)
@@ -287,7 +317,12 @@ class TestSelection:
         sources_result.all.return_value = [(src, 0)]
 
         session.execute = AsyncMock(
-            side_effect=[followed_result, interests_result, sources_result]
+            side_effect=[
+                followed_result,
+                interests_result,
+                sources_result,
+                _freshness_result(src),
+            ]
         )
 
         service = PepiteService(session)
@@ -295,6 +330,88 @@ class TestSelection:
         assert results
         assert perso.pepite_carousel_last_shown_at is not None
         session.flush.assert_awaited()
+
+
+class TestSafetyGateAndFreshness:
+    """Le carrousel Pépites applique le gate de sécurité + le filtre fraîcheur."""
+
+    def _wire(self, session, rows, freshness):
+        perso = SimpleNamespace(
+            pepite_carousel_last_shown_at=None,
+            pepite_carousel_dismissed_at=None,
+            muted_sources=[],
+        )
+        session.scalar = AsyncMock(return_value=perso)
+        session.add = MagicMock()
+        session.flush = AsyncMock()
+        followed_result = MagicMock()
+        followed_result.scalars.return_value.all.return_value = []
+        interests_result = MagicMock()
+        interests_result.all.return_value = []
+        sources_result = MagicMock()
+        sources_result.all.return_value = rows
+        session.execute = AsyncMock(
+            side_effect=[
+                followed_result,
+                interests_result,
+                sources_result,
+                freshness,
+            ]
+        )
+
+    @pytest.mark.asyncio
+    async def test_excludes_alternative_bias_source(self):
+        session = AsyncMock()
+        alt = _mk_source(name="Limit", bias_stance=BiasStance.ALTERNATIVE)
+        ok = _mk_source(name="Vert")
+        self._wire(session, [(alt, 5), (ok, 5)], _freshness_result(alt, ok))
+
+        service = PepiteService(session)
+        results = await service.get_pepites_for_user(str(uuid4()), limit=4)
+        assert [r.name for r in results] == ["Vert"]
+
+    @pytest.mark.asyncio
+    async def test_excludes_unknown_reliability_source(self):
+        session = AsyncMock()
+        unknown = _mk_source(
+            name="Les Lueurs", reliability_score=ReliabilityScore.UNKNOWN
+        )
+        ok = _mk_source(name="Vert")
+        self._wire(session, [(unknown, 5), (ok, 5)], _freshness_result(unknown, ok))
+
+        service = PepiteService(session)
+        results = await service.get_pepites_for_user(str(uuid4()), limit=4)
+        assert [r.name for r in results] == ["Vert"]
+
+    @pytest.mark.asyncio
+    async def test_excludes_dead_article_feed(self):
+        session = AsyncMock()
+        dead = _mk_source(name="StreetPress", source_type=SourceType.ARTICLE)
+        alive = _mk_source(name="Vert", source_type=SourceType.ARTICLE)
+        # `dead` absente du résultat fraîcheur ⇒ 0/0 ⇒ feed mort exclu.
+        self._wire(session, [(dead, 5), (alive, 5)], _freshness_result(alive))
+
+        service = PepiteService(session)
+        results = await service.get_pepites_for_user(str(uuid4()), limit=4)
+        assert [r.name for r in results] == ["Vert"]
+
+    @pytest.mark.asyncio
+    async def test_slow_podcast_kept_but_downgraded(self):
+        session = AsyncMock()
+        # Podcast sans article sur 30j mais actif sur 90j ⇒ conservé, déclassé.
+        slow = _mk_source(name="Monsieur Phi", source_type=SourceType.PODCAST)
+        fresh = _mk_source(name="Next.ink", source_type=SourceType.ARTICLE)
+        freshness = MagicMock()
+        freshness.all.return_value = [
+            (slow.id, _now() - timedelta(days=45)),  # silencieux 30j, actif 90j
+            (fresh.id, _now() - timedelta(days=1)),
+        ]
+        # slow a plus de followers → sans déclassement il passerait devant.
+        self._wire(session, [(slow, 99), (fresh, 1)], freshness)
+
+        service = PepiteService(session)
+        results = await service.get_pepites_for_user(str(uuid4()), limit=4)
+        assert [r.name for r in results] == ["Next.ink", "Monsieur Phi"]
 
 
 class TestDismiss:

--- a/packages/api/tests/services/test_source_freshness.py
+++ b/packages/api/tests/services/test_source_freshness.py
@@ -1,0 +1,54 @@
+"""Tests unitaires de la règle de fraîcheur cadence-aware (source_freshness)."""
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+from app.models.enums import SourceType
+from app.services.source_freshness import classify
+
+
+def _src(source_type=SourceType.ARTICLE):
+    return SimpleNamespace(type=source_type)
+
+
+def _days_ago(n):
+    return datetime.now(UTC) - timedelta(days=n)
+
+
+class TestClassifyArticle:
+    def test_fresh_article_kept(self):
+        v = classify(_src(SourceType.ARTICLE), _days_ago(3))
+        assert not v.excluded and not v.downgraded
+
+    def test_dead_article_excluded(self):
+        v = classify(_src(SourceType.ARTICLE), _days_ago(60))
+        assert v.excluded
+
+    def test_article_no_publication_excluded(self):
+        v = classify(_src(SourceType.ARTICLE), None)
+        assert v.excluded
+
+
+class TestClassifySlowCadence:
+    def test_fresh_podcast_kept(self):
+        v = classify(_src(SourceType.PODCAST), _days_ago(10))
+        assert not v.excluded and not v.downgraded
+
+    def test_silent_30d_but_alive_90d_downgraded(self):
+        v = classify(_src(SourceType.YOUTUBE), _days_ago(45))
+        assert not v.excluded and v.downgraded
+
+    def test_truly_dead_slow_source_excluded(self):
+        v = classify(_src(SourceType.PODCAST), _days_ago(120))
+        assert v.excluded
+
+    def test_slow_no_publication_excluded(self):
+        v = classify(_src(SourceType.YOUTUBE), None)
+        assert v.excluded
+
+
+def test_naive_datetime_is_handled():
+    # published_at sans tzinfo ne doit pas lever (comparaison aware/naive).
+    naive = datetime.utcnow() - timedelta(days=2)
+    v = classify(_src(SourceType.ARTICLE), naive)
+    assert not v.excluded


### PR DESCRIPTION
## Quoi
Les sources recommandées à l'onboarding n'étaient filtrées ni sur la fraîcheur, ni (pour le carrousel Pépites) sur le gate de sécurité. Cette PR ajoute un garde-fou de fraîcheur **cadence-aware** (nouveau `source_freshness.py`) sur les 3 surfaces poussées et applique `passes_safety_gate` au carrousel.

## Pourquoi (constat prod)
- **18 des 117 curées actives = 0 article/30j** (dont 8 feeds jamais ingérés : Libération, Les Échos, Le Point, Brut…), remontées aussi haut que des sources vivantes par le tri alphabétique.
- Carrousel Pépites sans gate → poussait **Limit** (biais *alternative*) et **Les Lueurs** (fiabilité *unknown*).
- Le Collimateur (cité) est en fait **sain** ; Frandroid = souci UX non mesurable en base (follow-up éditorial).

## Comportement
- `type=article` sans article sur 30j → **exclu** des surfaces poussées.
- `type∈{podcast,youtube,reddit}` (cadence lente) → exclu seulement si silence sur 90j ; sinon **conservé mais déclassé**.
- Arbitrages validés PO : exclusion dure des feeds morts, léger déclassement des cadences lentes, fix de la fuite du gate.

## Perf (exigence PO « pas plus lent »)
La fraîcheur lit le **dernier `published_at` par source via un sous-select corrélé** (backward index-scan sur `ix_contents_source_published`), mesuré **~27 ms / 40 sources** — vs 2,8 s (`max GROUP BY`) et 11,8 s (`count`) écartés par EXPLAIN ANALYZE sur prod. `GET /sources` (endpoint caché, hot path onboarding) **n'est pas touché**. Un seul aller-retour par surface via le helper `freshness_verdicts`.

## Comment ça a été vérifié
- [x] `pytest` complet : **2630 passed**, 0 échec (DB locale)
- [x] EXPLAIN ANALYZE prod : plan corrélé confirmé ~27 ms
- [x] Nouveaux tests : `test_source_freshness.py`, cas gate+fraîcheur `test_pepite_service.py`, `test_by_theme_freshness.py`, fixtures `test_suggest_for_theme.py`
- [x] ruff check + format clean
- [x] `/simplify` passé (helper `freshness_verdicts` mutualisé, scan_limit simplifié)
- [ ] N/A Flutter (backend-only) · aucune migration

## Zones à risque
Endpoints de découverte de sources (`sources.py` by-theme / suggest, `pepite_service`). Aucune migration, aucun schéma modifié.

## Follow-ups (hors périmètre)
Matérialiser `last_article_at` (job) ; tri qualité FQS ; nettoyage éditorial (dépublier 8 feeds morts, backfill `pepite_for_themes`, dédoublonner « The Conversation », retirer Frandroid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)