### PR TITLE
feat(reco): rendre la jauge CTR exécutable + arbitrage step-up qualité (PR0)

### DIFF
--- a/docs/maintenance/maintenance-feed-ranking-gauge.md
+++ b/docs/maintenance/maintenance-feed-ranking-gauge.md
@@ -1,0 +1,174 @@
+# Maintenance — Runbook de la jauge CTR ranking (`evaluate_feed_ranking.py`)
+
+> **Date** : 2026-07-29
+> **Branche** : `boujonlaurin-dotcom/reco-quality-entity-affinity-audit`
+> **PR ciblée** : `main`
+> **Type** : outillage de mesure (aucun réglage)
+> **Script** : `packages/api/scripts/evaluate_feed_ranking.py`
+> **Tests** : `packages/api/tests/scripts/test_evaluate_feed_ranking.py`
+> **Doc sœur** : [`maintenance-reco-quality-step-up.md`](./maintenance-reco-quality-step-up.md)
+
+## À quoi sert cette jauge
+
+Croiser ce que le ranking a **livré** (`daily_digest.items`) avec ce que
+l'utilisateur a **consommé** (`user_content_status.status = 'consumed'`), et en
+sortir un CTR découpé par rang de sujet, slot, sujet, topic, entité et bande de
+score.
+
+C'est l'instrument de mesure des PRs de reco. Sans lui, tout réglage de scoring
+est une conviction non testée.
+
+## Pourquoi elle ne tournait pas (et ce qui a été réparé)
+
+Trois défauts, tous silencieux — le script s'exécutait sans erreur et
+retournait un rapport vide, ce qui se lit comme « pas de signal » et pas comme
+« instrument cassé ».
+
+1. **Le format de prod n'était pas lu.** La requête ne connaissait que
+   `flat_v1` (`items` = tableau) et `topics_v1` (`items.topics[]`). Or 100 % des
+   digests non-sereins des 30 derniers jours sont en `editorial_v3`
+   (`items.subjects[]`) : 3 493 digests non-sereins + 1 069 sereins ; les seuls
+   `topics_v1` restants (266) sont tous sereins, donc écartés par défaut.
+   ⇒ **0 ligne**. Une CTE `editorial_items` a été ajoutée.
+2. **Le dénominateur reposait sur `last_impressed_at`**, colonne écrite
+   seulement au pull-to-refresh et au « déjà vu » manuel : ni impression ni
+   position. Remplacée par `--denominator` (cf. section suivante).
+3. **Un NULL non typé cassait la requête.** `(:mode IS NULL OR dd.mode = :mode)`
+   avec `--mode` non fourni ⇒ `psycopg.errors.AmbiguousParameter: could not
+   determine data type of parameter $3`. Corrigé par des `CAST` explicites.
+
+Ajouté au passage : histogramme `format_version` en en-tête, pour qu'un futur
+changement de format soit **bruyant** au lieu d'être silencieux.
+
+## Les 3 dénominateurs
+
+Le rapport publie **toujours les trois côte à côte**. Ne jamais en citer un seul
+hors contexte.
+
+| dénominateur | définition | mesuré en prod (30 j, non-sereins) |
+|---|---|---|
+| `all` | tout slot livré | **566 / 45 735 = 1,24 %** |
+| `engaged` | slots des digests avec ≥ 1 consommé | **566 / 3 081 = 18,37 %** |
+| `engaged-loo` (**défaut**) | slots des digests avec ≥ 1 consommé **autre que l'article mesuré** | **459 / 2 974 = 15,43 %** |
+
+- **`all` mesure la distribution, pas la pertinence.** ~93 % des digests générés
+  n'ont jamais eu un seul article consommé : le 1,24 % dit surtout que l'app
+  n'est pas ouverte, et il écrase toute différence de ranking.
+- **`engaged` est circulaire** : l'article consommé conditionne son propre
+  dénominateur, ce qui gonfle mécaniquement le CTR.
+- **`engaged-loo` dé-circularise** : l'article *i* n'est compté que si son
+  digest a un consommé **autre que lui**. Conséquence à connaître : un digest
+  avec exactement un article consommé ne contribue **aucun** numérateur (cet
+  article est son propre conditionneur, donc exclu). C'est voulu.
+
+Invariants de construction (testés) : `CTR(all) ≤ CTR(engaged)` — `engaged` ne
+retire que des non-consommés — et `CTR(engaged-loo) ≤ CTR(engaged)` — le LOO ne
+retire ensuite que des consommés.
+
+### Conditionneurs rejetés, et pourquoi
+
+- **`digest_completions`** — rejeté. **0 ligne sur 60 j** (58 all-time, dernière
+  le 2026-05-10) **et** circulaire par construction : la ligne est insérée à
+  `consumed/total ≥ 0,8` (`digest_service.py`), donc le CTR conditionné serait
+  ≈ 100 % par définition. C'est écrit ici pour que personne ne le re-propose.
+- **`morning_ritual_opened`** — 206 events / 34 users / 60 j, couvrant 2,5 % des
+  digests. Utilisable en **tranche de robustesse**, jamais en filtre principal :
+  la puissance statistique s'effondre.
+
+## Lancer la jauge
+
+```bash
+cd packages/api
+PYTHONPATH=. python scripts/evaluate_feed_ranking.py --days 30
+PYTHONPATH=. python scripts/evaluate_feed_ranking.py --days 30 --tag pr1-before
+PYTHONPATH=. python scripts/evaluate_feed_ranking.py --compare \
+  ../../.context/feed-ranking-pr1-before-2026-07-29.json \
+  ../../.context/feed-ranking-pr1-after-2026-08-05.json
+```
+
+Sorties appariées dans `.context/`, comme les harnais frères
+(`evaluate_event_clustering.py`, `evaluate_veille_curation.py`) :
+`feed-ranking-<tag>-<date>.json` (machine, consommé par `--compare`) et
+`.md` (humain).
+
+Options utiles : `--denominator {all,engaged,engaged-loo}`, `--mode`,
+`--include-serene`, `--min-shown`, `--top`, `--row-limit`, `--no-write`.
+
+> Pas de `--sweep` : contrairement aux deux autres harnais, ce script n'a aucun
+> dial à balayer. Il mesure, il ne règle rien.
+
+### ⚠️ Prérequis d'accès : RLS
+
+`DATABASE_URL_RO` (`claude_analytics_ro`) **retourne 0 ligne** sur
+`daily_digest`, `contents` et `user_content_status` : les trois tables ont
+`relrowsecurity = true` et le rôle a `rolbypassrls = false`. Le script tourne
+sans erreur et rapporte un CTR vide — le même faux négatif que le bug qu'il
+vient de corriger.
+
+Deux voies :
+
+1. **Recommandé, décision PO** : `ALTER ROLE claude_analytics_ro BYPASSRLS;` sur
+   la DB de prod. C'est un changement de permission prod, à faire
+   explicitement, pas en passant.
+2. **Contournement** : rejouer la requête via le MCP Supabase (rôle `postgres`,
+   `rolbypassrls = true`). C'est ce qui a servi à valider la requête et à
+   produire les chiffres de ce runbook.
+
+## Biais connus (à ne pas maquiller)
+
+- **Persistance des scores forward-only.** `score` / `pillar_scores` sont
+  persistés sur `subjects[].actu_article` depuis cette PR seulement. Toute
+  fenêtre antérieure au merge affiche une bande `missing` massive : c'est
+  attendu. Le CTR **par sujet / entité / rang de sujet / slot** est en revanche
+  **rétroactif** sur tout l'historique `editorial_v3`.
+- **Les `extra_actu_articles` ne sont jamais scorés** — `actu_matcher` les trie
+  sur `(thumbnail, published_at)`. Leur `score` restera `null` **pour toujours** :
+  ce n'est pas un trou de données à combler mais une propriété du pipeline.
+- **Le fallback clusters-vides** (`digest_selector`) produit des sujets sans
+  score : `null` légitime.
+- **Effet de position vs effet de ranking** : le rang 1 est aussi « À la Une »
+  et occupe le haut de l'écran. La jauge ne peut pas séparer les deux sans une
+  randomisation de position. Toute lecture du rang 1 doit le dire.
+- **Puissance** : ~2 974 slots LOO sur 30 j, ~220 par rang de sujet ⇒ **±5 pp à
+  95 %**. Un écart de 2 pp entre deux rangs n'est pas un signal.
+
+## Première lecture (30 j au 2026-07-29, `engaged-loo`)
+
+CTR par rang de sujet, slots `actu` :
+
+| rang | slots | consommés | CTR |
+|---:|---:|---:|---:|
+| 1 | 215 | 66 | **30,7 %** |
+| 2 | 225 | 43 | 19,1 % |
+| 3 | 223 | 44 | 19,7 % |
+| 4 | 227 | 32 | 14,1 % |
+| 5 | 223 | 44 | 19,7 % |
+| 6 | 226 | 49 | 21,7 % |
+| 7 | 223 | 44 | 19,7 % |
+| 8 | 219 | 49 | 22,4 % |
+| 9 | 225 | 43 | 19,1 % |
+| 10 | 223 | 34 | 15,3 % |
+
+Slots `extra`, tous rangs confondus : **11 / 745 = 1,5 %** en LOO
+(11 / 11 085 = 0,1 % en `all`).
+
+Deux constats, à confirmer sur une deuxième fenêtre avant d'en tirer une
+roadmap :
+
+1. **Le rang 1 se détache (30,7 % vs ~19 %), le reste est plat.** Les rangs 2 à
+   10 tiennent tous dans ±5 pp autour de 19 % — c'est-à-dire dans la barre
+   d'erreur. Le re-ranking per-user n'a **aucun pouvoir discriminant mesurable
+   au-delà du rang 1**. On ne peut pas encore dire si l'avantage du rang 1 vient
+   du ranking ou de la position.
+2. **Les `extra_actu_articles` sont un angle mort.** 11 085 slots livrés sur
+   30 j pour 11 consommations : ~24 % des slots du digest, jamais scorés,
+   quasiment jamais lus.
+
+## Ce que la jauge ne mesure pas
+
+- **Les surfaces hors digest** : Tournée, Veille, Flux Continu ont leurs propres
+  chemins de scoring et ne sont pas dans `daily_digest.items`. Un levier qui ne
+  bouge pas ici peut bouger là — c'est explicitement le cas des abonnements
+  entités (cf. doc sœur).
+- **Le rappel** : elle ne dit rien des bons articles jamais candidats.
+- **La satisfaction** : `consumed` est un proxy de clic, pas de valeur.

--- a/docs/maintenance/maintenance-reco-quality-step-up.md
+++ b/docs/maintenance/maintenance-reco-quality-step-up.md
@@ -1,0 +1,281 @@
+# Maintenance — Step-up qualité des recos : arbitrage et séquence
+
+> **Date** : 2026-07-29
+> **Branche** : `boujonlaurin-dotcom/reco-quality-entity-affinity-audit`
+> **PR ciblée** : `main`
+> **Type** : arbitrage écrit + 2 PRs (PR0 outillage, PR1 câblage)
+> **Brief d'origine** : `.context/reco-quality-architect-brief.md`
+> **Runbook de l'instrument** : [`maintenance-feed-ranking-gauge.md`](./maintenance-feed-ranking-gauge.md)
+
+## Résumé
+
+Le brief posait que le plafond de qualité des recos était **la granularité de la
+taxonomie (51 slugs) et l'absence de vectorisation**, et proposait 4 leads :
+A fiabiliser le tagging, B créer la granularité, C nourrir la jauge,
+D vectoriser.
+
+La vérification (code + DB de prod, 2026-07-29) **infirme ce cadrage sur trois
+points matériels**. Le plafond n'est pas la finesse du tagging : ce sont des
+signaux **débranchés ou numériquement inertes**, et un instrument de mesure
+**qui ne parsait pas le format de digest de production**.
+
+> Avant d'être loin de Google News, on est loin d'avoir branché ce qui est déjà
+> écrit.
+
+D'où la séquence retenue : **PR0 rend la jauge exécutable**, **PR1 rebranche les
+signaux existants**. B (taxonomie) et D (vecteurs) sont **différés**, avec des
+critères de ré-entrée chiffrés (§ Différé).
+
+## Ce que l'évidence corrige dans le brief
+
+Toutes les mesures ci-dessous ont été refaites sur la DB de prod le 2026-07-29
+(via le MCP Supabase — cf. la note RLS du runbook).
+
+| Le brief disait | L'évidence dit |
+|---|---|
+| PR2 « affinité entités » a mergé pendant le blackout classif ⇒ **calibration à refaire** | **Le levier est inerte, pas mal calibré.** Prod : `user_entity_affinity` = 871 lignes / 34 users, **affinité max = 1,588**, moyenne **1,030**, **2 lignes > 1,3**, `interaction_count` max = **14**. Avec `ENTITY_AFFINITY_BASE = 8` ⇒ ~**0,4 pt brut sur `MAX_PERTINENCE_RAW = 160`** (0,25 % d'un pilier). Ça ne peut pas changer un ordre. Recalibrer un signal à 0,25 % ne sert à rien. |
+| Cause = blackout du tagging | **Cause = câblage.** `digest_service.py:1396-1449` (READ / SAVE / LIKE / UNLIKE de l'Essentiel, la surface phare) appelle `_adjust_subtopic_weights` **4 fois et `_adjust_entity_affinity` 0 fois**. Idem `routers/contents.py:440`. `content_service.py` est symétrique partout (`:187/192`, `:476/477`, `:514/517`, `:562/565`, `:646/649`) — le chemin digest ne l'est pas. |
+| « Aucun pont entité → sujet suivable » | **Inversé : le pont existe et il est livré.** `user_topic_profiles.entity_type` / `canonical_name`, canonicalisé par LLM (`ml/topic_enrichment_service.py`), `InterestState` à 4 états, épinglable (`FavoriteTabKind.subjectEntity`), alertable. 93 lignes / 30 users. |
+| La résolution d'entités est un prérequis (B1) | **La résolution n'est pas le goulot** : 72/93 (77 %) des entités suivies exact-matchent une chaîne de `contents.entities` sous 30 j. Le vrai défaut : `pertinence._score_custom_topics` ne lit **jamais** `content.entities` ni `canonical_name` — il ne teste que `slug_parent` et `keywords`. Le pont entité n'existe que dans une couche de recall legacy (`layers/user_custom_topics.py`) qui **ne s'applique pas aux surfaces scorées par piliers**. |
+| Lead C « lancer la jauge, coût ≈ nul » | **La jauge n'est pas non-lancée, elle est non-lançable.** 3 défauts silencieux, cf. le runbook : format `editorial_v3` non parsé (100 % des digests non-sereins), dénominateur assis sur `last_impressed_at` (ni impression ni position), et un NULL non typé qui faisait échouer la requête (`AmbiguousParameter`). **C'est une PR, pas une commande.** |
+| — *(absent du brief)* | **`_adjust_interest_weight` est le seul signal appris sans decay.** +0,05 par lecture sur `source.theme`, cap 3,0 ; `scheduler.py` ne décaie que les subtopics et les entités. Prod : 724 lignes / 126 users, **32 au cap (≥ 2,99)**, 83 dans ]1,5 ; 3,0[, moyenne 1,260. Une ligne au cap vaut `50 × (3,0 − 1,0)` = **100 pts bruts = 62 % du pilier pertinence**. Chez les comptes les plus anciens, **l'âge du compte bat la pertinence du jour**. |
+| — *(absent du brief)* | **`_score_custom_topics` n'a jamais tiré sur l'Essentiel / le Digest.** `digest_selector._score_candidates` construit le `ScoringContext` **sans `user_custom_topics`** ⇒ la garde `if not context.user_custom_topics: return 0.0, []` avale tout. Sujets custom **et** abonnements entités sont muets sur la surface phare. |
+
+## Décisions PO (2026-07-29)
+
+1. **« Flâner » chrono est voulu.** L'early-return de `recommendation_service.py`
+   n'est pas un bug. La qualité reco se joue sur **Essentiel / sections Tournée /
+   Digest / Veille**. *Ne pas y toucher.* Corollaire ironique : la surface phare
+   est justement celle où le custom-topic est muet.
+2. **Séquence = doc + PR0 + PR1**, avant tout chantier taxonomie ou vecteurs.
+3. **Vocabulaire des entités noté, non traité ce cycle** : 24 089 chaînes
+   distinctes sur 14 j dont **73 % vues une seule fois**, avec du non-entité
+   dedans (« députés français », « ambassadeur français ») ; seules **2 324
+   entités atteignent ≥ 5 mentions / 14 j** — c'est l'univers réellement
+   suivable. Décision après mesure.
+
+## PR0 — rendre la jauge exécutable
+
+Détail complet dans le [runbook](./maintenance-feed-ranking-gauge.md). En bref :
+
+- **Zéro migration** — `pillar_scores` n'est pas une colonne mais une clé JSON
+  dans `daily_digest.items` (JSONB). Tout est additif.
+- Dénominateur explicite `--denominator {all,engaged,engaged-loo}`, défaut
+  `engaged-loo`, **les trois publiés côte à côte**.
+- CTE `editorial_items` : `subjects[].actu_article` + `extra_actu_articles`, avec
+  rang de sujet, libellé de sujet et **slot** (`actu` / `extra`).
+- Persistance **forward-only** de `score` / `pillar_scores` sur le représentant
+  scoré.
+- Sorties `.json` + `.md` appariées et `--compare`, en miroir des harnais frères.
+
+### Première lecture, et elle est parlante
+
+30 j au 2026-07-29, dénominateur `engaged-loo`, slots `actu` :
+
+| rang de sujet | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| CTR | **30,7 %** | 19,1 % | 19,7 % | 14,1 % | 19,7 % | 21,7 % | 19,7 % | 22,4 % | 19,1 % | 15,3 % |
+
+(~220 slots par rang ⇒ **±5 pp à 95 %**.)
+
+Deux constats, à confirmer sur une deuxième fenêtre :
+
+1. **Le rang 1 se détache, le reste est plat.** Les rangs 2 à 10 tiennent tous
+   dans la barre d'erreur autour de ~19 %. Le re-ranking per-user n'a **aucun
+   pouvoir discriminant mesurable au-delà du rang 1** — et la jauge ne peut pas
+   dire si l'avantage du rang 1 vient du ranking ou de la position à l'écran.
+2. **Les `extra_actu_articles` sont un angle mort** : 11 085 slots livrés sur
+   30 j (≈ 24 % du digest), **11 consommations**, jamais scorés.
+
+Ces deux résultats pèsent lourd sur l'arbitrage : ils disent que le problème est
+en amont du réglage fin, pas dans la finesse de la taxonomie.
+
+## PR1 — rebrancher les signaux existants
+
+**Zéro migration** : les 3 tables (`user_entity_affinity`, `user_interests`,
+`user_topic_profiles`) ont déjà les colonnes. **4 commits indépendamment
+révocables.**
+
+### (a) Nourrir l'affinité entités depuis l'Essentiel
+
+Ajouter `_adjust_entity_affinity` à côté de chaque `_adjust_subtopic_weights`
+dans `digest_service.py` et `routers/contents.py`, **avec le même delta** —
+c'est l'invariant tenu partout dans `content_service.py`. READ →
+`READ_TOPIC_BOOST` (0,03), SAVE → `BOOKMARK_TOPIC_BOOST` (0,05), LIKE →
+`LIKE_TOPIC_BOOST` (0,15), UNLIKE → `−LIKE_TOPIC_BOOST`.
+
+`NOT_INTERESTED` est laissé seul (il route vers
+`_trigger_personalization_mute`), mais **l'asymétrie est signalée au PO plutôt
+que corrigée en silence** : `content_service.set_hide_status` applique bien
+`DISMISS_TOPIC_PENALTY` aux entités.
+
+### (b) Faire tirer les abonnements entités — le threading d'abord
+
+1. **Bloquant** : ajouter `user_custom_topics` à `DigestContext` et le passer au
+   `ScoringContext` de `digest_selector`. Sans ça, la garde de
+   `_score_custom_topics` avale tout et le reste de (b) est un **no-op**.
+2. Branche entité dans `_score_custom_topics`, en miroir de
+   `layers/user_custom_topics.py` : comparer `tp.canonical_name` aux clés de
+   `iter_entity_names` (`helpers/entities.py`, la primitive déjà partagée
+   write/read). Multiplicateur `ENTITY_MATCH_MULTIPLIER = 1.5`.
+3. **Réutilisation** : collapser le `_parse_content_entities` privé de
+   `layers/user_custom_topics.py` sur l'helper partagé, dans le même commit.
+4. **Point à surveiller** : `_score_entities` (affinité, cap
+   `ENTITY_AFFINITY_MAX_BONUS = 30`) et cette branche (`25 × 1,5 × mult`) sont
+   deux signaux distincts sur la même entité qui **s'empilent** dans un pilier
+   capé à 160.
+5. **Copy** : pour un profil entité, `topic_name` est un nom de personne ⇒ le
+   label actuel rend « Votre sujet : Kylian Mbappé ». Le mobile dit déjà
+   « Entité suivie ». **Décision PO avant merge** ; un label distinct exige un
+   bras assorti dans `reason_builder.py`. Rappel : **pas d'em-dash** dans la copy
+   user-facing.
+
+> ⚠️ **Blast radius assumé** : threader `user_custom_topics` dans le digest
+> active aussi la branche slug/keyword existante
+> (`CUSTOM_TOPIC_BASE_BONUS = 25 × multiplier`), **effet plus large que la
+> branche entités elle-même**, et rend `THEME_MISMATCH_MALUS = −8` atteignable
+> pour les users custom-topics-only. ⇒ **commit séparé, run de jauge
+> avant/après dédié.**
+
+### (c) Decay de `user_interests.weight`
+
+Cloner `decay_user_entity_affinity` en `decay_user_interest_weights()`, avec
+`INTEREST_WEIGHT_DECAY = 0.98` posé **à côté** de `SUBTOPIC_DECAY` et
+`ENTITY_AFFINITY_DECAY` dans `scoring_config.py` — une famille visible, pas une
+constante orpheline.
+
+Justification du 0,98 contre la distribution mesurée (724 lignes / 126 users ;
+338 à 1,0 exactement ; 258 dans ]1,0 ; 1,5] ; 83 dans ]1,5 ; 3,0[ ; **32 au
+cap** ; 15 sous 1,0 ; moyenne 1,260) : **demi-vie ≈ 34 j** sur l'excédent
+au-dessus du neutre. Une ligne au cap redescend à 2,0 après ~34 j sans lecture,
+alors qu'une lecture (+0,05) est rattrapée en ~2 j de lecture active. Ça vide les
+32 lignes saturées — qui à elles seules pèsent 62 % du pilier — sans effacer le
+profil d'un lecteur actif.
+
+**Décision explicite** : 15 lignes sont **sous** 1,0 et produisent un malus. Un
+decay symétrique les remonte vers le neutre et **efface ce signal négatif**.
+Recommandation retenue : décayer dans les deux sens (cohérence avec les deux
+sœurs) et l'écrire.
+
+### (e) Deux défauts d'explicabilité
+
+- **`SUBTOPIC_LABELS` désynchronisé de `VALID_TOPIC_SLUGS`** — mesuré :
+  **50 labels pour 51 slugs valides, 32 clés fantômes, 33 slugs valides sans
+  label** ⇒ `slug.capitalize()`. Ce sont des slugs très suivis qui tombent :
+  sur le top 16 par nombre d'abonnés, **8 n'ont pas de label** — `energy` (83
+  users) → « Energy », `politics` (75) → « Politics », `usa` (70) → « Usa »,
+  `environment` (63) → « Environment », `inequality` (54) → « Inequality »,
+  plus `justice`, `europe`, `tech`. Correctif : un edit de dict **et un test
+  d'invariant** (`set(SUBTOPIC_LABELS) <= VALID_TOPIC_SLUGS` et tout slug valide
+  a un label) pour que ça ne puisse plus dériver.
+- **Branche morte de raison dans le digest** — `digest_selector.py:1682` teste
+  `label.startswith("Sous-thème : ")` alors que le pilier émet
+  `"Sujet suivi : "` / `"Sujet : "` ⇒ les raisons du digest retombent sur le
+  thème large. Fix d'une ligne. **Change le texte de raison visible sur beaucoup
+  d'articles** ⇒ commit séparé + screenshot + entrée `changelog.json`.
+
+### (d) Ne PAS recalibrer ce cycle
+
+Ni `ENTITY_AFFINITY_BASE` ni les deltas d'interaction — **un levier mesuré à la
+fois** (cf. `maintenance-clustering-calibration.md`).
+
+**Conséquence assumée** : la portée de (b) est plus mince que « 93 entités ×
+30 users ». Mesuré sur 30 j, les abonnements entités matchent 1 945 articles
+candidats (4,2 % d'un pool de 46 549) ⇒ ~6,8 candidats/j/user abonné pour ~10
+slots, mais seulement **37 des 42 916 slots actu livrés** (0,086 %), 13 users.
+⇒ **(b) n'est pas résoluble en une semaine sur le digest.** Le mesurer sur
+**Tournée / Veille** (où `user_custom_topics` circule déjà) et traiter le digest
+comme directionnel. Le 77 % mesurait le pool de candidats, pas le livré.
+
+## Différé, avec critères de ré-entrée
+
+Ni B ni D ne sont écartés sur le fond : ils sont **non-ordonnançables tant que
+rien n'est mesurable**.
+
+- **Lead A — fiabiliser le tagging.** Le socle a 3 couches de garde
+  (`_on_task_done`, job santé 30 min à seuil 12 h, `/api/health/classification`).
+  Deux trous connus subsistent : `MISTRAL_API_KEY` vide ⇒ la queue **draine** en
+  écrivant `topics=[]` sans qu'aucune alerte ne parte (l'âge du pending reste
+  bas), et la fuite `exhausted_retries` documentée comme cause du plafond de
+  couverture ~68 %. **Pas de backfill des ~25k articles du blackout** (corpus
+  périmé). → PR séparée, hors de ce cycle.
+- **Lead B — granularité de la taxonomie.** Ré-entrée si la jauge montre que le
+  **CTR par sujet est plat entre slugs larges et slugs spécifiques** — c'est-à-
+  dire que la finesse manque vraiment. Deux prérequis structurels déjà
+  identifiés : le classifieur ne voit que **titre + 200 caractères de
+  description** ⇒ **plafond d'information avant plafond de taxonomie** ; et il
+  n'y a **pas de colonne `classification_version`** ⇒ aucune migration de
+  taxonomie pilotable (6 copies de la liste de slugs, dont `TOPIC_TO_THEME` non
+  testée ⇒ `theme = NULL` silencieux).
+- **Lead D — vecteurs.** La conviction « pas d'excellent sans vecteurs » n'est
+  pas fausse, elle est **prématurée** : `pgvector` est *disponible* (0.8.0) mais
+  `installed_version IS NULL` ⇒ c'est un `CREATE EXTENSION`, pas du gratuit ; et
+  sans dénominateur fiable on ne peut pas prouver qu'un étage de recall
+  vectoriel bat l'actuel. Ré-entrée quand PR0 donne une baseline CTR stable sur
+  deux fenêtres. Cible naturelle : **recall user-vector + re-rank explicable**
+  par-dessus les piliers, pas un remplacement.
+- **Vocabulaire des entités** (73 % de singletons, non-entités, ~2 324 entités à
+  ≥ 5 mentions) — décision après mesure, choix PO.
+
+### Suivis adjacents identifiés, non traités
+
+- `user_interest_states` est absent lui aussi du `ScoringContext` digest ⇒ le
+  plancher FAVORITE (`_FAVORITE_WEIGHT_FLOOR`) ne s'applique pas au digest.
+- Double-compte pré-existant subtopic ↔ custom-topic : l'onboarding miroite
+  chaque `UserSubtopic` en `UserTopicProfile(keywords=[slug])`
+  (`user_service.py`) ⇒ 45 + 18 + 25 points pour un seul signal.
+- `_score_coverage` est inerte (`cluster_source_counts` jamais peuplé).
+- `user_entity_preferences` est mort (0 ligne) ; le mute entité passe en réalité
+  par `user_personalization.muted_topics`.
+- **Les `extra_actu_articles`** : ~24 % des slots livrés, jamais scorés, CTR
+  1,5 %. Soit on les score, soit on les réduit — mais les laisser tels quels,
+  c'est laisser un quart du digest hors du système de reco.
+
+## Vérification
+
+```bash
+# PR0
+cd packages/api && PYTHONPATH=. pytest tests/scripts/test_evaluate_feed_ranking.py -q
+cd packages/api && PYTHONPATH=. pytest tests/test_digest_per_user_projection.py \
+  tests/test_digest_service.py tests/editorial -q
+cd packages/api && PYTHONPATH=. python scripts/evaluate_feed_ranking.py --days 30
+#   attendu : ~3 000 slots en engaged-loo, CTR global ~15 %, rang 1 nettement
+#   au-dessus des rangs 2-10. Si 0 ligne : soit la branche editorial_v3 est
+#   fausse, soit le rôle DB est bloqué par RLS (cf. runbook).
+
+# PR1
+cd packages/api && PYTHONPATH=. pytest tests/recommendation/test_pertinence_pillar.py \
+  tests/test_digest_service.py tests/test_content_interactions.py \
+  tests/workers/test_scheduler.py tests/test_digest_per_user_projection.py \
+  tests/test_digest_selector.py -q
+
+# suite complète (anticipe stop-verify-tests.sh)
+cd packages/api && pytest -v
+```
+
+**Alembic** : aucune migration dans les deux PRs (vérifié : tout est JSON
+additif ou colonnes existantes) ⇒ le risque expand-contract de la DB partagée
+`main` / `production` ne s'applique pas ici. Confirmer `alembic heads` = 1 avant
+PR par réflexe.
+
+**UI** : PR0 est backend-only. PR1 (e) change du **texte de raison visible** ⇒
+passage Playwright CLI sur la feuille « Pourquoi cet article ? » (skill
+`facteur-qa-web`, viewport 390x844, sémantique activée) + screenshot, et une
+entrée `changelog.json`. Pas de nouvelle UI.
+
+## Risques
+
+1. **(b) est un no-op sans le threading `DigestContext`** — l'item le plus sévère.
+2. **Threader `user_custom_topics` active aussi la branche slug/keyword à 25 pts**
+   dans le digest : effet plus large que l'objectif déclaré ⇒ commit isolé,
+   jauge avant/après.
+3. **`THEME_MISMATCH_MALUS = −8` devient atteignable** pour les users
+   custom-topics-only.
+4. **Puissance statistique** : ~3 000 slots LOO (~220/rang, ±5 pp à 95 %) ;
+   **37 slots** entité-matchés ⇒ (b) directionnel sur le digest, mesurable sur
+   Tournée / Veille.
+5. **Persistance des scores forward-only** : bandes de score vides jusqu'à ~2
+   semaines post-merge ; `extra_actu_articles` à `null` définitivement.
+6. **`digest_completions` doit être rejeté par écrit** (0 ligne / 60 j **et**
+   circulaire), sinon quelqu'un le re-proposera. C'est fait dans le runbook et
+   dans l'en-tête du rapport généré.

--- a/packages/api/app/services/digest_selector.py
+++ b/packages/api/app/services/digest_selector.py
@@ -1240,11 +1240,15 @@ class DigestSelector:
 
         # 2. Scoring unifié (réutilise _score_candidates / pillar_engine).
         score_map: dict[UUID, float] = {}
+        # Conservé pour être persisté sur l'article (jauge CTR). Sans ça le
+        # détail par pilier est calculé puis jeté à chaque digest.
+        pillar_map: dict[UUID, dict[str, float]] = {}
         score_inputs = rep_contents + solo_candidates
         if score_inputs:
             try:
                 scored = await self._score_candidates(score_inputs, context, mode=mode)
                 score_map = {c.id: sc for c, sc, _bd, _pillar_scores in scored}
+                pillar_map = {c.id: ps for c, _sc, _bd, ps in scored}
             except Exception:
                 # Dégradation sûre : sans scoring on garde l'ordre run_for_user.
                 logger.exception(
@@ -1322,14 +1326,23 @@ class DigestSelector:
 
         renumbered: list[EditorialSubject] = []
         for new_rank, s in enumerate(ordered, start=1):
-            renumbered.append(
-                s.model_copy(
-                    update={
-                        "rank": new_rank,
-                        "is_a_la_une": s.is_a_la_une and new_rank == 1,
-                    }
-                )
-            )
+            update: dict[str, object] = {
+                "rank": new_rank,
+                "is_a_la_une": s.is_a_la_une and new_rank == 1,
+            }
+            # Le score du représentant est attaché ICI et pas plus haut : les
+            # sujets sont recopiés par cette boucle, donc tout `model_copy`
+            # antérieur serait redroppé.
+            if s.actu_article is not None:
+                content_id = s.actu_article.content_id
+                if content_id in score_map:
+                    update["actu_article"] = s.actu_article.model_copy(
+                        update={
+                            "score": score_map[content_id],
+                            "pillar_scores": pillar_map.get(content_id) or None,
+                        }
+                    )
+            renumbered.append(s.model_copy(update=update))
 
         actu_hits = sum(1 for s in renumbered if s.actu_article is not None)
         deep_hits = sum(1 for s in renumbered if s.deep_article is not None)

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -1964,6 +1964,11 @@ class DigestService:
                         if s.representative_content_id
                         else None
                     ),
+                    # `score` / `pillar_scores` : forward-only, alimentent la
+                    # jauge CTR (scripts/evaluate_feed_ranking.py). `None` sur
+                    # les chemins non scorés (fallback clusters vides) et sur
+                    # tous les `extra_actu_articles`, qui ne passent jamais par
+                    # le scoring.
                     "actu_article": {
                         "content_id": str(s.actu_article.content_id),
                         "title": s.actu_article.title,
@@ -1972,6 +1977,8 @@ class DigestService:
                         "is_user_source": s.actu_article.is_user_source,
                         "badge": "actu",
                         "published_at": s.actu_article.published_at.isoformat(),
+                        "score": s.actu_article.score,
+                        "pillar_scores": s.actu_article.pillar_scores,
                     }
                     if s.actu_article
                     else None,

--- a/packages/api/app/services/editorial/schemas.py
+++ b/packages/api/app/services/editorial/schemas.py
@@ -38,7 +38,17 @@ class SelectedTopic(BaseModel):
 
 
 class MatchedActuArticle(BaseModel):
-    """ÉTAPE 3A output — news article from user's sources."""
+    """ÉTAPE 3A output — news article from user's sources.
+
+    `score` / `pillar_scores` sont **facultatifs et forward-only** : ils ne sont
+    renseignés que pour le représentant re-scoré per-user
+    (`digest_selector._project_editorial_for_user`), afin que la jauge CTR
+    (`scripts/evaluate_feed_ranking.py`) puisse croiser consommation et score.
+    Les `extra_actu_articles` ne passent jamais par le scoring (tri
+    `(thumbnail, published_at)` dans `actu_matcher`) : ils resteront `None`.
+    Les défauts Pydantic garantissent que les snapshots déjà persistés
+    continuent de parser.
+    """
 
     content_id: UUID
     title: str
@@ -46,6 +56,8 @@ class MatchedActuArticle(BaseModel):
     source_id: UUID
     is_user_source: bool
     published_at: datetime
+    score: float | None = None
+    pillar_scores: dict[str, float] | None = None
 
 
 class MatchedDeepArticle(BaseModel):

--- a/packages/api/scripts/evaluate_feed_ranking.py
+++ b/packages/api/scripts/evaluate_feed_ranking.py
@@ -1,12 +1,56 @@
-"""Offline CTR gauge for digest/feed ranking.
+"""Jauge CTR hors-ligne du ranking digest / feed.
 
-The script reads persisted ``daily_digest.items`` and joins them with
-``user_content_status`` plus ``contents``. It reports CTR by topic, entity,
-rank, and pillar score band.
+Le script lit les `daily_digest.items` persistés et les joint à
+`user_content_status` + `contents`. Il rapporte le CTR par rang, sujet, entité,
+slot et bande de score.
 
-Usage:
+Deux choses le distinguent de sa version initiale, et ce sont les deux raisons
+pour lesquelles il ne produisait rien :
+
+1. **Le format de prod est lu.** 97 % des digests des 60 derniers jours sont en
+   `editorial_v3` (`items.subjects[]`), format que l'ancienne requête ignorait —
+   elle ne connaissait que `flat_v1` (`items` = tableau) et `topics_v1`
+   (`items.topics[]`). Les trois formats sont désormais unis, avec le rang de
+   sujet, le libellé de sujet et le **slot** (`actu` vs `extra`).
+
+2. **Le dénominateur ne dépend plus de `last_impressed_at`.** Cette colonne
+   n'est écrite qu'au pull-to-refresh et au « déjà vu » manuel : ce n'est ni une
+   impression ni une position. Le dénominateur est maintenant explicite
+   (`--denominator`) et les **trois valeurs sont publiées côte à côte** pour que
+   la dilution soit visible au lieu d'être masquée :
+
+   - `all` — tout slot livré compte. Mesure la distribution, pas la pertinence :
+     94 % des digests générés n'ont jamais eu un seul article consommé.
+   - `engaged` — ne compte que les slots des digests avec ≥ 1 article consommé.
+     Circulaire : l'article consommé se conditionne lui-même.
+   - `engaged-loo` (**défaut**) — compte l'article *i* seulement si son digest a
+     ≥ 1 consommé **autre que *i***. Dé-circularise le conditionnement.
+
+`digest_completions` est **explicitement rejeté** comme conditionneur : 0 ligne
+sur 60 j (58 all-time, dernière le 2026-05-10) **et** circulaire par
+construction (inséré à `consumed/total >= 0,8` ⇒ CTR ≈ 100 % garanti).
+`morning_ritual_opened` ne couvre que 2,5 % des digests ⇒ tranche de robustesse,
+pas filtre.
+
+Biais connus, écrits dans l'en-tête du rapport plutôt que maquillés :
+
+- les `extra_actu_articles` **ne sont jamais scorés** (tri `(thumbnail,
+  published_at)` dans `actu_matcher`) ⇒ leur `score` restera `null` ;
+- la persistance des scores est **forward-only** ⇒ les bandes de score sont
+  vides avant la date de merge. CTR par sujet / entité / rang de sujet est en
+  revanche rétroactif sur tout l'historique `editorial_v3`.
+
+Usage :
     cd packages/api
-    PYTHONPATH=. python scripts/evaluate_feed_ranking.py --days 14
+    PYTHONPATH=. python scripts/evaluate_feed_ranking.py --days 30
+    PYTHONPATH=. python scripts/evaluate_feed_ranking.py --days 30 --tag pr1-before
+    PYTHONPATH=. python scripts/evaluate_feed_ranking.py --compare \\
+        ../../.context/feed-ranking-pr1-before-2026-07-29.json \\
+        ../../.context/feed-ranking-pr1-after-2026-08-05.json
+
+Sorties :
+    .context/feed-ranking-<tag>-<date>.json  (machine, consommé par --compare)
+    .context/feed-ranking-<tag>-<date>.md    (lisible humain)
 """
 
 from __future__ import annotations
@@ -31,6 +75,15 @@ CONTEXT_DIR = REPO_ROOT / ".context"
 
 PILLARS = ("pertinence", "source", "fraicheur", "qualite")
 
+DENOMINATORS = ("all", "engaged", "engaged-loo")
+DEFAULT_DENOMINATOR = "engaged-loo"
+
+DENOMINATOR_HELP = {
+    "all": "tout slot livré (mesure la distribution, pas la pertinence)",
+    "engaged": "slots des digests avec >= 1 consommé (circulaire)",
+    "engaged-loo": "slots des digests avec >= 1 consommé AUTRE que l'article mesuré",
+}
+
 
 @dataclass
 class CtrBucket:
@@ -47,6 +100,14 @@ class CtrBucket:
         if self.shown == 0:
             return 0.0
         return self.consumed / self.shown
+
+    def as_dict(self, key: Any) -> dict[str, Any]:
+        return {
+            "key": key,
+            "shown": self.shown,
+            "consumed": self.consumed,
+            "ctr": self.ctr,
+        }
 
 
 def _load_env_file(path: Path) -> None:
@@ -171,67 +232,153 @@ def _pct(value: float) -> str:
     return f"{value * 100:.1f}%"
 
 
-def _format_rows(
-    rows: list[tuple[str, CtrBucket]],
+# ---------------------------------------------------------------------------
+# Dénominateur
+# ---------------------------------------------------------------------------
+
+
+def consumed_counts_by_digest(rows: Iterable[dict[str, Any]]) -> dict[str, int]:
+    """Pré-passe : nombre d'articles consommés par digest.
+
+    C'est la seule information nécessaire aux trois dénominateurs — le
+    leave-one-out se déduit en retranchant l'article courant.
+    """
+    counts: defaultdict[str, int] = defaultdict(int)
+    for row in rows:
+        if _is_consumed(row):
+            counts[str(row.get("digest_id"))] += 1
+    return dict(counts)
+
+
+def _is_consumed(row: dict[str, Any]) -> bool:
+    return str(row.get("status") or "").lower() == "consumed"
+
+
+def is_counted(
+    row: dict[str, Any],
     *,
-    key_label: str,
+    denominator: str,
+    consumed_by_digest: dict[str, int],
+) -> bool:
+    """Le slot entre-t-il au dénominateur ?
+
+    - `all` : toujours.
+    - `engaged` : son digest a >= 1 consommé.
+    - `engaged-loo` : son digest a >= 1 consommé **autre que lui**. Un digest à
+      un seul article consommé ne contribue donc rien (cas limite : l'article
+      consommé lui-même est exclu).
+    """
+    if denominator == "all":
+        return True
+    total = consumed_by_digest.get(str(row.get("digest_id")), 0)
+    if denominator == "engaged":
+        return total >= 1
+    if denominator == "engaged-loo":
+        return total - (1 if _is_consumed(row) else 0) >= 1
+    raise ValueError(f"unknown denominator: {denominator}")
+
+
+# ---------------------------------------------------------------------------
+# Métriques
+# ---------------------------------------------------------------------------
+
+
+def _by_shown_desc(item: tuple[Any, CtrBucket]) -> tuple[int, float, str]:
+    return (-item[1].shown, -item[1].ctr, str(item[0]).casefold())
+
+
+def _by_key_asc(item: tuple[Any, CtrBucket]) -> Any:
+    return item[0]
+
+
+def _by_band(item: tuple[Any, CtrBucket]) -> tuple[bool, str]:
+    return (item[0] == "missing", str(item[0]))
+
+
+def _bucket_rows(
+    buckets: dict[Any, CtrBucket],
+    *,
     min_shown: int,
-    top: int | None = None,
-) -> list[str]:
-    filtered = [(label, bucket) for label, bucket in rows if bucket.shown >= min_shown]
+    top: int | None,
+    sort_key,
+) -> list[dict[str, Any]]:
+    ordered = sorted(buckets.items(), key=sort_key)
+    kept = [bucket.as_dict(key) for key, bucket in ordered if bucket.shown >= min_shown]
     if top is not None:
-        filtered = filtered[:top]
-    if not filtered:
-        return ["_No rows above threshold._"]
-
-    lines = [
-        f"| {key_label} | shown | consumed | CTR |",
-        f"| {'-' * len(key_label)} | ---: | ---: | ---: |",
-    ]
-    for label, bucket in filtered:
-        lines.append(
-            f"| {label} | {bucket.shown} | {bucket.consumed} | {_pct(bucket.ctr)} |"
-        )
-    return lines
+        kept = kept[:top]
+    return kept
 
 
-def _build_report(
+def build_metrics(
     *,
     rows: list[dict[str, Any]],
-    since: dt.datetime,
-    until: dt.datetime,
-    mode: str | None,
-    include_serene: bool,
-    min_shown: int,
-    top: int,
-) -> str:
+    denominator: str = DEFAULT_DENOMINATOR,
+    min_shown: int = 5,
+    top: int = 25,
+) -> dict[str, Any]:
+    """Agrège les lignes en métriques CTR. Pur Python — ni DB ni réseau."""
+    if denominator not in DENOMINATORS:
+        raise ValueError(f"unknown denominator: {denominator}")
+
+    consumed_by_digest = consumed_counts_by_digest(rows)
+
+    # Les trois dénominateurs sont toujours calculés : publier le seul retenu
+    # masquerait la dilution que ce script est censé rendre visible.
+    all_denominators = {name: CtrBucket() for name in DENOMINATORS}
+
     global_bucket = CtrBucket()
     by_rank: defaultdict[int, CtrBucket] = defaultdict(CtrBucket)
+    by_subject_rank: defaultdict[int, CtrBucket] = defaultdict(CtrBucket)
+    by_slot: defaultdict[str, CtrBucket] = defaultdict(CtrBucket)
+    by_subject: defaultdict[str, CtrBucket] = defaultdict(CtrBucket)
     by_topic: defaultdict[str, CtrBucket] = defaultdict(CtrBucket)
     by_entity: defaultdict[str, CtrBucket] = defaultdict(CtrBucket)
+    by_score_band: defaultdict[str, CtrBucket] = defaultdict(CtrBucket)
     by_pillar_band: dict[str, defaultdict[str, CtrBucket]] = {
         pillar: defaultdict(CtrBucket) for pillar in PILLARS
     }
 
-    skipped_unshown = 0
-    shown_digest_ids: set[str] = set()
-    shown_user_ids: set[str] = set()
+    formats: defaultdict[str, dict[str, Any]] = defaultdict(
+        lambda: {"slots": 0, "digests": set()}
+    )
+
+    skipped = 0
+    counted_digest_ids: set[str] = set()
+    counted_user_ids: set[str] = set()
 
     for row in rows:
-        status = str(row.get("status") or "").lower()
-        consumed = status == "consumed"
-        shown = row.get("last_impressed_at") is not None or consumed
-        if not shown:
-            skipped_unshown += 1
+        consumed = _is_consumed(row)
+        fmt = str(row.get("format_version") or "unknown")
+        formats[fmt]["slots"] += 1
+        formats[fmt]["digests"].add(str(row.get("digest_id")))
+
+        for name, bucket in all_denominators.items():
+            if is_counted(row, denominator=name, consumed_by_digest=consumed_by_digest):
+                bucket.add(consumed=consumed)
+
+        if not is_counted(
+            row, denominator=denominator, consumed_by_digest=consumed_by_digest
+        ):
+            skipped += 1
             continue
 
         global_bucket.add(consumed=consumed)
-        shown_digest_ids.add(str(row.get("digest_id")))
-        shown_user_ids.add(str(row.get("user_id")))
+        counted_digest_ids.add(str(row.get("digest_id")))
+        counted_user_ids.add(str(row.get("user_id")))
 
         rank = row.get("rank")
         if isinstance(rank, int):
             by_rank[rank].add(consumed=consumed)
+
+        subject_rank = row.get("topic_rank")
+        if isinstance(subject_rank, int):
+            by_subject_rank[subject_rank].add(consumed=consumed)
+
+        by_slot[str(row.get("slot") or "unknown")].add(consumed=consumed)
+
+        subject_label = row.get("subject_label")
+        if isinstance(subject_label, str) and subject_label.strip():
+            by_subject[subject_label.strip()].add(consumed=consumed)
 
         for topic in _topic_slugs(row.get("topics")):
             by_topic[topic].add(consumed=consumed)
@@ -239,118 +386,415 @@ def _build_report(
         for entity in _entity_names(row.get("entities")):
             by_entity[entity].add(consumed=consumed)
 
+        by_score_band[_score_band(row.get("final_score"))].add(consumed=consumed)
+
         pillar_scores = _coerce_json_object(row.get("pillar_scores"))
         for pillar in PILLARS:
-            band = _score_band(pillar_scores.get(pillar))
-            by_pillar_band[pillar][band].add(consumed=consumed)
+            by_pillar_band[pillar][_score_band(pillar_scores.get(pillar))].add(
+                consumed=consumed
+            )
 
-    generated_at = dt.datetime.now(dt.UTC).strftime("%Y-%m-%d %H:%M:%SZ")
+    return {
+        "denominator": denominator,
+        "denominators": {
+            name: bucket.as_dict(name) for name, bucket in all_denominators.items()
+        },
+        "rows_fetched": len(rows),
+        "rows_skipped": skipped,
+        "digests_counted": len(counted_digest_ids),
+        "users_counted": len(counted_user_ids),
+        "global": global_bucket.as_dict("global"),
+        "format_versions": [
+            {
+                "key": fmt,
+                "slots": payload["slots"],
+                "digests": len(payload["digests"]),
+            }
+            for fmt, payload in sorted(
+                formats.items(), key=lambda item: -item[1]["slots"]
+            )
+        ],
+        "by_rank": _bucket_rows(
+            by_rank, min_shown=min_shown, top=None, sort_key=_by_key_asc
+        ),
+        "by_subject_rank": _bucket_rows(
+            by_subject_rank, min_shown=min_shown, top=None, sort_key=_by_key_asc
+        ),
+        "by_slot": _bucket_rows(by_slot, min_shown=1, top=None, sort_key=_by_key_asc),
+        "by_subject": _bucket_rows(
+            by_subject, min_shown=min_shown, top=top, sort_key=_by_shown_desc
+        ),
+        "by_topic": _bucket_rows(
+            by_topic, min_shown=min_shown, top=top, sort_key=_by_shown_desc
+        ),
+        "by_entity": _bucket_rows(
+            by_entity, min_shown=min_shown, top=top, sort_key=_by_shown_desc
+        ),
+        "by_score_band": _bucket_rows(
+            by_score_band, min_shown=1, top=None, sort_key=_by_band
+        ),
+        "by_pillar_band": {
+            pillar: _bucket_rows(
+                by_pillar_band[pillar], min_shown=1, top=None, sort_key=_by_band
+            )
+            for pillar in PILLARS
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Rendu
+# ---------------------------------------------------------------------------
+
+
+def _render_table(rows: list[dict[str, Any]], *, key_label: str) -> list[str]:
+    if not rows:
+        return ["_Aucune ligne au-dessus du seuil._"]
     lines = [
-        f"# Feed Ranking CTR Gauge - {generated_at}",
-        "",
-        f"- Window: {since.isoformat()} -> {until.isoformat()}",
-        f"- Mode: {mode or 'all'}",
-        f"- Includes serene digests: {'yes' if include_serene else 'no'}",
-        f"- Rows fetched: {len(rows)}",
-        f"- Rows skipped because not shown: {skipped_unshown}",
-        f"- Shown digests: {len(shown_digest_ids)}",
-        f"- Users with shown items: {len(shown_user_ids)}",
-        f"- Global CTR: {global_bucket.consumed}/{global_bucket.shown} = {_pct(global_bucket.ctr)}",
-        "",
-        "## CTR by Rank",
-        "",
+        f"| {key_label} | shown | consumed | CTR |",
+        f"| {'-' * len(key_label)} | ---: | ---: | ---: |",
     ]
-
-    rank_rows = [
-        (str(rank), bucket)
-        for rank, bucket in sorted(by_rank.items(), key=lambda x: x[0])
-    ]
-    lines.extend(
-        _format_rows(rank_rows, key_label="rank", min_shown=min_shown, top=None)
-    )
-
-    lines.extend(["", "## CTR by Topic", ""])
-    topic_rows = sorted(by_topic.items(), key=lambda x: (-x[1].shown, -x[1].ctr, x[0]))
-    lines.extend(
-        _format_rows(topic_rows, key_label="topic", min_shown=min_shown, top=top)
-    )
-
-    lines.extend(["", "## CTR by Entity", ""])
-    entity_rows = sorted(
-        by_entity.items(), key=lambda x: (-x[1].shown, -x[1].ctr, x[0].casefold())
-    )
-    lines.extend(
-        _format_rows(entity_rows, key_label="entity", min_shown=min_shown, top=top)
-    )
-
-    lines.extend(["", "## CTR by Pillar Score Band", ""])
-    for pillar in PILLARS:
-        lines.extend([f"### {pillar.capitalize()}", ""])
-        band_rows = sorted(
-            by_pillar_band[pillar].items(),
-            key=lambda x: (x[0] == "missing", x[0]),
+    for row in rows:
+        lines.append(
+            f"| {row['key']} | {row['shown']} | {row['consumed']} | "
+            f"{_pct(row['ctr'])} |"
         )
+    return lines
+
+
+def render_report(
+    metrics: dict[str, Any],
+    *,
+    since: dt.datetime,
+    until: dt.datetime,
+    mode: str | None,
+    include_serene: bool,
+    tag: str,
+    row_limit_hit: bool,
+) -> str:
+    generated_at = dt.datetime.now(dt.UTC).strftime("%Y-%m-%d %H:%M:%SZ")
+    denominator = metrics["denominator"]
+    lines = [
+        f"# Jauge CTR ranking feed / digest — {generated_at}",
+        "",
+        f"- Tag : `{tag}`",
+        f"- Fenêtre : {since.isoformat()} -> {until.isoformat()}",
+        f"- Mode : {mode or 'tous'}",
+        f"- Digests sereins inclus : {'oui' if include_serene else 'non'}",
+        f"- Slots lus : {metrics['rows_fetched']}",
+        f"- **Dénominateur retenu : `{denominator}`** "
+        f"({DENOMINATOR_HELP[denominator]})",
+        f"- Slots écartés par ce dénominateur : {metrics['rows_skipped']}",
+        f"- Digests comptés : {metrics['digests_counted']} · "
+        f"users comptés : {metrics['users_counted']}",
+        "",
+    ]
+
+    if row_limit_hit:
         lines.extend(
-            _format_rows(band_rows, key_label="score band", min_shown=1, top=None)
+            [
+                "> ⚠️ **`--row-limit` atteint** : la fenêtre est tronquée aux slots "
+                "les plus récents. Les chiffres ci-dessous ne couvrent pas toute la "
+                "période demandée — relancer avec un `--row-limit` plus haut.",
+                "",
+            ]
         )
-        lines.append("")
+
+    lines.extend(
+        [
+            "## Les 3 dénominateurs côte à côte",
+            "",
+            "Publiés ensemble volontairement : le CTR `all` mesure la "
+            "distribution (la grande majorité des digests générés n'a jamais eu "
+            "un seul article consommé), pas la pertinence du ranking.",
+            "",
+            "| dénominateur | slots | consommés | CTR | lecture |",
+            "| --- | ---: | ---: | ---: | --- |",
+        ]
+    )
+    for name in DENOMINATORS:
+        bucket = metrics["denominators"][name]
+        marker = " **(retenu)**" if name == denominator else ""
+        lines.append(
+            f"| `{name}`{marker} | {bucket['shown']} | {bucket['consumed']} | "
+            f"{_pct(bucket['ctr'])} | {DENOMINATOR_HELP[name]} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "`digest_completions` est rejeté comme conditionneur : 0 ligne sur "
+            "60 j **et** circulaire par construction (inséré à "
+            "`consumed/total >= 0,8`).",
+            "",
+            "## Formats de digest lus",
+            "",
+            "Un format absent de ce tableau n'est **pas** parsé par la requête : "
+            "c'est le symptôme qui a rendu cette jauge muette pendant des mois.",
+            "",
+            "| format_version | slots | digests |",
+            "| --- | ---: | ---: |",
+        ]
+    )
+    for entry in metrics["format_versions"]:
+        lines.append(f"| `{entry['key']}` | {entry['slots']} | {entry['digests']} |")
+
+    global_bucket = metrics["global"]
+    lines.extend(
+        [
+            "",
+            f"## CTR global ({denominator})",
+            "",
+            f"{global_bucket['consumed']}/{global_bucket['shown']} = "
+            f"**{_pct(global_bucket['ctr'])}**",
+            "",
+            "## CTR par rang de sujet (editorial_v3)",
+            "",
+        ]
+    )
+    lines.extend(_render_table(metrics["by_subject_rank"], key_label="rang de sujet"))
+
+    lines.extend(["", "## CTR par slot", ""])
+    lines.extend(
+        [
+            "`actu` = représentant scoré du sujet · `extra` = articles "
+            "complémentaires, **jamais scorés** (tri thumbnail/date) · `flat` / "
+            "`topic` = formats legacy.",
+            "",
+        ]
+    )
+    lines.extend(_render_table(metrics["by_slot"], key_label="slot"))
+
+    lines.extend(["", "## CTR par rang d'article", ""])
+    lines.extend(_render_table(metrics["by_rank"], key_label="rang"))
+
+    lines.extend(["", "## CTR par sujet", ""])
+    lines.extend(_render_table(metrics["by_subject"], key_label="sujet"))
+
+    lines.extend(["", "## CTR par topic", ""])
+    lines.extend(_render_table(metrics["by_topic"], key_label="topic"))
+
+    lines.extend(["", "## CTR par entité", ""])
+    lines.extend(_render_table(metrics["by_entity"], key_label="entité"))
+
+    lines.extend(
+        [
+            "",
+            "## CTR par bande de score",
+            "",
+            "**Forward-only** : `score` et `pillar_scores` ne sont persistés que "
+            "depuis leur mise en production. Une bande `missing` massive sur une "
+            "fenêtre ancienne est attendue, pas un bug. Les `extra_actu_articles` "
+            "resteront `missing` pour toujours (jamais scorés).",
+            "",
+            "### Score final",
+            "",
+        ]
+    )
+    lines.extend(_render_table(metrics["by_score_band"], key_label="bande"))
+
+    for pillar in PILLARS:
+        lines.extend(["", f"### Pilier {pillar}", ""])
+        lines.extend(
+            _render_table(metrics["by_pillar_band"][pillar], key_label="bande")
+        )
 
     return "\n".join(lines).rstrip() + "\n"
 
 
+def _bucket_index(rows: list[dict[str, Any]]) -> dict[Any, dict[str, Any]]:
+    return {row["key"]: row for row in rows}
+
+
+def render_compare(baseline: dict[str, Any], after: dict[str, Any]) -> str:
+    """Comparatif baseline ↔ after, en miroir des harnais frères."""
+    lines = [
+        "# Comparaison baseline ↔ after — jauge ranking",
+        "",
+        f"Dénominateur baseline = `{baseline['metrics']['denominator']}` · "
+        f"after = `{after['metrics']['denominator']}`",
+        "",
+    ]
+    if baseline["metrics"]["denominator"] != after["metrics"]["denominator"]:
+        lines.extend(
+            [
+                "> ⚠️ Dénominateurs différents : les CTR ne sont pas comparables.",
+                "",
+            ]
+        )
+
+    b_global = baseline["metrics"]["global"]
+    a_global = after["metrics"]["global"]
+    lines.extend(
+        [
+            "| Métrique | baseline | after | Δ |",
+            "| --- | ---: | ---: | ---: |",
+            f"| slots | {b_global['shown']} | {a_global['shown']} | "
+            f"{a_global['shown'] - b_global['shown']:+d} |",
+            f"| consommés | {b_global['consumed']} | {a_global['consumed']} | "
+            f"{a_global['consumed'] - b_global['consumed']:+d} |",
+            f"| CTR global | {_pct(b_global['ctr'])} | {_pct(a_global['ctr'])} | "
+            f"{(a_global['ctr'] - b_global['ctr']) * 100:+.1f} pp |",
+            "",
+            "## CTR par rang de sujet",
+            "",
+            "| rang | baseline | after | Δ | slots after |",
+            "| ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    b_ranks = _bucket_index(baseline["metrics"]["by_subject_rank"])
+    a_ranks = _bucket_index(after["metrics"]["by_subject_rank"])
+    for key in sorted(set(b_ranks) | set(a_ranks), key=lambda k: (k is None, k)):
+        b = b_ranks.get(key)
+        a = a_ranks.get(key)
+        b_ctr = _pct(b["ctr"]) if b else "-"
+        a_ctr = _pct(a["ctr"]) if a else "-"
+        delta = f"{(a['ctr'] - b['ctr']) * 100:+.1f} pp" if b and a else "-"
+        lines.append(
+            f"| {key} | {b_ctr} | {a_ctr} | {delta} | {a['shown'] if a else 0} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## CTR par slot",
+            "",
+            "| slot | baseline | after | Δ | slots after |",
+            "| --- | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    b_slots = _bucket_index(baseline["metrics"]["by_slot"])
+    a_slots = _bucket_index(after["metrics"]["by_slot"])
+    for key in sorted(set(b_slots) | set(a_slots)):
+        b = b_slots.get(key)
+        a = a_slots.get(key)
+        b_ctr = _pct(b["ctr"]) if b else "-"
+        a_ctr = _pct(a["ctr"]) if a else "-"
+        delta = f"{(a['ctr'] - b['ctr']) * 100:+.1f} pp" if b and a else "-"
+        lines.append(
+            f"| {key} | {b_ctr} | {a_ctr} | {delta} | {a['shown'] if a else 0} |"
+        )
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# ---------------------------------------------------------------------------
+# SQL
+# ---------------------------------------------------------------------------
+
 SQL = """
-WITH flat_items AS (
+WITH digest_scope AS (
     SELECT
-        dd.id AS digest_id,
+        dd.id,
         dd.user_id,
         dd.target_date,
         dd.generated_at,
         dd.mode,
         dd.is_serene,
-        item AS item_json,
-        NULL::integer AS topic_rank
+        dd.format_version,
+        dd.items
     FROM daily_digest dd
+    WHERE dd.generated_at >= :since
+      AND dd.generated_at < :until
+      -- CAST explicite : sans lui `--mode` non fourni envoie un NULL non typé
+      -- et Postgres refuse la requête (AmbiguousParameter). C'est la deuxième
+      -- raison pour laquelle cette jauge ne tournait pas.
+      AND (CAST(:mode AS text) IS NULL OR dd.mode = CAST(:mode AS text))
+      AND (CAST(:include_serene AS boolean) OR dd.is_serene = false)
+),
+flat_items AS (
+    SELECT
+        d.id AS digest_id,
+        d.user_id,
+        d.target_date,
+        d.generated_at,
+        d.mode,
+        d.is_serene,
+        d.format_version,
+        item AS item_json,
+        NULL::integer AS topic_rank,
+        NULL::text AS subject_label,
+        'flat'::text AS slot
+    FROM digest_scope d
     CROSS JOIN LATERAL jsonb_array_elements(
         CASE
-            WHEN jsonb_typeof(dd.items) = 'array' THEN dd.items
+            WHEN jsonb_typeof(d.items) = 'array' THEN d.items
             ELSE '[]'::jsonb
         END
     ) AS item
-    WHERE dd.generated_at >= :since
-      AND dd.generated_at < :until
-      AND (:mode IS NULL OR dd.mode = :mode)
-      AND (:include_serene OR dd.is_serene = false)
 ),
 topic_items AS (
     SELECT
-        dd.id AS digest_id,
-        dd.user_id,
-        dd.target_date,
-        dd.generated_at,
-        dd.mode,
-        dd.is_serene,
+        d.id AS digest_id,
+        d.user_id,
+        d.target_date,
+        d.generated_at,
+        d.mode,
+        d.is_serene,
+        d.format_version,
         article_item AS item_json,
-        NULLIF(topic_item->>'rank', '')::integer AS topic_rank
-    FROM daily_digest dd
+        NULLIF(topic_item->>'rank', '')::integer AS topic_rank,
+        NULLIF(topic_item->>'label', '') AS subject_label,
+        'topic'::text AS slot
+    FROM digest_scope d
     CROSS JOIN LATERAL jsonb_array_elements(
         CASE
-            WHEN jsonb_typeof(dd.items) = 'object'
-                THEN COALESCE(dd.items->'topics', '[]'::jsonb)
+            WHEN jsonb_typeof(d.items) = 'object'
+                THEN COALESCE(d.items->'topics', '[]'::jsonb)
             ELSE '[]'::jsonb
         END
     ) AS topic_item
     CROSS JOIN LATERAL jsonb_array_elements(
         COALESCE(topic_item->'articles', '[]'::jsonb)
     ) AS article_item
-    WHERE dd.generated_at >= :since
-      AND dd.generated_at < :until
-      AND (:mode IS NULL OR dd.mode = :mode)
-      AND (:include_serene OR dd.is_serene = false)
+),
+-- editorial_v1/v2/v3 : `items.subjects[]`, un représentant `actu_article`
+-- (scoré) + N `extra_actu_articles` (jamais scorés). C'est 97 % de la prod.
+editorial_items AS (
+    SELECT
+        d.id AS digest_id,
+        d.user_id,
+        d.target_date,
+        d.generated_at,
+        d.mode,
+        d.is_serene,
+        d.format_version,
+        art.article_item AS item_json,
+        NULLIF(subject_item->>'rank', '')::integer AS topic_rank,
+        NULLIF(subject_item->>'label', '') AS subject_label,
+        art.slot
+    FROM digest_scope d
+    CROSS JOIN LATERAL jsonb_array_elements(
+        CASE
+            WHEN jsonb_typeof(d.items) = 'object'
+                THEN COALESCE(d.items->'subjects', '[]'::jsonb)
+            ELSE '[]'::jsonb
+        END
+    ) AS subject_item
+    CROSS JOIN LATERAL (
+        -- `actu_article` peut être un JSON `null` (sujet sans représentant).
+        SELECT
+            subject_item->'actu_article' AS article_item,
+            'actu'::text AS slot
+        WHERE subject_item->'actu_article' IS NOT NULL
+          AND subject_item->'actu_article' <> 'null'::jsonb
+        UNION ALL
+        SELECT extra AS article_item, 'extra'::text AS slot
+        FROM jsonb_array_elements(
+            CASE
+                WHEN jsonb_typeof(subject_item->'extra_actu_articles') = 'array'
+                    THEN subject_item->'extra_actu_articles'
+                ELSE '[]'::jsonb
+            END
+        ) AS extra
+    ) AS art
 ),
 digest_items AS (
     SELECT * FROM flat_items
     UNION ALL
     SELECT * FROM topic_items
+    UNION ALL
+    SELECT * FROM editorial_items
 ),
 parsed_items AS (
     SELECT
@@ -360,6 +804,10 @@ parsed_items AS (
         generated_at,
         mode,
         is_serene,
+        format_version,
+        topic_rank,
+        subject_label,
+        slot,
         NULLIF(item_json->>'content_id', '') AS content_id_text,
         COALESCE(NULLIF(item_json->>'rank', '')::integer, topic_rank) AS rank,
         COALESCE(
@@ -377,12 +825,15 @@ SELECT
     pi.generated_at,
     pi.mode,
     pi.is_serene,
+    pi.format_version,
+    pi.topic_rank,
+    pi.subject_label,
+    pi.slot,
     pi.content_id_text::uuid AS content_id,
     pi.rank,
     pi.final_score,
     pi.pillar_scores,
     ucs.status::text AS status,
-    ucs.last_impressed_at,
     c.topics,
     c.entities
 FROM parsed_items pi
@@ -421,21 +872,39 @@ async def _fetch_rows(args: argparse.Namespace) -> list[dict[str, Any]]:
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--days", type=int, default=14, help="Lookback window in days")
-    parser.add_argument("--since", help="UTC ISO datetime/date lower bound")
-    parser.add_argument("--until", help="UTC ISO datetime/date upper bound")
-    parser.add_argument("--mode", help="Filter daily_digest.mode")
+    parser.add_argument("--days", type=int, default=14, help="Fenêtre en jours")
+    parser.add_argument("--since", help="Borne basse UTC (ISO)")
+    parser.add_argument("--until", help="Borne haute UTC (ISO)")
+    parser.add_argument("--mode", help="Filtre daily_digest.mode")
     parser.add_argument(
         "--include-serene",
         action="store_true",
-        help="Include serene digest variants",
+        help="Inclure les variantes sereines",
+    )
+    parser.add_argument(
+        "--denominator",
+        choices=DENOMINATORS,
+        default=DEFAULT_DENOMINATOR,
+        help="Dénominateur retenu (les 3 sont publiés côte à côte de toute façon)",
     )
     parser.add_argument("--min-shown", type=int, default=5)
     parser.add_argument("--top", type=int, default=25)
-    parser.add_argument("--row-limit", type=int, default=20000)
+    parser.add_argument(
+        "--row-limit",
+        type=int,
+        default=200_000,
+        help="Garde-fou mémoire ; le rapport signale si la limite est atteinte",
+    )
     parser.add_argument("--tag", default="latest")
-    parser.add_argument("--output", type=Path)
+    parser.add_argument("--out-json", type=Path)
+    parser.add_argument("--out-md", type=Path)
     parser.add_argument("--no-write", action="store_true")
+    parser.add_argument(
+        "--compare",
+        nargs=2,
+        metavar=("BASELINE", "AFTER"),
+        help="2 JSON produits par ce script",
+    )
     args = parser.parse_args(argv)
 
     now = dt.datetime.now(dt.UTC)
@@ -448,25 +917,57 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
 
 async def _main(argv: list[str]) -> int:
     args = _parse_args(argv)
+
+    if args.compare:
+        baseline = json.loads(Path(args.compare[0]).read_text(encoding="utf-8"))
+        after = json.loads(Path(args.compare[1]).read_text(encoding="utf-8"))
+        print(render_compare(baseline, after))
+        return 0
+
     rows = await _fetch_rows(args)
-    report = _build_report(
+    metrics = build_metrics(
         rows=rows,
+        denominator=args.denominator,
+        min_shown=args.min_shown,
+        top=args.top,
+    )
+    report = render_report(
+        metrics,
         since=args.since,
         until=args.until,
         mode=args.mode,
         include_serene=args.include_serene,
-        min_shown=args.min_shown,
-        top=args.top,
+        tag=args.tag,
+        row_limit_hit=len(rows) >= args.row_limit,
     )
     print(report)
 
-    if not args.no_write:
-        CONTEXT_DIR.mkdir(parents=True, exist_ok=True)
-        timestamp = dt.datetime.now(dt.UTC).strftime("%Y%m%d-%H%M%S")
-        output = args.output or CONTEXT_DIR / f"feed-ranking-{args.tag}-{timestamp}.md"
-        output.write_text(report)
-        print(f"Wrote {output}")
+    if args.no_write:
+        return 0
 
+    today = dt.datetime.now(dt.UTC).date().isoformat()
+    out_json = args.out_json or CONTEXT_DIR / f"feed-ranking-{args.tag}-{today}.json"
+    out_md = args.out_md or CONTEXT_DIR / f"feed-ranking-{args.tag}-{today}.md"
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+
+    payload = {
+        "generated_at": dt.datetime.now(dt.UTC).isoformat(),
+        "tag": args.tag,
+        "since": args.since.isoformat(),
+        "until": args.until.isoformat(),
+        "mode": args.mode,
+        "include_serene": args.include_serene,
+        "row_limit_hit": len(rows) >= args.row_limit,
+        "metrics": metrics,
+    }
+    out_json.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    out_md.write_text(report, encoding="utf-8")
+
+    print(f"✅ Résultats : {out_json}")
+    print(f"✅ Rapport   : {out_md}")
     return 0
 
 

--- a/packages/api/tests/scripts/fixtures/toy_feed_ranking_rows.json
+++ b/packages/api/tests/scripts/fixtures/toy_feed_ranking_rows.json
@@ -1,0 +1,80 @@
+[
+  {
+    "_comment": "D1 — editorial_v3, 3 sujets + 1 extra, 2 articles consommés.",
+    "digest_id": "D1", "user_id": "U1", "format_version": "editorial_v3",
+    "slot": "actu", "topic_rank": 1, "subject_label": "Réforme des retraites",
+    "rank": 1, "final_score": 82.0,
+    "pillar_scores": {"pertinence": 74.0, "source": 55.0, "fraicheur": 90.0, "qualite": 61.0},
+    "status": "consumed", "topics": ["politics", "economy"], "entities": ["Élisabeth Borne"]
+  },
+  {
+    "digest_id": "D1", "user_id": "U1", "format_version": "editorial_v3",
+    "slot": "actu", "topic_rank": 2, "subject_label": "Sommet climat",
+    "rank": 2, "final_score": 64.0,
+    "pillar_scores": {"pertinence": 41.0, "source": 30.0, "fraicheur": 88.0, "qualite": 52.0},
+    "status": "consumed", "topics": ["environment"], "entities": ["COP30"]
+  },
+  {
+    "digest_id": "D1", "user_id": "U1", "format_version": "editorial_v3",
+    "slot": "actu", "topic_rank": 3, "subject_label": "Ligue 1",
+    "rank": 3, "final_score": 21.0,
+    "pillar_scores": {"pertinence": 12.0, "source": 8.0, "fraicheur": 70.0, "qualite": 33.0},
+    "status": null, "topics": ["sport"], "entities": ["Kylian Mbappé"]
+  },
+  {
+    "_comment": "Extra : jamais scoré ⇒ final_score et pillar_scores absents.",
+    "digest_id": "D1", "user_id": "U1", "format_version": "editorial_v3",
+    "slot": "extra", "topic_rank": 2, "subject_label": "Sommet climat",
+    "rank": 2, "final_score": null, "pillar_scores": {},
+    "status": null, "topics": ["environment"], "entities": ["COP30"]
+  },
+  {
+    "_comment": "D2 — un SEUL article consommé : cas limite leave-one-out.",
+    "digest_id": "D2", "user_id": "U2", "format_version": "editorial_v3",
+    "slot": "actu", "topic_rank": 1, "subject_label": "Réforme des retraites",
+    "rank": 1, "final_score": 77.0,
+    "pillar_scores": {"pertinence": 68.0, "source": 44.0, "fraicheur": 85.0, "qualite": 59.0},
+    "status": "consumed", "topics": ["politics"], "entities": ["Élisabeth Borne"]
+  },
+  {
+    "digest_id": "D2", "user_id": "U2", "format_version": "editorial_v3",
+    "slot": "actu", "topic_rank": 2, "subject_label": "Sommet climat",
+    "rank": 2, "final_score": 55.0,
+    "pillar_scores": {"pertinence": 33.0, "source": 25.0, "fraicheur": 80.0, "qualite": 48.0},
+    "status": null, "topics": ["environment"], "entities": ["COP30"]
+  },
+  {
+    "_comment": "D3 — digest sans aucune consommation : les 94 % de la prod.",
+    "digest_id": "D3", "user_id": "U3", "format_version": "editorial_v3",
+    "slot": "actu", "topic_rank": 1, "subject_label": "Réforme des retraites",
+    "rank": 1, "final_score": 70.0, "pillar_scores": {},
+    "status": null, "topics": ["politics"], "entities": ["Élisabeth Borne"]
+  },
+  {
+    "digest_id": "D3", "user_id": "U3", "format_version": "editorial_v3",
+    "slot": "actu", "topic_rank": 2, "subject_label": "Ligue 1",
+    "rank": 2, "final_score": 30.0, "pillar_scores": {},
+    "status": "saved", "topics": ["sport"], "entities": ["Kylian Mbappé"]
+  },
+  {
+    "_comment": "D4 — legacy flat_v1 : pas de rang de sujet, slot flat.",
+    "digest_id": "D4", "user_id": "U4", "format_version": "flat_v1",
+    "slot": "flat", "topic_rank": null, "subject_label": null,
+    "rank": 1, "final_score": 66.0,
+    "pillar_scores": {"pertinence": 50.0, "source": 40.0, "fraicheur": 75.0, "qualite": 44.0},
+    "status": "consumed", "topics": ["politics"], "entities": ["Élisabeth Borne"]
+  },
+  {
+    "digest_id": "D4", "user_id": "U4", "format_version": "flat_v1",
+    "slot": "flat", "topic_rank": null, "subject_label": null,
+    "rank": 2, "final_score": 40.0, "pillar_scores": {},
+    "status": null, "topics": ["economy"], "entities": []
+  },
+  {
+    "_comment": "D5 — legacy topics_v1 : rang porté par le groupe de topics.",
+    "digest_id": "D5", "user_id": "U5", "format_version": "topics_v1",
+    "slot": "topic", "topic_rank": 1, "subject_label": "Politique",
+    "rank": 1, "final_score": null, "pillar_scores": {},
+    "status": null, "topics": ["politics"], "entities": []
+  }
+]

--- a/packages/api/tests/scripts/test_evaluate_feed_ranking.py
+++ b/packages/api/tests/scripts/test_evaluate_feed_ranking.py
@@ -1,0 +1,279 @@
+"""Tests hermétiques pour `scripts/evaluate_feed_ranking.py`.
+
+Ni DB ni réseau : le toy `toy_feed_ranking_rows.json` rejoue la **forme des
+lignes que la requête SQL retourne** (un slot livré par ligne, déjà aplati), et
+on fait tourner l'agrégation pure Python dessus.
+
+Couvre :
+- les **3 dénominateurs**, dont le cas limite leave-one-out (un digest à un seul
+  article consommé ne contribue rien : l'article se conditionnerait lui-même) ;
+- `editorial_v3` : slots `actu` **et** `extra`, rang de sujet, libellé de sujet ;
+- `pillar_scores` absent ⇒ bande `missing` (les extras, jamais scorés, et tout
+  l'historique antérieur à la persistance forward-only) ;
+- `flat_v1` / `topics_v1` parsent toujours (pas de régression legacy) ;
+- l'histogramme `format_version`, garde-fou contre un futur changement de format
+  qui rendrait la jauge muette en silence — le défaut d'origine ;
+- `render_report` / `render_compare` produisent du markdown non vide.
+
+Limite assumée : la requête SQL elle-même n'est pas exécutée ici (elle exige la
+prod). Elle a été validée contre la DB de prod à l'écriture de la PR ; le test
+`test_sql_reads_the_three_formats` ne garde que sa **structure**, pas son
+résultat.
+"""
+
+import datetime as dt
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.evaluate_feed_ranking import (
+    DENOMINATORS,
+    SQL,
+    build_metrics,
+    consumed_counts_by_digest,
+    is_counted,
+    render_compare,
+    render_report,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "toy_feed_ranking_rows.json"
+
+
+def _rows() -> list[dict]:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def _metrics(denominator: str = "engaged-loo", **kwargs) -> dict:
+    return build_metrics(
+        rows=_rows(), denominator=denominator, min_shown=1, top=25, **kwargs
+    )
+
+
+def _keyed(rows: list[dict]) -> dict:
+    return {row["key"]: row for row in rows}
+
+
+# ---------------------------------------------------------------------------
+# Dénominateurs
+# ---------------------------------------------------------------------------
+
+
+def test_consumed_counts_by_digest():
+    """Seuls les digests ayant au moins un consommé apparaissent."""
+    assert consumed_counts_by_digest(_rows()) == {"D1": 2, "D2": 1, "D4": 1}
+
+
+def test_denominator_all_counts_every_delivered_slot():
+    metrics = _metrics("all")
+    assert metrics["global"]["shown"] == 11
+    assert metrics["global"]["consumed"] == 4
+    assert metrics["rows_skipped"] == 0
+
+
+def test_denominator_engaged_drops_digests_without_any_consumption():
+    """D3 (aucun consommé) et D5 sortent ; D1+D2+D4 restent entiers."""
+    metrics = _metrics("engaged")
+    assert metrics["global"]["shown"] == 8
+    assert metrics["global"]["consumed"] == 4
+
+
+def test_denominator_loo_excludes_the_lone_consumed_article():
+    """Cas limite : dans D2 et D4 le seul consommé est son propre conditionneur.
+
+    Il est donc retiré du dénominateur — c'est exactement ce que le
+    leave-one-out dé-circularise. Restent D1 (4 slots, 2 consommés) + D2 (1
+    slot, 0) + D4 (1 slot, 0).
+    """
+    metrics = _metrics("engaged-loo")
+    assert metrics["global"]["shown"] == 6
+    assert metrics["global"]["consumed"] == 2
+    assert metrics["rows_skipped"] == 5
+
+
+def test_loo_edge_case_single_consumed_digest_contributes_nothing_consumed():
+    rows = [
+        {"digest_id": "X", "status": "consumed"},
+        {"digest_id": "X", "status": None},
+    ]
+    counts = consumed_counts_by_digest(rows)
+    assert (
+        is_counted(rows[0], denominator="engaged-loo", consumed_by_digest=counts)
+        is False
+    )
+    assert (
+        is_counted(rows[1], denominator="engaged-loo", consumed_by_digest=counts)
+        is True
+    )
+
+
+def test_the_three_denominators_are_always_published_side_by_side():
+    """Publier le seul dénominateur retenu masquerait la dilution mesurée."""
+    metrics = _metrics("engaged-loo")
+    assert set(metrics["denominators"]) == set(DENOMINATORS)
+    assert metrics["denominators"]["all"]["shown"] == 11
+    assert metrics["denominators"]["engaged"]["shown"] == 8
+    assert metrics["denominators"]["engaged-loo"]["shown"] == 6
+    # Invariants de construction : `engaged` ne retire que des non-consommés
+    # (donc gonfle le CTR) et le LOO ne retire ensuite que des consommés (donc
+    # le redescend). C'est cet encadrement qui rend la dilution lisible ; en
+    # prod l'écart `all` -> `engaged` est d'un facteur ~15.
+    assert (
+        metrics["denominators"]["all"]["ctr"]
+        <= metrics["denominators"]["engaged"]["ctr"]
+    )
+    assert (
+        metrics["denominators"]["engaged-loo"]["ctr"]
+        <= metrics["denominators"]["engaged"]["ctr"]
+    )
+
+
+def test_unknown_denominator_is_rejected():
+    with pytest.raises(ValueError):
+        build_metrics(rows=_rows(), denominator="engaged-somehow")
+
+
+# ---------------------------------------------------------------------------
+# editorial_v3 : rang de sujet, slot, libellé
+# ---------------------------------------------------------------------------
+
+
+def test_by_subject_rank_uses_the_subject_rank():
+    metrics = _metrics("all")
+    ranks = _keyed(metrics["by_subject_rank"])
+    # D1(r1) + D2(r1) + D3(r1) + D5(r1) — les lignes flat_v1 n'ont pas de rang
+    # de sujet et n'entrent donc pas dans ce breakdown.
+    assert ranks[1]["shown"] == 4
+    assert ranks[1]["consumed"] == 2
+    assert ranks[3]["shown"] == 1
+    assert ranks[3]["consumed"] == 0
+
+
+def test_by_slot_separates_actu_from_extra():
+    metrics = _metrics("all")
+    slots = _keyed(metrics["by_slot"])
+    assert slots["actu"]["shown"] == 7
+    assert slots["extra"]["shown"] == 1
+    assert slots["flat"]["shown"] == 2
+    assert slots["topic"]["shown"] == 1
+
+
+def test_by_subject_aggregates_across_users():
+    metrics = _metrics("all")
+    subjects = _keyed(metrics["by_subject"])
+    # « Réforme des retraites » : D1, D2, D3 — 2 consommés sur 3.
+    assert subjects["Réforme des retraites"]["shown"] == 3
+    assert subjects["Réforme des retraites"]["consumed"] == 2
+    # « Sommet climat » : actu D1 + extra D1 + actu D2.
+    assert subjects["Sommet climat"]["shown"] == 3
+
+
+def test_rows_without_subject_label_are_not_bucketed_as_empty():
+    metrics = _metrics("all")
+    assert all(row["key"] for row in metrics["by_subject"])
+    assert None not in _keyed(metrics["by_subject"])
+
+
+# ---------------------------------------------------------------------------
+# Bandes de score : forward-only, donc `missing` attendu
+# ---------------------------------------------------------------------------
+
+
+def test_missing_pillar_scores_fall_into_the_missing_band():
+    metrics = _metrics("all")
+    bands = _keyed(metrics["by_pillar_band"]["pertinence"])
+    # D1 extra + D3 (x2) + D4 rang 2 + D5 n'ont pas de pillar_scores.
+    assert bands["missing"]["shown"] == 5
+    assert bands["60-80"]["shown"] == 2  # D1 r1 (74) et D2 r1 (68)
+
+
+def test_missing_final_score_falls_into_the_missing_band():
+    metrics = _metrics("all")
+    bands = _keyed(metrics["by_score_band"])
+    assert bands["missing"]["shown"] == 2  # l'extra de D1 et la ligne topics_v1
+    assert bands["80-100"]["shown"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Legacy + garde-fou format
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_formats_still_parse():
+    metrics = _metrics("all")
+    formats = _keyed(metrics["format_versions"])
+    assert formats["editorial_v3"]["slots"] == 8
+    assert formats["editorial_v3"]["digests"] == 3
+    assert formats["flat_v1"]["slots"] == 2
+    assert formats["topics_v1"]["slots"] == 1
+
+
+def test_flat_v1_rank_is_read_from_the_item():
+    metrics = _metrics("all")
+    ranks = _keyed(metrics["by_rank"])
+    # rang 2 : D1 sujet 2 + son extra, D2 sujet 2, D3 sujet 2, D4 item 2.
+    assert ranks[2]["shown"] == 5
+
+
+def test_sql_reads_the_three_formats():
+    """Garde-fou : la requête doit couvrir les 3 layouts de `daily_digest.items`.
+
+    Le défaut d'origine de cette jauge était de n'en connaître que deux — elle
+    retournait 0 ligne sur 97 % de la prod sans le dire.
+    """
+    for cte in ("flat_items", "topic_items", "editorial_items"):
+        assert cte in SQL
+    assert "'subjects'" in SQL
+    assert "'extra_actu_articles'" in SQL
+    assert "format_version" in SQL
+
+
+# ---------------------------------------------------------------------------
+# Rendu
+# ---------------------------------------------------------------------------
+
+
+def _render(metrics: dict) -> str:
+    return render_report(
+        metrics,
+        since=dt.datetime(2026, 7, 1, tzinfo=dt.UTC),
+        until=dt.datetime(2026, 7, 29, tzinfo=dt.UTC),
+        mode=None,
+        include_serene=False,
+        tag="test",
+        row_limit_hit=False,
+    )
+
+
+def test_render_report_states_the_denominator_and_the_three_columns():
+    report = _render(_metrics("engaged-loo"))
+    assert "Dénominateur retenu : `engaged-loo`" in report
+    for name in DENOMINATORS:
+        assert f"`{name}`" in report
+    assert "digest_completions" in report  # le rejet est écrit, pas implicite
+    assert "Forward-only" in report
+
+
+def test_render_report_warns_when_row_limit_is_hit():
+    metrics = _metrics("all")
+    report = render_report(
+        metrics,
+        since=dt.datetime(2026, 7, 1, tzinfo=dt.UTC),
+        until=dt.datetime(2026, 7, 29, tzinfo=dt.UTC),
+        mode=None,
+        include_serene=False,
+        tag="test",
+        row_limit_hit=True,
+    )
+    assert "`--row-limit` atteint" in report
+
+
+def test_render_compare_flags_mismatched_denominators():
+    baseline = {"metrics": _metrics("engaged-loo")}
+    after = {"metrics": _metrics("all")}
+    compare = render_compare(baseline, after)
+    assert "ne sont pas comparables" in compare
+
+    same = render_compare({"metrics": _metrics("all")}, {"metrics": _metrics("all")})
+    assert "ne sont pas comparables" not in same
+    assert "+0.0 pp" in same

--- a/packages/api/tests/test_digest_per_user_projection.py
+++ b/packages/api/tests/test_digest_per_user_projection.py
@@ -456,3 +456,89 @@ async def test_polarization_breaks_tie_between_multi_sources():
     )
     order = [s.topic_id for s in res.subjects]
     assert order.index("polar") < order.index("plain")
+
+
+# ─── Tests: persistance des scores (jauge CTR) ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_representative_carries_its_score_and_pillar_scores():
+    """Le score du représentant survit à la boucle de renumérotation.
+
+    C'est la donnée que `scripts/evaluate_feed_ranking.py` croise avec la
+    consommation. Avant cette PR le `pillar_scores` était calculé puis jeté
+    (`score_map` ne gardait que le score final), et le rattacher AVANT la
+    renumérotation ne servait à rien : cette boucle recopie chaque sujet.
+    """
+    srcA, srcB = uuid4(), uuid4()
+    now = datetime.now(UTC)
+    a1 = _make_content(srcA, published_at=now, title="Article A")
+    a2 = _make_content(srcB, published_at=now, title="Article B")
+
+    clusters = [_make_topic_cluster("c1", [a1]), _make_topic_cluster("c2", [a2])]
+    subjects = [_make_subject("c1", a1, rank=1), _make_subject("c2", a2, rank=2)]
+    global_ctx = types.SimpleNamespace(subjects=subjects, cluster_data=[])
+
+    selector = _make_selector()
+    res = await selector._project_editorial_for_user(
+        pipeline=_StubPipeline(),
+        global_ctx=global_ctx,
+        clusters=clusters,
+        context=_make_context(uuid4(), {srcA}),
+        mode="pour_vous",
+    )
+
+    for subject in res.subjects:
+        assert subject.actu_article is not None
+        assert subject.actu_article.score is not None
+        assert set(subject.actu_article.pillar_scores) == {
+            "pertinence",
+            "source",
+            "fraicheur",
+            "qualite",
+        }
+
+    # La source suivie doit scorer au-dessus de la non-suivie : le score
+    # persisté est bien celui qui a servi au tri, pas une valeur décorative.
+    by_topic = {s.topic_id: s for s in res.subjects}
+    assert by_topic["c1"].actu_article.score > by_topic["c2"].actu_article.score
+
+
+@pytest.mark.asyncio
+async def test_score_stays_none_when_scoring_fails():
+    """Dégradation sûre : un scoring en échec ne doit pas casser le digest."""
+    src = uuid4()
+    a1 = _make_content(src, published_at=datetime.now(UTC), title="Article A")
+    clusters = [_make_topic_cluster("c1", [a1])]
+    global_ctx = types.SimpleNamespace(
+        subjects=[_make_subject("c1", a1, rank=1)], cluster_data=[]
+    )
+
+    selector = _make_selector()
+    selector._score_candidates = AsyncMock(side_effect=RuntimeError("boom"))
+
+    res = await selector._project_editorial_for_user(
+        pipeline=_StubPipeline(),
+        global_ctx=global_ctx,
+        clusters=clusters,
+        context=_make_context(uuid4(), {src}),
+        mode="pour_vous",
+    )
+
+    assert len(res.subjects) == 1
+    assert res.subjects[0].actu_article.score is None
+    assert res.subjects[0].actu_article.pillar_scores is None
+
+
+def test_legacy_snapshots_without_score_still_parse():
+    """Les digests déjà persistés n'ont ni `score` ni `pillar_scores`."""
+    article = MatchedActuArticle(
+        content_id=uuid4(),
+        title="Legacy",
+        source_name="Source",
+        source_id=uuid4(),
+        is_user_source=False,
+        published_at=datetime.now(UTC),
+    )
+    assert article.score is None
+    assert article.pillar_scores is None


### PR DESCRIPTION
## Contexte

Le brief `.context/reco-quality-architect-brief.md` posait que le plafond de qualité des recos était la **granularité de la taxonomie** (51 slugs) et l'**absence de vectorisation**. La vérification (code + DB de prod, 2026-07-29) infirme ce cadrage : le plafond, ce sont des **signaux débranchés ou numériquement inertes**, et un **instrument de mesure qui ne parsait pas le format de digest de production**.

Cette PR livre l'arbitrage écrit + **PR0 : rendre la jauge exécutable**. PR1 (rebrancher les signaux) suit dans une PR séparée.

## Pourquoi la jauge ne mesurait rien

Trois défauts silencieux — le script s'exécutait sans erreur et retournait un rapport vide, ce qui se lit comme « pas de signal » et pas comme « instrument cassé ».

1. **Le format de prod n'était pas lu.** La requête ne connaissait que `flat_v1` (`items` = tableau) et `topics_v1` (`items.topics[]`). Or **100 % des digests non-sereins des 30 derniers jours sont en `editorial_v3`** (`items.subjects[]`) : 3 493 non-sereins + 1 069 sereins ; les 266 `topics_v1` restants sont tous sereins, donc écartés par défaut. ⇒ **0 ligne**.
2. **Le dénominateur reposait sur `last_impressed_at`**, colonne écrite seulement au pull-to-refresh et au « déjà vu » manuel : ni impression ni position.
3. **Un NULL non typé cassait la requête** : `(:mode IS NULL OR dd.mode = :mode)` sans `--mode` ⇒ `psycopg.errors.AmbiguousParameter: could not determine data type of parameter \$3`.

## Ce que fait la PR

- **CTE `editorial_items`** : `subjects[].actu_article` + `extra_actu_articles`, avec rang de sujet, libellé de sujet et **slot** (`actu` / `extra`). Requête validée contre la DB de prod.
- **`--denominator {all,engaged,engaged-loo}`**, défaut `engaged-loo`, **les trois publiés côte à côte** :

  | dénominateur | définition | prod, 30 j, non-sereins |
  |---|---|---|
  | `all` | tout slot livré | 566 / 45 735 = **1,24 %** |
  | `engaged` | digests avec ≥ 1 consommé (circulaire) | 566 / 3 081 = **18,37 %** |
  | `engaged-loo` **(défaut)** | ≥ 1 consommé **autre que l'article mesuré** | 459 / 2 974 = **15,43 %** |

  `all` mesure la distribution, pas la pertinence : ~93 % des digests générés n'ont jamais eu un seul article consommé.
- **`digest_completions` rejeté par écrit** comme conditionneur — **0 ligne sur 60 j** (58 all-time, dernière 2026-05-10) **et** circulaire par construction (inséré à `consumed/total ≥ 0,8` ⇒ CTR ≈ 100 % garanti). C'est dans le runbook *et* dans l'en-tête du rapport généré, pour que personne ne le re-propose.
- **Persistance forward-only de `score` / `pillar_scores`** sur le représentant scoré. Le `pillar_scores` était calculé puis jeté (`score_map` ne gardait que le score final). Rattaché **dans la boucle de renumérotation**, sinon il est redroppé.
- **Histogramme `format_version` en en-tête** : un futur changement de format sera bruyant, pas silencieux.
- Sorties `.json` + `.md` appariées dans `.context/` et `--compare`, en miroir de `evaluate_event_clustering.py` / `evaluate_veille_curation.py`. Pas de `--sweep` : ce script n'a aucun dial.

## Première lecture — et elle est parlante

30 j au 2026-07-29, `engaged-loo`, slots `actu` (~220 slots/rang ⇒ **±5 pp à 95 %**) :

| rang | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| CTR | **30,7 %** | 19,1 % | 19,7 % | 14,1 % | 19,7 % | 21,7 % | 19,7 % | 22,4 % | 19,1 % | 15,3 % |

1. **Le rang 1 se détache, le reste est plat.** Les rangs 2 à 10 tiennent tous dans la barre d'erreur autour de ~19 % : le re-ranking per-user n'a **aucun pouvoir discriminant mesurable au-delà du rang 1**. La jauge ne peut pas dire si l'avantage du rang 1 vient du ranking ou de la position à l'écran — c'est écrit dans le runbook.
2. **Les `extra_actu_articles` sont un angle mort** : 11 085 slots livrés sur 30 j (≈ 24 % du digest), **11 consommations** (1,5 % en LOO), jamais scorés.

## Docs

- `docs/maintenance/maintenance-reco-quality-step-up.md` — arbitrage : tableau brief ↔ évidence (chiffres refaits sur la prod ce jour), séquence PR0 → PR1, et **B (taxonomie) / D (vecteurs) différés avec critères de ré-entrée chiffrés**.
- `docs/maintenance/maintenance-feed-ranking-gauge.md` — runbook : les 3 dénominateurs, comment lancer, les biais connus.

## ⚠️ Point d'attention : RLS bloque l'exécution réelle

`DATABASE_URL_RO` (`claude_analytics_ro`) **retourne 0 ligne** sur `daily_digest`, `contents` et `user_content_status` : les 3 tables ont `relrowsecurity = true` et le rôle a `rolbypassrls = false`. Le script tourne sans erreur et rapporte un CTR vide — exactement le faux négatif qu'il vient de corriger.

**Je n'ai donc pas pu lancer le script lui-même contre la prod.** La requête et tous les chiffres ci-dessus ont été produits en rejouant le SQL via le MCP Supabase (rôle `postgres`). Décision PO à prendre : `ALTER ROLE claude_analytics_ro BYPASSRLS;` sur la prod (changement de permission, pas fait en passant).

## Vérification

- `pytest tests/scripts/test_evaluate_feed_ranking.py` — **19 tests**, nouveau fichier (les 3 harnais frères en avaient un, pas celui-ci). Couvre les 3 dénominateurs dont le cas limite LOO, `editorial_v3` actu + extra, `pillar_scores` absent ⇒ bande `missing`, `flat_v1` / `topics_v1` toujours parsés, et un garde-fou structurel sur le SQL.
- `pytest tests/test_digest_per_user_projection.py` — **11 tests**, dont 3 nouveaux sur la persistance du score (attaché, dégradation sûre si le scoring échoue, snapshots legacy sans score qui parsent toujours).
- **Suite complète : 2 635 passed, 18 skipped, 2 xfailed.**
- Script lancé de bout en bout contre une DB locale (rendu, argparse, 0 ligne sans crash).
- **Zéro migration** — `pillar_scores` est une clé JSON dans `daily_digest.items` (JSONB), tout est additif. Le risque expand-contract de la DB partagée `main`/`production` ne s'applique pas.
- Backend-only, aucun impact UI.

## Limites assumées

- **Forward-only** : les bandes de score sont vides avant le merge. Le CTR par sujet / entité / rang de sujet / slot est en revanche **rétroactif** sur tout l'historique `editorial_v3`.
- **Les `extra_actu_articles` resteront `null`** — `actu_matcher` les trie sur `(thumbnail, published_at)`, ils ne passent jamais par le scoring. Ce n'est pas un trou de données à combler, c'est une propriété du pipeline.
- **Le SQL n'est pas exécuté par les tests** (il exige la prod). Le test `test_sql_reads_the_three_formats` ne garde que sa structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)