### PR TITLE
feat(reco): rebrancher les signaux de reco déjà écrits (PR1)

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Pourquoi cet article",
+      "summary": "Les raisons affichées sous tes articles disent enfin le sujet précis plutôt que le grand thème : « Énergie » au lieu de « Energy », « États-Unis » au lieu de « Usa », et le sujet que tu suis vraiment au lieu de la catégorie qui l'englobe."
+    },
+    {
       "tag": "Ma Tournée",
       "summary": "Réorganise ta tournée sans quitter ta lecture : maintiens un onglet du bandeau en haut de l'écran, puis fais-le glisser à sa nouvelle place. Ton Essentiel reste en tête, le Mot du jour et la citation gardent la leur."
     },
@@ -19,6 +23,8 @@
     {
       "tag": "Alertes",
       "summary": "Pose une alerte sur n'importe quelle source ou n'importe quel sujet que tu suis. Avant de l'activer, Facteur t'annonce franchement le rythme : « environ 12 alertes par semaine », par exemple. Si c'est trop, coche « seulement les plus marquantes » et tu n'en recevras qu'une par jour, la plus pertinente pour toi. Cinq alertes maximum, toujours en silence, dans ta tournée. Le réglage est aussi devenu plus simple à trouver : « Notifications et alertes », directement dans les Réglages."
+    },
+    {
       "tag": "Ton avis compte",
       "summary": "Django et Laurin t'invitent à un café en visio de 5 minutes pour te demander ce qui te plaît, ou ce que tu aimes moins. L'invitation apparaît vers la fin de ta tournée, avec nos deux visages, et se referme en un geste : « Plus tard » ou « On l'a déjà fait ». Au passage, la carte de fin de tournée a été allégée pour tenir dans l'écran."
     },

--- a/apps/mobile/test/features/release_notes/changelog_service_test.dart
+++ b/apps/mobile/test/features/release_notes/changelog_service_test.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -171,5 +174,57 @@ void main() {
     expect(release.version, '2.0.0');
     expect(release.entries.single.tag, 'X');
     expect(release.entries.single.summary, 'Y');
+  });
+
+  // ─── Garde-fou sur l'asset réel ─────────────────────────────────────────
+  //
+  // `assets/changelog.json` a été livré cassé deux fois (dernière : PR #1029,
+  // une entrée insérée sans son `},{`, ce qui fusionnait deux entrées). Comme
+  // `loadReleased` fait un `json.decode` du document entier et que le provider
+  // traite l'erreur comme « liste vide », la panne est **silencieuse** : plus
+  // aucune note de version, sans un log. Les tests ci-dessus ne tournaient que
+  // sur un payload en dur, donc ne voyaient rien. Ceux-ci lisent le vrai
+  // fichier.
+  group('assets/changelog.json (fichier réel)', () {
+    Map<String, dynamic> decodeAsset() {
+      final raw = File('assets/changelog.json').readAsStringSync();
+      return json.decode(raw) as Map<String, dynamic>;
+    }
+
+    test('est un JSON valide', () {
+      expect(decodeAsset, returnsNormally);
+    });
+
+    test('chaque entrée a exactement un tag et un summary non vides', () {
+      final decoded = decodeAsset();
+      final blocks = <String, dynamic>{
+        'unreleased': decoded['unreleased'],
+        'released': decoded['released'],
+      };
+
+      for (final entry in (blocks['unreleased'] as List<dynamic>)) {
+        final map = entry as Map<String, dynamic>;
+        expect(map.keys.toSet(), {'tag', 'summary'},
+            reason: 'entrée unreleased malformée : $map');
+        expect((map['tag'] as String).trim(), isNotEmpty);
+        expect((map['summary'] as String).trim(), isNotEmpty);
+      }
+
+      for (final release in (blocks['released'] as List<dynamic>)) {
+        final map = release as Map<String, dynamic>;
+        expect(map.containsKey('version'), isTrue);
+        for (final entry in (map['entries'] as List<dynamic>)) {
+          final e = entry as Map<String, dynamic>;
+          expect(e.keys.toSet(), {'tag', 'summary'},
+              reason: 'entrée released malformée : $e');
+        }
+      }
+    });
+
+    test("pas d'em-dash dans la copy user-facing", () {
+      final raw = File('assets/changelog.json').readAsStringSync();
+      expect(raw.contains('\u2014'), isFalse,
+          reason: 'le tiret cadratin est proscrit dans la copy user-facing');
+    });
   });
 }

--- a/docs/maintenance/maintenance-reco-quality-step-up.md
+++ b/docs/maintenance/maintenance-reco-quality-step-up.md
@@ -93,8 +93,62 @@ en amont du réglage fin, pas dans la finesse de la taxonomie.
 ## PR1 — rebrancher les signaux existants
 
 **Zéro migration** : les 3 tables (`user_entity_affinity`, `user_interests`,
-`user_topic_profiles`) ont déjà les colonnes. **4 commits indépendamment
-révocables.**
+`user_topic_profiles`) ont déjà les colonnes. Commits indépendamment
+révocables.
+
+> **État : livrée.** 7 commits. Le plan en prévoyait 4 ; trois se sont ajoutés
+> en cours de route, chacun parce que le câblage prévu aurait été inopérant ou
+> invisible sans lui. Ils sont marqués **(hors plan)** ci-dessous.
+
+| # | Commit | Objet |
+|---|---|---|
+| 1 | `PR1a` | affinité entités nourrie depuis l'Essentiel + route feedback |
+| 2 | `PR1a'` | **(hors plan)** purge du cache feed sur les actions du digest |
+| 3 | `PR1b1` | threading `user_custom_topics` → `ScoringContext` du digest |
+| 4 | `PR1b2` | branche entité dans le pilier + collapse du parser dupliqué |
+| 5 | `PR1c` | decay de `user_interests.weight` |
+| 6 | `PR1e1` | libellés de sujets resynchronisés + **(hors plan)** fix veille |
+| 7 | `PR1e2` | raisons de sélection (2 branches mortes) + **(hors plan)** `changelog.json` |
+
+### Ce que la mise en œuvre a corrigé du plan
+
+Trois écarts valent d'être écrits, parce qu'ils changent le diagnostic :
+
+1. **Le plan sous-estimait (a) : nourrir l'affinité ne suffisait pas.**
+   `POST /digest/{id}/action` n'invalidait **rien** dans `FEED_CACHE`, alors que
+   la règle « une écriture qui touche `UserSubtopic.weight` /
+   `UserEntityAffinity.affinity` purge tout » est explicite et déjà épinglée
+   pour les routes `/contents/*` équivalentes. Un LIKE depuis l'Essentiel
+   écrivait donc le signal derrière un classement caché périmé — le même motif
+   « écrit mais pas branché » que PR1 corrige ailleurs. D'où le commit 2.
+2. **(e1) était un défaut de réutilisation, pas un dict à éditer.**
+   `SLUG_TO_LABEL` existait déjà, canonique et complète (51/51), utilisée par 5
+   modules. Le correctif est donc une **suppression** de la copie périmée, pas
+   une reprise à la main. Et cette copie servait de **liste de slugs valides**
+   dans `veille/feed_filter` (`frozenset(SUBTOPIC_LABELS)`) : la veille
+   neutralisait des `topic_id` parfaitement valides — dont `energy`, `politics`,
+   `usa`, `justice`, `europe`, `tech` — tout en laissant passer 32 fantômes.
+   Effet de bord non anticipé par le plan, corrigé dans le même commit.
+3. **(e2) portait sur deux branches mortes, pas une.**
+   `digest_service._determine_top_reason` avait le même préfixe fantôme, et
+   était en plus inatteignable (`"Thème" in "Sous-thème : …"` est vrai et testé
+   avant). Le test qui couvrait la branche de `digest_selector` **pinnait le
+   libellé fantôme** `"Sous-thème : AI"` : le code mort a survécu à sa propre
+   couverture. C'est le mécanisme à retenir, plus que le fix.
+
+### Deux trouvailles à arbitrer (PO)
+
+- **`DIGEST_SPORT_PENALTY = −80` écrase le signal Sujet.** Un match custom-topic
+  vaut +25 brut (~+16 après normalisation) : un Sujet suivi qui *est* un sportif
+  (« Mbappé ») reste structurellement invisible dans le digest, câblage ou pas.
+  Découvert en écrivant les tests de (b1). Non traité.
+- **`changelog.json` était cassé sur `main` depuis la PR #1029** : une entrée
+  insérée sans son `},{`. `loadReleased()` décode le document entier et le
+  provider traite l'erreur comme « liste vide » ⇒ **toutes les notes de version
+  in-app étaient mortes, en silence**. 2e occurrence pour ce fichier. Réparé et
+  gardé par 3 tests sur le vrai asset. À noter : **la CI ne lance pas
+  `flutter test`**, elle n'aurait donc pas attrapé #1029 et n'attrapera pas la
+  prochaine — le filet ne tient que par l'étape VERIFY locale.
 
 ### (a) Nourrir l'affinité entités depuis l'Essentiel
 

--- a/packages/api/app/routers/contents.py
+++ b/packages/api/app/routers/contents.py
@@ -455,7 +455,7 @@ async def submit_article_feedback(
         )
         await db.execute(stmt)
 
-        # Adjust subtopic weights based on sentiment
+        # Adjust subtopic weights + entity affinity based on sentiment
         service = ContentService(db)
         delta = (
             ScoringWeights.LIKE_TOPIC_BOOST
@@ -463,6 +463,7 @@ async def submit_article_feedback(
             else ScoringWeights.DISMISS_TOPIC_PENALTY
         )
         await service._adjust_subtopic_weights(user_uuid, content_id, delta)
+        await service._adjust_entity_affinity(user_uuid, content_id, delta)
 
         await db.commit()
         FEED_CACHE.invalidate(user_uuid)

--- a/packages/api/app/routers/digest.py
+++ b/packages/api/app/routers/digest.py
@@ -41,6 +41,7 @@ from app.services.community_recommendation_service import (
     CommunityRecommendationService,
 )
 from app.services.digest_service import DigestService, read_digest_or_fallback
+from app.services.feed_cache import FEED_CACHE
 from app.utils.time import today_paris
 
 logger = structlog.get_logger()
@@ -322,6 +323,18 @@ async def apply_digest_action(
             content_id=request.content_id,
             action=request.action,
         )
+
+        # Les actions apprenantes ajustent `UserSubtopic.weight` /
+        # `UserEntityAffinity.affinity` : elles rebalancent le classement de
+        # **toutes** les sections, donc purge complète (jamais
+        # `invalidate_content`, qui laisserait un ordre périmé partout
+        # ailleurs). Même règle que les routes `/contents/*` équivalentes,
+        # épinglée par `tests/routers/test_feed_cache_invalidation_sites.py`.
+        # UNDO ne touche que l'état d'affichage d'un article → purge ciblée.
+        if request.action == DigestAction.UNDO:
+            FEED_CACHE.invalidate_content(user_uuid, request.content_id)
+        else:
+            FEED_CACHE.invalidate(user_uuid)
 
         elapsed = time.monotonic() - start
         logger.info(

--- a/packages/api/app/services/digest_selector.py
+++ b/packages/api/app/services/digest_selector.py
@@ -187,6 +187,10 @@ class DigestContext:
     subscribed_source_ids: set[UUID] = field(default_factory=set)
     # PR2: learned positive affinity per named entity {entity_canonical: affinity}
     user_entity_affinity: dict[str, float] = field(default_factory=dict)
+    # PR1b: profils Sujets (Epic 11) + abonnements entités. Le Feed et la Veille
+    # les passaient déjà au ScoringContext ; le digest ne les chargeait pas, donc
+    # la garde de `_score_custom_topics` renvoyait 0 à chaque scoring digest.
+    user_custom_topics: list[Any] = field(default_factory=list)
 
 
 @dataclass
@@ -713,6 +717,19 @@ class DigestSelector:
 
         user_entity_affinity = await _load_entity_affinity_safe(self.session, user_id)
 
+        # PR1b: profils Sujets (Epic 11) + abonnements entités. Même requête que
+        # le Feed (`recommendation_service`) : les lignes portent déjà
+        # `entity_type` / `canonical_name`, rien à changer côté chargement.
+        from app.models.user_topic_profile import UserTopicProfile
+
+        user_custom_topics = list(
+            (
+                await self.session.scalars(
+                    select(UserTopicProfile).where(UserTopicProfile.user_id == user_id)
+                )
+            ).all()
+        )
+
         # Construire les sets d'intérêts et poids
         user_interests = set()
         user_interest_weights = {}
@@ -802,6 +819,7 @@ class DigestSelector:
             source_priority_multipliers=source_priority_multipliers,
             subscribed_source_ids=subscribed_source_ids,
             user_entity_affinity=user_entity_affinity,
+            user_custom_topics=user_custom_topics,
         )
 
     async def _get_candidates(
@@ -1401,6 +1419,7 @@ class DigestSelector:
             user_subtopics=context.user_subtopics,
             user_subtopic_weights=context.user_subtopic_weights,
             user_entity_affinity=context.user_entity_affinity,
+            user_custom_topics=context.user_custom_topics,
             muted_sources=context.muted_sources,
             muted_themes=context.muted_themes,
             muted_topics=context.muted_topics,

--- a/packages/api/app/services/digest_selector.py
+++ b/packages/api/app/services/digest_selector.py
@@ -1695,12 +1695,17 @@ class DigestSelector:
                 if b.label == "À la une":
                     return "À la une"
 
-        # 1. Sous-thème matché (le plus précis) — ex: "Thème : AI"
+        # 1. Sujet matché (le plus précis) — ex: "Thème : IA"
+        #
+        # Cette branche testait `"Sous-thème : "`, un préfixe que **plus aucun
+        # pilier n'émet** : `_score_subtopics` produit "Sujet suivi : …" (poids
+        # appris > 1) ou "Sujet : …". Elle était donc morte et toutes les raisons
+        # du digest retombaient sur le thème large (cas 2 ci-dessous).
         if breakdown:
             for b in breakdown:
-                if b.label.startswith("Sous-thème : "):
-                    topic = b.label.removeprefix("Sous-thème : ")
-                    return f"Thème : {topic}"
+                for prefix in ("Sujet suivi : ", "Sujet : "):
+                    if b.label.startswith(prefix):
+                        return f"Thème : {b.label.removeprefix(prefix)}"
 
         # 2. Thème article ML ou thème source — ex: "Thème : Environnement"
         theme = None

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -2060,6 +2060,22 @@ class DigestService:
         positive.sort(key=lambda x: x.points, reverse=True)
         top = positive[0]
 
+        # Le sujet précis d'abord : `_score_subtopics` émet "Sujet suivi : …" /
+        # "Sujet : …". La branche qui suivait testait `"Sous-thème"`, préfixe
+        # qu'aucun pilier n'émet plus — et elle était de toute façon
+        # inatteignable, puisque `"Thème" in "Sous-thème : …"` est vrai et
+        # arrivait avant. Les raisons du digest tombaient donc sur "Vos
+        # intérêts : …" avec un thème large, ou sur le label brut.
+        for prefix in ("Sujet suivi : ", "Sujet : "):
+            if top.label.startswith(prefix):
+                topics = [
+                    b.label.removeprefix(p)
+                    for b in positive
+                    for p in ("Sujet suivi : ", "Sujet : ")
+                    if b.label.startswith(p)
+                ][:2]
+                return f"Vos centres d'intérêt : {', '.join(topics)}"
+
         # Format based on top reason type
         if "Thème" in top.label:
             theme = top.label.split(": ")[1] if ": " in top.label else ""
@@ -2080,19 +2096,6 @@ class DigestService:
                 f"Renforcé par vos j'aime : {', '.join(topics)}"
                 if topics
                 else "Renforcé par vos j'aime"
-            )
-        elif "Sous-thème" in top.label:
-            topics = [
-                parts[1]
-                for b in positive
-                if "Sous-thème" in b.label
-                for parts in [b.label.split(": ", 1)]
-                if len(parts) > 1
-            ][:2]
-            return (
-                f"Vos centres d'intérêt : {', '.join(topics)}"
-                if topics
-                else "Vos centres d'intérêt"
             )
         else:
             return top.label

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -1398,7 +1398,7 @@ class DigestService:
             status.is_hidden = False
             # Increment regular streak via StreakService
             await self.streak_service.increment_consumption(str(user_id))
-            # Feedback: reinforce theme + subtopic weights
+            # Feedback: reinforce theme + subtopic weights + named entities
             from app.services.content_service import ContentService
             from app.services.recommendation.scoring_config import ScoringWeights
 
@@ -1407,12 +1407,15 @@ class DigestService:
             await content_service._adjust_subtopic_weights(
                 user_id, content_id, ScoringWeights.READ_TOPIC_BOOST
             )
+            await content_service._adjust_entity_affinity(
+                user_id, content_id, ScoringWeights.READ_TOPIC_BOOST
+            )
 
         elif action == DigestAction.SAVE:
             status.is_saved = True
             status.saved_at = datetime.utcnow()
             status.is_hidden = False
-            # Reinforce subtopic weights on bookmark
+            # Reinforce subtopic weights + named entities on bookmark
             from app.services.content_service import ContentService
 
             content_service = ContentService(self.session)
@@ -1421,11 +1424,14 @@ class DigestService:
             await content_service._adjust_subtopic_weights(
                 user_id, content_id, ScoringWeights.BOOKMARK_TOPIC_BOOST
             )
+            await content_service._adjust_entity_affinity(
+                user_id, content_id, ScoringWeights.BOOKMARK_TOPIC_BOOST
+            )
 
         elif action == DigestAction.LIKE:
             status.is_liked = True
             status.liked_at = datetime.utcnow()
-            # Reinforce subtopic weights via ContentService
+            # Reinforce subtopic weights + named entities via ContentService
             from app.services.content_service import ContentService
 
             content_service = ContentService(self.session)
@@ -1434,17 +1440,23 @@ class DigestService:
             await content_service._adjust_subtopic_weights(
                 user_id, content_id, ScoringWeights.LIKE_TOPIC_BOOST
             )
+            await content_service._adjust_entity_affinity(
+                user_id, content_id, ScoringWeights.LIKE_TOPIC_BOOST
+            )
 
         elif action == DigestAction.UNLIKE:
             status.is_liked = False
             status.liked_at = None
-            # Reverse subtopic weight adjustment
+            # Reverse subtopic weight + entity affinity adjustment
             from app.services.content_service import ContentService
 
             content_service = ContentService(self.session)
             from app.services.recommendation.scoring_config import ScoringWeights
 
             await content_service._adjust_subtopic_weights(
+                user_id, content_id, -ScoringWeights.LIKE_TOPIC_BOOST
+            )
+            await content_service._adjust_entity_affinity(
                 user_id, content_id, -ScoringWeights.LIKE_TOPIC_BOOST
             )
 

--- a/packages/api/app/services/recommendation/layers/user_custom_topics.py
+++ b/packages/api/app/services/recommendation/layers/user_custom_topics.py
@@ -10,27 +10,13 @@ Score = CUSTOM_TOPIC_BASE_BONUS * priority_multiplier (max 1 match per article).
 Entity matches get a 1.5x multiplier bonus (precise match).
 """
 
-import json
-
 from app.models.content import Content
-from app.services.recommendation.helpers import matches_word_boundary
+from app.services.recommendation.helpers import (
+    iter_entity_names,
+    matches_word_boundary,
+)
 from app.services.recommendation.scoring_config import ScoringWeights
 from app.services.recommendation.scoring_engine import BaseScoringLayer, ScoringContext
-
-ENTITY_MATCH_MULTIPLIER = 1.5
-
-
-def _parse_content_entities(content: Content) -> list[dict]:
-    """Parse JSON-string entities from Content.entities array."""
-    if not content.entities:
-        return []
-    parsed: list[dict] = []
-    for raw in content.entities:
-        try:
-            parsed.append(json.loads(raw))
-        except (json.JSONDecodeError, TypeError):
-            continue
-    return parsed
 
 
 class UserCustomTopicLayer(BaseScoringLayer):
@@ -52,8 +38,11 @@ class UserCustomTopicLayer(BaseScoringLayer):
         title_lower = (content.title or "").lower()
         desc_lower = (content.description or "").lower()
 
-        # Lazy-parse entities only if needed
-        _content_entities: list[dict] | None = None
+        # Lazy-parse entities only if needed. `iter_entity_names` est la
+        # primitive partagée write/read (mute, affinité, pilier Pertinence) :
+        # elle tolère aussi une entité stockée en clair, ce que le parse JSON
+        # local ici laissait tomber en silence.
+        _entity_keys: set[str] | None = None
 
         best_score = 0.0
         best_topic_name = ""
@@ -83,22 +72,19 @@ class UserCustomTopicLayer(BaseScoringLayer):
                 and topic_profile.entity_type is not None
                 and topic_profile.canonical_name is not None
             ):
-                if _content_entities is None:
-                    _content_entities = _parse_content_entities(content)
-                canonical_lower = topic_profile.canonical_name.lower()
-                for entity in _content_entities:
-                    entity_name = entity.get("name", "")
-                    if (
-                        isinstance(entity_name, str)
-                        and entity_name.lower() == canonical_lower
-                    ):
-                        matched = True
-                        match_type = f"entity:{topic_profile.canonical_name}"
-                        break
+                if _entity_keys is None:
+                    _entity_keys = {
+                        key for _display, key in iter_entity_names(content.entities)
+                    }
+                if topic_profile.canonical_name.strip().lower() in _entity_keys:
+                    matched = True
+                    match_type = f"entity:{topic_profile.canonical_name}"
 
             if matched:
                 multiplier = (
-                    ENTITY_MATCH_MULTIPLIER if match_type.startswith("entity:") else 1.0
+                    ScoringWeights.ENTITY_MATCH_MULTIPLIER
+                    if match_type.startswith("entity:")
+                    else 1.0
                 )
                 topic_score = (
                     ScoringWeights.CUSTOM_TOPIC_BASE_BONUS

--- a/packages/api/app/services/recommendation/pillars/pertinence.py
+++ b/packages/api/app/services/recommendation/pillars/pertinence.py
@@ -435,6 +435,18 @@ class PertinencePillar(BasePillar):
         topics Epic 11 (`is_veille` absent) gardent le chemin plat `+25`
         inchangé. On ne retient qu'un seul angle (le meilleur) — pas
         d'empilement non borné.
+
+        Trois façons de matcher un profil, dans l'ordre : `slug_parent` dans
+        `content.topics`, mot-clé au mot près dans titre/description, puis
+        `canonical_name` parmi les entités nommées de l'article
+        (`ENTITY_MATCH_MULTIPLIER`). Les branches sont gardées par
+        `if not matched`, donc un profil qui matche par slug **et** par entité
+        n'est compté qu'une fois, et seul `best_score` survit entre profils.
+
+        ⚠️ À surveiller à la jauge : `_score_entities` (affinité apprise, capée
+        à `ENTITY_AFFINITY_MAX_BONUS`) et la branche entité ci-dessous sont deux
+        signaux **distincts** sur la même entité, qui s'empilent dans un pilier
+        capé à `MAX_PERTINENCE_RAW`.
         """
         if not context.user_custom_topics:
             return 0.0, []
@@ -445,6 +457,11 @@ class PertinencePillar(BasePillar):
 
         title_lower = (content.title or "").lower()
         desc_lower = (content.description or "").lower()
+
+        # Clés canoniques des entités de l'article, parsées au plus une fois
+        # pour tous les profils (hors boucle) et seulement si un abonnement
+        # entité est rencontré.
+        entity_keys: set[str] | None = None
 
         best_score = 0.0
         best_topic_name = ""
@@ -466,6 +483,7 @@ class PertinencePillar(BasePillar):
                 continue
 
             matched = False
+            is_entity_match = False
             if tp.slug_parent in content_topics:
                 matched = True
             if not matched and tp.keywords:
@@ -475,11 +493,30 @@ class PertinencePillar(BasePillar):
                         matched = True
                         break
 
+            # 3e condition — abonnement entité, en miroir de
+            # `layers/user_custom_topics`. Le pilier ne lisait ni
+            # `content.entities` ni `canonical_name` : le pont entité n'existait
+            # que dans une couche de recall legacy qui ne s'applique pas aux
+            # surfaces scorées par piliers (digest, Essentiel).
+            if not matched and tp.entity_type and tp.canonical_name:
+                if entity_keys is None:
+                    entity_keys = {
+                        key
+                        for _display, key in iter_entity_names(
+                            getattr(content, "entities", None)
+                        )
+                    }
+                if tp.canonical_name.strip().lower() in entity_keys:
+                    matched = True
+                    is_entity_match = True
+
             if matched:
                 multiplier = tp.priority_multiplier
                 if tp_state == InterestState.FAVORITE:
                     multiplier = max(multiplier, _FAVORITE_WEIGHT_FLOOR)
                 topic_score = ScoringWeights.CUSTOM_TOPIC_BASE_BONUS * multiplier
+                if is_entity_match:
+                    topic_score *= ScoringWeights.ENTITY_MATCH_MULTIPLIER
                 if topic_score > best_score:
                     best_score = topic_score
                     best_topic_name = tp.topic_name

--- a/packages/api/app/services/recommendation/pillars/pertinence.py
+++ b/packages/api/app/services/recommendation/pillars/pertinence.py
@@ -6,6 +6,7 @@ Consolide : CoreLayer (theme), ArticleTopicLayer, BehavioralLayer,
 
 from app.models.content import Content
 from app.models.enums import ContentType, InterestState
+from app.services.ml.classification_service import SLUG_TO_LABEL
 from app.services.recommendation.helpers import (
     compute_coverage_score,
     iter_entity_names,
@@ -35,67 +36,44 @@ THEME_LABELS = {
     "culture_ideas": "Culture & Idées",
 }
 
-# Mapping 50 sous-thèmes slugs -> Français
-SUBTOPIC_LABELS = {
-    "ai": "IA",
-    "llm": "LLM",
-    "crypto": "Crypto",
-    "web3": "Web3",
-    "space": "Spatial",
-    "biotech": "Biotech",
-    "quantum": "Quantique",
-    "cybersecurity": "Cybersécurité",
-    "robotics": "Robotique",
-    "gaming": "Gaming",
-    "cleantech": "Cleantech",
-    "data-privacy": "Données",
-    "social-justice": "Justice sociale",
-    "feminism": "Féminisme",
-    "lgbtq": "LGBTQ+",
-    "immigration": "Immigration",
-    "health": "Santé",
-    "education": "Éducation",
-    "urbanism": "Urbanisme",
-    "housing": "Logement",
-    "work-reform": "Travail",
-    "justice-system": "Justice",
-    "climate": "Climat",
-    "biodiversity": "Biodiversité",
-    "energy-transition": "Transition énergétique",
-    "pollution": "Pollution",
-    "circular-economy": "Économie circulaire",
-    "agriculture": "Agriculture",
-    "oceans": "Océans",
-    "forests": "Forêts",
-    "macro": "Macro-économie",
-    "finance": "Finance",
-    "startups": "Startups",
-    "venture-capital": "VC",
-    "labor-market": "Emploi",
-    "inflation": "Inflation",
-    "trade": "Commerce",
-    "taxation": "Fiscalité",
-    "elections": "Élections",
-    "institutions": "Institutions",
-    "local-politics": "Politique locale",
-    "activism": "Activisme",
-    "democracy": "Démocratie",
-    "philosophy": "Philosophie",
-    "art": "Art",
-    "cinema": "Cinéma",
-    "media-critics": "Critique des médias",
-    "fundamental-research": "Recherche",
-    "applied-science": "Sciences appliquées",
-    "geopolitics": "Géopolitique",
-}
-
 
 def _theme_label(slug: str) -> str:
     return THEME_LABELS.get(slug.lower().strip(), slug.capitalize())
 
 
+# Forme courte pour les 4 slugs dont le libellé canonique est trop long pour
+# une ligne de raison (« Sujet : … », affichée sous la carte). `SLUG_TO_LABEL`
+# est écrit pour les prompts LLM et les sélecteurs de sujets, où la verbosité
+# aide ; ici elle coûte. Tout le reste vient de la table canonique, et
+# l'invariant de test impose que ces clés soient des slugs valides — c'est une
+# liste d'exceptions assumée, pas une seconde taxonomie.
+_SHORT_SUBTOPIC_LABELS = {
+    "ai": "IA",
+    "feminism": "Féminisme",
+    "gaming": "Gaming",
+    "space": "Spatial",
+}
+
+
 def _subtopic_label(slug: str) -> str:
-    return SUBTOPIC_LABELS.get(slug.lower().strip(), slug.capitalize())
+    """Libellé français d'un slug de la taxonomie.
+
+    S'appuie sur `SLUG_TO_LABEL`, la table canonique déjà partagée par
+    `topic_selector`, `custom_topics`, `topic_enrichment` et `user_service`, et
+    qui couvre exactement `VALID_TOPIC_SLUGS` (invariant testé).
+
+    Il y avait ici un `SUBTOPIC_LABELS` local, copie dérivée d'une ancienne
+    taxonomie : 50 entrées dont **32 slugs fantômes** (`llm`, `crypto`,
+    `energy-transition`…) et **33 slugs valides sans libellé**. Le `.capitalize()`
+    de repli tombait donc sur les slugs les plus suivis et rendait des raisons
+    anglaises dans une UI française : `energy` (83 abonnés) → « Energy »,
+    `politics` (75) → « Politics », `usa` (70) → « Usa », `environment` (63),
+    `inequality` (54), plus `justice`, `europe`, `tech`.
+    """
+    key = slug.lower().strip()
+    if key in _SHORT_SUBTOPIC_LABELS:
+        return _SHORT_SUBTOPIC_LABELS[key]
+    return SLUG_TO_LABEL.get(key, slug.capitalize())
 
 
 def _get_effective_theme(content: Content, user_interests: set[str]) -> str | None:

--- a/packages/api/app/services/recommendation/scoring_config.py
+++ b/packages/api/app/services/recommendation/scoring_config.py
@@ -54,6 +54,13 @@ class ScoringWeights:
     # peser autant qu'un TRUSTED_SOURCE (35) à multiplier max 2.0.
     CUSTOM_TOPIC_BASE_BONUS = 25.0
 
+    # Un profil Sujet peut être un **abonnement entité** (`entity_type` +
+    # `canonical_name`, canonicalisés par LLM). Matcher une entité nommée de
+    # l'article est plus précis qu'un mot-clé libre, d'où la prime. Partagé par
+    # la couche legacy (`layers/user_custom_topics`) et le pilier Pertinence :
+    # un seul barème, pas deux.
+    ENTITY_MATCH_MULTIPLIER = 1.5
+
     # --- DIGEST RECENCY BONUSES (Tiered) ---
     # Bonus de fraîcheur hiérarchisés pour l'algorithme de digest
 

--- a/packages/api/app/services/recommendation/scoring_config.py
+++ b/packages/api/app/services/recommendation/scoring_config.py
@@ -143,6 +143,22 @@ class ScoringWeights:
     SUBTOPIC_POSITION_FACTOR = 0.6
     SUBTOPIC_DECAY = 0.98
 
+    # --- DECAY DES SIGNAUX APPRIS (famille de 3, un job/jour chacun) ---
+    # `SUBTOPIC_DECAY` (ci-dessus, `user_subtopics.weight`),
+    # `ENTITY_AFFINITY_DECAY` (plus bas, `user_entity_affinity.affinity`) et
+    # `INTEREST_WEIGHT_DECAY` (`user_interests.weight`). Les trois ramènent d'un
+    # cran vers le neutre 1.0, dans les deux sens.
+    #
+    # `user_interests.weight` était le seul des trois **sans decay** : +0,05 par
+    # lecture (`_adjust_interest_weight`), cap 3,0, et rien ne redescendait. En
+    # prod : 724 lignes / 126 users, 32 au cap. Une ligne au cap vaut
+    # `50 × (3,0 − 1,0)` = 100 pts bruts, soit 62 % du pilier pertinence — chez
+    # les comptes les plus anciens, l'âge du compte battait la pertinence du
+    # jour. À 0,98, la demi-vie de l'excédent au-dessus du neutre est de ~34 j :
+    # une ligne au cap redescend à 2,0 après ~34 j sans lecture, alors qu'une
+    # lecture active la rattrape en ~2 j.
+    INTEREST_WEIGHT_DECAY = 0.98
+
     # Bonus de précision : si article a match thème ET sous-thème
     # Réduit de 20→18.
     SUBTOPIC_PRECISION_BONUS = 18.0

--- a/packages/api/app/services/veille/feed_filter.py
+++ b/packages/api/app/services/veille/feed_filter.py
@@ -29,13 +29,13 @@ from app.models.veille import (
     VeilleStatus,
     VeilleTopic,
 )
+from app.services.ml.classification_service import VALID_TOPIC_SLUGS
 from app.services.recommendation.filter_presets import (
     apply_serein_filter,
     load_serein_preferences,
 )
 from app.services.recommendation.helpers.diversification import diversify
 from app.services.recommendation.helpers.keyword_match import matches_word_boundary
-from app.services.recommendation.pillars.pertinence import SUBTOPIC_LABELS
 from app.services.recommendation.scoring_config import ScoringWeights
 from app.services.recommendation.scoring_engine import PillarScoringEngine
 from app.services.veille.scoring_context import build_veille_scoring_context
@@ -146,7 +146,13 @@ async def load_veille_filters(
     # suggestions LLM) est neutralisé en "" : il sort du prédicat SQL, de
     # `matched_on` et de `user_subtopics` (le floor redevient honnête). Sa grappe
     # de mots-clés survit (custom-topic `slug_parent=""` côté scoring_context).
-    canon = frozenset(SUBTOPIC_LABELS)
+    # La canonicité se lit sur `VALID_TOPIC_SLUGS`, pas sur les clés d'une table
+    # de libellés : ce test portait sur l'ancien `SUBTOPIC_LABELS` du pilier
+    # Pertinence, dérivé d'une taxonomie périmée. Il neutralisait donc des
+    # `topic_id` parfaitement valides — et parmi les plus suivis (`energy`,
+    # `politics`, `usa`, `justice`, `europe`, `tech`) — tout en laissant passer
+    # 32 slugs fantômes.
+    canon = VALID_TOPIC_SLUGS
     angles = [
         VeilleAngle(
             topic_id=topic_id if (topic_id or "").lower().strip() in canon else "",

--- a/packages/api/app/workers/scheduler.py
+++ b/packages/api/app/workers/scheduler.py
@@ -134,6 +134,49 @@ async def decay_user_entity_affinity() -> None:
         )
 
 
+async def decay_user_interest_weights() -> None:
+    """Apply the daily O(1) decay to all learned theme interest weights.
+
+    Troisième et dernier membre de la famille de decay, aligné sur
+    `decay_user_subtopic_weights` et `decay_user_entity_affinity`.
+    `user_interests.weight` était le seul signal appris **sans** decay : il
+    montait de +0,05 par lecture jusqu'au cap 3,0 et ne redescendait jamais.
+
+    Décay **symétrique** (`weight != 1.0`, pas `weight > 1.0`), comme ses deux
+    sœurs : les lignes sous 1.0 remontent aussi vers le neutre, ce qui efface
+    progressivement le malus de `_score_behavioral`. C'est assumé — un signal
+    négatif appris il y a des mois ne doit pas être plus permanent qu'un signal
+    positif. Idempotent (no-op sur les lignes déjà à 1.0).
+    """
+    from app.database import safe_async_session
+
+    try:
+        async with safe_async_session() as session:
+            result = await session.execute(
+                text(
+                    """
+                    UPDATE user_interests
+                    SET weight = 1.0 + (weight - 1.0) * :decay
+                    WHERE weight != 1.0
+                    """
+                ),
+                {"decay": ScoringWeights.INTEREST_WEIGHT_DECAY},
+            )
+            await session.commit()
+            logger.info(
+                "interest_weight_decay_completed",
+                decay=ScoringWeights.INTEREST_WEIGHT_DECAY,
+                rowcount=getattr(result, "rowcount", None),
+            )
+    except Exception as exc:
+        logger.error(
+            "interest_weight_decay_failed",
+            error=str(exc),
+            error_type=type(exc).__name__,
+            exc_info=True,
+        )
+
+
 async def _digest_watchdog() -> None:
     """Watchdog 8h15 : vérifie la couverture digest et relance si nécessaire.
 
@@ -513,6 +556,23 @@ def start_scheduler() -> None:
         ),
         id="entity_affinity_decay",
         name="Entity Affinity Decay",
+        replace_existing=True,
+        misfire_grace_time=14400,
+        coalesce=True,
+        max_instances=1,
+    )
+
+    # Daily learned-interest-weight decay (06h50 Paris) — 3e membre de la
+    # famille. Même fenêtre que ses deux sœurs, donc avant le digest (07h30).
+    scheduler.add_job(
+        decay_user_interest_weights,
+        trigger=CronTrigger(
+            hour=SUBTOPIC_DECAY_HOUR_PARIS,
+            minute=SUBTOPIC_DECAY_MINUTE_PARIS,
+            timezone=_PARIS_TZ,
+        ),
+        id="interest_weight_decay",
+        name="Interest Weight Decay",
         replace_existing=True,
         misfire_grace_time=14400,
         coalesce=True,

--- a/packages/api/tests/recommendation/test_core_layer.py
+++ b/packages/api/tests/recommendation/test_core_layer.py
@@ -1,6 +1,7 @@
 """
 Tests unitaires pour CoreLayer - Theme Matching (Phase 1 + Phase 2 diversité)
 """
+
 import pytest
 from datetime import datetime, timedelta
 from uuid import uuid4
@@ -13,6 +14,7 @@ from app.services.recommendation.scoring_config import ScoringWeights
 
 class MockSource:
     """Mock Source pour les tests."""
+
     def __init__(self, theme: str = None, id=None, secondary_themes=None):
         self.theme = theme
         self.id = id or uuid4()
@@ -21,6 +23,7 @@ class MockSource:
 
 class MockContent:
     """Mock Content pour les tests."""
+
     def __init__(
         self,
         source_theme: str = None,
@@ -31,18 +34,25 @@ class MockContent:
     ):
         self.id = uuid4()
         self.theme = theme  # Article-level ML theme
-        self.source = MockSource(
-            theme=source_theme, id=source_id,
-            secondary_themes=secondary_themes
-        ) if source_theme is not None else None
-        self.source_id = source_id if source_id else (self.source.id if self.source else None)
+        self.source = (
+            MockSource(
+                theme=source_theme, id=source_id, secondary_themes=secondary_themes
+            )
+            if source_theme is not None
+            else None
+        )
+        self.source_id = (
+            source_id if source_id else (self.source.id if self.source else None)
+        )
         self.published_at = published_at or datetime.now()
 
 
 class TestCoreLayerThemeMatching:
     """Tests pour le matching de thèmes dans CoreLayer."""
 
-    def create_context(self, user_interests=None, followed_sources=None, custom_sources=None):
+    def create_context(
+        self, user_interests=None, followed_sources=None, custom_sources=None
+    ):
         """Helper pour créer un ScoringContext de test."""
         user_profile = MagicMock()
         user_profile.id = uuid4()
@@ -55,7 +65,7 @@ class TestCoreLayerThemeMatching:
             user_prefs={},
             now=datetime.now(),
             user_subtopics=set(),
-            custom_source_ids=set(custom_sources or [])
+            custom_source_ids=set(custom_sources or []),
         )
 
     def test_theme_match_with_aligned_taxonomy(self):
@@ -130,8 +140,16 @@ class TestCoreLayerThemeMatching:
 
     def test_all_valid_themes_matching(self):
         """Test exhaustif de tous les thèmes valides."""
-        valid_themes = ["tech", "society", "environment", "economy",
-                       "politics", "culture", "science", "international"]
+        valid_themes = [
+            "tech",
+            "society",
+            "environment",
+            "economy",
+            "politics",
+            "culture",
+            "science",
+            "international",
+        ]
 
         layer = CoreLayer()
 
@@ -143,7 +161,9 @@ class TestCoreLayerThemeMatching:
 
             assert score >= ScoringWeights.THEME_MATCH, f"Theme {theme} should match"
             reasons = context.reasons.get(content.id, [])
-            theme_reasons = [r for r in reasons if f"Thème: {theme}" in r.get("details", "")]
+            theme_reasons = [
+                r for r in reasons if f"Thème: {theme}" in r.get("details", "")
+            ]
             assert len(theme_reasons) == 1, f"Theme {theme} should have a reason"
 
     def test_theme_match_with_followed_source(self):
@@ -151,8 +171,7 @@ class TestCoreLayerThemeMatching:
         source_id = uuid4()
         content = MockContent(source_theme="tech", source_id=source_id)
         context = self.create_context(
-            user_interests={"tech"},
-            followed_sources={source_id}
+            user_interests={"tech"}, followed_sources={source_id}
         )
         layer = CoreLayer()
 
@@ -199,7 +218,9 @@ class TestCoreLayerThemeMatching:
 class TestCoreLayerSecondaryThemes:
     """Tests Phase 1: Secondary theme matching."""
 
-    def create_context(self, user_interests=None, followed_sources=None, custom_sources=None):
+    def create_context(
+        self, user_interests=None, followed_sources=None, custom_sources=None
+    ):
         user_profile = MagicMock()
         user_profile.id = uuid4()
         return ScoringContext(
@@ -210,31 +231,33 @@ class TestCoreLayerSecondaryThemes:
             user_prefs={},
             now=datetime.now(),
             user_subtopics=set(),
-            custom_source_ids=set(custom_sources or [])
+            custom_source_ids=set(custom_sources or []),
         )
 
     def test_secondary_theme_match(self):
         """Source international avec secondary tech → match tech users à 70%."""
         content = MockContent(
-            source_theme="international",
-            secondary_themes=["tech", "economy"]
+            source_theme="international", secondary_themes=["tech", "economy"]
         )
         context = self.create_context(user_interests={"tech"})
         layer = CoreLayer()
 
         score = layer.score(content, context)
 
-        expected_secondary = ScoringWeights.THEME_MATCH * ScoringWeights.SECONDARY_THEME_FACTOR
+        expected_secondary = (
+            ScoringWeights.THEME_MATCH * ScoringWeights.SECONDARY_THEME_FACTOR
+        )
         reasons = context.reasons.get(content.id, [])
         secondary_reasons = [r for r in reasons if "secondaire" in r.get("details", "")]
         assert len(secondary_reasons) == 1
-        assert secondary_reasons[0]["score_contribution"] == pytest.approx(expected_secondary)
+        assert secondary_reasons[0]["score_contribution"] == pytest.approx(
+            expected_secondary
+        )
 
     def test_primary_takes_precedence_over_secondary(self):
         """Le thème principal doit avoir priorité sur le secondaire."""
         content = MockContent(
-            source_theme="tech",
-            secondary_themes=["science", "economy"]
+            source_theme="tech", secondary_themes=["science", "economy"]
         )
         context = self.create_context(user_interests={"tech", "science"})
         layer = CoreLayer()
@@ -276,7 +299,7 @@ class TestCoreLayerSecondaryThemes:
         """Même si plusieurs secondaires matchent, un seul bonus est donné."""
         content = MockContent(
             source_theme="international",
-            secondary_themes=["tech", "science", "economy"]
+            secondary_themes=["tech", "science", "economy"],
         )
         context = self.create_context(user_interests={"tech", "science", "economy"})
         layer = CoreLayer()
@@ -291,7 +314,9 @@ class TestCoreLayerSecondaryThemes:
 class TestCoreLayerContentTheme:
     """Tests Phase 2: Article-level content.theme matching."""
 
-    def create_context(self, user_interests=None, followed_sources=None, custom_sources=None):
+    def create_context(
+        self, user_interests=None, followed_sources=None, custom_sources=None
+    ):
         user_profile = MagicMock()
         user_profile.id = uuid4()
         return ScoringContext(
@@ -302,7 +327,7 @@ class TestCoreLayerContentTheme:
             user_prefs={},
             now=datetime.now(),
             user_subtopics=set(),
-            custom_source_ids=set(custom_sources or [])
+            custom_source_ids=set(custom_sources or []),
         )
 
     def test_content_theme_takes_precedence(self):
@@ -314,9 +339,13 @@ class TestCoreLayerContentTheme:
         score = layer.score(content, context)
 
         reasons = context.reasons.get(content.id, [])
-        article_theme_reasons = [r for r in reasons if "Thème article" in r.get("details", "")]
+        article_theme_reasons = [
+            r for r in reasons if "Thème article" in r.get("details", "")
+        ]
         assert len(article_theme_reasons) == 1
-        assert article_theme_reasons[0]["score_contribution"] == ScoringWeights.THEME_MATCH
+        assert (
+            article_theme_reasons[0]["score_contribution"] == ScoringWeights.THEME_MATCH
+        )
 
     def test_content_theme_none_falls_to_source(self):
         """content.theme=None → fallback vers source.theme."""
@@ -327,15 +356,15 @@ class TestCoreLayerContentTheme:
         score = layer.score(content, context)
 
         reasons = context.reasons.get(content.id, [])
-        source_theme_reasons = [r for r in reasons if r.get("details", "") == "Thème: tech"]
+        source_theme_reasons = [
+            r for r in reasons if r.get("details", "") == "Thème: tech"
+        ]
         assert len(source_theme_reasons) == 1
 
     def test_content_theme_mismatch_falls_to_secondary(self):
         """content.theme="culture" (non matché) → fallback secondary "tech"."""
         content = MockContent(
-            source_theme="international",
-            secondary_themes=["tech"],
-            theme="culture"
+            source_theme="international", secondary_themes=["tech"], theme="culture"
         )
         context = self.create_context(user_interests={"tech"})
         layer = CoreLayer()
@@ -362,9 +391,7 @@ class TestCoreLayerContentTheme:
         """content.theme (tier 1) > source.theme (tier 2) > secondary (tier 3)."""
         # Tous les tiers matchent, seul tier 1 doit être retenu
         content = MockContent(
-            source_theme="science",
-            secondary_themes=["economy"],
-            theme="tech"
+            source_theme="science", secondary_themes=["economy"], theme="tech"
         )
         context = self.create_context(user_interests={"tech", "science", "economy"})
         layer = CoreLayer()

--- a/packages/api/tests/recommendation/test_coverage_score.py
+++ b/packages/api/tests/recommendation/test_coverage_score.py
@@ -18,9 +18,7 @@ def test_log2_progression():
     assert compute_coverage_score(3) == pytest.approx(
         ScoringWeights.COVERAGE_BASE * math.log2(3)
     )
-    assert compute_coverage_score(4) == pytest.approx(
-        ScoringWeights.COVERAGE_BASE * 2
-    )
+    assert compute_coverage_score(4) == pytest.approx(ScoringWeights.COVERAGE_BASE * 2)
 
 
 def test_capped_at_max():

--- a/packages/api/tests/recommendation/test_pertinence_pillar.py
+++ b/packages/api/tests/recommendation/test_pertinence_pillar.py
@@ -258,3 +258,135 @@ class TestEntityAffinity:
         assert any(
             c.label == "Parce que tu lis souvent Emmanuel Macron" for c in contribs
         )
+
+
+class TestCustomTopicEntityBranch:
+    """PR1b2 — `canonical_name` matché contre `content.entities`.
+
+    Le pilier ne lisait ni `content.entities` ni `canonical_name` : le pont
+    entité n'existait que dans `layers/user_custom_topics`, une couche de recall
+    qui ne s'applique pas aux surfaces scorées par piliers.
+    """
+
+    @staticmethod
+    def _profile(**overrides):
+        import types
+
+        from app.models.enums import InterestState
+
+        base = dict(
+            topic_name="Kylian Mbappé",
+            slug_parent="",
+            keywords=[],
+            entity_type="PERSON",
+            canonical_name="Kylian Mbappé",
+            priority_multiplier=1.0,
+            state=InterestState.FOLLOWED,
+            is_veille=False,
+        )
+        base.update(overrides)
+        return types.SimpleNamespace(**base)
+
+    def _score(self, content, profile):
+        pillar = PertinencePillar()
+        return pillar._score_custom_topics(
+            content, _context(user_custom_topics=[profile])
+        )
+
+    def test_entity_match_scores_with_multiplier(self):
+        content = MockContent(entities=[_entity("Kylian Mbappé")])
+
+        score, contribs = self._score(content, self._profile())
+
+        expected = (
+            ScoringWeights.CUSTOM_TOPIC_BASE_BONUS
+            * 1.0
+            * ScoringWeights.ENTITY_MATCH_MULTIPLIER
+        )
+        assert score == pytest.approx(expected)
+        assert contribs[0].label == "Votre sujet : Kylian Mbappé"
+
+    def test_priority_multiplier_still_applies(self):
+        content = MockContent(entities=[_entity("Kylian Mbappé")])
+
+        score, _ = self._score(content, self._profile(priority_multiplier=2.0))
+
+        assert score == pytest.approx(
+            ScoringWeights.CUSTOM_TOPIC_BASE_BONUS
+            * 2.0
+            * ScoringWeights.ENTITY_MATCH_MULTIPLIER
+        )
+
+    def test_no_match_scores_zero(self):
+        content = MockContent(entities=[_entity("Emmanuel Macron")])
+
+        score, contribs = self._score(content, self._profile())
+
+        assert score == 0.0
+        assert contribs == []
+
+    @pytest.mark.parametrize(
+        "stored,followed",
+        [
+            ("kylian mbappé", "Kylian Mbappé"),
+            ("KYLIAN MBAPPÉ", "kylian mbappé"),
+            ("Kylian Mbappé", "  Kylian Mbappé  "),
+        ],
+    )
+    def test_match_is_case_and_whitespace_insensitive(self, stored, followed):
+        content = MockContent(entities=[_entity(stored)])
+
+        score, _ = self._score(content, self._profile(canonical_name=followed))
+
+        assert score > 0
+
+    def test_plain_string_entity_is_tolerated(self):
+        """`iter_entity_names` accepte une entité stockée hors JSON."""
+        content = MockContent(entities=["Kylian Mbappé"])
+
+        score, _ = self._score(content, self._profile())
+
+        assert score > 0
+
+    def test_no_entities_on_content_scores_zero(self):
+        score, contribs = self._score(MockContent(entities=None), self._profile())
+
+        assert score == 0.0
+        assert contribs == []
+
+    def test_profile_without_entity_type_ignores_branch(self):
+        """Un Sujet classique ne doit pas matcher par entité."""
+        content = MockContent(entities=[_entity("Kylian Mbappé")])
+
+        score, _ = self._score(
+            content, self._profile(entity_type=None, canonical_name=None)
+        )
+
+        assert score == 0.0
+
+    def test_slug_and_entity_match_counted_once(self):
+        """Garde `if not matched` : pas de double-compte sur un même profil."""
+        content = MockContent(topics=["sport"], entities=[_entity("Kylian Mbappé")])
+
+        score, contribs = self._score(content, self._profile(slug_parent="sport"))
+
+        # Le slug matche d'abord → barème plat, sans la prime entité.
+        assert score == pytest.approx(ScoringWeights.CUSTOM_TOPIC_BASE_BONUS)
+        assert len(contribs) == 1
+
+    def test_best_profile_wins_between_profiles(self):
+        content = MockContent(entities=[_entity("Kylian Mbappé")])
+        weak = self._profile(topic_name="Faible", priority_multiplier=1.0)
+        strong = self._profile(topic_name="Fort", priority_multiplier=2.0)
+
+        pillar = PertinencePillar()
+        score, contribs = pillar._score_custom_topics(
+            content, _context(user_custom_topics=[weak, strong])
+        )
+
+        assert contribs[0].label == "Votre sujet : Fort"
+        assert score == pytest.approx(
+            ScoringWeights.CUSTOM_TOPIC_BASE_BONUS
+            * 2.0
+            * ScoringWeights.ENTITY_MATCH_MULTIPLIER
+        )

--- a/packages/api/tests/recommendation/test_pertinence_pillar.py
+++ b/packages/api/tests/recommendation/test_pertinence_pillar.py
@@ -167,7 +167,9 @@ class TestSubtopicPositionWeighting:
             1.0 + ScoringWeights.SUBTOPIC_POSITION_FACTOR
         )
         assert score == pytest.approx(expected)
-        assert contributions[0].label == "Sujet : IA, Tech"
+        # `tech` rendait « Tech » via une table de libellés périmée ; le libellé
+        # canonique est « Technologie ». `ai` garde sa forme courte.
+        assert contributions[0].label == "Sujet : IA, Technologie"
 
 
 class TestEntityAffinity:
@@ -390,3 +392,67 @@ class TestCustomTopicEntityBranch:
             * 2.0
             * ScoringWeights.ENTITY_MATCH_MULTIPLIER
         )
+
+
+class TestSubtopicLabelInvariant:
+    """PR1e — garde-fou contre la re-dérive de la table de libellés.
+
+    Le pilier portait sa propre copie (`SUBTOPIC_LABELS`, 50 entrées) d'une
+    taxonomie à 51 slugs : 32 clés fantômes et 33 slugs valides sans libellé,
+    donc un `.capitalize()` anglais dans des raisons françaises. Elle est
+    supprimée au profit de `SLUG_TO_LABEL` ; ces tests interdisent qu'une
+    nouvelle divergence passe en silence.
+    """
+
+    def test_every_valid_slug_has_a_french_label(self):
+        from app.services.ml.classification_service import (
+            SLUG_TO_LABEL,
+            VALID_TOPIC_SLUGS,
+        )
+
+        assert VALID_TOPIC_SLUGS - set(SLUG_TO_LABEL) == set()
+
+    def test_no_label_for_an_unknown_slug(self):
+        from app.services.ml.classification_service import (
+            SLUG_TO_LABEL,
+            VALID_TOPIC_SLUGS,
+        )
+
+        assert set(SLUG_TO_LABEL) - VALID_TOPIC_SLUGS == set()
+
+    @pytest.mark.parametrize(
+        "slug,expected",
+        [
+            ("energy", "Énergie"),
+            ("politics", "Politique"),
+            ("usa", "États-Unis"),
+            ("environment", "Environnement"),
+            ("inequality", "Inégalités sociales"),
+            ("middleeast", "Moyen-Orient"),
+        ],
+    )
+    def test_most_followed_slugs_render_in_french(self, slug, expected):
+        """Ces slugs rendaient « Energy », « Politics », « Usa »…"""
+        from app.services.recommendation.pillars.pertinence import _subtopic_label
+
+        assert _subtopic_label(slug) == expected
+
+    def test_unknown_slug_still_falls_back(self):
+        from app.services.recommendation.pillars.pertinence import _subtopic_label
+
+        assert _subtopic_label("slug-inexistant") == "Slug-inexistant"
+
+    def test_short_label_overrides_are_valid_slugs(self):
+        """La liste d'exceptions courtes ne doit pas devenir une 2e taxonomie."""
+        from app.services.ml.classification_service import VALID_TOPIC_SLUGS
+        from app.services.recommendation.pillars.pertinence import (
+            _SHORT_SUBTOPIC_LABELS,
+        )
+
+        assert set(_SHORT_SUBTOPIC_LABELS) <= VALID_TOPIC_SLUGS
+
+    def test_short_label_wins_over_canonical(self):
+        from app.services.recommendation.pillars.pertinence import _subtopic_label
+
+        assert _subtopic_label("ai") == "IA"
+        assert _subtopic_label("space") == "Spatial"

--- a/packages/api/tests/recommendation/test_pertinence_state.py
+++ b/packages/api/tests/recommendation/test_pertinence_state.py
@@ -75,12 +75,8 @@ def test_followed_default_unchanged_from_legacy():
     pillar = PertinencePillar()
     content = _content_with_theme("tech")
 
-    high_score, _ = pillar._score_behavioral(
-        content, _context(weight=2.0, state=None)
-    )
-    low_score, _ = pillar._score_behavioral(
-        content, _context(weight=0.5, state=None)
-    )
+    high_score, _ = pillar._score_behavioral(content, _context(weight=2.0, state=None))
+    low_score, _ = pillar._score_behavioral(content, _context(weight=0.5, state=None))
     neutral_score, _ = pillar._score_behavioral(
         content, _context(weight=1.0, state=None)
     )

--- a/packages/api/tests/routers/test_feed_cache_invalidation_sites.py
+++ b/packages/api/tests/routers/test_feed_cache_invalidation_sites.py
@@ -293,6 +293,45 @@ async def test_note_upsert_purges_everything(auth_client, article, user_id, seed
     _assert_full(user_id)
 
 
+# --- Digest actions --------------------------------------------------------
+#
+# `POST /digest/{id}/action` ajuste les mêmes poids que ses équivalents
+# `/contents/*` (subtopics, et depuis PR1a l'affinité entités) mais ne purgeait
+# rien : le signal partait en base derrière un classement caché périmé.
+
+
+@pytest.mark.parametrize("action", ["read", "save", "like", "unlike"])
+@pytest.mark.asyncio
+async def test_digest_learning_action_purges_everything(
+    auth_client, article, user_id, seed_cache, action
+):
+    seed_cache(user_id, article.id)
+
+    resp = await auth_client.post(
+        f"/api/digest/{uuid4()}/action",
+        json={"content_id": str(article.id), "action": action},
+    )
+
+    assert resp.status_code == 200, resp.text
+    _assert_full(user_id)
+
+
+@pytest.mark.asyncio
+async def test_digest_undo_purges_only_matching_sections(
+    auth_client, article, user_id, seed_cache
+):
+    """UNDO ne remet aucun poids : seul l'affichage d'un article change."""
+    seed_cache(user_id, article.id)
+
+    resp = await auth_client.post(
+        f"/api/digest/{uuid4()}/action",
+        json={"content_id": str(article.id), "action": "undo"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    _assert_targeted(user_id)
+
+
 # --- Cross-user ------------------------------------------------------------
 
 

--- a/packages/api/tests/test_content_interactions.py
+++ b/packages/api/tests/test_content_interactions.py
@@ -221,3 +221,99 @@ async def test_adjust_entity_affinity_negative_clamps_lower(db_session, test_sou
 
     rows = await _affinity_rows(db_session, user_id)
     assert rows["emmanuel macron"].affinity == pytest.approx(0.1)
+
+
+# ---------------------------------------------------------------------------
+# PR1 (a) — l'Essentiel nourrit l'affinité entités (DB réelle)
+#
+# `DigestService.apply_action` appelait `_adjust_subtopic_weights` sans son
+# miroir entités : la surface phare n'alimentait donc jamais l'affinité, ce qui
+# expliquait un levier numériquement inerte en prod (max 1,59 sur 871 lignes).
+# On vérifie ici le câblage bout-en-bout, avec le même delta que le subtopic.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "action_name,expected_delta",
+    [
+        ("SAVE", 0.05),  # BOOKMARK_TOPIC_BOOST
+        ("LIKE", 0.15),  # LIKE_TOPIC_BOOST
+    ],
+)
+@pytest.mark.asyncio
+async def test_digest_action_feeds_entity_affinity(
+    db_session, test_source, action_name, expected_delta
+):
+    """SAVE / LIKE depuis l'Essentiel créent la ligne d'affinité entités."""
+    from app.schemas.digest import DigestAction
+    from app.services.digest_service import DigestService
+
+    user_id, content_id = await _seed_user_and_content(
+        db_session,
+        test_source,
+        [_entity_json("Emmanuel Macron"), _entity_json("OpenAI", "ORG")],
+    )
+
+    await DigestService(db_session).apply_action(
+        digest_id=uuid4(),
+        user_id=user_id,
+        content_id=content_id,
+        action=getattr(DigestAction, action_name),
+    )
+    await db_session.commit()
+
+    rows = await _affinity_rows(db_session, user_id)
+    assert set(rows) == {"emmanuel macron", "openai"}
+    assert rows["emmanuel macron"].affinity == pytest.approx(1.0 + expected_delta)
+    assert rows["emmanuel macron"].interaction_count == 1
+
+
+@pytest.mark.asyncio
+async def test_digest_unlike_decrements_entity_affinity(db_session, test_source):
+    """UNLIKE reprend exactement ce que LIKE a donné (delta symétrique)."""
+    from app.schemas.digest import DigestAction
+    from app.services.digest_service import DigestService
+
+    user_id, content_id = await _seed_user_and_content(
+        db_session, test_source, [_entity_json("Emmanuel Macron")]
+    )
+    service = DigestService(db_session)
+
+    await service.apply_action(
+        digest_id=uuid4(),
+        user_id=user_id,
+        content_id=content_id,
+        action=DigestAction.LIKE,
+    )
+    await service.apply_action(
+        digest_id=uuid4(),
+        user_id=user_id,
+        content_id=content_id,
+        action=DigestAction.UNLIKE,
+    )
+    await db_session.commit()
+
+    rows = await _affinity_rows(db_session, user_id)
+    assert rows["emmanuel macron"].affinity == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_digest_read_feeds_entity_affinity(db_session, test_source):
+    """READ applique READ_TOPIC_BOOST (signal implicite le plus faible)."""
+    from app.schemas.digest import DigestAction
+    from app.services.digest_service import DigestService
+
+    user_id, content_id = await _seed_user_and_content(
+        db_session, test_source, [_entity_json("Emmanuel Macron")]
+    )
+
+    await DigestService(db_session).apply_action(
+        digest_id=uuid4(),
+        user_id=user_id,
+        content_id=content_id,
+        action=DigestAction.READ,
+    )
+    await db_session.commit()
+
+    rows = await _affinity_rows(db_session, user_id)
+    assert rows["emmanuel macron"].affinity == pytest.approx(1.03)

--- a/packages/api/tests/test_digest_per_user_projection.py
+++ b/packages/api/tests/test_digest_per_user_projection.py
@@ -101,9 +101,7 @@ class _StubPipeline:
             user_source_ids=user_source_ids,
             excluded_content_ids=excluded_content_ids,
         )
-        return EditorialPipelineResult(
-            subjects=subjects, metadata={"matching_ms": 0}
-        )
+        return EditorialPipelineResult(subjects=subjects, metadata={"matching_ms": 0})
 
 
 class _FakeSessionMaker:
@@ -279,9 +277,7 @@ async def test_two_users_diverge_on_followed_source_order():
     top_a = res_a.subjects[0]
     assert top_a.actu_article.is_user_source is True
     # Les rangs sont renumérotés 1..n.
-    assert [s.rank for s in res_a.subjects] == list(
-        range(1, len(res_a.subjects) + 1)
-    )
+    assert [s.rank for s in res_a.subjects] == list(range(1, len(res_a.subjects) + 1))
 
 
 @pytest.mark.asyncio
@@ -295,9 +291,7 @@ async def test_solo_subject_created_for_follower_only(monkeypatch):
     now = datetime.now(UTC)
     # c1 contient a1 (représentant, plus récent) + a3 (même source srcA, leftover).
     a1 = _make_content(srcA, published_at=now, title="Rep A")
-    a3 = _make_content(
-        srcA, published_at=now - timedelta(hours=1), title="Solo A"
-    )
+    a3 = _make_content(srcA, published_at=now - timedelta(hours=1), title="Solo A")
     a2 = _make_content(srcB, published_at=now, title="Rep B")
 
     c1 = _make_topic_cluster("c1", [a1, a3])
@@ -321,7 +315,9 @@ async def test_solo_subject_created_for_follower_only(monkeypatch):
         context=ctx_follower,
         mode="pour_vous",
     )
-    solo_ids = [s.topic_id for s in res_follower.subjects if s.topic_id.startswith("solo-")]
+    solo_ids = [
+        s.topic_id for s in res_follower.subjects if s.topic_id.startswith("solo-")
+    ]
     assert solo_ids, "le suiveur doit obtenir un sujet solo"
     solo = next(s for s in res_follower.subjects if s.topic_id.startswith("solo-"))
     assert solo.actu_article.content_id == a3.id
@@ -351,7 +347,9 @@ async def test_multi_source_ranks_above_personalized_single_source():
     srcMulti, srcFollowed = uuid4(), uuid4()
     now = datetime.now(UTC)
     a_multi = _make_content(srcMulti, published_at=now, title="Sujet très couvert")
-    a_solo = _make_content(srcFollowed, published_at=now, title="Sujet d'une source suivie")
+    a_solo = _make_content(
+        srcFollowed, published_at=now, title="Sujet d'une source suivie"
+    )
 
     c_multi = _make_topic_cluster("multi", [a_multi])
     c_solo = _make_topic_cluster("solo", [a_solo])
@@ -469,7 +467,9 @@ async def test_polarization_breaks_tie_between_multi_sources():
     ]
     subjects = [
         _make_subject("plain", a_plain, rank=1, source_count=4, divergence_level="low"),
-        _make_subject("polar", a_polar, rank=2, source_count=4, divergence_level="high"),
+        _make_subject(
+            "polar", a_polar, rank=2, source_count=4, divergence_level="high"
+        ),
     ]
     global_ctx = types.SimpleNamespace(subjects=subjects, cluster_data=[])
 
@@ -633,9 +633,7 @@ async def test_custom_topic_keyword_match_outranks_neutral_article():
     assert by_id[matching.id] > by_id[neutral.id]
 
     breakdown = next(bd for c, _s, bd, _ps in scored if c.id == matching.id)
-    assert any(
-        b.label == "Votre sujet : Intelligence artificielle" for b in breakdown
-    )
+    assert any(b.label == "Votre sujet : Intelligence artificielle" for b in breakdown)
 
 
 @pytest.mark.asyncio
@@ -651,3 +649,30 @@ async def test_no_custom_topics_leaves_scoring_unchanged():
 
     breakdown = scored[0][2]
     assert not any("Votre sujet" in b.label for b in breakdown)
+
+
+@pytest.mark.asyncio
+async def test_entity_subscription_outranks_neutral_article_in_digest():
+    """PR1b2 bout-en-bout : abonnement entité -> l'article monte dans le digest."""
+    import json
+
+    src = uuid4()
+    selector = _make_selector()
+    profile = _make_topic_profile(
+        "Angela Merkel", entity_type="PERSON", canonical_name="Angela Merkel"
+    )
+
+    matching = _scorable(src, title="Une décision européenne")
+    matching.entities = [json.dumps({"name": "Angela Merkel", "type": "PERSON"})]
+    neutral = _scorable(src, title="Un tout autre sujet")
+
+    scored = await selector._score_candidates(
+        [matching, neutral],
+        _make_context(uuid4(), [src], custom_topics=[profile]),
+    )
+    by_id = {c.id: score for c, score, _bd, _ps in scored}
+
+    assert by_id[matching.id] > by_id[neutral.id]
+
+    breakdown = next(bd for c, _s, bd, _ps in scored if c.id == matching.id)
+    assert any(b.label == "Votre sujet : Angela Merkel" for b in breakdown)

--- a/packages/api/tests/test_digest_per_user_projection.py
+++ b/packages/api/tests/test_digest_per_user_projection.py
@@ -139,7 +139,7 @@ def _make_selector(session_maker=None):
     return sel
 
 
-def _make_context(user_id, followed_source_ids, interests=None):
+def _make_context(user_id, followed_source_ids, interests=None, custom_topics=None):
     return DigestContext(
         user_id=user_id,
         user_profile=Mock(),
@@ -154,6 +154,36 @@ def _make_context(user_id, followed_source_ids, interests=None):
         muted_themes=set(),
         muted_topics=set(),
         muted_content_types=set(),
+        user_custom_topics=custom_topics or [],
+    )
+
+
+def _make_topic_profile(
+    topic_name,
+    *,
+    slug_parent="",
+    keywords=None,
+    entity_type=None,
+    canonical_name=None,
+    priority_multiplier=1.0,
+):
+    """Stub `UserTopicProfile`.
+
+    `types.SimpleNamespace` et pas `MagicMock` : `_score_custom_topics` fait
+    `getattr(tp, "is_veille", False)`, et un MagicMock renverrait un Mock
+    truthy qui routerait vers le barème veille.
+    """
+    from app.models.enums import InterestState
+
+    return types.SimpleNamespace(
+        topic_name=topic_name,
+        slug_parent=slug_parent,
+        keywords=keywords or [],
+        entity_type=entity_type,
+        canonical_name=canonical_name,
+        priority_multiplier=priority_multiplier,
+        state=InterestState.FOLLOWED,
+        is_veille=False,
     )
 
 
@@ -542,3 +572,82 @@ def test_legacy_snapshots_without_score_still_parse():
     )
     assert article.score is None
     assert article.pillar_scores is None
+
+
+# ─── Tests: threading user_custom_topics (PR1b) ───────────────────────────────
+
+
+def _scorable(source_id, *, title, description=""):
+    """Content scorable par le pilier Pertinence (titre/description réels)."""
+    c = _make_content(source_id, title=title)
+    c.description = description
+    c.entities = None
+    c.cluster_id = None
+    c.duration_seconds = None
+    return c
+
+
+@pytest.mark.asyncio
+async def test_custom_topics_reach_the_scoring_context():
+    """`_score_candidates` construisait le ScoringContext sans les Sujets.
+
+    La garde `if not context.user_custom_topics: return 0.0, []` avalait donc
+    tout : `_score_custom_topics` n'a jamais tiré sur le digest.
+    """
+    src = uuid4()
+    profile = _make_topic_profile("Intelligence artificielle", keywords=["openai"])
+    selector = _make_selector()
+    context = _make_context(uuid4(), [src], custom_topics=[profile])
+
+    captured = {}
+    real_engine = selector.rec_service.pillar_engine
+    selector.rec_service.pillar_engine = Mock()
+    selector.rec_service.pillar_engine.compute_score = lambda content, ctx: (
+        captured.setdefault("topics", ctx.user_custom_topics),
+        real_engine.compute_score(content, ctx),
+    )[1]
+
+    await selector._score_candidates(
+        [_scorable(src, title="OpenAI annonce un nouveau modèle")], context
+    )
+
+    assert captured["topics"] == [profile]
+
+
+@pytest.mark.asyncio
+async def test_custom_topic_keyword_match_outranks_neutral_article():
+    """Le blast radius assumé de PR1b : la branche slug/keyword à +25 s'active."""
+    src = uuid4()
+    selector = _make_selector()
+    profile = _make_topic_profile("Intelligence artificielle", keywords=["openai"])
+
+    matching = _scorable(src, title="OpenAI annonce un nouveau modèle")
+    neutral = _scorable(src, title="Un tout autre sujet")
+
+    scored = await selector._score_candidates(
+        [matching, neutral],
+        _make_context(uuid4(), [src], custom_topics=[profile]),
+    )
+    by_id = {c.id: score for c, score, _bd, _ps in scored}
+
+    assert by_id[matching.id] > by_id[neutral.id]
+
+    breakdown = next(bd for c, _s, bd, _ps in scored if c.id == matching.id)
+    assert any(
+        b.label == "Votre sujet : Intelligence artificielle" for b in breakdown
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_custom_topics_leaves_scoring_unchanged():
+    """Sans Sujet suivi, aucun bonus ni malus custom-topic n'apparaît."""
+    src = uuid4()
+    selector = _make_selector()
+
+    scored = await selector._score_candidates(
+        [_scorable(src, title="OpenAI annonce un nouveau modèle")],
+        _make_context(uuid4(), [src]),
+    )
+
+    breakdown = scored[0][2]
+    assert not any("Votre sujet" in b.label for b in breakdown)

--- a/packages/api/tests/test_digest_selector.py
+++ b/packages/api/tests/test_digest_selector.py
@@ -903,21 +903,56 @@ class TestGenerateReasonTrending:
         )
         assert reason == "À la une"
 
-    def test_no_trending_falls_through_to_subtopic(self, selector):
-        """Sans trending/une, le comportement existant est préservé."""
+    @pytest.mark.parametrize("label", ["Sujet : IA", "Sujet suivi : IA"])
+    def test_no_trending_falls_through_to_subtopic(self, selector, label):
+        """Sans trending/une, le sujet précis gagne.
+
+        Ce test pinnait « Sous-thème : AI », un libellé qu'**aucun pilier
+        n'émet** : c'est précisément pour ça que la branche est restée morte sans
+        être vue. `_score_subtopics` produit "Sujet : …" ou, si le poids appris
+        est > 1, "Sujet suivi : …".
+        """
+        source = make_source(name="Test", theme="tech")
+        content = make_content(source=source)
+
+        breakdown = [
+            DigestScoreBreakdown(label=label, points=45.0, is_positive=True),
+        ]
+
+        reason = selector._generate_reason(
+            content, defaultdict(int), defaultdict(int), breakdown
+        )
+        assert reason == "Thème : IA"
+
+    def test_subtopic_wins_over_the_broad_theme(self, selector):
+        """Le sujet précis doit battre le thème de la source (« Tech »)."""
+        source = make_source(name="Test", theme="tech")
+        content = make_content(source=source)
+
+        breakdown = [
+            DigestScoreBreakdown(label="Sujet : IA", points=45.0, is_positive=True),
+        ]
+
+        reason = selector._generate_reason(
+            content, defaultdict(int), defaultdict(int), breakdown
+        )
+        assert reason == "Thème : IA"
+
+    def test_masked_subtopic_is_not_read_as_a_reason(self, selector):
+        """« Sujet masqué : … » (pénalité) ne doit pas devenir une raison."""
         source = make_source(name="Test", theme="tech")
         content = make_content(source=source)
 
         breakdown = [
             DigestScoreBreakdown(
-                label="Sous-thème : AI", points=45.0, is_positive=True
+                label="Sujet masqué : IA", points=-30.0, is_positive=False
             ),
         ]
 
         reason = selector._generate_reason(
             content, defaultdict(int), defaultdict(int), breakdown
         )
-        assert reason == "Thème : AI"
+        assert reason == "Thème : Tech & Innovation"
 
 
 # ─── Helpers: pillar engine ──────────────────────────────────────────────────

--- a/packages/api/tests/test_digest_service.py
+++ b/packages/api/tests/test_digest_service.py
@@ -1367,3 +1367,82 @@ async def test_topics_response_propagates_read_at(service, mock_session):
     assert len(response.topics) == 1
     assert response.topics[0].articles[0].is_read is True
     assert response.topics[0].articles[0].read_at == read_at
+
+
+# ─── Tests: _determine_top_reason (PR1e2) ─────────────────────────────────────
+
+
+class TestDetermineTopReason:
+    """La branche « Sous-thème » était doublement morte.
+
+    Aucun pilier n'émet ce préfixe (`_score_subtopics` produit "Sujet : …" /
+    "Sujet suivi : …"), **et** elle était inatteignable de toute façon puisque
+    `"Thème" in "Sous-thème : …"` est vrai et testé avant.
+    """
+
+    @pytest.mark.parametrize("label", ["Sujet : IA", "Sujet suivi : IA"])
+    def test_precise_subject_becomes_the_reason(self, service, label):
+        from app.schemas.digest import DigestScoreBreakdown
+
+        reason = service._determine_top_reason(
+            [DigestScoreBreakdown(label=label, points=45.0, is_positive=True)]
+        )
+
+        assert reason == "Vos centres d'intérêt : IA"
+
+    def test_subject_wins_over_a_broad_theme(self, service):
+        """Le sujet précis passe devant « Thème : … », même à points égaux."""
+        from app.schemas.digest import DigestScoreBreakdown
+
+        reason = service._determine_top_reason(
+            [
+                DigestScoreBreakdown(label="Sujet : IA", points=50.0, is_positive=True),
+                DigestScoreBreakdown(
+                    label="Thème : Tech & Innovation",
+                    points=50.0,
+                    is_positive=True,
+                ),
+            ]
+        )
+
+        assert reason == "Vos centres d'intérêt : IA"
+
+    def test_at_most_two_subjects_are_listed(self, service):
+        from app.schemas.digest import DigestScoreBreakdown
+
+        reason = service._determine_top_reason(
+            [
+                DigestScoreBreakdown(
+                    label=f"Sujet : S{i}", points=50.0 - i, is_positive=True
+                )
+                for i in range(4)
+            ]
+        )
+
+        assert reason == "Vos centres d'intérêt : S0, S1"
+
+    def test_broad_theme_still_reads_as_before(self, service):
+        from app.schemas.digest import DigestScoreBreakdown
+
+        reason = service._determine_top_reason(
+            [
+                DigestScoreBreakdown(
+                    label="Thème : Environnement", points=50.0, is_positive=True
+                )
+            ]
+        )
+
+        assert reason == "Vos intérêts : Environnement"
+
+    def test_negative_contributions_are_ignored(self, service):
+        from app.schemas.digest import DigestScoreBreakdown
+
+        reason = service._determine_top_reason(
+            [
+                DigestScoreBreakdown(
+                    label="Sujet masqué : IA", points=-30.0, is_positive=False
+                )
+            ]
+        )
+
+        assert reason == "Sélectionné pour vous"

--- a/packages/api/tests/workers/test_scheduler.py
+++ b/packages/api/tests/workers/test_scheduler.py
@@ -23,6 +23,7 @@ from app.workers.scheduler import (
     _classification_queue_health_check,
     _digest_watchdog,
     decay_user_entity_affinity,
+    decay_user_interest_weights,
     decay_user_subtopic_weights,
     decayed_subtopic_weight,
     start_scheduler,
@@ -389,6 +390,39 @@ class TestDigestJobConfiguration:
             job = captured_jobs["entity_affinity_decay"]
             assert job["func"] is decay_user_entity_affinity
             assert job["name"] == "Entity Affinity Decay"
+            trigger = job["trigger"]
+            assert isinstance(trigger, CronTrigger)
+            assert str(trigger.fields[5]) == str(SUBTOPIC_DECAY_HOUR_PARIS)
+            assert str(trigger.fields[6]) == str(SUBTOPIC_DECAY_MINUTE_PARIS)
+            decay_minutes = SUBTOPIC_DECAY_HOUR_PARIS * 60 + SUBTOPIC_DECAY_MINUTE_PARIS
+            digest_minutes = DIGEST_CRON_HOUR_PARIS * 60 + DIGEST_CRON_MINUTE_PARIS
+            assert decay_minutes < digest_minutes
+
+    def test_scheduler_includes_interest_weight_decay_job(self):
+        """PR1c — `user_interests.weight` était le seul signal appris sans decay."""
+        with patch("app.workers.scheduler.AsyncIOScheduler") as mock_scheduler_class:
+            mock_scheduler = Mock()
+            mock_scheduler_class.return_value = mock_scheduler
+
+            captured_jobs = {}
+
+            def capture_add_job(*args, **kwargs):
+                job_id = kwargs.get("id")
+                if job_id:
+                    captured_jobs[job_id] = {
+                        "func": args[0] if args else kwargs.get("func"),
+                        "trigger": kwargs.get("trigger"),
+                        "name": kwargs.get("name"),
+                    }
+
+            mock_scheduler.add_job = capture_add_job
+
+            start_scheduler()
+
+            assert "interest_weight_decay" in captured_jobs
+            job = captured_jobs["interest_weight_decay"]
+            assert job["func"] is decay_user_interest_weights
+            assert job["name"] == "Interest Weight Decay"
             trigger = job["trigger"]
             assert isinstance(trigger, CronTrigger)
             assert str(trigger.fields[5]) == str(SUBTOPIC_DECAY_HOUR_PARIS)


### PR DESCRIPTION
## Ce que fait cette PR

PR1 du step-up qualité des recos : **rebrancher les signaux déjà écrits**. Aucun
nouveau signal, aucun nouveau barème, **zéro migration**. Le diagnostic (PR0,
#1034) tenait en une phrase : avant d'être loin de Google News, on est loin
d'avoir branché ce qui est déjà dans le code.

8 commits indépendamment révocables.

| # | Commit | Objet |
|---|---|---|
| 1 | `PR1a` | affinité entités nourrie depuis l'Essentiel + route feedback |
| 2 | `PR1a'` | **(hors plan)** purge du cache feed sur les actions du digest |
| 3 | `PR1b1` | threading `user_custom_topics` → `ScoringContext` du digest |
| 4 | `PR1b2` | branche entité dans le pilier + collapse du parser dupliqué |
| 5 | `PR1c` | decay de `user_interests.weight` |
| 6 | `PR1e1` | libellés de sujets resynchronisés + **(hors plan)** fix veille |
| 7 | `PR1e2` | raisons de sélection (2 branches mortes) + **(hors plan)** `changelog.json` |
| 8 | `docs` | ce que la mise en œuvre a corrigé du plan |

### (a) L'affinité entités était inerte, pas mal calibrée

`apply_action` appelait `_adjust_subtopic_weights` sur READ/SAVE/LIKE/UNLIKE et
**jamais** `_adjust_entity_affinity`, alors que `content_service` tient
l'invariant partout ailleurs. En prod : 871 lignes, affinité max **1,588**,
`interaction_count` max **14** ⇒ ~0,4 pt brut sur `MAX_PERTINENCE_RAW = 160`.
Mêmes deltas que le subtopic, jamais un barème parallèle.

### (b) Le pilier Sujets n'a jamais tiré sur la surface phare

`_score_candidates` construisait le `ScoringContext` **sans**
`user_custom_topics` ⇒ la garde `if not context.user_custom_topics: return 0.0`
avalait tout. Sujets custom **et** abonnements entités étaient muets sur
l'Essentiel et le Digest, alors que le Feed et la Veille les passaient déjà.
Puis la branche entité (`canonical_name` vs `iter_entity_names`,
`ENTITY_MATCH_MULTIPLIER = 1.5`), en miroir de la couche legacy dont le parser
dupliqué est collapsé sur l'helper partagé.

### (c) Le seul signal appris sans decay

`user_interests.weight` montait de +0,05/lecture jusqu'à 3,0 et ne redescendait
jamais. 32 lignes au cap en prod, et une ligne au cap vaut `50 × (3,0 − 1,0)` =
**62 % du pilier pertinence** : chez les comptes anciens, l'âge du compte battait
la pertinence du jour. Decay symétrique à 0,98, demi-vie ~34 j (vérifié en SQL :
3,0 → **2,006** après 34 j).

### (e) Deux défauts d'explicabilité

Libellés : `SUBTOPIC_LABELS` était une copie périmée (32 clés fantômes, 33 slugs
valides sans libellé) ⇒ « Energy », « Politics », « Usa » dans une UI française.
Supprimée au profit de `SLUG_TO_LABEL`, déjà canonique et utilisée par 5 modules.
Raisons : deux branches testaient un préfixe `"Sous-thème : "` qu'aucun pilier
n'émet ⇒ les raisons du digest retombaient toutes sur le thème large.

## Ce que la mise en œuvre a corrigé du plan

Trois commits **hors plan**, chacun parce que le câblage prévu aurait été
inopérant ou invisible sans lui :

1. **`POST /digest/{id}/action` ne purgeait rien dans `FEED_CACHE`.** La règle
   « une écriture qui touche `UserSubtopic.weight` / `UserEntityAffinity.affinity`
   purge tout » est explicite et déjà épinglée pour les routes `/contents/*`.
   Sans ce commit, PR1a écrivait le signal **derrière un classement caché
   périmé** : le même motif « écrit mais pas branché » que la PR corrige ailleurs.
2. **La copie de libellés périmée servait de liste de slugs valides à la veille**
   (`canon = frozenset(SUBTOPIC_LABELS)`). La veille neutralisait donc des
   `topic_id` parfaitement valides — dont `energy`, `politics`, `usa`, `justice`,
   `europe`, `tech` — tout en laissant passer les 32 fantômes.
3. **`digest_service._determine_top_reason` avait la même branche morte**, en
   plus inatteignable (`"Thème" in "Sous-thème : …"` est vrai et testé avant).
   Le test qui couvrait l'autre branche **pinnait le libellé fantôme** : le code
   mort a survécu à sa propre couverture. C'est le mécanisme à retenir.

## Deux trouvailles à arbitrer (PO)

- **`DIGEST_SPORT_PENALTY = −80` écrase le signal Sujet.** Un match custom-topic
  vaut +25 brut (~+16 normalisé) : un Sujet suivi qui *est* un sportif
  (« Mbappé ») reste structurellement invisible dans le digest, câblage ou pas.
  Trouvé en écrivant les tests de (b1). Non traité.
- **Copy des profils entités inchangée volontairement** : un abonnement entité
  rend « Votre sujet : Angela Merkel » alors que le mobile dit « Entité suivie ».
  Un libellé distinct exige un bras assorti dans `reason_builder` ⇒ décision PO,
  pas un changement en silence.

## ⚠️ Deux pannes préexistantes trouvées sur `main` (hors périmètre)

1. **Le build mobile est rouge depuis la PR #1026** (`5a7e9b2f`, 29/07 16:55).
   `flux_continu_screen.dart:1868` référence `firstPreparingIndex`, **défini
   nulle part** ⇒ `build-apk.yml` **et** `build-web.yml` échouent à chaque merge
   sur `main` (**6 échecs consécutifs**, confirmé dans les logs de run). Aucun
   APK beta ni build web ne sort depuis. Invisible en CI : `ci-tests.yml` ne
   lance que pytest. **Non corrigé ici** — le fix demande de trancher l'intention
   du libellé d'attente ; à faire en PR dédiée.
2. **`changelog.json` était invalide sur `main` depuis la PR #1029.** Une entrée
   insérée sans son `},{` fusionnait deux entrées. `loadReleased()` décode le
   document entier et le provider traite l'erreur comme « liste vide » ⇒ **toutes
   les notes de version in-app étaient mortes, en silence**. 2ᵉ occurrence pour
   ce fichier. **Réparé ici** (il fallait y ajouter l'entrée de (e2)) et gardé par
   3 tests qui lisent le **vrai** asset — garde vérifiée non-vacuously (elle
   échoue bien sur la version de `main`).

## Vérification

- **Backend : `2729 passed, 18 skipped, 2 xfailed`**, 0 échec (suite complète).
- **Alembic** : exactement 1 head (`sa02_alerts_v2`), **aucune migration** dans
  la PR (tout est colonnes existantes) ⇒ le risque expand-contract de la DB
  partagée `main`/`production` ne s'applique pas.
- **Mobile** : les 21 tests `release_notes` passent (dont les 3 nouvelles gardes).
  `flutter analyze` ne remonte **qu'une** ligne `error`, celle de `main` décrite
  ci-dessus ; les 2 seuls tests qui importent ce screen échouent à la
  compilation pour la même raison préexistante.
- **SQL du job de decay** exercé sur la DB de test avant commit (le job avale ses
  exceptions en les loguant : une faute de colonne ne se verrait qu'à 06h50).
- **Jauge PR0 `--tag pr1-before` : non lancée.** Blocage documenté dans le
  runbook de PR0 : `claude_analytics_ro` a `rolbypassrls = false` et retourne 0
  ligne ; la tentative avec le rôle RO n'a pas abouti en 10 min. Il faut soit la
  décision PO `ALTER ROLE … BYPASSRLS`, soit un rejeu via le MCP Supabase. **La
  première lecture publiée dans PR0 (30 j, même fenêtre) fait office de
  baseline avant** ; le run « après » est de toute façon post-merge (+1 semaine).

## Risques assumés

1. **Le threading de (b1) active aussi la branche slug/keyword à +25**, effet
   plus large que les abonnements entités eux-mêmes ⇒ commit isolé pour pouvoir
   le révoquer seul, et jauge avant/après dédiée.
2. **`THEME_MISMATCH_MALUS = −8` devient atteignable** pour les users
   custom-topics-only.
3. **`_score_entities` (affinité) et la branche entité de (b2) s'empilent** sur
   la même entité dans un pilier capé — noté dans la docstring, à surveiller à
   la jauge. Aucune recalibration ce cycle (un levier mesuré à la fois).
4. **Portée réelle de (b) sur le digest, assumée** : les abonnements entités ne
   matchent que 37 des 42 916 slots actu livrés sur 30 j (13 users) ⇒
   directionnel sur le digest, mesurable sur Tournée/Veille.
5. **(e2) change du texte visible** sur beaucoup d'articles ⇒ entrée
   `changelog.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
