### PR TITLE
fix(flux-continu): restaure firstPreparingIndex supprimé par #1026 (build cassé)

### DIFF
--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -1813,6 +1813,13 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
         ? -1
         : math.max(1, state.sections.length - 3);
 
+    // Un seul indicateur d'attente pour toute la Tournée : la **première**
+    // coquille de section encore non résolue porte le libellé « Ta tournée se
+    // prépare… » (les autres restent des cartes shimmer nues).
+    final firstPreparingIndex = state.sections.indexWhere(
+      (s) => s is FeedThemeSection && s.isPlaceholder,
+    );
+
     final slivers = <SliverToBoxAdapter>[];
     for (var i = 0; i < state.sections.length; i++) {
       if (state.grilleSlotIndex == i) {


### PR DESCRIPTION
## Quoi
Réintroduit la définition de `firstPreparingIndex` dans `_buildSectionSlivers` (`flux_continu_screen.dart`), supprimée par erreur lors du refactor de `inlineTargetIndex` en #1026 (story 13.3) alors que son usage subsiste (`showPreparingLabel: i == firstPreparingIndex`).

## Pourquoi
Symbole non défini → le fichier ne compile plus → build APK/web rouge sur `main` depuis #1026 (la CI backend ne le voit pas, flutter n'y tourne pas). Effet visible : squelette « attente lisible » mort, libellé « Ta tournée se prépare… » disparu, carte Essentiel tronquée au cold boot.

## Comment ça a été vérifié
- [x] `flutter analyze` — 0 error (avant : erreur sur le symbole non défini)
- [x] `flutter test test/features/flux_continu/` — 489 tests OK
- [x] Définition restaurée à l'identique de l'original (`git show 5a7e9b2f`)

## Zones à risque
`flux_continu_screen.dart` (rendu Tournée/Essentiel). Fix minimal, 1 ligne réintroduite, aucun autre changement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)