### PR TITLE
feat(lecture): 3ème état « Ouvert » (spectre d'engagement) — story 30.4

### DIFF
--- a/apps/mobile/lib/features/feed/models/content_model.dart
+++ b/apps/mobile/lib/features/feed/models/content_model.dart
@@ -84,6 +84,90 @@ class ContentEntity {
   }
 }
 
+/// Seuil (s) au-delà duquel une ouverture compte comme « Lu en partie » plutôt
+/// que « Ouvert ». Pendant produit d'`articleReadThreshold` (1 s, seuil
+/// `consumed` dans `read_sync_service.dart`) : ouvrir marque `consumed` en 1 s,
+/// mais il faut rester au moins [kPartialReadThresholdSeconds] pour dépasser
+/// « Ouvert ».
+///
+/// Edge case assumé : `time_spent` s'accumule côté serveur → N micro-ouvertures
+/// peuvent franchir le seuil et faire passer une carte en « Lu en partie ».
+const int kPartialReadThresholdSeconds = 5;
+
+/// Spectre d'engagement d'un article — source de vérité unique pour l'opacité et
+/// la coche des cartes (remplace la dispersion `isRead`/`isCompleted`).
+///
+/// Ordre = engagement croissant : plus on s'engage, plus la carte s'efface.
+enum ReadState { unread, opened, partiallyRead, completed }
+
+/// Dérive l'état de lecture depuis les signaux bruts.
+///
+/// [timeSpentSeconds] `null` = signal absent du payload (ex. Flux via
+/// `DigestItem`) : on retombe alors sur `partiallyRead` (comportement historique
+/// `0.6`), jamais sur « Ouvert ». « Ouvert » n'apparaît que si le temps passé
+/// est réellement connu et faible.
+ReadState deriveReadState({
+  required bool isConsumed,
+  required int readingProgress,
+  required bool isVideo,
+  required int? timeSpentSeconds,
+  required bool isCompleted,
+  bool consumedThisSession = false,
+}) {
+  if (isCompleted) return ReadState.completed;
+  final opened = isConsumed || readingProgress > 0 || consumedThisSession;
+  if (!opened) return ReadState.unread;
+  // Vidéo : la progression n'est pas plafonnée à 25, elle prime.
+  if (isVideo && readingProgress >= 25) return ReadState.partiallyRead;
+  // Signal de temps absent → on préserve « Lu en partie » (pas de downgrade).
+  if (timeSpentSeconds == null) return ReadState.partiallyRead;
+  if (timeSpentSeconds >= kPartialReadThresholdSeconds) {
+    return ReadState.partiallyRead;
+  }
+  return ReadState.opened;
+}
+
+/// Libellé d'état de lecture pour un [ReadState]. `null` pour `unread`.
+String? readingLabelForState(ReadState state, {required bool isVideo}) {
+  switch (state) {
+    case ReadState.completed:
+      return isVideo ? 'Vu jusqu\'au bout' : 'Lu jusqu\'au bout';
+    case ReadState.partiallyRead:
+      return isVideo ? 'Vu en partie' : 'Lu en partie';
+    case ReadState.opened:
+      return 'Ouvert';
+    case ReadState.unread:
+      return null;
+  }
+}
+
+/// Opacité de carte pour un [ReadState].
+double opacityForReadState(ReadState state) {
+  switch (state) {
+    case ReadState.unread:
+      return 1.0;
+    case ReadState.opened:
+      return 0.8;
+    case ReadState.partiallyRead:
+    case ReadState.completed:
+      return 0.6;
+  }
+}
+
+/// Fusionne l'état serveur [base] avec l'état de session : un article lu cette
+/// session (POST du statut différé au `dispose`) n'a pas encore de `time_spent`
+/// synchronisé — il doit rester au minimum « Ouvert », jamais « non lu ». Il
+/// montera à `partiallyRead`/`completed` au prochain refresh feed.
+ReadState effectiveReadState(
+  ReadState base, {
+  required bool consumedThisSession,
+  required bool completedThisSession,
+}) {
+  if (completedThisSession) return ReadState.completed;
+  if (consumedThisSession && base == ReadState.unread) return ReadState.opened;
+  return base;
+}
+
 class Content {
   final String id;
   final String title;
@@ -111,6 +195,11 @@ class Content {
   /// lecture. Conservé pour l'historique ; [completedAt] est le signal de
   /// complétion.
   final int readingProgress;
+
+  /// Temps passé cumulé (s) — départage « Ouvert » (< 5 s) de « Lu en partie »
+  /// (voir [readState]). `null` = signal absent du payload (le feed le porte,
+  /// certains chemins non) : dans ce cas on ne descend jamais à « Ouvert ».
+  final int? timeSpentSeconds;
 
   /// Horodatage « lu jusqu'au bout » (estampillé serveur, premier écrit gagne).
   /// Null = inconnu, pas « non terminé ».
@@ -180,6 +269,7 @@ class Content {
     this.entities = const [],
     this.recommendationReason,
     this.readingProgress = 0,
+    this.timeSpentSeconds,
     this.completedAt,
     this.noteText,
     this.noteUpdatedAt,
@@ -223,27 +313,18 @@ class Content {
   /// menées à leur terme.
   bool get isCompleted => completedAt != null;
 
+  /// État de lecture serveur-truth (hors fusion session — cf.
+  /// [effectiveReadState] côté carte).
+  ReadState get readState => deriveReadState(
+        isConsumed: status == ContentStatus.consumed,
+        readingProgress: readingProgress,
+        isVideo: isVideo,
+        timeSpentSeconds: timeSpentSeconds,
+        isCompleted: isCompleted,
+      );
+
   /// Libellé d'état de lecture. `null` si l'article n'a pas été ouvert.
-  String? get readingLabel {
-    if (isCompleted) {
-      return isVideo ? 'Vu jusqu\'au bout' : 'Lu jusqu\'au bout';
-    }
-    if (status == ContentStatus.unseen && readingProgress == 0) return null;
-
-    if (isVideo) {
-      // La vidéo n'a pas de cap partiel : sa progression reste exploitable.
-      if (readingProgress >= 25 || status == ContentStatus.consumed) {
-        return 'Vu en partie';
-      }
-      return null;
-    }
-
-    // Ouvrir un article le marque `consumed` au bout d'1 s
-    // (`articleReadThreshold`) : « Lu » ne dit donc rien de plus que
-    // « ouvert », d'où un libellé unique et sans jugement.
-    if (readingProgress > 0 || status == ContentStatus.consumed) return 'Lu';
-    return null;
-  }
+  String? get readingLabel => readingLabelForState(readState, isVideo: isVideo);
 
   /// Returns a copy with note fields explicitly set to null.
   /// Needed because copyWith uses ?? which can't set nullable fields to null.
@@ -269,6 +350,7 @@ class Content {
       entities: entities,
       recommendationReason: recommendationReason,
       readingProgress: readingProgress,
+      timeSpentSeconds: timeSpentSeconds,
       completedAt: completedAt,
       noteText: null,
       noteUpdatedAt: null,
@@ -341,6 +423,7 @@ class Content {
             ? RecommendationReason.fromJson(recJson)
             : null,
         readingProgress: (json['reading_progress'] as int?) ?? 0,
+        timeSpentSeconds: json['time_spent_seconds'] as int?,
         completedAt: json['completed_at'] != null
             ? DateTime.tryParse(json['completed_at'] as String)
             : null,
@@ -388,6 +471,7 @@ class Content {
     List<ContentEntity>? entities,
     RecommendationReason? recommendationReason,
     int? readingProgress,
+    int? timeSpentSeconds,
     DateTime? completedAt,
     String? noteText,
     DateTime? noteUpdatedAt,
@@ -435,6 +519,7 @@ class Content {
       entities: entities ?? this.entities,
       recommendationReason: recommendationReason ?? this.recommendationReason,
       readingProgress: readingProgress ?? this.readingProgress,
+      timeSpentSeconds: timeSpentSeconds ?? this.timeSpentSeconds,
       completedAt: completedAt ?? this.completedAt,
       noteText: noteText ?? this.noteText,
       noteUpdatedAt: noteUpdatedAt ?? this.noteUpdatedAt,

--- a/apps/mobile/lib/features/feed/widgets/feed_card.dart
+++ b/apps/mobile/lib/features/feed/widgets/feed_card.dart
@@ -151,19 +151,30 @@ class _FeedCardState extends ConsumerState<FeedCard>
     final colors = context.facteurColors;
     final textTheme = Theme.of(context).textTheme;
 
-    final isConsumed = widget.content.status == ContentStatus.consumed;
     final isVideo = widget.content.contentType == ContentType.youtube || widget.content.contentType == ContentType.video;
 
-    final hasBeenRead = isConsumed || widget.content.readingProgress > 0;
-    // Complété pendant la session : la carte reflète l'état sans refetch.
-    final isCompleted = widget.content.isCompleted ||
-        ref.watch(
-          completedContentIdsProvider.select(
-            (ids) => ids.contains(widget.content.id),
-          ),
-        );
+    // État serveur fusionné avec l'état de session : consommé/complété cette
+    // session se reflète sans attendre un refetch. Un consommé de session sans
+    // `time_spent` synchronisé reste au minimum « Ouvert » (cf.
+    // effectiveReadState).
+    final consumedThisSession = ref.watch(
+      consumedContentIdsProvider.select(
+        (ids) => ids.contains(widget.content.id),
+      ),
+    );
+    final completedThisSession = ref.watch(
+      completedContentIdsProvider.select(
+        (ids) => ids.contains(widget.content.id),
+      ),
+    );
+    final readState = effectiveReadState(
+      widget.content.readState,
+      consumedThisSession: consumedThisSession,
+      completedThisSession: completedThisSession,
+    );
+    final isCompleted = readState == ReadState.completed;
     final card = Opacity(
-      opacity: hasBeenRead ? 0.6 : 1.0,
+      opacity: opacityForReadState(readState),
       child: Stack(
         fit: widget.expandContent ? StackFit.expand : StackFit.loose,
         children: [
@@ -549,11 +560,11 @@ class _FeedCardState extends ConsumerState<FeedCard>
                 ),
               ),
             ),
-          if (isConsumed || widget.content.readingProgress > 0)
+          if (readState != ReadState.unread)
             Positioned(
               top: 12,
               right: 12,
-              child: ReadingBadge(content: widget.content),
+              child: ReadingBadge(content: widget.content, readState: readState),
             ),
         ],
       ),

--- a/apps/mobile/lib/features/feed/widgets/reading_badge.dart
+++ b/apps/mobile/lib/features/feed/widgets/reading_badge.dart
@@ -6,29 +6,29 @@ import '../models/content_model.dart';
 
 /// Badge d'état de lecture sur les cartes article.
 ///
-/// Deux états seulement — « Lu » (ouvert) et « Lu jusqu'au bout » (complété) —
-/// adossés à `completedAt` et non plus à `readingProgress`, qui est plafonné à
-/// 25 pour ~90 % du catalogue et affichait donc « Parcouru » sur des lectures
-/// pourtant menées à leur terme.
-///
-/// Le niveau « Parcouru » (icône `eye`, gris) a été retiré : ce n'est pas un
-/// accomplissement, et le nommer revient à commenter la lecture superficielle
-/// de l'utilisateur. L'opacité de la carte suffit à le signaler.
+/// Trois marches sur un spectre d'engagement (cf. [ReadState]) — « Ouvert »,
+/// « Lu en partie » et « Lu jusqu'au bout ». Piloté par [readState] quand la
+/// carte le fournit (état serveur fusionné avec la session), sinon retombe sur
+/// `content.readState`.
 class ReadingBadge extends StatelessWidget {
   final Content content;
 
-  const ReadingBadge({super.key, required this.content});
+  /// État effectif (fusion session incluse). `null` → dérivé de [content].
+  final ReadState? readState;
+
+  const ReadingBadge({super.key, required this.content, this.readState});
 
   @override
   Widget build(BuildContext context) {
-    final label = content.readingLabel;
+    final state = readState ?? content.readState;
+    final label = readingLabelForState(state, isVideo: content.isVideo);
     if (label == null) return const SizedBox.shrink();
 
     final colors = context.facteurColors;
 
     final Color bgColor = colors.success;
     const Color fgColor = Colors.white;
-    final IconData icon = content.isCompleted
+    final IconData icon = state == ReadState.completed
         ? PhosphorIcons.checks(PhosphorIconsStyle.bold)
         : PhosphorIcons.checkCircle(PhosphorIconsStyle.fill);
 

--- a/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
+++ b/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
@@ -170,6 +170,10 @@ class EssentielArticle {
   final bool isLiked;
   final bool isDismissed;
 
+  /// Temps passé cumulé (s) — départage « Ouvert » de « Lu en partie » sur la
+  /// carte héros. `null` = signal absent (payload plus ancien).
+  final int? timeSpentSeconds;
+
   /// « Lu jusqu'au bout ». Servi par `/api/essentiel`, distinct de [isRead] que
   /// le seuil d'ouverture d'1 s suffit à déclencher.
   final DateTime? completedAt;
@@ -198,11 +202,22 @@ class EssentielArticle {
     this.isSaved = false,
     this.isLiked = false,
     this.isDismissed = false,
+    this.timeSpentSeconds,
     this.completedAt,
     this.isFollowedSource = false,
     this.isFollowedTopic = false,
     this.isActuDuJour = false,
   });
+
+  /// État de lecture serveur-truth (avant fusion session), miroir de
+  /// [Content.readState] — l'Essentiel n'a que des articles (jamais vidéo).
+  ReadState get readState => deriveReadState(
+        isConsumed: isRead,
+        readingProgress: 0,
+        isVideo: false,
+        timeSpentSeconds: timeSpentSeconds,
+        isCompleted: completedAt != null,
+      );
 
   factory EssentielArticle.fromJson(Map<String, dynamic> json) {
     final source =
@@ -228,6 +243,7 @@ class EssentielArticle {
       isSaved: (json['is_saved'] as bool?) ?? false,
       isLiked: (json['is_liked'] as bool?) ?? false,
       isDismissed: (json['is_dismissed'] as bool?) ?? false,
+      timeSpentSeconds: json['time_spent_seconds'] as int?,
       completedAt: DateTime.tryParse(json['completed_at'] as String? ?? ''),
       isFollowedSource: (json['is_followed_source'] as bool?) ?? false,
       isFollowedTopic: (json['is_followed_topic'] as bool?) ?? false,
@@ -253,6 +269,7 @@ class EssentielArticle {
     'is_saved': isSaved,
     'is_liked': isLiked,
     'is_dismissed': isDismissed,
+    'time_spent_seconds': timeSpentSeconds,
     'completed_at': completedAt?.toIso8601String(),
     'is_followed_source': isFollowedSource,
     'is_followed_topic': isFollowedTopic,

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -8,6 +8,7 @@ import 'package:google_fonts/google_fonts.dart';
 import '../../../config/theme.dart';
 import '../../../shared/widgets/read_state_mark.dart';
 import '../../../widgets/article_preview_modal.dart';
+import '../../feed/models/content_model.dart';
 import '../../feed/services/read_sync_service.dart';
 import '../../feed/widgets/animated_feed_card.dart';
 import '../../detail/content_preview_mapper.dart';
@@ -55,11 +56,15 @@ class EssentielHiFiCard extends ConsumerWidget {
     final accent = colors.sectionEssentiel;
     final spec = ref.watch(displayModeSpecProvider);
 
-    // Un seul point de lecture du provider : le booléen descend ensuite dans
-    // les tuiles, qui restent des `StatelessWidget`.
+    // Un seul point de lecture des providers de session : l'état dérivé descend
+    // ensuite dans les tuiles, qui restent des `StatelessWidget`.
     final completedIds = ref.watch(completedContentIdsProvider);
-    bool isCompleted(EssentielArticle a) =>
-        a.completedAt != null || completedIds.contains(a.contentId);
+    final consumedIds = ref.watch(consumedContentIdsProvider);
+    ReadState readStateFor(EssentielArticle a) => effectiveReadState(
+          a.readState,
+          consumedThisSession: consumedIds.contains(a.contentId),
+          completedThisSession: completedIds.contains(a.contentId),
+        );
 
     final lead = articles.isNotEmpty ? articles.first : null;
     final remaining = articles.length > 1
@@ -142,7 +147,7 @@ class EssentielHiFiCard extends ConsumerWidget {
                 article: lead,
                 accent: accent,
                 spec: spec,
-                isCompleted: isCompleted(lead),
+                readState: readStateFor(lead),
                 onTap: () => onTapArticle(lead),
               ),
             for (final a in remaining) ...[
@@ -154,7 +159,7 @@ class EssentielHiFiCard extends ConsumerWidget {
               _MediumTile(
                 article: a,
                 spec: spec,
-                isCompleted: isCompleted(a),
+                readState: readStateFor(a),
                 onTap: () => onTapArticle(a),
               ),
             ],
@@ -645,9 +650,9 @@ class _LeadTile extends StatelessWidget {
   final Color accent;
   final DisplayModeSpec spec;
 
-  /// Lu jusqu'au bout : double coche + filet vert au bord gauche. Descendu par
-  /// la carte plutôt que relu ici — un seul point de lecture du provider.
-  final bool isCompleted;
+  /// État de lecture effectif (fusion session incluse). Descendu par la carte
+  /// plutôt que relu ici — un seul point de lecture des providers.
+  final ReadState readState;
 
   final VoidCallback onTap;
 
@@ -656,7 +661,7 @@ class _LeadTile extends StatelessWidget {
     required this.accent,
     required this.spec,
     required this.onTap,
-    required this.isCompleted,
+    required this.readState,
   });
 
   @override
@@ -674,13 +679,14 @@ class _LeadTile extends StatelessWidget {
           child: InkWell(
         onTap: onTap,
         borderRadius: BorderRadius.circular(FacteurRadius.medium),
-        // Lu : grise la tuile (0.6) + coche verte, comme les autres sections
+        // Lu : grise la tuile (0.8 « Ouvert » / 0.6 lu, cf. opacityForReadState)
+        // + coche verte, comme les autres sections
         // (cf. flux_continu_article_card.dart). Le badge est inclus dans
         // l'Opacity pour s'estomper de concert avec le contenu.
         child: Opacity(
-          opacity: article.isRead ? 0.6 : 1.0,
+          opacity: opacityForReadState(readState),
           child: AnimatedFeedCard(
-            isCompleted: isCompleted,
+            isCompleted: readState == ReadState.completed,
             animate: false,
             child: Stack(
             children: [
@@ -724,13 +730,13 @@ class _LeadTile extends StatelessWidget {
                   ],
                 ),
               ),
-              if (article.isRead)
+              if (readState != ReadState.unread)
                 Positioned(
                   top: 8,
                   right: 8,
                   child: ReadStateMark(
                     color: colors.success,
-                    isCompleted: isCompleted,
+                    state: readState,
                   ),
                 ),
             ],
@@ -747,14 +753,14 @@ class _LeadTile extends StatelessWidget {
 class _MediumTile extends StatelessWidget {
   final EssentielArticle article;
   final DisplayModeSpec spec;
-  final bool isCompleted;
+  final ReadState readState;
   final VoidCallback onTap;
 
   const _MediumTile({
     required this.article,
     required this.spec,
     required this.onTap,
-    required this.isCompleted,
+    required this.readState,
   });
 
   @override
@@ -771,11 +777,11 @@ class _MediumTile extends StatelessWidget {
           child: InkWell(
         onTap: onTap,
         borderRadius: BorderRadius.circular(FacteurRadius.small),
-        // Lu : grise la tuile (0.6) + petite coche verte (cf. _LeadTile).
+        // Lu : grise la tuile (0.8/0.6) + petite coche verte (cf. _LeadTile).
         child: Opacity(
-          opacity: article.isRead ? 0.6 : 1.0,
+          opacity: opacityForReadState(readState),
           child: AnimatedFeedCard(
-            isCompleted: isCompleted,
+            isCompleted: readState == ReadState.completed,
             animate: false,
             child: Stack(
             children: [
@@ -798,7 +804,8 @@ class _MediumTile extends StatelessWidget {
                         ),
                         // Réserve l'espace de la coche pour qu'elle ne
                         // chevauche pas la source ellipsée.
-                        if (article.isRead) const SizedBox(width: 22),
+                        if (readState != ReadState.unread)
+                          const SizedBox(width: 22),
                       ],
                     ),
                     const SizedBox(height: 4),
@@ -817,13 +824,13 @@ class _MediumTile extends StatelessWidget {
                   ],
                 ),
               ),
-              if (article.isRead)
+              if (readState != ReadState.unread)
                 Positioned(
                   top: 0,
                   right: 0,
                   child: ReadStateMark(
                     color: colors.success,
-                    isCompleted: isCompleted,
+                    state: readState,
                     size: 18,
                   ),
                 ),

--- a/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
@@ -35,11 +35,12 @@ class FluxArticleVM {
   final int? durationSeconds;
   final DateTime? publishedAt;
   final bool isFollowedSource;
-  final bool isRead;
 
-  /// « Lu jusqu'au bout » — adossé à `completedAt`, distinct de [isRead] que le
-  /// seuil d'ouverture d'1 s suffit à déclencher.
-  final bool isCompleted;
+  /// État de lecture serveur-truth (avant fusion session), source unique dont
+  /// dérivent [hasBeenRead] et [isCompleted]. Porte la 3ᵉ marche « Ouvert »
+  /// quand le temps passé est connu (chemin `Content`) ; retombe sur « Lu en
+  /// partie » quand il ne l'est pas (chemin `DigestItem`).
+  final ReadState readState;
 
   const FluxArticleVM({
     required this.contentId,
@@ -52,11 +53,14 @@ class FluxArticleVM {
     this.durationSeconds,
     this.publishedAt,
     this.isFollowedSource = false,
-    this.isRead = false,
-    this.isCompleted = false,
+    this.readState = ReadState.unread,
   });
 
-  bool get hasBeenRead => isRead;
+  bool get hasBeenRead => readState != ReadState.unread;
+
+  /// « Lu jusqu'au bout » — distinct de [hasBeenRead] que le seuil d'ouverture
+  /// d'1 s suffit à déclencher.
+  bool get isCompleted => readState == ReadState.completed;
 
   factory FluxArticleVM.from(Object article) {
     if (article is DigestItem) {
@@ -74,11 +78,17 @@ class FluxArticleVM {
         durationSeconds: article.durationSeconds,
         publishedAt: article.publishedAt,
         isFollowedSource: article.isFollowedSource,
-        isRead: article.isRead,
-        // `DigestItem` n'a pas de getter `isCompleted` : freezed exigerait un
-        // `const DigestItem._();` que la classe n'a pas. Inliné plutôt que
-        // régénéré.
-        isCompleted: article.completedAt != null,
+        // Le modèle mobile `DigestItem` (freezed) ne parse pas encore
+        // `time_spent_seconds` (câblage déféré, cf. story 30.4) → signal inconnu :
+        // `deriveReadState` retombe sur « Lu en partie » (0.6), jamais « Ouvert ».
+        readState: deriveReadState(
+          isConsumed: article.isRead,
+          readingProgress: 0,
+          isVideo: article.contentType == ContentType.youtube ||
+              article.contentType == ContentType.video,
+          timeSpentSeconds: null,
+          isCompleted: article.completedAt != null,
+        ),
       );
     }
     if (article is Content) {
@@ -93,9 +103,7 @@ class FluxArticleVM {
         durationSeconds: article.durationSeconds,
         publishedAt: article.publishedAt,
         isFollowedSource: article.isFollowedSource,
-        isRead: article.status == ContentStatus.consumed ||
-            article.readingProgress > 0,
-        isCompleted: article.isCompleted,
+        readState: article.readState,
       );
     }
     throw ArgumentError('Unsupported article type: ${article.runtimeType}');
@@ -163,13 +171,18 @@ class _FluxContinuArticleCardState
     final wasConsumedThisSession = ref.watch(
       consumedContentIdsProvider.select((ids) => ids.contains(vm.contentId)),
     );
-    final hasBeenRead = vm.hasBeenRead || wasConsumedThisSession;
     // Complétée pendant la session : la carte reflète l'état sans attendre un
     // refetch du feed.
     final completedThisSession = ref.watch(
       completedContentIdsProvider.select((ids) => ids.contains(vm.contentId)),
     );
-    final isCompleted = vm.isCompleted || completedThisSession;
+    final readState = effectiveReadState(
+      vm.readState,
+      consumedThisSession: wasConsumedThisSession,
+      completedThisSession: completedThisSession,
+    );
+    final hasBeenRead = readState != ReadState.unread;
+    final isCompleted = readState == ReadState.completed;
     final colors = context.facteurColors;
     final spec = ref.watch(displayModeSpecProvider);
     // Reclaim the thumb slot when the network image fails — avoids the
@@ -185,7 +198,7 @@ class _FluxContinuArticleCardState
     Widget card = Padding(
       padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
       child: Opacity(
-        opacity: hasBeenRead ? 0.6 : 1.0,
+        opacity: opacityForReadState(readState),
         child: Stack(
           children: [
             // `animate: false` au montage : le filet d'une carte déjà aboutie
@@ -234,7 +247,7 @@ class _FluxContinuArticleCardState
                 right: 4,
                 child: ReadStateMark(
                   color: colors.success,
-                  isCompleted: isCompleted,
+                  state: readState,
                 ),
               ),
           ],

--- a/apps/mobile/lib/shared/widgets/read_state_mark.dart
+++ b/apps/mobile/lib/shared/widgets/read_state_mark.dart
@@ -1,34 +1,80 @@
+import 'package:facteur/features/feed/models/content_model.dart';
+import 'package:facteur/features/grille/widgets/dashed_border.dart';
 import 'package:flutter/material.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
-/// Pastille d'état de lecture d'un article : simple coche s'il a été ouvert,
-/// double coche s'il a été lu **jusqu'au bout**.
+/// Pastille d'état de lecture d'un article, sur un spectre à trois marches
+/// (cf. [ReadState]) :
+/// - **[ReadState.opened]** : cercle **non plein**, contour **pointillé** vert,
+///   coche verte → « ouvert, à peine parcouru », signal secondaire.
+/// - **[ReadState.partiallyRead]** : cercle plein, simple coche blanche.
+/// - **[ReadState.completed]** : cercle plein, double coche blanche.
 ///
 /// Widget partagé et non recopié : la duplication précédente avait déjà produit
 /// un bug — la copie de la carte Essentiel codait `check` en dur, donc était
-/// structurellement incapable d'afficher une complétion. Le choix
-/// `check`/`checks` ne doit vivre qu'à un seul endroit.
+/// structurellement incapable d'afficher une complétion. Le choix de la variante
+/// ne doit vivre qu'à un seul endroit.
 ///
-/// Ne rend rien de plus pour un article non abouti : même taille, même couleur,
-/// un chevron de plus. Aucun état vide, aucun contre-signal.
+/// [ReadState.unread] ne rend rien : les cartes n'instancient la pastille que
+/// pour un article lu.
 class ReadStateMark extends StatelessWidget {
   const ReadStateMark({
     super.key,
     required this.color,
-    this.isCompleted = false,
+    required this.state,
     this.size = 22,
   });
 
+  /// Token couleur (palette `success`) — jamais une couleur brute.
   final Color color;
 
-  /// Lu jusqu'au bout (`completedAt != null`), pas seulement ouvert — ce que le
-  /// seuil d'1 s suffit à déclencher.
-  final bool isCompleted;
+  /// Marche du spectre de lecture. `unread` → widget vide.
+  final ReadState state;
 
   final double size;
 
   @override
   Widget build(BuildContext context) {
+    if (state == ReadState.unread) return const SizedBox.shrink();
+
+    // Variante « Ouvert » : contour pointillé, fond quasi transparent, coche
+    // verte — délibérément moins affirmée que la coche pleine des marches
+    // supérieures.
+    if (state == ReadState.opened) {
+      return Container(
+        width: size,
+        height: size,
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.12),
+          shape: BoxShape.circle,
+        ),
+        alignment: Alignment.center,
+        child: CustomPaint(
+          size: Size(size, size),
+          painter: DashedRRectPainter(
+            color: color,
+            radius: size / 2,
+            strokeWidth: 1.5,
+            dashLength: 2.5,
+            gapLength: 2,
+          ),
+          child: SizedBox(
+            width: size,
+            height: size,
+            child: Center(
+              child: Icon(
+                PhosphorIcons.check(PhosphorIconsStyle.bold),
+                size: size * 0.55,
+                color: color,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Variantes « Lu en partie » / « Lu jusqu'au bout » : cercle plein, icône
+    // blanche (simple vs double coche).
     return Container(
       width: size,
       height: size,
@@ -45,7 +91,7 @@ class ReadStateMark extends StatelessWidget {
       ),
       alignment: Alignment.center,
       child: Icon(
-        isCompleted
+        state == ReadState.completed
             ? PhosphorIcons.checks(PhosphorIconsStyle.bold)
             : PhosphorIcons.check(PhosphorIconsStyle.bold),
         size: size * 0.55,

--- a/apps/mobile/test/features/digest/youtube_card_test.dart
+++ b/apps/mobile/test/features/digest/youtube_card_test.dart
@@ -24,6 +24,7 @@ void main() {
     ContentType contentType = ContentType.youtube,
     ContentStatus status = ContentStatus.unseen,
     int readingProgress = 0,
+    int? timeSpentSeconds,
     Source? source,
     DateTime? completedAt,
   }) {
@@ -36,6 +37,7 @@ void main() {
       source: source ?? mockSource,
       status: status,
       readingProgress: readingProgress,
+      timeSpentSeconds: timeSpentSeconds,
       completedAt: completedAt,
     );
   }
@@ -104,9 +106,11 @@ void main() {
       expect(c.readingLabel, 'Vu en partie');
     });
 
-    test('returns null below 25% progress when seen', () {
+    test('progress > 0 below 25% (time unknown) → "Vu en partie"', () {
+      // Spectre unifié : progress > 0 compte comme ouvert ; sans time_spent
+      // connu on ne descend jamais à « Ouvert » → « Vu en partie ».
       final c = makeContent(readingProgress: 10, status: ContentStatus.seen);
-      expect(c.readingLabel, isNull);
+      expect(c.readingLabel, 'Vu en partie');
     });
 
     test('returns "Vu en partie" when consumed via timer but no progress', () {
@@ -159,34 +163,46 @@ void main() {
       expect(c.readingLabel, 'Lu jusqu\'au bout');
     });
 
-    test('returns "Lu" at mid progress without a completion stamp', () {
+    test('mid progress, time unknown → "Lu en partie"', () {
       final c = makeContent(
         contentType: ContentType.article,
         readingProgress: 50,
         status: ContentStatus.seen,
         source: mockArticleSource,
       );
-      expect(c.readingLabel, 'Lu');
+      expect(c.readingLabel, 'Lu en partie');
     });
 
-    test('returns "Lu" at low progress — « Parcouru » a été retiré', () {
+    test('consumed via timer, time < 5s → "Ouvert"', () {
       final c = makeContent(
         contentType: ContentType.article,
-        readingProgress: 15,
-        status: ContentStatus.seen,
+        readingProgress: 0,
+        status: ContentStatus.consumed,
+        timeSpentSeconds: 2,
         source: mockArticleSource,
       );
-      expect(c.readingLabel, 'Lu');
+      expect(c.readingLabel, 'Ouvert');
     });
 
-    test('returns "Lu" when consumed via timer with 0 scroll', () {
+    test('consumed via timer, time ≥ 5s → "Lu en partie"', () {
+      final c = makeContent(
+        contentType: ContentType.article,
+        readingProgress: 0,
+        status: ContentStatus.consumed,
+        timeSpentSeconds: 30,
+        source: mockArticleSource,
+      );
+      expect(c.readingLabel, 'Lu en partie');
+    });
+
+    test('consumed via timer, time unknown → "Lu en partie" (jamais Ouvert)', () {
       final c = makeContent(
         contentType: ContentType.article,
         readingProgress: 0,
         status: ContentStatus.consumed,
         source: mockArticleSource,
       );
-      expect(c.readingLabel, 'Lu');
+      expect(c.readingLabel, 'Lu en partie');
     });
   });
 }

--- a/apps/mobile/test/features/feed/feed_carousel_consumed_state_test.dart
+++ b/apps/mobile/test/features/feed/feed_carousel_consumed_state_test.dart
@@ -97,8 +97,11 @@ void main() {
     expect(updated[1].items[0].status, ContentStatus.consumed);
   });
 
-  testWidgets('ReadingBadge renders "Lu" with green check for consumed status',
+  testWidgets(
+      'ReadingBadge renders "Lu en partie" for consumed status without time signal',
       (tester) async {
+    // Sans time_spent (carrousel : payload sans le signal), consommé retombe sur
+    // « Lu en partie », jamais « Ouvert ».
     final consumed = mkContent('a', ContentStatus.consumed);
     await tester.pumpWidget(
       MaterialApp(
@@ -106,7 +109,21 @@ void main() {
         home: Scaffold(body: ReadingBadge(content: consumed)),
       ),
     );
-    expect(find.text('Lu'), findsOneWidget);
+    expect(find.text('Lu en partie'), findsOneWidget);
+  });
+
+  testWidgets('ReadingBadge renders "Ouvert" for opened readState',
+      (tester) async {
+    final consumed = mkContent('a', ContentStatus.consumed);
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: FacteurTheme.lightTheme,
+        home: Scaffold(
+          body: ReadingBadge(content: consumed, readState: ReadState.opened),
+        ),
+      ),
+    );
+    expect(find.text('Ouvert'), findsOneWidget);
   });
 
   test('silent revalidation merge preserves consumed status from current state',

--- a/apps/mobile/test/features/feed/read_state_spectrum_test.dart
+++ b/apps/mobile/test/features/feed/read_state_spectrum_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/feed/models/content_model.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
+
+/// Story 30.4 — spectre d'engagement « Non lu / Ouvert / Lu en partie / Lu
+/// jusqu'au bout ». Fichier volontairement sans dépendance widget/écran : la
+/// logique de dérivation est du pur modèle et doit rester compilable/testable
+/// indépendamment du reste de l'app.
+void main() {
+  final source = Source(
+    id: 's1',
+    name: 'Le Monde',
+    url: 'https://lemonde.fr',
+    type: SourceType.article,
+  );
+
+  Content content({
+    ContentType contentType = ContentType.article,
+    ContentStatus status = ContentStatus.unseen,
+    int readingProgress = 0,
+    int? timeSpentSeconds,
+    DateTime? completedAt,
+  }) {
+    return Content(
+      id: 'c1',
+      title: 'T',
+      url: 'https://lemonde.fr/a',
+      contentType: contentType,
+      publishedAt: DateTime(2026, 7, 24),
+      source: source,
+      status: status,
+      readingProgress: readingProgress,
+      timeSpentSeconds: timeSpentSeconds,
+      completedAt: completedAt,
+    );
+  }
+
+  group('Content.readState', () {
+    test('jamais ouvert → unread', () {
+      expect(content().readState, ReadState.unread);
+      expect(content().readingLabel, isNull);
+    });
+
+    test('consommé + temps < 5s → opened', () {
+      final c = content(status: ContentStatus.consumed, timeSpentSeconds: 2);
+      expect(c.readState, ReadState.opened);
+      expect(c.readingLabel, 'Ouvert');
+    });
+
+    test('consommé + temps ≥ 5s → partiallyRead', () {
+      final c = content(status: ContentStatus.consumed, timeSpentSeconds: 12);
+      expect(c.readState, ReadState.partiallyRead);
+      expect(c.readingLabel, 'Lu en partie');
+    });
+
+    test('temps inconnu (null) → partiallyRead, jamais opened', () {
+      expect(content(status: ContentStatus.consumed).readState,
+          ReadState.partiallyRead);
+    });
+
+    test('vidéo progress ≥ 25 → partiallyRead même sans temps', () {
+      final c = content(
+        contentType: ContentType.youtube,
+        status: ContentStatus.consumed,
+        readingProgress: 25,
+      );
+      expect(c.readState, ReadState.partiallyRead);
+      expect(c.readingLabel, 'Vu en partie');
+    });
+
+    test('vidéo ouverte < 5s → opened', () {
+      final c = content(
+        contentType: ContentType.youtube,
+        status: ContentStatus.consumed,
+        timeSpentSeconds: 1,
+      );
+      expect(c.readState, ReadState.opened);
+    });
+
+    test('completé prime sur tout → completed', () {
+      final c = content(
+        status: ContentStatus.consumed,
+        timeSpentSeconds: 1,
+        completedAt: DateTime(2026, 7, 24, 9),
+      );
+      expect(c.readState, ReadState.completed);
+    });
+  });
+
+  group('opacityForReadState — plus on s\'engage, plus la carte s\'efface', () {
+    test('barème', () {
+      expect(opacityForReadState(ReadState.unread), 1.0);
+      expect(opacityForReadState(ReadState.opened), 0.8);
+      expect(opacityForReadState(ReadState.partiallyRead), 0.6);
+      expect(opacityForReadState(ReadState.completed), 0.6);
+    });
+  });
+
+  group('effectiveReadState — fusion session', () {
+    test('consommé cette session → opened minimum (jamais unread)', () {
+      expect(
+        effectiveReadState(ReadState.unread,
+            consumedThisSession: true, completedThisSession: false),
+        ReadState.opened,
+      );
+    });
+
+    test('complété cette session prime', () {
+      expect(
+        effectiveReadState(ReadState.opened,
+            consumedThisSession: true, completedThisSession: true),
+        ReadState.completed,
+      );
+    });
+
+    test('n\'écrase pas un état serveur déjà plus engagé', () {
+      expect(
+        effectiveReadState(ReadState.partiallyRead,
+            consumedThisSession: true, completedThisSession: false),
+        ReadState.partiallyRead,
+      );
+    });
+  });
+
+  group('Content.fromJson — time_spent_seconds', () {
+    final base = <String, dynamic>{
+      'id': 'c1',
+      'title': 'T',
+      'url': 'https://x',
+      'content_type': 'article',
+      'published_at': '2026-07-24T08:00:00Z',
+      'source': {'id': 's1', 'name': 'S', 'url': 'https://s', 'type': 'article'},
+    };
+
+    test('absent → null', () {
+      expect(Content.fromJson(base).timeSpentSeconds, isNull);
+    });
+
+    test('présent → int', () {
+      expect(
+        Content.fromJson({...base, 'time_spent_seconds': 3}).timeSpentSeconds,
+        3,
+      );
+    });
+  });
+}

--- a/apps/mobile/test/features/feed/reading_completion_test.dart
+++ b/apps/mobile/test/features/feed/reading_completion_test.dart
@@ -62,16 +62,12 @@ void main() {
       },
     );
 
-    test('« Parcouru » a disparu — deux états seulement', () {
-      expect(
-        content(readingProgress: 5, status: ContentStatus.seen).readingLabel,
-        'Lu',
-      );
-    });
-
     test('un article jamais ouvert n\'a aucun libellé', () {
       expect(content().readingLabel, isNull);
     });
+
+    // Spectre complet (opened / partiallyRead / completed), opacité et fusion
+    // session : cf. read_state_spectrum_test.dart (sans dépendance écran).
   });
 
   group('Content.fromJson', () {

--- a/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
@@ -6,6 +6,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/feed/models/content_model.dart';
 import 'package:facteur/features/flux_continu/models/flux_continu_models.dart';
 import 'package:facteur/features/flux_continu/models/weather_location.dart';
 import 'package:facteur/features/flux_continu/models/weather_snapshot.dart';
@@ -163,15 +164,15 @@ void main() {
         findsOneWidget,
       );
       expect(
-        tester
-            .widget<ReadStateMark>(find.byType(ReadStateMark))
-            .isCompleted,
-        isTrue,
+        tester.widget<ReadStateMark>(find.byType(ReadStateMark)).state,
+        ReadState.completed,
       );
     });
 
-    testWidgets('une tuile seulement ouverte reste strictement inchangée',
+    testWidgets('une tuile lue sans temps connu → « Lu en partie »',
         (tester) async {
+      // isRead sans completedAt ni time_spent → spectre retombe sur
+      // partiallyRead (coche pleine simple, 0.6), jamais « Ouvert ».
       await tester.pumpWidget(_wrap(
         EssentielHiFiCard(
           articles: [_article(rank: 1, isRead: true)],
@@ -189,10 +190,8 @@ void main() {
         findsNothing,
       );
       expect(
-        tester
-            .widget<ReadStateMark>(find.byType(ReadStateMark))
-            .isCompleted,
-        isFalse,
+        tester.widget<ReadStateMark>(find.byType(ReadStateMark)).state,
+        ReadState.partiallyRead,
       );
     });
 

--- a/apps/mobile/test/shared/widgets/read_state_mark_test.dart
+++ b/apps/mobile/test/shared/widgets/read_state_mark_test.dart
@@ -2,11 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
+import 'package:facteur/features/feed/models/content_model.dart';
 import 'package:facteur/shared/widgets/read_state_mark.dart';
 
 /// La duplication de cette pastille en trois copies avait déjà produit un bug :
 /// celle de la carte Essentiel codait `check` en dur, donc ne pouvait pas
-/// afficher une complétion. Le choix `check`/`checks` ne vit plus qu'ici.
+/// afficher une complétion. Le choix de la variante ne vit plus qu'ici, piloté
+/// par [ReadState].
 void main() {
   Widget wrap(Widget child) => Directionality(
         textDirection: TextDirection.ltr,
@@ -16,42 +18,70 @@ void main() {
   IconData iconOf(WidgetTester tester) =>
       tester.widget<Icon>(find.byType(Icon)).icon!;
 
-  testWidgets('ouvert seulement → simple coche', (tester) async {
-    await tester.pumpWidget(wrap(const ReadStateMark(color: Colors.green)));
-
-    expect(iconOf(tester), PhosphorIcons.check(PhosphorIconsStyle.bold));
+  testWidgets('unread → rien', (tester) async {
+    await tester.pumpWidget(
+      wrap(const ReadStateMark(color: Colors.green, state: ReadState.unread)),
+    );
+    expect(find.byType(Icon), findsNothing);
   });
 
-  testWidgets('lu jusqu\'au bout → double coche', (tester) async {
+  testWidgets('opened → coche verte + contour pointillé, pas de coche pleine',
+      (tester) async {
     await tester.pumpWidget(
-      wrap(const ReadStateMark(color: Colors.green, isCompleted: true)),
+      wrap(const ReadStateMark(color: Colors.green, state: ReadState.opened)),
+    );
+
+    expect(iconOf(tester), PhosphorIcons.check(PhosphorIconsStyle.bold));
+    // Coche verte (couleur du token), pas blanche → signal secondaire.
+    expect(tester.widget<Icon>(find.byType(Icon)).color, Colors.green);
+    // Contour pointillé présent (CustomPaint du DashedRRectPainter).
+    expect(find.byType(CustomPaint), findsWidgets);
+  });
+
+  testWidgets('partiallyRead → simple coche blanche pleine', (tester) async {
+    await tester.pumpWidget(
+      wrap(
+        const ReadStateMark(color: Colors.green, state: ReadState.partiallyRead),
+      ),
+    );
+
+    expect(iconOf(tester), PhosphorIcons.check(PhosphorIconsStyle.bold));
+    expect(tester.widget<Icon>(find.byType(Icon)).color, Colors.white);
+  });
+
+  testWidgets('completed → double coche blanche', (tester) async {
+    await tester.pumpWidget(
+      wrap(
+        const ReadStateMark(color: Colors.green, state: ReadState.completed),
+      ),
     );
 
     expect(iconOf(tester), PhosphorIcons.checks(PhosphorIconsStyle.bold));
+    expect(tester.widget<Icon>(find.byType(Icon)).color, Colors.white);
   });
 
-  testWidgets('même taille et même couleur dans les deux états',
-      (tester) async {
-    Size sizeOf(Finder f) => tester.getSize(f);
-
+  testWidgets('taille conservée entre les marches', (tester) async {
     await tester.pumpWidget(
-      wrap(const ReadStateMark(color: Colors.green, size: 18)),
+      wrap(
+        const ReadStateMark(
+          color: Colors.green,
+          size: 18,
+          state: ReadState.partiallyRead,
+        ),
+      ),
     );
-    final open = sizeOf(find.byType(ReadStateMark));
-    final openColor = tester.widget<Icon>(find.byType(Icon)).color;
+    final read = tester.getSize(find.byType(ReadStateMark));
 
     await tester.pumpWidget(
       wrap(
         const ReadStateMark(
           color: Colors.green,
           size: 18,
-          isCompleted: true,
+          state: ReadState.completed,
         ),
       ),
     );
 
-    // Un chevron de plus, rien d'autre : aucune surface où lire un reproche.
-    expect(sizeOf(find.byType(ReadStateMark)), open);
-    expect(tester.widget<Icon>(find.byType(Icon)).color, openColor);
+    expect(tester.getSize(find.byType(ReadStateMark)), read);
   });
 }

--- a/docs/stories/core/30.lecture-aboutie/30.4.etat-lecture-ouvert.md
+++ b/docs/stories/core/30.lecture-aboutie/30.4.etat-lecture-ouvert.md
@@ -1,0 +1,77 @@
+# Story 30.4 — 3ème état de lecture « Ouvert »
+
+**Type** : Feature
+**Statut** : En cours
+**Branche** : `boujonlaurin-dotcom/article-opened-state`
+
+## Contexte produit
+
+Une carte d'article avait deux états visuels :
+
+- **« Lu »** → `status == consumed` (ou `reading_progress > 0`). Opacité `0.6`, coche simple.
+- **« Lu jusqu'au bout »** → `completed_at != null`. Opacité `0.6`, double-coche.
+
+Problème : ouvrir un article le passe `consumed` au bout d'**1 s** (`articleReadThreshold`).
+« Lu » ne distingue donc pas *« j'ai parcouru »* de *« j'ai juste ouvert pour voir »* /
+*« j'ai sauvegardé à plus tard puis fermé »*.
+
+## Objectif
+
+Ajouter un 3ème état **« Ouvert »** = ouvert mais quitté vite. Déclencheur : **temps passé
+faible** (`< 5 s`, `kPartialReadThresholdSeconds`), pas le bookmark — ce qui capture
+naturellement le cas « à regarder plus tard ». Les trois états forment un **spectre
+d'engagement unique** (plus on s'engage, plus la carte s'efface).
+
+| État | Déclencheur | Opacité | Coche |
+|---|---|---|---|
+| Non lu | rien | `1.0` | aucune |
+| **Ouvert** (nouveau) | `consumed` && `time_spent < 5s` && non complété | `0.8` | coche verte + contour pointillé |
+| Lu en partie | `consumed` && (`time_spent ≥ 5s` ou vidéo `progress ≥ 25`) | `0.6` | coche pleine blanche |
+| Lu complètement | `completed_at != null` | `0.6` | double-coche |
+
+**Signal « inconnu »** : quand le payload ne porte pas `time_spent_seconds` (`null`), on
+retombe sur **`partiallyRead`** (comportement actuel `0.6`) — pas de régression. « Ouvert »
+n'apparaît que là où le back-end fournit réellement le signal.
+
+## Changements
+
+### Backend (additif, aucune migration — `user_content_status.time_spent_seconds` existe)
+
+- `schemas/content.py` `ContentResponse` : `time_spent_seconds: int = 0` (hérité par
+  `FeedItemResponse`).
+- `schemas/digest.py` `DigestTopicArticle` + `DigestItem` : `time_spent_seconds: int = 0`.
+- `schemas/essentiel.py` `EssentielArticle` : `time_spent_seconds: int = 0`.
+- `recommendation_service.py` : hydrate le champ transient dans `_hydrate_user_status`
+  (feed principal) et le chemin feed sauvegardés.
+- `digest_service.py` : `action_state` porte `time_spent_seconds` ; propagé aux
+  `DigestItem` / `DigestTopicArticle`.
+- `essentiel_service._to_essentiel_article` : passe `time_spent_seconds`.
+
+### Mobile
+
+- `content_model.dart` : champ `timeSpentSeconds` (`int?`, nullable = signal inconnu),
+  enum **`ReadState { unread, opened, partiallyRead, completed }`**, seuil
+  `kPartialReadThresholdSeconds = 5`, helpers `deriveReadState` / `opacityForReadState` /
+  `effectiveReadState` (fusion état session), getter `readState`, `readingLabel` avec cas
+  « Ouvert ».
+- `read_state_mark.dart` : paramètre `ReadState` → 3 variantes (opened = cercle pointillé
+  vert non plein ; read/completed = cercle plein `check`/`checks`).
+- `feed_card.dart` / `flux_continu_article_card.dart` / `essentiel_hi_fi_card.dart` :
+  opacité pilotée par `readState`, coche par `readState`, fusion session
+  (`consumedContentIdsProvider` → `opened` minimum).
+- `essentiel_hi_fi_card` : `EssentielArticle` porte `timeSpentSeconds`.
+- `reading_badge.dart` : libellé « Ouvert ».
+
+## Hors-scope (fast-follow)
+
+- **Flux Continu alimenté par `DigestItem`** (modèle freezed) : reste sur le comportement
+  actuel (`time_spent` inconnu → `partiallyRead`, `0.6`). Câbler `time_spent_seconds` dans
+  le schéma freezed + regen `build_runner` dans une PR suivante.
+
+## Vérification
+
+1. `cd packages/api && pytest -v` (dont test feed exposant `time_spent_seconds`).
+2. `alembic heads` = 1, aucune migration ajoutée.
+3. `cd apps/mobile && flutter test && flutter analyze`.
+4. QA web Playwright (390x844) : ouvrir/fermer < 5 s → « Ouvert » (0.8, coche pointillée
+   verte) ; > 5 s → « Lu en partie » ; lu au bout → « Lu jusqu'au bout ».

--- a/packages/api/app/schemas/content.py
+++ b/packages/api/app/schemas/content.py
@@ -116,6 +116,10 @@ class ContentResponse(BaseModel):
     content_quality: str | None = None  # In-App Reading: 'full', 'partial', 'none'
     recommendation_reason: RecommendationReason | None = None
     reading_progress: int = 0
+    # Temps passé cumulé (s) — départage « Ouvert » (< 5 s) de « Lu en partie »
+    # côté carte. Défaut 0 : sûr quand aucun `UserContentStatus` (item non ouvert
+    # → l'UI le lit comme « non lu » via `status`).
+    time_spent_seconds: int = 0
     completed_at: datetime | None = None
     note_text: str | None = None
     note_updated_at: datetime | None = None

--- a/packages/api/app/schemas/digest.py
+++ b/packages/api/app/schemas/digest.py
@@ -74,6 +74,8 @@ class DigestTopicArticle(BaseModel):
     is_liked: bool = False
     is_dismissed: bool = False
     read_at: datetime | None = None
+    # Temps passé cumulé (s) — départage « Ouvert » (< 5 s) de « Lu en partie ».
+    time_spent_seconds: int = 0
     # « Lu jusqu'au bout » (Epic 30) — null = inconnu, pas « non terminé ».
     completed_at: datetime | None = None
     # Langue détectée du titre (forward-compat — label éventuel mobile).
@@ -166,6 +168,7 @@ class DigestItem(BaseModel):
     is_saved: bool = False
     is_liked: bool = False
     is_dismissed: bool = False
+    time_spent_seconds: int = 0
     completed_at: datetime | None = None
 
     @field_serializer("entities", when_used="always")

--- a/packages/api/app/schemas/essentiel.py
+++ b/packages/api/app/schemas/essentiel.py
@@ -60,6 +60,8 @@ class EssentielArticle(BaseModel):
     is_liked: bool = False
     is_dismissed: bool = False
     read_at: datetime | None = None
+    # Temps passé cumulé (s) — départage « Ouvert » (< 5 s) de « Lu en partie ».
+    time_spent_seconds: int = 0
     # Lecture aboutie (fin d'article atteinte), pas seulement ouverte : c'est ce
     # qui permet à la carte héros de la Tournée d'afficher le filet de complétion.
     completed_at: datetime | None = None

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -2215,6 +2215,7 @@ class DigestService:
                     is_saved=action_state["is_saved"],
                     is_liked=action_state["is_liked"],
                     is_dismissed=action_state["is_dismissed"],
+                    time_spent_seconds=action_state.get("time_spent_seconds", 0),
                     completed_at=action_state.get("completed_at"),
                 )
             )
@@ -2358,6 +2359,7 @@ class DigestService:
                     is_saved=action_state["is_saved"],
                     is_liked=action_state["is_liked"],
                     is_dismissed=action_state["is_dismissed"],
+                    time_spent_seconds=action_state.get("time_spent_seconds", 0),
                     completed_at=action_state.get("completed_at"),
                     read_at=action_state.get("read_at"),
                 )
@@ -2389,6 +2391,7 @@ class DigestService:
                         is_saved=action_state["is_saved"],
                         is_liked=action_state["is_liked"],
                         is_dismissed=action_state["is_dismissed"],
+                        time_spent_seconds=action_state.get("time_spent_seconds", 0),
                         completed_at=action_state.get("completed_at"),
                     )
                 )
@@ -2610,6 +2613,7 @@ class DigestService:
                     is_saved=action_state["is_saved"],
                     is_liked=action_state["is_liked"],
                     is_dismissed=action_state["is_dismissed"],
+                    time_spent_seconds=action_state.get("time_spent_seconds", 0),
                     completed_at=action_state.get("completed_at"),
                     read_at=action_state.get("read_at"),
                 )
@@ -2640,6 +2644,7 @@ class DigestService:
                         is_saved=action_state["is_saved"],
                         is_liked=action_state["is_liked"],
                         is_dismissed=action_state["is_dismissed"],
+                        time_spent_seconds=action_state.get("time_spent_seconds", 0),
                         completed_at=action_state.get("completed_at"),
                     )
                 )
@@ -2712,6 +2717,7 @@ class DigestService:
             "is_saved": status.is_saved,
             "is_liked": status.is_liked,
             "is_dismissed": status.is_hidden,
+            "time_spent_seconds": status.time_spent_seconds or 0,
             "completed_at": status.completed_at,
         }
 
@@ -2742,6 +2748,7 @@ class DigestService:
                 "is_liked": status.is_liked,
                 "is_dismissed": status.is_hidden,
                 "read_at": status.seen_at,
+                "time_spent_seconds": status.time_spent_seconds or 0,
                 "completed_at": status.completed_at,
             }
             for status in statuses

--- a/packages/api/app/services/essentiel_service.py
+++ b/packages/api/app/services/essentiel_service.py
@@ -705,6 +705,7 @@ def _to_essentiel_article(
         is_liked=article.is_liked,
         is_dismissed=article.is_dismissed,
         read_at=article.read_at,
+        time_spent_seconds=article.time_spent_seconds,
         completed_at=article.completed_at,
         is_followed_source=_is_followed_source(article, ctx),
         is_followed_topic=_is_followed_topic(topic, ctx),

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -452,6 +452,7 @@ class RecommendationService:
                 content.hidden_reason = st.hidden_reason
                 content.status = st.status
                 content.reading_progress = st.reading_progress
+                content.time_spent_seconds = st.time_spent_seconds
                 content.completed_at = st.completed_at
                 content.note_text = st.note_text
                 content.note_updated_at = st.note_updated_at
@@ -1057,6 +1058,7 @@ class RecommendationService:
             content.is_hidden = st.is_hidden if st else False
             content.hidden_reason = st.hidden_reason if st else None
             content.status = st.status if st else ContentStatus.UNSEEN
+            content.time_spent_seconds = st.time_spent_seconds if st else 0
             content.completed_at = st.completed_at if st else None
             if followed_source_ids is not None:
                 content.is_followed_source = content.source_id in followed_source_ids

--- a/packages/api/tests/test_feed_time_spent_exposure.py
+++ b/packages/api/tests/test_feed_time_spent_exposure.py
@@ -1,0 +1,88 @@
+"""Story 30.4 — le feed expose `time_spent_seconds` pour départager, côté carte,
+« Ouvert » (< 5 s) de « Lu en partie ».
+
+Pas de DB : on mocke la session et on inspecte l'hydratation du champ transient
++ la sérialisation `ContentResponse`.
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from app.models.content import Content, UserContentStatus
+from app.models.enums import ContentStatus, ContentType
+from app.schemas.content import ContentResponse
+from app.services.recommendation_service import RecommendationService
+
+
+def _content(content_id) -> Content:
+    return Content(id=content_id, source_id=uuid4())
+
+
+def _response_kwargs() -> dict:
+    return {
+        "id": uuid4(),
+        "title": "T",
+        "url": "https://x",
+        "thumbnail_url": None,
+        "content_type": ContentType.ARTICLE,
+        "duration_seconds": None,
+        "published_at": datetime(2026, 7, 24, 8),
+        "source": {
+            "id": uuid4(),
+            "name": "S",
+            "logo_url": None,
+            "type": "article",
+            "theme": None,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_hydrate_user_status_sets_time_spent_seconds():
+    user_id = uuid4()
+    cid_low = uuid4()
+    cid_high = uuid4()
+    cid_none = uuid4()
+
+    statuses = [
+        UserContentStatus(
+            user_id=user_id,
+            content_id=cid_low,
+            status=ContentStatus.CONSUMED,
+            time_spent_seconds=2,
+        ),
+        UserContentStatus(
+            user_id=user_id,
+            content_id=cid_high,
+            status=ContentStatus.CONSUMED,
+            time_spent_seconds=42,
+        ),
+    ]
+
+    session = AsyncMock()
+    session.scalars.return_value = statuses
+
+    items = [_content(cid_low), _content(cid_high), _content(cid_none)]
+    service = RecommendationService(session)
+    await service._hydrate_user_status(items, user_id)
+
+    by_id = {c.id: c for c in items}
+    # Valeur accumulée reflétée telle quelle…
+    assert by_id[cid_low].time_spent_seconds == 2
+    assert by_id[cid_high].time_spent_seconds == 42
+    # …et défaut sûr à 0 quand aucun statut (item jamais ouvert).
+    assert by_id[cid_none].time_spent_seconds == 0
+
+
+def test_content_response_serializes_time_spent_seconds():
+    dumped = ContentResponse(**_response_kwargs(), time_spent_seconds=3).model_dump()
+    assert dumped["time_spent_seconds"] == 3
+
+
+def test_content_response_defaults_time_spent_to_zero():
+    # Champ absent → défaut 0 (jamais None : l'UI lit un int).
+    dumped = ContentResponse(**_response_kwargs()).model_dump()
+    assert dumped["time_spent_seconds"] == 0


### PR DESCRIPTION
## Quoi

Ajoute un 3ème état de lecture **« Ouvert »** = article ouvert mais quitté vite (`time_spent < 5 s`), entre « Non lu » et « Lu en partie ». Les états forment un **spectre d'engagement unique** : plus on s'engage, plus la carte s'efface.

| État | Déclencheur | Opacité | Coche |
|---|---|---|---|
| Non lu | rien | 1.0 | aucune |
| **Ouvert** (nouveau) | `consumed` && `time_spent < 5s` && non complété | 0.8 | verte + contour pointillé |
| Lu en partie | `consumed` && (`time_spent ≥ 5s` ou vidéo `progress ≥ 25`) | 0.6 | pleine blanche |
| Lu jusqu'au bout | `completed_at != null` | 0.6 | double-coche |

Story : `docs/stories/core/30.lecture-aboutie/30.4.etat-lecture-ouvert.md`.

## Comment

- **`ReadState { unread, opened, partiallyRead, completed }`** = source de vérité unique. `deriveReadState` / `opacityForReadState` / `readingLabelForState` / `effectiveReadState` (fusion session) centralisent toute la logique dans `content_model.dart`.
- **Signal « inconnu »** : `timeSpentSeconds` nullable. `null` ⇒ retombe sur `partiallyRead` (comportement historique 0.6), **jamais « Ouvert »** — pas de régression là où le back-end ne fournit pas encore le signal.
- **Fusion session** : un article consommé cette session (POST différé au dispose) reste au minimum « Ouvert », jamais « non lu ».
- `ReadStateMark` : 3 variantes (cercle pointillé vert pour « Ouvert », réutilise `DashedRRectPainter`).

### Backend (additif, **aucune migration** — `user_content_status.time_spent_seconds` préexiste)
`ContentResponse` / `DigestTopicArticle` / `DigestItem` / `EssentielArticle` exposent `time_spent_seconds` ; hydratation dans `recommendation_service` (feed + sauvegardés), `digest_service` (action_state), `essentiel_service`.

## Différé (documenté dans la story)
Le flux alimenté par le modèle mobile **`DigestItem` (freezed)** ne parse pas encore `time_spent_seconds` → reste sur « Lu en partie ». Le back-end est déjà prêt ; la PR suivante n'aura qu'à ajouter le champ + regen `build_runner`.

## Vérification
- **Backend** : suite complète **2687 passed, 0 failed** (dont nouveau `test_feed_time_spent_exposure.py` + digest/essentiel DB). `alembic heads` = 1, 0 migration. `ruff check` clean.
- **Mobile** : logique du spectre verte — `read_state_spectrum_test.dart` (13), `youtube_card_test`, `read_state_mark_test`, `feed_carousel_consumed_state_test`. `flutter analyze` sans erreur sur les fichiers modifiés.
- ⚠️ **Pré-existant hors-scope** : plusieurs fichiers de tests widget (essentiel/flux/reading_completion) ne **compilent pas** sur `main` à cause du bug `firstPreparingIndex` (`flux_continu_screen.dart`, cassé depuis PR #1026) — sans rapport avec cette feature. Mes assertions y sont mises à jour et passeront une fois le screen réparé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)