### PR TITLE
fix(flux-continu): borne le pull-to-refresh Essentiel + escalade « rien de neuf »

### DIFF
--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -1618,17 +1618,55 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     await ref.read(tourneeProgressServiceProvider).markEssentielViewedToday();
   }
 
-  /// Pull-to-refresh: refetch all upstream calls from scratch.
+  /// Budget maximal d'un pull-to-refresh. Un appel nominal se résout bien en
+  /// dessous ; ce plafond coupe le pire cas (chaque appel Dio = 30s timeout +
+  /// [RetryInterceptor] `[1s, 3s]` ⇒ ~94s) qui faisait tourner le
+  /// [RefreshIndicator] > 20s. Vit **uniquement** sur le chemin [refresh] :
+  /// [_fetchAll] (build/cold-boot) et les retries globaux restent intacts.
+  static const _kRefreshBudget = Duration(seconds: 8);
+
+  /// Pull-to-refresh: refetch all upstream calls from scratch, borné à
+  /// [_kRefreshBudget].
   ///
   /// Crucially we do NOT bounce through [AsyncLoading] — doing so would
   /// tear down the [RefreshIndicator] mid-pull (the screen renders the
   /// loading skeleton in place of the scroll view), making the gesture
   /// feel broken. Keeping the previous data mounted lets the native
   /// indicator stay visible until the refetch resolves.
-  Future<void> refresh() async {
-    final next = await AsyncValue.guard(_fetchAll);
+  ///
+  /// Renvoie un record léger permettant à l'écran de distinguer « rien de neuf »
+  /// (`succeeded=true`, `newSinceMorning==0`) d'un refresh borné/échoué
+  /// (`succeeded=false` — on ne redirige alors PAS vers Flâner, ce serait
+  /// masquer un souci de perf). En cas de timeout/erreur **avec** un état déjà
+  /// monté, on **conserve** les données précédentes (le spinner s'arrête net,
+  /// feed inchangé, pas d'écran d'erreur). Le [_fetchAll] abandonné continue en
+  /// arrière-plan (Dart n'a pas d'annulation sans `CancelToken`) : ses futures
+  /// Dio sont avalées par [_safe] (inoffensif) et son cache write final finit
+  /// par s'exécuter avec du contenu frais — seul le spinner est borné, pas le
+  /// travail sous-jacent.
+  Future<({bool succeeded, int newSinceMorning})> refresh() async {
+    final next =
+        await AsyncValue.guard(() => _fetchAll().timeout(_kRefreshBudget));
+    if (next.hasError) {
+      // Refresh borné (timeout) ou échoué. Si on a déjà des données montées, on
+      // les garde (contrat « keep previous data mounted ») ; sinon on remonte
+      // l'erreur comme aujourd'hui (cold-boot sans donnée à préserver).
+      if (!state.hasValue) state = next;
+      return (succeeded: false, newSinceMorning: 0);
+    }
     state = next;
+    final value = next.value;
+    return (
+      succeeded: true,
+      newSinceMorning: value == null ? 0 : _newSinceMorningOf(value),
+    );
   }
+
+  /// `new_since_this_morning` porté par l'[EssentielSection] d'un état, 0 si
+  /// absente. Signal non-fragile consommé par l'escalade « rien de neuf ».
+  int _newSinceMorningOf(FluxContinuState value) =>
+      value.sections.whereType<EssentielSection>().firstOrNull?.newSinceMorning ??
+      0;
 
   /// Builds the v3 "L'Essentiel du jour" hi-fi section from the 5 articles
   /// returned by `GET /api/essentiel`. Returns `null` when the endpoint hasn't

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -157,6 +157,47 @@ bool shouldRefreshEssentielOnForeground({
   return true;
 }
 
+/// Fenêtre pendant laquelle un **re-pull** explicite à vide compte comme « tout
+/// de suite après » le précédent → escalade vers la redirection auto Flâner.
+const Duration essentielRePullWindow = Duration(seconds: 45);
+
+/// Escalade « rien de neuf » d'un pull-to-refresh explicite de L'Essentiel.
+enum EssentielEmptyPullAction {
+  /// Nouveauté, ou refresh borné/échoué : aucun hint, on reset l'escalade.
+  none,
+
+  /// 1er pull à vide : SnackBar + CTA « Flâner », pas de redirection.
+  hint,
+
+  /// Re-pull à vide rapproché (< [essentielRePullWindow]) : bascule auto Flâner.
+  redirect,
+}
+
+/// Décision pure de l'escalade « rien de neuf » sur un pull-to-refresh
+/// **explicite** (décidée avec le PO). Testable sans monter l'écran
+/// (cf. [shouldRefreshEssentielOnForeground]).
+///
+/// - On n'escalade QUE sur un refresh réussi ET sans nouveauté : un refresh
+///   borné/échoué (`succeeded == false`) ne redirige jamais — ce serait masquer
+///   un souci de perf. Un `newSinceMorning > 0` remet l'escalade à zéro.
+/// - Un 1er pull à vide → [EssentielEmptyPullAction.hint] ; un re-pull dans la
+///   [rePullWindow] → [EssentielEmptyPullAction.redirect].
+@visibleForTesting
+EssentielEmptyPullAction essentielEmptyPullAction({
+  required bool succeeded,
+  required int newSinceMorning,
+  required DateTime? lastEmptyPullAt,
+  required DateTime now,
+  Duration rePullWindow = essentielRePullWindow,
+}) {
+  if (!succeeded || newSinceMorning > 0) return EssentielEmptyPullAction.none;
+  final repulledFast = lastEmptyPullAt != null &&
+      now.difference(lastEmptyPullAt) <= rePullWindow;
+  return repulledFast
+      ? EssentielEmptyPullAction.redirect
+      : EssentielEmptyPullAction.hint;
+}
+
 /// Comptabilité de la session Essentiel pour le garde-fou doomscroll (story
 /// 9.8). Chrono **foreground** (suspendu en arrière-plan) + flag de complétion
 /// de la carte de clôture, avec émission fire-once. Pur et à horloge injectée
@@ -390,6 +431,14 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
   /// (cf. [shouldRefreshEssentielOnForeground]).
   DateTime? _backgroundedAt;
   DateTime? _lastForegroundRefreshAt;
+
+  /// Escalade « rien de neuf » → Flâner (décidée avec le PO). Horodatage du
+  /// dernier pull explicite à vide : un 1er pull à vide affiche un SnackBar +
+  /// CTA « Flâner », un **re-pull** rapproché (dans [essentielRePullWindow])
+  /// bascule automatiquement vers l'onglet Flâner. Un refresh avec nouveauté ou
+  /// borné/échoué le remet à `null`. L'auto-redirect ne se déclenche jamais sur
+  /// le refresh foreground (réservé au geste explicite).
+  DateTime? _lastEmptyPullAt;
 
   /// Story 9.8 — instrumentation « garde-fou doomscroll ». Durée foreground de
   /// la session Essentiel + complétion de la carte de clôture, émises une fois
@@ -863,11 +912,35 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
     if (_pendingFeedback.isNotEmpty) {
       setState(_pendingFeedback.clear);
     }
-    await ref.read(fluxContinuProvider.notifier).refresh();
+    final outcome = await ref.read(fluxContinuProvider.notifier).refresh();
+    final now = DateTime.now();
     // Un refresh explicite réarme le cooldown foreground : pas de double refetch
     // si l'app repasse en arrière-plan puis revient juste après.
-    _lastForegroundRefreshAt = DateTime.now();
+    _lastForegroundRefreshAt = now;
     if (!mounted) return;
+    // Escalade « rien de neuf » → Flâner (décidée avec le PO). Décision pure
+    // déléguée à [essentielEmptyPullAction] (testable sans monter l'écran).
+    final action = essentielEmptyPullAction(
+      succeeded: outcome.succeeded,
+      newSinceMorning: outcome.newSinceMorning,
+      lastEmptyPullAt: _lastEmptyPullAt,
+      now: now,
+    );
+    switch (action) {
+      case EssentielEmptyPullAction.redirect:
+        // Re-pull à vide rapproché → bascule auto vers Flâner (contenu frais).
+        // Return early : pas de scroll-to-top, on change d'onglet.
+        _lastEmptyPullAt = null;
+        context.go(RoutePaths.flaner);
+        return;
+      case EssentielEmptyPullAction.hint:
+        // 1er pull à vide → SnackBar + CTA « Flâner » (aucune redirection).
+        _lastEmptyPullAt = now;
+        _showRienDeNeufFlanerSnackBar();
+      case EssentielEmptyPullAction.none:
+        // Nouveauté ou refresh borné/échoué → reset de l'escalade.
+        _lastEmptyPullAt = null;
+    }
     if (_scroll.hasClients) {
       unawaited(
         _scroll.animateTo(
@@ -954,7 +1027,31 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
       return;
     }
     _lastForegroundRefreshAt = now;
-    unawaited(ref.read(fluxContinuProvider.notifier).refresh());
+    // Refresh auto au retour premier plan : à vide → SnackBar « Flâner »
+    // uniquement (jamais de redirection auto — réservée au re-pull explicite),
+    // et **sans** toucher le compteur d'escalade. Déjà cooldown-gaté par
+    // [shouldRefreshEssentielOnForeground], donc pas de spam.
+    unawaited(
+      ref.read(fluxContinuProvider.notifier).refresh().then((outcome) {
+        if (!mounted) return;
+        if (outcome.succeeded && outcome.newSinceMorning == 0) {
+          _showRienDeNeufFlanerSnackBar();
+        }
+      }),
+    );
+  }
+
+  /// SnackBar « rien de neuf » + CTA « Flâner » de L'Essentiel. Les deux chemins
+  /// de refresh (pull explicite et retour premier plan) l'affichent à l'identique
+  /// ; l'appelant garantit `mounted` au préalable.
+  void _showRienDeNeufFlanerSnackBar() {
+    NotificationService.showInfo(
+      'Rien de neuf dans ton Essentiel pour l\'instant.',
+      actionLabel: 'Flâner',
+      icon: PhosphorIcons.compass(),
+      onAction: () => context.go(RoutePaths.flaner),
+      context: context,
+    );
   }
 
   /// Opens the dedicated full-page view for a [FeedThemeSection]. The
@@ -1812,6 +1909,13 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
     final inviteTargetIndex = state.sections.length < 2
         ? -1
         : math.max(1, state.sections.length - 3);
+
+    // Un seul indicateur d'attente pour toute la Tournée : la **première**
+    // coquille de section encore non résolue porte le libellé « Ta tournée se
+    // prépare… » (les autres restent des cartes shimmer nues). -1 = aucune.
+    final firstPreparingIndex = state.sections.indexWhere(
+      (s) => s is FeedThemeSection && s.isPlaceholder,
+    );
 
     final slivers = <SliverToBoxAdapter>[];
     for (var i = 0; i < state.sections.length; i++) {

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -346,7 +346,7 @@ packages:
     source: hosted
     version: "2.0.8"
   fake_async:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: fake_async
       sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -110,6 +110,7 @@ dependencies:
 dev_dependencies:
   mocktail: ^1.0.3
   mockito: ^5.4.4
+  fake_async: ^1.3.1
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
@@ -1,5 +1,7 @@
+import 'dart:async';
 import 'dart:io';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:facteur/core/auth/auth_state.dart' as app_auth;
 import 'package:facteur/features/digest/models/digest_models.dart';
 import 'package:facteur/features/digest/models/dual_digest_response.dart';
@@ -1635,6 +1637,127 @@ void main() {
       );
     });
   });
+
+  group('FluxContinuNotifier — refresh borné + record', () {
+    EssentielArticle essArticle(String id, {int rank = 1}) => EssentielArticle(
+          contentId: id,
+          title: 'Essentiel $id',
+          url: 'https://x.test/$id',
+          publishedAt: DateTime(2026, 1, 1),
+          sourceName: 'Source',
+          sourceLetter: 'S',
+          sectionLabel: 'Tech',
+          rank: rank,
+        );
+
+    ProviderContainer makeRefreshContainer(
+      _ControllableEssentielRepository essentiel,
+    ) {
+      return ProviderContainer(
+        overrides: [
+          digestRepositoryProvider.overrideWithValue(digestRepo),
+          feedRepositoryProvider.overrideWithValue(feedRepo),
+          fluxContinuRepositoryProvider.overrideWithValue(fluxRepo),
+          essentielRepositoryProvider.overrideWithValue(essentiel),
+          grilleRepositoryProvider.overrideWithValue(_NoGrilleRepository()),
+          userInterestsProvider.overrideWith(
+            () => _StubUserInterestsNotifier(_interestsState()),
+          ),
+          sereinToggleProvider
+              .overrideWith((ref) => SereinToggleNotifier(ref, null)),
+          displayModeSpecProvider.overrideWithValue(DisplayModeSpec.normal),
+        ],
+      );
+    }
+
+    test('refresh réussi → succeeded=true + newSinceMorning remonté', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final essentiel = _ControllableEssentielRepository(
+        articles: [essArticle('a'), essArticle('b', rank: 2), essArticle('c', rank: 3)],
+        newSinceMorning: 3,
+      );
+      final container = makeRefreshContainer(essentiel);
+      addTearDown(container.dispose);
+
+      final baseline = await settle(container);
+      expect(
+        baseline.sections.whereType<EssentielSection>().single.newSinceMorning,
+        3,
+      );
+
+      final outcome =
+          await container.read(fluxContinuProvider.notifier).refresh();
+      expect(outcome.succeeded, isTrue);
+      expect(outcome.newSinceMorning, 3);
+    });
+
+    test(
+      'refresh borné (repo qui hang) → Future résolu ~budget, état conservé, '
+      'succeeded=false',
+      () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        final essentiel = _ControllableEssentielRepository(
+          articles: [essArticle('a'), essArticle('b', rank: 2), essArticle('c', rank: 3)],
+          newSinceMorning: 2,
+        );
+        final container = makeRefreshContainer(essentiel);
+        addTearDown(container.dispose);
+
+        final baseline = await settle(container);
+        expect(baseline.sections.whereType<EssentielSection>(), isNotEmpty);
+
+        // À partir de maintenant l'endpoint essentiel « pend » indéfiniment :
+        // seul le budget de [refresh] doit dénouer l'attente.
+        essentiel.hang = true;
+
+        ({bool succeeded, int newSinceMorning})? outcome;
+        fakeAsync((async) {
+          container
+              .read(fluxContinuProvider.notifier)
+              .refresh()
+              .then((v) => outcome = v);
+          // En deçà du budget (8s), rien n'est résolu.
+          async.elapse(const Duration(seconds: 7));
+          expect(outcome, isNull);
+          // Passé le budget, le refresh se dénoue (timeout interne).
+          async.elapse(const Duration(seconds: 2));
+          async.flushMicrotasks();
+        });
+
+        expect(outcome, isNotNull);
+        expect(outcome!.succeeded, isFalse);
+        // Contrat « keep previous data mounted » : l'état affiché est inchangé.
+        expect(
+          identical(
+            container.read(fluxContinuProvider).requireValue,
+            baseline,
+          ),
+          isTrue,
+        );
+      },
+    );
+  });
+}
+
+/// EssentielRepository pilotable : renvoie une liste fixe, ou « pend »
+/// indéfiniment quand [hang] est vrai — pour exercer la borne de [refresh].
+class _ControllableEssentielRepository implements EssentielRepository {
+  _ControllableEssentielRepository({
+    required this.articles,
+    this.newSinceMorning = 0,
+  });
+
+  final List<EssentielArticle> articles;
+  final int newSinceMorning;
+  bool hang = false;
+
+  @override
+  Future<EssentielFetchResult?> fetch({bool? serein, DateTime? date}) {
+    if (hang) return Completer<EssentielFetchResult?>().future;
+    return Future.value(
+      (articles: articles, newSinceMorning: newSinceMorning),
+    );
+  }
 }
 
 /// Stub EssentielRepository centré sur un [EssentielArticle] précis (dont les

--- a/apps/mobile/test/features/flux_continu/screens/flux_continu_foreground_refresh_test.dart
+++ b/apps/mobile/test/features/flux_continu/screens/flux_continu_foreground_refresh_test.dart
@@ -79,4 +79,72 @@ void main() {
       );
     });
   });
+
+  group('essentielEmptyPullAction', () {
+    final now = DateTime(2026, 7, 30, 9);
+
+    test('refresh borné/échoué → aucune escalade (jamais de redirection)', () {
+      // On ne redirige pas sur un `succeeded == false` : ce serait masquer un
+      // souci de perf plutôt qu'un manque de nouveauté.
+      expect(
+        essentielEmptyPullAction(
+          succeeded: false,
+          newSinceMorning: 0,
+          lastEmptyPullAt: now.subtract(const Duration(seconds: 5)),
+          now: now,
+        ),
+        EssentielEmptyPullAction.none,
+      );
+    });
+
+    test('nouveauté (newSinceMorning > 0) → reset, aucune escalade', () {
+      expect(
+        essentielEmptyPullAction(
+          succeeded: true,
+          newSinceMorning: 2,
+          lastEmptyPullAt: now.subtract(const Duration(seconds: 5)),
+          now: now,
+        ),
+        EssentielEmptyPullAction.none,
+      );
+    });
+
+    test('1er pull à vide → hint (SnackBar + CTA, pas de redirection)', () {
+      expect(
+        essentielEmptyPullAction(
+          succeeded: true,
+          newSinceMorning: 0,
+          lastEmptyPullAt: null,
+          now: now,
+        ),
+        EssentielEmptyPullAction.hint,
+      );
+    });
+
+    test('re-pull à vide rapproché (< fenêtre) → redirection auto', () {
+      expect(
+        essentielEmptyPullAction(
+          succeeded: true,
+          newSinceMorning: 0,
+          lastEmptyPullAt: now.subtract(essentielRePullWindow -
+              const Duration(seconds: 1)),
+          now: now,
+        ),
+        EssentielEmptyPullAction.redirect,
+      );
+    });
+
+    test('pull à vide hors fenêtre → hint (l\'escalade s\'est refroidie)', () {
+      expect(
+        essentielEmptyPullAction(
+          succeeded: true,
+          newSinceMorning: 0,
+          lastEmptyPullAt: now.subtract(essentielRePullWindow +
+              const Duration(seconds: 1)),
+          now: now,
+        ),
+        EssentielEmptyPullAction.hint,
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Quoi

Le pull-to-refresh de L'Essentiel pouvait faire tourner le `RefreshIndicator`
>20s (pire cas ~94s : 30s de timeout Dio × retries), donnant un ressenti de
« chargement infini ». On borne chaque pull à un budget de **8s** : le spinner
s'arrête net, les données déjà montées sont conservées (pas d'écran d'erreur),
et le `_fetchAll` abandonné finit en tâche de fond (Dart n'annule pas sans
`CancelToken`).

`refresh()` renvoie désormais un record `(succeeded, newSinceMorning)` qui
pilote l'escalade **« rien de neuf » → Flâner** (décidée avec le PO) :
- 1er pull à vide → SnackBar + CTA « Flâner »
- re-pull rapproché (< 45s) → bascule auto vers Flâner
- refresh borné/échoué → **jamais** de redirection (ne pas masquer un souci de perf)

La décision est une fonction pure testable (`essentielEmptyPullAction`), sans
monter l'écran.

## Pourquoi

Bug « refresh infini » de l'écran Essentiel : un backend lent + la politique de
retry globale faisaient tourner l'indicateur bien au-delà du raisonnable. Le
budget côté client coupe le pire cas tout en gardant les retries globaux
intacts sur le chemin cold-boot/build.

## Comment ça a été vérifié

- [x] `flutter test` sur les deux suites touchées (44 tests OK)
- [x] `flutter analyze` sur les fichiers modifiés → No issues found
- [x] Suite mobile complète : 1914 pass / 30 fails **tous pré-existants** sur `origin/main` (aucune régression ; suites modifiées vertes)
- [x] `/simplify` passé (SnackBar dupliqué extrait, `_newSinceMorningOf` simplifié, doc corrigée)

## Zones à risque

- `flux_continu_provider.dart` — `refresh()` change de signature (`Future<void>` → record) ; tous les appelants dans `flux_continu_screen.dart` mis à jour.
- Timeout côté UI = mitigation ciblée, pas un fix backend : la vraie racine (retry-interceptor sur le chemin interactif) reste un suivi.