### PR TITLE
fix(flux-continu): restaure firstPreparingSectionIndex (build mobile cassé)

### DIFF
--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -157,6 +157,17 @@ bool shouldRefreshEssentielOnForeground({
   return true;
 }
 
+/// Un seul indicateur d'attente pour toute la Tournée : la **première** coquille
+/// de section encore non résolue porte le libellé « Ta tournée se prépare… »
+/// (les autres restent des cartes shimmer nues). `-1` = aucune coquille.
+///
+/// Extrait de `build` pour être testable sans monter l'écran (Supabase, Hive et
+/// GoRouter y sont requis) : la déclaration inline avait été supprimée par
+/// erreur lors d'une résolution de conflit, cassant tout build mobile.
+@visibleForTesting
+int firstPreparingSectionIndex(List<FluxSection> sections) =>
+    sections.indexWhere((s) => s is FeedThemeSection && s.isPlaceholder);
+
 /// Comptabilité de la session Essentiel pour le garde-fou doomscroll (story
 /// 9.8). Chrono **foreground** (suspendu en arrière-plan) + flag de complétion
 /// de la carte de clôture, avec émission fire-once. Pur et à horloge injectée
@@ -1812,6 +1823,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
     final inviteTargetIndex = state.sections.length < 2
         ? -1
         : math.max(1, state.sections.length - 3);
+    final firstPreparingIndex = firstPreparingSectionIndex(state.sections);
 
     final slivers = <SliverToBoxAdapter>[];
     for (var i = 0; i < state.sections.length; i++) {

--- a/apps/mobile/test/features/flux_continu/screens/flux_continu_preparing_label_test.dart
+++ b/apps/mobile/test/features/flux_continu/screens/flux_continu_preparing_label_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:facteur/features/feed/models/content_model.dart';
+import 'package:facteur/features/flux_continu/models/flux_continu_models.dart';
+import 'package:facteur/features/flux_continu/screens/flux_continu_screen.dart';
+import 'package:facteur/features/sources/models/source_model.dart';
+
+/// Garde-fou du libellé d'attente « Ta tournée se prépare… ». Le test widget de
+/// `SectionBlock` couvre `showPreparingLabel: true/false` **en isolation** : il
+/// n'a donc pas pu attraper la suppression accidentelle du calcul d'index côté
+/// écran (build mobile cassé sur `main`). Ce fichier couvre l'autre moitié : sur
+/// une Tournée partiellement résolue, **une seule** coquille est désignée.
+///
+/// Monter `FluxContinuScreen` entier n'est pas jouable en test unitaire
+/// (Supabase, Hive et GoRouter y sont requis) — d'où le helper top-level
+/// `firstPreparingSectionIndex`, référencé ici : le supprimer casse la
+/// compilation du test, pas seulement celle de l'app.
+
+FeedThemeSection _resolvedTheme(String slug) => FeedThemeSection(
+      kind: SectionKind.theme,
+      label: 'Thème $slug',
+      accent: const Color(0xFF1565C0),
+      coreVisibleCount: 5,
+      themeSlug: slug,
+      items: [
+        Content(
+          id: '$slug-1',
+          title: 'titre-$slug',
+          url: 'https://x/$slug/1',
+          contentType: ContentType.article,
+          publishedAt: DateTime(2026, 1, 1),
+          source: Source(id: 's', name: 'S', type: SourceType.article),
+        ),
+      ],
+    );
+
+FeedThemeSection _placeholderTheme(String slug) => FeedThemeSection(
+      kind: SectionKind.theme,
+      label: 'Thème $slug',
+      accent: const Color(0xFF1565C0),
+      coreVisibleCount: 5,
+      themeSlug: slug,
+      items: const <Content>[],
+      hasMore: false,
+      isPlaceholder: true,
+    );
+
+void main() {
+  group('firstPreparingSectionIndex', () {
+    test('désigne la première coquille et une seule', () {
+      // 1 section résolue puis 2 coquilles : seul l'index 1 porte le libellé.
+      final sections = <FluxSection>[
+        _resolvedTheme('tech'),
+        _placeholderTheme('monde'),
+        _placeholderTheme('sport'),
+      ];
+      final designated = firstPreparingSectionIndex(sections);
+
+      expect(designated, 1);
+      // Exactement une section désignée sur toute la Tournée : échoue si le
+      // libellé disparaît (-1) comme s'il se duplique sur chaque coquille.
+      final labelled = [
+        for (var i = 0; i < sections.length; i++)
+          if (i == designated) i,
+      ];
+      expect(labelled, hasLength(1));
+    });
+
+    test('aucune coquille → aucun libellé', () {
+      expect(
+        firstPreparingSectionIndex([_resolvedTheme('tech')]),
+        -1,
+      );
+      expect(firstPreparingSectionIndex(const []), -1);
+    });
+
+    test('une Tournée entièrement en coquilles ne désigne que la première', () {
+      expect(
+        firstPreparingSectionIndex([
+          _placeholderTheme('monde'),
+          _placeholderTheme('sport'),
+        ]),
+        0,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Base `main`. **Aucune migration.** Mobile-only (2 fichiers).

## Le bug

Depuis #1026, **tout build mobile échoue à la compilation** — APK comme web.
La résolution de conflit de cette PR a supprimé la déclaration de
`firstPreparingIndex` dans `build()`, alors que la boucle de sections continuait
de l'utiliser plus bas. La CI ne l'a pas vu : `flutter` n'y tourne pas (cf.
`project_ci_no_flutter_tests`), seule la CI backend est verte.

## Le fix

Le calcul est réextrait en fonction top-level `firstPreparingSectionIndex`,
annotée `@visibleForTesting` :

```dart
int firstPreparingSectionIndex(List<FluxSection> sections) =>
    sections.indexWhere((s) => s is FeedThemeSection && s.isPlaceholder);
```

L'extraction n'est pas cosmétique : monter `FluxContinuScreen` en test exige
Supabase, Hive et GoRouter, donc la règle n'était couvrable qu'au prix d'un
widget test lourd. Top-level, elle se teste en pur.

**Comportement inchangé** : un seul indicateur d'attente pour toute la Tournée —
la première coquille de section non résolue porte « Ta tournée se prépare… », les
autres restent des cartes shimmer nues. `-1` = aucune coquille.

## Tests

`test/features/flux_continu/screens/flux_continu_preparing_label_test.dart`, 3 cas :
désignation de la première coquille **et d'une seule** ; aucune coquille → aucun
libellé ; Tournée entièrement en coquilles → seule la première est désignée.

## Vérification

| Étape | Résultat |
|---|---|
| `flutter build apk --debug --flavor beta` | ✅ `app-beta-debug.apk` — **c'est la preuve du fix** |
| Test ciblé | ✅ 3/3 |
| `flutter analyze` (fichiers touchés) | ✅ No issues found |
| `flutter test` (suite) | 1910 pass / 30 échecs, **tous pré-existants et hors périmètre** (bookmark, feed_sources, topic_chip, changelog_asset, notification, router_redirection, widget_test) ; aucun test `flux_continu` ne casse |

Note : le flavor de smoke est `beta` (les flavors Android sont `beta` /
`playstore`) ; `CLAUDE.md` documente encore `--flavor staging`, qui n'existe pas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)