### PR TITLE
feat(reco): carrousels semi-éditorialisés partagés Essentiel ⇄ Flâner (story 32.1)

### DIFF
--- a/apps/mobile/lib/core/auth/auth_state.dart
+++ b/apps/mobile/lib/core/auth/auth_state.dart
@@ -453,8 +453,14 @@ class AuthStateNotifier extends StateNotifier<AuthState>
               ) ==
               true;
 
-      // Capturer AVANT la mise à jour du state pour détecter les transitions
-      final bool isNewSignIn = state.user == null && user != null;
+      // Capturer AVANT la mise à jour du state pour détecter les transitions.
+      // Comparer par id (pas juste null → non-null) : une session anonyme a
+      // déjà un `state.user` non-null, donc se connecter à un compte réel
+      // depuis l'anonyme (CTA « J'ai déjà un compte ») ne doit pas être
+      // ignoré ici — sinon `needsOnboarding` reste bloqué sur la valeur de
+      // l'anonyme (toujours `true`) et le vrai statut DB n'est jamais relu.
+      final bool isNewSignIn =
+          user != null && state.user?.id != user.id;
       _noteRealAccount(user);
 
       state = state.copyWith(

--- a/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
+++ b/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
@@ -25,7 +25,7 @@ const int kThemeFewFollowedSources = 6; // < 6 = « peu de sources »
 /// réutilisant le payload [FeedThemeSection] (champs `sourceId`/`sourceLogoUrl`).
 /// `alerts` (6ème kind) porte le rappel des cloches « alerte source rare » ayant
 /// du neuf : une carte compacte, pas un flux d'articles (cf. [AlertsSection]).
-enum SectionKind { essentiel, bonnes, theme, veille, source, alerts }
+enum SectionKind { essentiel, bonnes, theme, veille, source, alerts, carousel }
 
 /// Origine d'une section de la Tournée du jour (Story 22.3).
 ///
@@ -98,6 +98,7 @@ String sectionKey(FluxSection section) {
   return switch (section) {
     EssentielSection() => 'essentiel_v3',
     AlertsSection() => kAlertsSectionKey,
+    CarouselSection() => kCarouselSectionKey,
     DigestTopicSection() => section.kind.name,
     FeedThemeSection(
       :final kind,
@@ -334,6 +335,33 @@ class AlertsSection extends FluxSection {
   int get totalCount => items.length;
 }
 
+/// Clé stable de la carte carrousel du jour (Story 32.1). Constante (comme
+/// [kAlertsSectionKey]) : la carte vit hors de l'ordre configurable de la
+/// Tournée, insérée directement dans `_compose`.
+const String kCarouselSectionKey = 'carousel';
+
+/// Carte carrousel semi-éditorialisé du jour (Story 32.1), mutualisée avec
+/// Flâner. Un seul type par jour (rotation date-seedée côté backend), servi par
+/// `GET /api/essentiel` (champ `carousel`).
+///
+/// Comme [AlertsSection], c'est une carte **auto-portée** (taille fixe) : elle
+/// vit hors du cap de sections et échappe au fit (`_capSectionToFit`). Rendue
+/// par `FeedCarousel` (PageView paginé + dots).
+class CarouselSection extends FluxSection {
+  final FeedCarouselData data;
+
+  CarouselSection({required this.data})
+      : super(
+          kind: SectionKind.carousel,
+          label: data.title,
+          accent: const Color(0xFFB0470A),
+          coreVisibleCount: data.items.length,
+        );
+
+  @override
+  int get totalCount => data.items.length;
+}
+
 /// Section backed by `digest.topics` (Essentiel, Bonnes Nouvelles). One
 /// card per topic — the lead article is selected via [pickTopicLead].
 class DigestTopicSection extends FluxSection {
@@ -516,6 +544,12 @@ Set<String> renderedContentIds(List<FluxSection> sections) {
       case AlertsSection():
         // Le rappel ne rend aucun article : il n'a rien à retirer de l'Explorer.
         break;
+      case CarouselSection(:final data):
+        // Les articles du carrousel sont bien rendus : on les retire de
+        // l'Explorer aval pour éviter un doublon vertical sous la carte.
+        for (final item in data.items) {
+          seen.add(item.id);
+        }
       case DigestTopicSection(:final topics):
         for (final topic in topics) {
           if (topic.articles.isEmpty) continue;
@@ -540,7 +574,12 @@ FluxSection? nextSectionAfter(List<FluxSection> sections, String currentKey) {
   final ordered = sections
       .whereType<FluxSection>()
       .where((s) {
-        if (s is EssentielSection || s is AlertsSection) return false;
+        // La carte carrousel n'a pas de page dédiée (comme Essentiel/Alertes).
+        if (s is EssentielSection ||
+            s is AlertsSection ||
+            s is CarouselSection) {
+          return false;
+        }
         return true;
       })
       .toList(growable: false);

--- a/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
+++ b/apps/mobile/lib/features/flux_continu/providers/flux_continu_provider.dart
@@ -152,6 +152,11 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
   // celle-ci reprend les topics du digest sous le nouveau nom.
   FluxSection? _actusDuJour;
   FluxSection? _bonnes;
+  // Story 32.1 — carrousel semi-éditorialisé du jour servi par `/api/essentiel`
+  // (`carousel`), mutualisé avec Flâner. `null` hors édition du jour ou si aucun
+  // type n'est éligible. Inséré hors-cap en fin de `_compose` (comme les
+  // alertes). Non caché (surface additive, live, today-only).
+  FeedCarouselData? _essentielCarousel;
   // Up to [_kMaxFavoriteSections] theme/topic sections, ordered to mirror
   // `userInterestsProvider.favorites`. Empty when the user has no favorites
   // — the tournée then collapses to digest only.
@@ -486,9 +491,17 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
         // dépendance à la persistance DB de la préférence au moment du refetch.
         () async =>
             (await _essentielRepo.fetch(serein: isSerene)) ??
-            (articles: const <EssentielArticle>[], newSinceMorning: 0),
+            (
+              articles: const <EssentielArticle>[],
+              newSinceMorning: 0,
+              carousel: null,
+            ),
         'fetchEssentiel',
-        fallback: (articles: const <EssentielArticle>[], newSinceMorning: 0),
+        fallback: (
+          articles: const <EssentielArticle>[],
+          newSinceMorning: 0,
+          carousel: null,
+        ),
       ),
     ]);
     final dual = results[0] as DualDigestResponse?;
@@ -505,6 +518,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       isSerene: isSerene,
       fetchThemes: true,
       newSinceMorning: newSinceMorning,
+      essentielCarousel: essentielResult?.carousel,
     );
     if (dual != null) {
       unawaited(
@@ -546,7 +560,14 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     required bool isSerene,
     required bool fetchThemes,
     int newSinceMorning = 0,
+    // Story 32.1 — carrousel du jour (null hors chemin live/aujourd'hui, ex.
+    // hydratation depuis cache). Additif : ne change rien quand absent.
+    FeedCarouselData? essentielCarousel,
   }) async {
+    // Story 32.1 — mémorise le carrousel du jour pour `_compose` (inséré
+    // hors-cap en fin de Tournée). Réinitialisé à chaque payload : un refetch
+    // sans carrousel (édition passée / plus d'éligible) le retire proprement.
+    _essentielCarousel = essentielCarousel;
     // PR2 — la section "Essentiel" du haut du feed est désormais alimentée
     // par GET /api/essentiel (5 articles transversaux). Si l'endpoint n'a
     // rien servi (preparing/erreur), on ne rend pas la section : le digest
@@ -955,6 +976,13 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
       for (final key in orderedKeys)
         if (key != kTourneeGrilleKey && sectionByKey[key] != null)
           sectionByKey[key]!,
+      // Story 32.1 — carrousel du jour inséré directement (comme AlertsSection),
+      // en toute fin de Tournée (après les Cartes Suggérées, avant la clôture).
+      // Hors de `orderedKeys` donc hors du cap de sections, et non déplaçable.
+      // Auto-porté : traverse dédup/fit intact (cf. _capSectionToFit /
+      // _dedupeSectionsInOrder). Présent uniquement quand le backend l'a servi
+      // (édition du jour + type éligible).
+      if (_essentielCarousel != null) CarouselSection(data: _essentielCarousel!),
     ];
     // Dédup réel (ordre dépriorisé) en capturant les retirés par section, puis
     // réinjection (backfill) des sections favorites maigres **affichées**.
@@ -1151,6 +1179,9 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     // Le rappel d'alertes est un signal contextuel de taille fixe (≤3 lignes),
     // pas une section de contenu qui se dispute la hauteur d'écran.
     if (s is AlertsSection) return s;
+    // La carte carrousel est auto-portée (PageView à hauteur fixe) : elle
+    // échappe au fit vertical (Story 32.1), comme le rappel d'alertes.
+    if (s is CarouselSection) return s;
     // Issue #1 — une coquille (placeholder, `totalCount == 0`) doit **réserver**
     // sa hauteur nominale (`coreVisibleCount`). Sans ce court-circuit, le fit
     // rabattrait son compte à 1 (pool vide) et la réserve squelette ne ferait
@@ -1210,6 +1241,7 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
     return switch (s) {
       EssentielSection() => s,
       AlertsSection() => s,
+      CarouselSection() => s,
       DigestTopicSection() => DigestTopicSection(
           kind: s.kind,
           label: s.label,
@@ -1292,6 +1324,9 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
             ),
           // Un swipe porte sur un article ; le rappel d'alertes n'en liste pas.
           AlertsSection() => s,
+          // Le carrousel est un scroller horizontal auto-porté : le swipe
+          // vertical de dismiss ne s'y applique pas (traversée intacte).
+          CarouselSection() => s,
           DigestTopicSection(:final topics) => DigestTopicSection(
               kind: s.kind,
               label: s.label,
@@ -1359,6 +1394,11 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
           );
         case AlertsSection():
           // Aucun contentId à réserver : le rappel traverse la dédup intact.
+          result.add(s);
+        case CarouselSection():
+          // Carte auto-portée (Story 32.1) : elle traverse la dédup intacte et
+          // ne réserve pas ses ids (backend a déjà exclu les 5 de l'Essentiel ;
+          // un rare doublon avec un thème vertical est assumé, hors-cap).
           result.add(s);
         case DigestTopicSection(:final topics):
           final kept = topics
@@ -1445,6 +1485,9 @@ class FluxContinuNotifier extends AsyncNotifier<FluxContinuState> {
           // Le compteur d'une cloche vient du serveur (contenus non lus ≤24h) :
           // il se corrige au prochain `refresh`, pas article par article.
           AlertsSection() => s,
+          // Le carrousel reflète l'état « lu » de ses items au prochain refresh
+          // (comme le rappel d'alertes) — pas de mutation article par article.
+          CarouselSection() => s,
           DigestTopicSection(:final topics) => DigestTopicSection(
               kind: s.kind,
               label: s.label,

--- a/apps/mobile/lib/features/flux_continu/repositories/essentiel_repository.dart
+++ b/apps/mobile/lib/features/flux_continu/repositories/essentiel_repository.dart
@@ -3,14 +3,18 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/api/api_client.dart';
 import '../../../core/api/providers.dart';
+import '../../feed/models/content_model.dart';
 import '../models/flux_continu_models.dart';
 
 /// Résultat de `GET /api/essentiel` : les articles transversaux + le delta
-/// « N nouveaux articles » (`new_since_this_morning`, borné côté
-/// backend). `newSinceMorning == 0` ⇒ pas de pastille sur le héros.
+/// « N nouveaux articles » (`new_since_this_morning`, borné côté backend) +
+/// le carrousel semi-éditorialisé du jour (Story 32.1, `carousel`, `null` hors
+/// édition du jour ou si aucun type éligible). `newSinceMorning == 0` ⇒ pas de
+/// pastille sur le héros.
 typedef EssentielFetchResult = ({
   List<EssentielArticle> articles,
   int newSinceMorning,
+  FeedCarouselData? carousel,
 });
 
 /// `GET /api/essentiel` — Story 9.1/9.2.
@@ -59,9 +63,15 @@ class EssentielRepository {
           .whereType<Map<String, dynamic>>()
           .map(EssentielArticle.fromJson)
           .toList(growable: false);
+      // Story 32.1 — carrousel du jour (additif, peut être absent/null).
+      final rawCarousel = data['carousel'];
+      final carousel = rawCarousel is Map<String, dynamic>
+          ? FeedCarouselData.fromJson(rawCarousel)
+          : null;
       return (
         articles: articles,
         newSinceMorning: (data['new_since_this_morning'] as int?) ?? 0,
+        carousel: carousel,
       );
     } on DioException catch (e) {
       // ignore: avoid_print

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -1249,6 +1249,10 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
         case AlertsSection():
           // Le rappel d'alertes ne porte que des sources, jamais d'article.
           break;
+        case CarouselSection(:final data):
+          for (final c in data.items) {
+            if (c.id == contentId) return c;
+          }
         case DigestTopicSection(:final topics):
           for (final t in topics) {
             final lead = pickTopicLead(t);
@@ -1775,6 +1779,7 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
       (section) => switch (section) {
         EssentielSection() => false,
         AlertsSection() => false,
+        CarouselSection() => false,
         DigestTopicSection(:final topics) => topics.any(
             (topic) =>
                 !_pendingFeedback.contains(pickTopicLead(topic).contentId),
@@ -1809,9 +1814,16 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
     // page, personne ne la voyait. Jamais sur le hero Essentiel (index 0), et
     // embarquée dans le `KeyedSubtree` de sa section pour les mêmes raisons de
     // snap que l'inline ci-dessus.
-    final inviteTargetIndex = state.sections.length < 2
+    // Story 32.1 — la carte carrousel de fin (hors-cap, non déplaçable) ne doit
+    // pas décaler l'ancre : on l'exclut du décompte pour garder l'invitation ~2
+    // sections de CONTENU avant la fin, comme avant l'ajout du carrousel.
+    final anchorSectionCount =
+        state.sections.isNotEmpty && state.sections.last is CarouselSection
+        ? state.sections.length - 1
+        : state.sections.length;
+    final inviteTargetIndex = anchorSectionCount < 2
         ? -1
-        : math.max(1, state.sections.length - 3);
+        : math.max(1, anchorSectionCount - 3);
 
     final slivers = <SliverToBoxAdapter>[];
     for (var i = 0; i < state.sections.length; i++) {
@@ -2284,6 +2296,9 @@ class _FluxContinuSkeleton extends StatelessWidget {
         // Le rappel d'alertes n'a rien à pré-réserver : il n'existe que si des
         // cloches ont du neuf, ce que le squelette ne sait pas encore.
         if (section is AlertsSection) continue;
+        // La carte carrousel est auto-portée (pas de banner/skeleton) et
+        // n'apparaît qu'avec les vraies données de l'Essentiel — jamais en boot.
+        if (section is CarouselSection) continue;
         final isSource =
             section is FeedThemeSection && section.kind == SectionKind.source;
         children.add(

--- a/apps/mobile/lib/features/flux_continu/screens/morning_ritual_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/morning_ritual_screen.dart
@@ -421,10 +421,11 @@ class _DeepDiveListHost extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final flux = ref.watch(fluxContinuProvider).valueOrNull;
-    // Le rappel d'alertes n'est pas une destination de lecture : une ligne
-    // « Tes alertes, 0 article » n'aurait rien à ouvrir.
+    // Ni le rappel d'alertes ni la carte carrousel (Story 32.1) ne sont des
+    // destinations de lecture : ce sont des cartes auto-portées sans page dédiée
+    // (cf. `nextSectionAfter`), donc pas de ligne « ouvrir la section » ici.
     final sections = (flux?.sections ?? const <FluxSection>[])
-        .where((s) => s is! AlertsSection)
+        .where((s) => s is! AlertsSection && s is! CarouselSection)
         .toList(growable: false);
     if (sections.isEmpty) return const SizedBox.shrink();
     return SectionDeepDiveList(

--- a/apps/mobile/lib/features/flux_continu/utils/closing_recap.dart
+++ b/apps/mobile/lib/features/flux_continu/utils/closing_recap.dart
@@ -24,6 +24,14 @@ List<SectionRecap> buildClosingRecap({
           .length,
       // Le rappel d'alertes n'expose aucun article : rien à compter comme lu.
       AlertsSection() => 0,
+      CarouselSection(:final data) => data.items
+          .where(
+            (c) =>
+                c.status == ContentStatus.consumed ||
+                c.readingProgress > 0 ||
+                consumedIds.contains(c.id),
+          )
+          .length,
       DigestTopicSection(:final topics) => topics
           .expand((t) => t.articles)
           .where((a) => a.isRead || consumedIds.contains(a.contentId))

--- a/apps/mobile/lib/features/flux_continu/utils/theme_color_mapping.dart
+++ b/apps/mobile/lib/features/flux_continu/utils/theme_color_mapping.dart
@@ -70,6 +70,8 @@ String sectionEmoji(FluxSection section) {
       return _kSectionEmojiFallback;
     case AlertsSection():
       return '📯';
+    case CarouselSection(:final data):
+      return data.emoji;
     case DigestTopicSection():
       return section.kind == SectionKind.bonnes
           ? '🌱'

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
 
 import '../../../config/theme.dart';
+import '../../feed/widgets/feed_carousel.dart';
 import '../../feed/widgets/feedback_inline.dart';
 import '../models/flux_continu_models.dart';
 import 'alerts_section_card.dart';
@@ -136,6 +137,21 @@ class SectionBlock extends StatelessWidget {
         ],
       );
     }
+    // Carte carrousel du jour (Story 32.1) — scroller horizontal auto-porté
+    // (PageView + dots), sans banner ni shell de section, comme AlertsSection.
+    // `onTapArticle` du SectionBlock accepte un Object ; on lui passe le Content.
+    if (section is CarouselSection) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          FeedCarousel(
+            data: section.data,
+            onArticleTap: (content) => onTapArticle(content),
+          ),
+          const SizedBox(height: 16),
+        ],
+      );
+    }
     final cards = _buildCards();
     // Section source sans article récent (≤72h) mais avec des cartes plus
     // anciennes (repli 30 j backend) → on signale « Pas d'article récent. » dans
@@ -229,6 +245,9 @@ class SectionBlock extends StatelessWidget {
         return const [];
       case AlertsSection():
         // Idem : build() court-circuite sur AlertsSectionCard.
+        return const [];
+      case CarouselSection():
+        // Idem : build() court-circuite sur FeedCarousel avant _buildCards.
         return const [];
       case DigestTopicSection(:final topics, :final coreVisibleCount):
         final visible = topics.take(coreVisibleCount).toList();

--- a/apps/mobile/lib/features/onboarding/onboarding_strings.dart
+++ b/apps/mobile/lib/features/onboarding/onboarding_strings.dart
@@ -16,25 +16,30 @@ class OnboardingStrings {
   // Welcome Screen (ex-Intro 1)
   static const String welcomeTitle = 'Bienvenue sur Facteur !';
   static const String welcomeSubtitle =
-      "L'information devrait t'aider à comprendre le monde.\n\nPas nous submerger.";
+      "L'information devrait nous aider à comprendre le monde.";
   static const String welcomeManifestoButton = 'Lire notre Manifeste';
   static const String welcomeStartButton = 'Commencer';
+  static const String welcomeAlreadyHaveAccount = 'J\'ai déjà un compte';
 
   // Intro Screen 2
-  static const String intro2Title = 'Ton hub d\'infos fiables.';
+  static const String intro2Title = 'Ton espace de transparence.';
   static const String intro2Subtitle =
-      'Facteur est une app Open-Source pour retrouver le plaisir de s\'informer.\n\nUn espace de confiance, qui mêle transparence, contrôle et médias de qualité.';
-  static const String intro2SubtitlePart1 = 'Facteur est une app Open-Source pour ';
-  static const String intro2SubtitleBold1 = 'retrouver le plaisir de s\'informer';
-  static const String intro2SubtitlePart2 = '. Un espace de ';
-  static const String intro2SubtitleBold2 = 'confiance';
-  static const String intro2SubtitlePart3 = ', qui mêle ';
-  static const String intro2SubtitleBold3 = 'transparence';
-  static const String intro2SubtitlePart4 = ', ';
-  static const String intro2SubtitleBold4 = 'contrôle';
-  static const String intro2SubtitlePart5 = ' et ';
-  static const String intro2SubtitleBold5 = 'médias de qualité';
-  static const String intro2SubtitlePart6 = '.';
+      'Facteur est une app Open source et indépendante, pour retrouver le plaisir de s\'informer.\n\nUn espace de confiance, qui mêle transparence, contrôle et médias de qualité.';
+  static const String intro2SubtitlePart1 = 'Facteur est une app ';
+  static const String intro2SubtitleBold1 = 'Open source';
+  static const String intro2SubtitlePart2 = ' et ';
+  static const String intro2SubtitleBold2 = 'indépendante';
+  static const String intro2SubtitlePart3 = ', pour ';
+  static const String intro2SubtitleBold3 = 'retrouver le plaisir de s\'informer';
+  static const String intro2SubtitlePart4 = '.\n\nUn espace de ';
+  static const String intro2SubtitleBold4 = 'confiance';
+  static const String intro2SubtitlePart5 = ', qui mêle ';
+  static const String intro2SubtitleBold5 = 'transparence';
+  static const String intro2SubtitlePart6 = ', ';
+  static const String intro2SubtitleBold6 = 'contrôle';
+  static const String intro2SubtitlePart7 = ' et ';
+  static const String intro2SubtitleBold7 = 'médias de qualité';
+  static const String intro2SubtitlePart8 = '.';
   static const String intro2Button = 'Découvrir Facteur';
 
   // Media Concentration

--- a/apps/mobile/lib/features/onboarding/screens/onboarding_screen.dart
+++ b/apps/mobile/lib/features/onboarding/screens/onboarding_screen.dart
@@ -161,7 +161,14 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
           TextButton(
             onPressed: () {
               Navigator.of(context).pop();
-              ref.read(authStateProvider.notifier).setNeedsOnboarding(false);
+              // Différé au frame suivant : `setNeedsOnboarding` notifie le
+              // `refreshListenable` de GoRouter, qui recalcule `redirect` et
+              // remplace la route onboarding. Le déclencher dans la même
+              // frame que le `pop()` du dialog fait courir GoRouter contre le
+              // Navigator encore en train de fermer le dialog → crash.
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                ref.read(authStateProvider.notifier).setNeedsOnboarding(false);
+              });
             },
             child: const Text('Quitter'),
           ),

--- a/apps/mobile/lib/features/onboarding/screens/questions/intro_screen.dart
+++ b/apps/mobile/lib/features/onboarding/screens/questions/intro_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../../config/theme.dart';
+import '../../../../config/routes.dart';
 import '../../providers/onboarding_provider.dart';
 import '../../onboarding_strings.dart';
 
@@ -168,6 +170,10 @@ class _WelcomeScreenState extends ConsumerState<WelcomeScreen> {
             ),
             child: const Text(OnboardingStrings.welcomeStartButton),
           ),
+          TextButton(
+            onPressed: () => context.go(RoutePaths.login),
+            child: const Text(OnboardingStrings.welcomeAlreadyHaveAccount),
+          ),
           const SizedBox(height: FacteurSpacing.space4),
         ],
       ),
@@ -265,6 +271,16 @@ class IntroScreen2 extends ConsumerWidget {
                   style: TextStyle(fontWeight: FontWeight.w700),
                 ),
                 TextSpan(text: OnboardingStrings.intro2SubtitlePart6),
+                TextSpan(
+                  text: OnboardingStrings.intro2SubtitleBold6,
+                  style: TextStyle(fontWeight: FontWeight.w700),
+                ),
+                TextSpan(text: OnboardingStrings.intro2SubtitlePart7),
+                TextSpan(
+                  text: OnboardingStrings.intro2SubtitleBold7,
+                  style: TextStyle(fontWeight: FontWeight.w700),
+                ),
+                TextSpan(text: OnboardingStrings.intro2SubtitlePart8),
               ],
             ),
             textAlign: TextAlign.center,

--- a/apps/mobile/test/features/flux_continu/providers/edition_essentiel_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/edition_essentiel_provider_test.dart
@@ -29,7 +29,7 @@ class _FakeEssentielRepository implements EssentielRepository {
     final key = date == null ? 'today' : editionDayKey(date);
     final articles = byDay[key];
     if (articles == null) return null;
-    return (articles: articles, newSinceMorning: 0);
+    return (articles: articles, newSinceMorning: 0, carousel: null);
   }
 }
 

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_progressive_fanout_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_progressive_fanout_test.dart
@@ -47,7 +47,7 @@ class _MockFluxContinuRepository extends Mock
 class _StubEssentielRepository implements EssentielRepository {
   @override
   Future<EssentielFetchResult?> fetch({bool? serein, DateTime? date}) async =>
-      (articles: const <EssentielArticle>[], newSinceMorning: 0);
+      (articles: const <EssentielArticle>[], newSinceMorning: 0, carousel: null);
 }
 
 class _NoGrilleRepository implements GrilleRepository {

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_provider_test.dart
@@ -69,7 +69,7 @@ class _FakeAuthNotifier extends StateNotifier<app_auth.AuthState>
 class _StubEssentielRepository implements EssentielRepository {
   @override
   Future<EssentielFetchResult?> fetch({bool? serein, DateTime? date}) async =>
-      (articles: const <EssentielArticle>[], newSinceMorning: 0);
+      (articles: const <EssentielArticle>[], newSinceMorning: 0, carousel: null);
 }
 
 class _NoGrilleRepository implements GrilleRepository {
@@ -1543,7 +1543,8 @@ void main() {
         final essentielRepo = _MockEssentielRepository();
         when(() => essentielRepo.fetch(serein: any(named: 'serein')))
             .thenAnswer(
-          (_) async => (articles: const <EssentielArticle>[], newSinceMorning: 0),
+          (_) async =>
+              (articles: const <EssentielArticle>[], newSinceMorning: 0, carousel: null),
         );
 
         final container = ProviderContainer(
@@ -1755,7 +1756,7 @@ class _ControllableEssentielRepository implements EssentielRepository {
   Future<EssentielFetchResult?> fetch({bool? serein, DateTime? date}) {
     if (hang) return Completer<EssentielFetchResult?>().future;
     return Future.value(
-      (articles: articles, newSinceMorning: newSinceMorning),
+      (articles: articles, newSinceMorning: newSinceMorning, carousel: null),
     );
   }
 }
@@ -1794,6 +1795,7 @@ class _OneArticleEssentielRepository implements EssentielRepository {
           ),
         ],
         newSinceMorning: 0,
+        carousel: null,
       );
 }
 
@@ -1804,5 +1806,5 @@ class _FixedEssentielRepository implements EssentielRepository {
 
   @override
   Future<EssentielFetchResult?> fetch({bool? serein, DateTime? date}) async =>
-      (articles: _articles, newSinceMorning: 0);
+      (articles: _articles, newSinceMorning: 0, carousel: null);
 }

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_sources_races_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_sources_races_test.dart
@@ -47,7 +47,7 @@ class _MockFluxContinuRepository extends Mock
 class _StubEssentielRepository implements EssentielRepository {
   @override
   Future<EssentielFetchResult?> fetch({bool? serein, DateTime? date}) async =>
-      (articles: const <EssentielArticle>[], newSinceMorning: 0);
+      (articles: const <EssentielArticle>[], newSinceMorning: 0, carousel: null);
 }
 
 class _StubUserInterestsNotifier extends UserInterestsNotifier {

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_sources_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_sources_test.dart
@@ -41,7 +41,7 @@ class _MockFluxContinuRepository extends Mock
 class _StubEssentielRepository implements EssentielRepository {
   @override
   Future<EssentielFetchResult?> fetch({bool? serein, DateTime? date}) async =>
-      (articles: const <EssentielArticle>[], newSinceMorning: 0);
+      (articles: const <EssentielArticle>[], newSinceMorning: 0, carousel: null);
 }
 
 class _StubUserInterestsNotifier extends UserInterestsNotifier {

--- a/apps/mobile/test/features/flux_continu/providers/flux_continu_tournee_order_test.dart
+++ b/apps/mobile/test/features/flux_continu/providers/flux_continu_tournee_order_test.dart
@@ -50,7 +50,7 @@ class _MockFluxContinuRepository extends Mock
 class _StubEssentielRepository implements EssentielRepository {
   @override
   Future<EssentielFetchResult?> fetch({bool? serein, DateTime? date}) async =>
-      (articles: const <EssentielArticle>[], newSinceMorning: 0);
+      (articles: const <EssentielArticle>[], newSinceMorning: 0, carousel: null);
 }
 
 class _StubUserInterestsNotifier extends UserInterestsNotifier {

--- a/docs/stories/core/32.1.carrousels-partages-essentiel-flaner.md
+++ b/docs/stories/core/32.1.carrousels-partages-essentiel-flaner.md
@@ -1,0 +1,170 @@
+# Story 32.1 — Carrousels semi-éditorialisés partagés entre Flâner et l'Essentiel
+
+**Type** : Feature
+**Statut** : En cours (backend → front → tests → PR)
+**Branche** : `boujonlaurin-dotcom/shared-carrousels-essentiel-flaner`
+
+## Contexte (pourquoi)
+
+Facteur possède des carrousels semi-éditorialisés d'articles (« Plus tard, c'est
+maintenant ! », « Tes sources discrètes », « Recos de la communauté », « Récemment
+ajouté : X ») qui n'apparaissent **que dans Flâner** (`GET /api/feed/`). Or la plupart
+des power-users ne visitent **que l'Essentiel** (la Tournée du jour) et ne les voient
+jamais.
+
+Objectif : afficher **chaque jour un carrousel différent** en fin de Tournée, en
+**mutualisant** avec Flâner (même composant, même logique de reco), avec
+**complémentarité** (le type mis en avant dans l'Essentiel n'est pas re-servi dans
+Flâner le même jour). Au passage, remplacer la sélection **statique** par une rotation
+**dynamique** date-seedée, sans état DB.
+
+## Décisions produit (validées)
+
+- **Portée backend** : extraire les carrousels **Phase B** (DB-driven) dans un service
+  partagé. Phase A (`hot`/`favorite`/`decale`, dépendants du pool de feed) reste inchangée.
+- **Types en rotation Essentiel** : `saved`, `quiet_sources`, `new_source`, `community`.
+  Pas de `decale` (serein-spécifique) → carte serein-agnostique.
+- **`community` unifié** : Flâner **et** Essentiel passent désormais par
+  `CommunityRecommendationService.get_top_recommendations` (ordering **récence + nombre
+  de tournesols** via le score decay = `SUM(1/(1+heures/48))`). Supprime le bloc inline
+  dupliqué de `_build_carousels`. Le vieux `_enrich_community_carousel` du digest reste
+  inerte (hors scope).
+- **Dynamique = rotation déterministe date-seedée, SANS état DB** : `f(user_id, date)`
+  choisit le type du jour. Zéro migration.
+- **Complémentarité robuste** : l'éligibilité pour le **choix** est calculée de façon
+  **surface-indépendante** (exclusions = uniquement les articles *consommés*, jamais les
+  `promoted_ids` propres à Flâner). Les deux surfaces obtiennent donc le **même** ensemble
+  éligible et le **même** pick. La rotation est seedée sur la **liste fixe des 4 types**
+  (ordre métier `_CAROUSEL_BASE_POSITIONS`), pick du **premier disponible** → stable dans
+  la journée, varie chaque jour, identique sur les deux surfaces quel que soit le contexte
+  de requête.
+- **Placement** : slot **dédié hors quota** (`kTourneeSuggestQuota=3` /
+  `kTourneeVisibleCap=13` intacts), inséré directement (comme `AlertsSection`), en fin des
+  « Cartes Suggérées », avant les cartes de clôture. Non déplaçable.
+- **Feel** : réutiliser `FeedCarousel` tel quel (PageView paginé, dots).
+- **Éditions passées** : carte **uniquement sur l'édition du jour** (omise en rewind J-7).
+
+## État actuel (repères de code)
+
+- **Flâner** : `RecommendationService._build_carousels`
+  (`packages/api/app/services/recommendation_service.py:1398-2127`). Phase A : `hot`
+  (1447), `favorite` (1490), `deep`(off, 1537), `decale` (serein, 1595). Phase B (sous
+  `if user_id is not None`, 1651) : `new_source` (1653), `quiet_sources` (1767),
+  `community` (1887), `saved` (1989). Positions : `_CAROUSEL_BASE_POSITIONS`
+  (1369) + jitter (`_jitter_carousel_position`, 1380) + collision resolver `MIN_GAP=5`
+  (2093). Sortie → `CarouselInfo` (`app/schemas/feed.py:97`), `FeedResponse.carousels`.
+- **Essentiel** : `GET /api/essentiel` (`app/routers/essentiel.py:45`) → `EssentielResponse`.
+  Point d'injection propre : après le plancher qualité, avant `return response` (l.114).
+- **Patron fail-open** : `_enrich_community_carousel` (`app/routers/digest.py:71`) —
+  try/except large + rollback borné (`asyncio.wait_for(db.rollback(), 2s)` → `invalidate`).
+- **Randomisation** : `seeded_shuffle`/`compute_seed`
+  (`app/services/recommendation/randomization.py:62,72`).
+- **Community** : `CommunityRecommendationService.get_top_recommendations`
+  (`app/services/community_recommendation_service.py:35`) — decay-scored, `exclude_ids`.
+- **Session courte** (quiet_sources) : `safe_async_session(statement_timeout_ms=…,
+  idle_in_tx_timeout_ms=…)` (`app/database.py:211`), déjà le défaut de
+  `RecommendationService._session_maker`.
+- **Front Tournée** : `FluxContinuScreen` compose `sections` (hiérarchie **scellée**
+  `FluxSection`, `flux_continu/models/flux_continu_models.dart:125`) dans un
+  `CustomScrollView` snappant. « Cartes Suggérées » = `FeedThemeSection`
+  `origin: suggested`. Rendu : `SectionBlock.build()` + `_buildCards()`
+  (switch exhaustif). Fit : `_capSectionToFit` (`flux_continu_provider.dart:1149`).
+  `AlertsSection` = carte auto-portée insérée hors cap (`_compose` l.954), early-return
+  fit. Ancre invitation : `inviteTargetIndex = max(1, sections.length - 3)`
+  (`flux_continu_screen.dart:1812`).
+- **Composant** : `FeedCarousel` (`feed/widgets/feed_carousel.dart`) — PageView + dots,
+  DTO `FeedCarouselData` (`feed/models/content_model.dart:773`, champs `carouselType`,
+  `title`, `emoji`, `position`, `items`, `badges`), callback requis **`onArticleTap`**.
+
+## Implémentation
+
+### Backend
+
+1. **Catalogue Phase B** — `app/services/recommendation/carousel_catalog.py` (nouveau).
+   Chaque type = un `build_<type>(ctx) -> CarouselContent | None`, logique déplacée
+   **verbatim** depuis `_build_carousels` (mêmes requêtes, `seeded_shuffle`/`compute_seed`,
+   badges). `community` = `get_top_recommendations` (unification). `CarouselContent`
+   porte `carousel_type/title/emoji/items/badges` + helper `.excluding(ids, max)`
+   (filtre items+badges alignés). `ctx` = `{session, session_maker, user_id, consumed_ids}`.
+   **Les builds n'appliquent que `consumed_ids`** (jamais `promoted_ids`).
+
+2. **Service de sélection** — `app/services/recommendation/carousel_selection_service.py`
+   (nouveau) :
+   - `build_phase_b(ctx) -> dict[str, CarouselContent]` : lance chaque build, garde les
+     types ≥ `MIN_CAROUSEL_ITEMS`. **Surface-indépendant** (consumed-only).
+   - `pick_essentiel_type(user_id, date, eligible) -> str | None` : offset =
+     `md5(f"{user_id}|{date}") % 4`, rotation de `PHASE_B_ORDER`, retourne le **premier
+     disponible** dans `eligible`.
+
+3. **Câbler Flâner** — `_build_carousels` remplace les 4 blocs Phase B par :
+   `contents = build_phase_b(ctx)` ; `essentiel_type = pick_essentiel_type(...)` ; puis
+   pour chaque type de `PHASE_B_ORDER` **sauf `essentiel_type`**, post-filtre
+   `contents[type].excluding(promoted_ids, MAX)`, gate `MIN_DISPLAY_ITEMS`, ajoute au
+   carousel et accumule `promoted_ids` (préserve la déduplication intra-Flâner
+   Phase A↔B et inter-Phase-B). Positions/jitter/collision/sérialisation inchangés.
+
+4. **Carte Essentiel** — schéma : `carousel: CarouselInfo | None = None` sur
+   `EssentielResponse` (import de `app.schemas.feed`). Enrichissement :
+   `_enrich_essentiel_carousel(db, user_uuid, response, target_date)` appelé dans
+   `get_essentiel`, **fail-open** (patron `_enrich_community_carousel`), **skip si
+   `target_date != today_paris()`**. Sérialise `contents[essentiel_type]` (post-filtré
+   des IDs des 5 articles Essentiel) en `CarouselInfo`.
+
+### Front (mobile)
+
+1. **`CarouselSection extends FluxSection`** (`flux_continu_models.dart`) portant un
+   `FeedCarouselData` (hauteur fixe). Ajouter une branche dans **chaque** `switch`
+   exhaustif sur le type scellé (compile-time) : `sectionKey()`, `renderedContentIds()`,
+   provider `_capSectionToFit`/1285/1349/1413, screen 1245/1776, `_buildCards()`,
+   `utils/theme_color_mapping.dart`, `utils/closing_recap.dart`.
+2. **Parsing** — `essentiel_repository.dart` : parser `carousel` → `FeedCarouselData?`,
+   le porter dans `EssentielFetchResult` puis jusqu'au provider.
+3. **Composition** — dans `_compose`, après `_capSectionsToFit` (hors quota/cap), insérer
+   directement une `CarouselSection` en fin des sections `origin: suggested` quand
+   `carousel != null` (mécanisme d'insertion directe, pas via `orderedKeys`).
+   Recaler l'ancre `CallInviteEntry`.
+4. **Rendu** — `SectionBlock.build()` : early-return `FeedCarousel(data:…,
+   onArticleTap:…)` (carte auto-portée sans banner, comme `AlertsSection`).
+5. **Fit** — `_capSectionToFit` early-return pour `CarouselSection` (hauteur fixe).
+
+### Analytics (léger)
+Tracker impression + tap **par `carousel_type` × surface** (`analytics_service.dart`)
+pour mesurer la feature et préparer une rotation pondérée par l'engagement.
+
+## Réutilisation (pas de nouveau code)
+Widget `FeedCarousel` + DTO ; schéma `CarouselInfo`/`CarouselItemBadge` ; patron fail-open ;
+`seeded_shuffle`/`compute_seed` ; early-return fit `AlertsSection` ; insertion hors-cap
+`AlertsSection` ; `get_top_recommendations`.
+
+## Delta de comportement connu (borné, assumé)
+Flâner construit désormais ses Phase B avec exclusion **consumed-only** puis post-filtre
+`promoted_ids` en Python (au lieu d'exclure `promoted_ids` dans la requête). Au pire, un
+carrousel Flâner peut être légèrement plus fin (rare : chevauchement Phase A↔Phase B), en
+échange d'une complémentarité déterministe cross-surface. `community` bascule sur le
+tri decay de `get_top_recommendations` (récence + nombre), équivalent au bloc inline supprimé.
+
+## Fichiers touchés
+- **Backend** : `recommendation_service.py`, nouveaux `carousel_catalog.py` +
+  `carousel_selection_service.py`, `schemas/essentiel.py`, `routers/essentiel.py`.
+- **Front** : `flux_continu_models.dart`, `flux_continu_provider.dart`,
+  `flux_continu_screen.dart`, `widgets/section_block.dart`, `repositories/essentiel_repository.dart`,
+  `utils/theme_color_mapping.dart`, `utils/closing_recap.dart`.
+
+## Vérification (E2E)
+- **Backend** : `pytest -v` (dont `tests/test_feed_carousels*.py` MAJ pour l'extraction)
+  + nouveaux tests rotation déterministe, complémentarité (type exclu de Flâner),
+  fail-open Essentiel. `uvicorn` + `curl /api/essentiel` (présence `carousel`) et
+  `/api/feed/` (type réservé absent). **0 migration** (1 head Alembic inchangé).
+- **Mobile** : `flutter test && flutter analyze` + Playwright (viewport 390x844,
+  sémantique) : carte carrousel en fin de « Cartes Suggérées », **snappe** verticalement,
+  **scrolle** horizontalement, tap ouvre l'article ; console sans erreurs, réseau propre.
+- **Régression** : Flâner affiche toujours ses carrousels (moins le type réservé) ; ancre
+  `CallInviteEntry` non cassée.
+
+## Tasks
+- [ ] Backend : `carousel_catalog.py` + `carousel_selection_service.py`
+- [ ] Backend : câbler Flâner (exclusion) + `_enrich_essentiel_carousel` + schéma
+- [ ] Backend : tests (extraction MAJ, rotation, complémentarité, fail-open)
+- [ ] Front : `CarouselSection` + switches + parsing + composition + rendu + fit
+- [ ] Front : tests + `flutter analyze` + Playwright
+- [ ] `/go` (verify → simplify → PR base `main`)

--- a/packages/api/app/database.py
+++ b/packages/api/app/database.py
@@ -1,8 +1,9 @@
 """Configuration de la base de données avec SQLAlchemy async."""
 
+import asyncio
 import time
 from collections.abc import Callable
-from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from contextlib import AbstractAsyncContextManager, asynccontextmanager, suppress
 
 from sqlalchemy import event, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -272,6 +273,26 @@ async def safe_async_session(
                     error=str(exc),
                     exc_type=type(exc).__name__,
                 )
+
+
+async def safe_fail_open_rollback(db: AsyncSession) -> None:
+    """Rollback borné pour un handler **fail-open** sur une session `get_db`.
+
+    Un enrichissement additif (carrousel digest/essentiel) qui échoue attrape son
+    exception → `get_db` ne voit jamais le raise et ne peut donc pas rollback la
+    session potentiellement salie. On le fait ici, borné : sur une connexion tuée
+    par Supabase, asyncpg peut hang indéfiniment sur le ROLLBACK (que
+    `statement_timeout` ne couvre pas) → au timeout, `invalidate()` force le drop
+    de la connexion morte du pool. Extrait pour partager la logique entre
+    `digest._enrich_community_carousel` et `essentiel._enrich_essentiel_carousel`
+    (cf. incident 2026-04-28, long_session_checkout).
+    """
+    try:
+        await asyncio.wait_for(db.rollback(), timeout=2.0)
+    except (TimeoutError, Exception) as exc:
+        logger.debug("fail_open_rollback_failed", error=str(exc))
+        with suppress(Exception):
+            await asyncio.wait_for(db.invalidate(), timeout=1.0)
 
 
 # Round 3 fix (docs/bugs/bug-infinite-load-requests.md — Sentry PYTHON-4/5/6) :

--- a/packages/api/app/routers/digest.py
+++ b/packages/api/app/routers/digest.py
@@ -14,7 +14,6 @@ See docs/maintenance/maintenance-digest-readonly-hotpath.md.
 """
 
 import asyncio
-import contextlib
 import time
 from datetime import date, timedelta
 from uuid import UUID
@@ -26,7 +25,7 @@ from pydantic import BaseModel
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database import get_db, safe_async_session
+from app.database import get_db, safe_async_session, safe_fail_open_rollback
 from app.dependencies import get_current_user_id
 from app.models.daily_digest import DailyDigest
 from app.schemas.digest import (
@@ -167,16 +166,8 @@ async def _enrich_community_carousel(
         logger.exception("community_carousel_enrichment_failed")
         # Round 6 — mirror D3 (PR #437 community.py). Handler is fail-open so
         # get_db never sees the raise and cannot rollback a dirty session.
-        # Bound the rollback: on a Supabase-killed connection, asyncpg can
-        # hang indefinitely waiting for a server ACK that never comes
-        # (statement_timeout doesn't apply to ROLLBACK). On timeout, force
-        # invalidate so the dead conn is dropped from the pool.
-        try:
-            await asyncio.wait_for(db.rollback(), timeout=2.0)
-        except (TimeoutError, Exception) as rb_exc:
-            logger.debug("community_carousel_rollback_failed", error=str(rb_exc))
-            with contextlib.suppress(Exception):
-                await asyncio.wait_for(db.invalidate(), timeout=1.0)
+        # Bounded rollback+invalidate extracted to a shared helper (Story 32.1).
+        await safe_fail_open_rollback(db)
 
     return digest
 

--- a/packages/api/app/routers/essentiel.py
+++ b/packages/api/app/routers/essentiel.py
@@ -7,6 +7,8 @@ Strictement read-only : pas de pipeline LLM au request time. Réutilise la
 chaîne de fallback de `/api/digest` via `read_digest_or_fallback`.
 """
 
+import asyncio
+import contextlib
 import time
 from datetime import date
 from uuid import UUID
@@ -14,16 +16,28 @@ from uuid import UUID
 import structlog
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database import get_db
+from app.database import get_db, safe_async_session
 from app.dependencies import get_current_user_id
+from app.models.content import UserContentStatus
+from app.models.enums import ContentStatus
 from app.schemas.essentiel import EssentielResponse
+from app.schemas.feed import CarouselInfo, CarouselItemBadge
 from app.services.digest_service import DigestService, read_digest_or_fallback
 from app.services.essentiel_service import (
     ESSENTIEL_MIN_ARTICLES,
     build_essentiel_response_with_supplements,
     fetch_user_essentiel_context,
+)
+from app.services.recommendation.carousel_catalog import (
+    MAX_CAROUSEL_ITEMS,
+    CarouselBuildContext,
+)
+from app.services.recommendation.carousel_selection_service import (
+    build_phase_b,
+    pick_essentiel_type,
 )
 from app.utils.time import today_paris
 
@@ -40,6 +54,90 @@ def _preparing_response() -> JSONResponse:
             "message": "Votre essentiel est en cours de préparation...",
         },
     )
+
+
+# Nombre min d'items du carrousel Essentiel APRÈS retrait des 5 articles déjà
+# affichés dans la carte — en-deçà, on n'attache pas de carrousel (évite un
+# scroller à 1 item).
+_MIN_ESSENTIEL_CAROUSEL_ITEMS = 2
+
+
+async def _enrich_essentiel_carousel(
+    db: AsyncSession,
+    user_uuid: UUID,
+    response: EssentielResponse,
+    effective_date: date,
+) -> EssentielResponse:
+    """Attache le carrousel semi-éditorialisé du jour à la réponse Essentiel.
+
+    Story 32.1 — mutualise la Phase B des carrousels de Flâner via le catalogue
+    partagé. Le type mis en avant est choisi de façon déterministe (rotation
+    date-seedée sur `(user, date_paris)`) ; Flâner retire ce même type le même
+    jour → complémentarité cross-surface sans état DB.
+
+    Fail-open : toute exception laisse `response` inchangée (le carrousel est une
+    surface purement additive, il ne peut jamais casser le chargement de
+    l'Essentiel). Skip hors édition du jour (rewind J-7 en lecture seule).
+    """
+    if effective_date != today_paris():
+        return response
+
+    try:
+        consumed_ids = set(
+            (
+                await db.execute(
+                    select(UserContentStatus.content_id).where(
+                        UserContentStatus.user_id == user_uuid,
+                        UserContentStatus.status == ContentStatus.CONSUMED,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        ctx = CarouselBuildContext(
+            session=db,
+            session_maker=safe_async_session,
+            user_id=user_uuid,
+            consumed_ids=consumed_ids,
+        )
+        contents = await build_phase_b(ctx)
+        essentiel_type = pick_essentiel_type(
+            user_uuid, effective_date, set(contents.keys())
+        )
+        content = contents.get(essentiel_type) if essentiel_type else None
+        if content is None:
+            return response
+
+        # Ne pas re-servir les 5 articles déjà affichés dans la carte Essentiel.
+        shown_ids = {a.content_id for a in response.articles}
+        content = content.excluding(shown_ids, MAX_CAROUSEL_ITEMS)
+        if len(content.items) < _MIN_ESSENTIEL_CAROUSEL_ITEMS:
+            return response
+
+        response.carousel = CarouselInfo(
+            carousel_type=content.carousel_type,
+            title=content.title,
+            emoji=content.emoji,
+            position=0,  # slot dédié côté mobile ; non pertinent pour l'Essentiel
+            items=content.items,
+            badges=[CarouselItemBadge(**b) for b in content.badges],
+        )
+    except Exception:
+        logger.exception("essentiel_carousel_enrichment_failed")
+        # Mirror `_enrich_community_carousel` (digest.py) : handler fail-open →
+        # get_db ne voit jamais le raise, donc on rollback nous-mêmes la session
+        # potentiellement salie. Rollback borné : sur une conn tuée par Supabase,
+        # asyncpg peut hang indéfiniment (statement_timeout ne couvre pas ROLLBACK)
+        # → sur timeout, invalidate force le drop de la conn morte du pool.
+        try:
+            await asyncio.wait_for(db.rollback(), timeout=2.0)
+        except (TimeoutError, Exception) as rb_exc:
+            logger.debug("essentiel_carousel_rollback_failed", error=str(rb_exc))
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(db.invalidate(), timeout=1.0)
+
+    return response
 
 
 @router.get("", response_model=EssentielResponse)
@@ -100,6 +198,10 @@ async def get_essentiel(
     # atteint 3 articles, on signale au client que l'essentiel se prépare.
     if len(response.articles) < ESSENTIEL_MIN_ARTICLES:
         return _preparing_response()
+
+    # Carrousel semi-éditorialisé du jour (Story 32.1) — mutualisé avec Flâner.
+    # Additif et fail-open : n'altère jamais les 5 articles ni le code de statut.
+    response = await _enrich_essentiel_carousel(db, user_uuid, response, effective_date)
 
     logger.info(
         "essentiel_retrieved",

--- a/packages/api/app/routers/essentiel.py
+++ b/packages/api/app/routers/essentiel.py
@@ -7,8 +7,6 @@ Strictement read-only : pas de pipeline LLM au request time. Réutilise la
 chaîne de fallback de `/api/digest` via `read_digest_or_fallback`.
 """
 
-import asyncio
-import contextlib
 import time
 from datetime import date
 from uuid import UUID
@@ -16,15 +14,11 @@ from uuid import UUID
 import structlog
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database import get_db, safe_async_session
+from app.database import get_db, safe_async_session, safe_fail_open_rollback
 from app.dependencies import get_current_user_id
-from app.models.content import UserContentStatus
-from app.models.enums import ContentStatus
 from app.schemas.essentiel import EssentielResponse
-from app.schemas.feed import CarouselInfo, CarouselItemBadge
 from app.services.digest_service import DigestService, read_digest_or_fallback
 from app.services.essentiel_service import (
     ESSENTIEL_MIN_ARTICLES,
@@ -34,10 +28,10 @@ from app.services.essentiel_service import (
 from app.services.recommendation.carousel_catalog import (
     MAX_CAROUSEL_ITEMS,
     CarouselBuildContext,
+    fetch_consumed_ids,
 )
 from app.services.recommendation.carousel_selection_service import (
-    build_phase_b,
-    pick_essentiel_type,
+    select_essentiel_carousel,
 )
 from app.utils.time import today_paris
 
@@ -83,29 +77,16 @@ async def _enrich_essentiel_carousel(
         return response
 
     try:
-        consumed_ids = set(
-            (
-                await db.execute(
-                    select(UserContentStatus.content_id).where(
-                        UserContentStatus.user_id == user_uuid,
-                        UserContentStatus.status == ContentStatus.CONSUMED,
-                    )
-                )
-            )
-            .scalars()
-            .all()
-        )
+        consumed_ids = await fetch_consumed_ids(db, user_uuid)
         ctx = CarouselBuildContext(
             session=db,
             session_maker=safe_async_session,
             user_id=user_uuid,
             consumed_ids=consumed_ids,
         )
-        contents = await build_phase_b(ctx)
-        essentiel_type = pick_essentiel_type(
-            user_uuid, effective_date, set(contents.keys())
-        )
-        content = contents.get(essentiel_type) if essentiel_type else None
+        # Construit paresseusement le SEUL carrousel du jour (rotation date-seedée),
+        # sans bâtir les 3 types perdants → endpoint sensible à la latence.
+        content = await select_essentiel_carousel(ctx, effective_date)
         if content is None:
             return response
 
@@ -115,27 +96,12 @@ async def _enrich_essentiel_carousel(
         if len(content.items) < _MIN_ESSENTIEL_CAROUSEL_ITEMS:
             return response
 
-        response.carousel = CarouselInfo(
-            carousel_type=content.carousel_type,
-            title=content.title,
-            emoji=content.emoji,
-            position=0,  # slot dédié côté mobile ; non pertinent pour l'Essentiel
-            items=content.items,
-            badges=[CarouselItemBadge(**b) for b in content.badges],
-        )
+        # position=0 : slot dédié côté mobile, non pertinent pour l'Essentiel.
+        response.carousel = content.to_carousel_info(0)
     except Exception:
         logger.exception("essentiel_carousel_enrichment_failed")
-        # Mirror `_enrich_community_carousel` (digest.py) : handler fail-open →
-        # get_db ne voit jamais le raise, donc on rollback nous-mêmes la session
-        # potentiellement salie. Rollback borné : sur une conn tuée par Supabase,
-        # asyncpg peut hang indéfiniment (statement_timeout ne couvre pas ROLLBACK)
-        # → sur timeout, invalidate force le drop de la conn morte du pool.
-        try:
-            await asyncio.wait_for(db.rollback(), timeout=2.0)
-        except (TimeoutError, Exception) as rb_exc:
-            logger.debug("essentiel_carousel_rollback_failed", error=str(rb_exc))
-            with contextlib.suppress(Exception):
-                await asyncio.wait_for(db.invalidate(), timeout=1.0)
+        # Fail-open : rollback borné partagé (cf. `_enrich_community_carousel`).
+        await safe_fail_open_rollback(db)
 
     return response
 

--- a/packages/api/app/schemas/essentiel.py
+++ b/packages/api/app/schemas/essentiel.py
@@ -14,6 +14,7 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 
 from app.schemas.content import SourceMini
+from app.schemas.feed import CarouselInfo
 
 
 class EssentielKind(StrEnum):
@@ -93,6 +94,14 @@ class EssentielResponse(BaseModel):
         description=(
             "Nb d'articles frais (sources suivies + thèmes appréciés riches) "
             "publiés depuis la génération du digest du jour, borné pour l'affichage."
+        ),
+    )
+    carousel: CarouselInfo | None = Field(
+        default=None,
+        description=(
+            "Carrousel semi-éditorialisé du jour (Story 32.1), mutualisé avec "
+            "Flâner. Rotation déterministe date-seedée ; présent uniquement sur "
+            "l'édition du jour. Champ additif (rétro-compat clients anciens)."
         ),
     )
 

--- a/packages/api/app/services/recommendation/carousel_catalog.py
+++ b/packages/api/app/services/recommendation/carousel_catalog.py
@@ -31,6 +31,9 @@ from app.database import SessionMaker
 from app.models.content import Content, UserContentStatus
 from app.models.enums import ContentStatus, ContentType, InterestState
 from app.models.source import Source, UserSource
+
+# Sérialisation vers le schéma API partagé (même mapping que routers/feed.py).
+from app.schemas.feed import CarouselInfo, CarouselItemBadge
 from app.services.community_recommendation_service import (
     CommunityRecommendationService,
 )
@@ -48,10 +51,6 @@ FOLLOWED_SOURCE_STATES = (InterestState.FOLLOWED, InterestState.FAVORITE)
 MIN_CAROUSEL_ITEMS = 3  # community / saved
 MIN_DISPLAY_ITEMS = 2  # quiet_sources / new_source
 MAX_CAROUSEL_ITEMS = 5
-
-# Ordre métier stable (dérivé de `_CAROUSEL_BASE_POSITIONS`) : pilote la priorité
-# d'éligibilité ET la rotation date-seedée du type mis en avant dans l'Essentiel.
-PHASE_B_ORDER: tuple[str, ...] = ("quiet_sources", "saved", "new_source", "community")
 
 
 @dataclass
@@ -82,6 +81,19 @@ class CarouselContent:
             badges=[p[1] for p in pairs],
         )
 
+    def to_carousel_info(self, position: int) -> CarouselInfo:
+        """Sérialise en `CarouselInfo` (schéma API). Même mapping que
+        `routers/feed.py` : les `Content` sont validés en `FeedItemResponse` via
+        `from_attributes`, les badges convertis en `CarouselItemBadge`."""
+        return CarouselInfo(
+            carousel_type=self.carousel_type,
+            title=self.title,
+            emoji=self.emoji,
+            position=position,
+            items=self.items,
+            badges=[CarouselItemBadge(**b) for b in self.badges],
+        )
+
 
 @dataclass
 class CarouselBuildContext:
@@ -91,6 +103,28 @@ class CarouselBuildContext:
     session_maker: SessionMaker
     user_id: UUID
     consumed_ids: set[UUID]
+
+
+async def fetch_consumed_ids(session: AsyncSession, user_id: UUID) -> set[UUID]:
+    """Articles déjà consommés par l'utilisateur — exclus de tous les carrousels.
+
+    Règle unique partagée par Flâner (`_build_carousels`) et l'Essentiel
+    (`_enrich_essentiel_carousel`) : l'ensemble éligible est **surface-indépendant**
+    (exclusion `consumed` seulement), condition de la complémentarité déterministe.
+    """
+    rows = (
+        (
+            await session.execute(
+                select(UserContentStatus.content_id).where(
+                    UserContentStatus.user_id == user_id,
+                    UserContentStatus.status == ContentStatus.CONSUMED,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return set(rows)
 
 
 async def build_new_source(ctx: CarouselBuildContext) -> CarouselContent | None:
@@ -127,7 +161,7 @@ async def build_new_source(ctx: CarouselBuildContext) -> CarouselContent | None:
         exclusions = []
         if ctx.consumed_ids:
             exclusions.append(Content.id.notin_(ctx.consumed_ids))
-        src_articles = list(
+        items = list(
             (
                 await session.scalars(
                     select(Content)
@@ -142,7 +176,6 @@ async def build_new_source(ctx: CarouselBuildContext) -> CarouselContent | None:
                 )
             ).all()
         )
-        items = src_articles[:MAX_CAROUSEL_ITEMS]
         if len(items) < MIN_NEW_SOURCE_ITEMS:
             continue
         # Cooldown post-add 6 h — laisse les articles remonter dans le main feed
@@ -280,7 +313,7 @@ async def build_community(ctx: CarouselBuildContext) -> CarouselContent | None:
 
 async def build_saved(ctx: CarouselBuildContext) -> CarouselContent | None:
     """« Plus tard, c'est maintenant ! » — articles sauvegardés non consommés."""
-    saved_articles = list(
+    items = list(
         (
             await ctx.session.scalars(
                 select(Content)
@@ -307,7 +340,6 @@ async def build_saved(ctx: CarouselBuildContext) -> CarouselContent | None:
         ).all()
     )
 
-    items = saved_articles[:MAX_CAROUSEL_ITEMS]
     if len(items) < MIN_CAROUSEL_ITEMS:
         return None
 
@@ -368,3 +400,8 @@ PHASE_B_SPECS: tuple[CarouselSpec, ...] = (
 MIN_ITEMS_BY_CODE: dict[str, int] = {
     spec.code: spec.min_items for spec in PHASE_B_SPECS
 }
+
+# Ordre métier stable (dérivé du registre → une seule source de vérité) : pilote
+# la priorité d'éligibilité de Flâner ET la rotation date-seedée du type mis en
+# avant dans l'Essentiel (`carousel_selection_service`).
+PHASE_B_ORDER: tuple[str, ...] = tuple(spec.code for spec in PHASE_B_SPECS)

--- a/packages/api/app/services/recommendation/carousel_catalog.py
+++ b/packages/api/app/services/recommendation/carousel_catalog.py
@@ -1,0 +1,370 @@
+"""Catalogue des carrousels Phase B (DB-driven), partagé entre Flâner et l'Essentiel.
+
+Story 32.1 — extraction (quasi verbatim) de la logique de
+`RecommendationService._build_carousels` pour les 4 types DB-driven :
+`saved`, `quiet_sources`, `new_source`, `community`.
+
+Chaque type = une coroutine `build_<type>(ctx) -> CarouselContent | None`. Les
+builds n'appliquent QUE l'exclusion des articles *consommés* (`consumed_ids`) —
+jamais les `promoted_ids` propres à Flâner — pour que l'ensemble éligible soit
+**surface-indépendant** (complémentarité déterministe entre Flâner et l'Essentiel,
+cf. `carousel_selection_service.pick_essentiel_type`).
+
+Le carrousel `community` est **unifié** : il passe désormais par
+`CommunityRecommendationService.get_top_recommendations` (tri decay = récence +
+nombre de tournesols), consommé aussi bien par Flâner que par l'Essentiel.
+"""
+
+from __future__ import annotations
+
+import datetime
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, replace
+from uuid import UUID
+
+import structlog
+from sqlalchemy import desc, func, literal, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.database import SessionMaker
+from app.models.content import Content, UserContentStatus
+from app.models.enums import ContentStatus, ContentType, InterestState
+from app.models.source import Source, UserSource
+from app.services.community_recommendation_service import (
+    CommunityRecommendationService,
+)
+
+# Import du MODULE (pas des noms) pour que les tests qui patchent
+# `randomization.compute_seed` atteignent bien les appels ci-dessous — le
+# rebinding par-nom au load figerait la référence avant le patch.
+from app.services.recommendation import randomization
+
+logger = structlog.get_logger()
+
+FOLLOWED_SOURCE_STATES = (InterestState.FOLLOWED, InterestState.FAVORITE)
+
+# Seuils repris de `_build_carousels` (mêmes valeurs).
+MIN_CAROUSEL_ITEMS = 3  # community / saved
+MIN_DISPLAY_ITEMS = 2  # quiet_sources / new_source
+MAX_CAROUSEL_ITEMS = 5
+
+# Ordre métier stable (dérivé de `_CAROUSEL_BASE_POSITIONS`) : pilote la priorité
+# d'éligibilité ET la rotation date-seedée du type mis en avant dans l'Essentiel.
+PHASE_B_ORDER: tuple[str, ...] = ("quiet_sources", "saved", "new_source", "community")
+
+
+@dataclass
+class CarouselContent:
+    """Un carrousel construit (avant sérialisation en `CarouselInfo`)."""
+
+    carousel_type: str
+    title: str
+    emoji: str
+    items: list[Content]
+    badges: list[dict]
+
+    def excluding(self, exclude_ids: set[UUID], max_items: int) -> CarouselContent:
+        """Nouvelle copie sans les items exclus (badges alignés), capée à `max_items`.
+
+        Utilisé par Flâner pour retirer les articles déjà promus en Phase A / dans
+        un carrousel Phase B précédent, et par l'Essentiel pour ne pas re-servir un
+        des articles déjà affichés dans la carte.
+        """
+        pairs = [
+            (it, bd)
+            for it, bd in zip(self.items, self.badges, strict=False)
+            if it.id not in exclude_ids
+        ][:max_items]
+        return replace(
+            self,
+            items=[p[0] for p in pairs],
+            badges=[p[1] for p in pairs],
+        )
+
+
+@dataclass
+class CarouselBuildContext:
+    """Entrées communes aux builds Phase B."""
+
+    session: AsyncSession
+    session_maker: SessionMaker
+    user_id: UUID
+    consumed_ids: set[UUID]
+
+
+async def build_new_source(ctx: CarouselBuildContext) -> CarouselContent | None:
+    """« Récemment ajouté : X » — articles de LA source ajoutée récemment (T3).
+
+    Rotation jour à jour : collecte toutes les sources récentes valides puis en
+    tire UNE seedée par le jour (cooldown post-add 6 h, borne 8 sondes).
+    """
+    MIN_NEW_SOURCE_ITEMS = 2
+    session = ctx.session
+    seven_days_ago = datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=7)
+
+    new_src_rows = (
+        await session.execute(
+            select(
+                UserSource.source_id,
+                Source.name,
+                UserSource.added_at,
+            )
+            .join(Source, Source.id == UserSource.source_id)
+            .where(
+                UserSource.user_id == ctx.user_id,
+                UserSource.state.in_(FOLLOWED_SOURCE_STATES),
+                UserSource.added_at > seven_days_ago,
+            )
+            .order_by(UserSource.added_at.desc())
+        )
+    ).all()
+
+    MAX_NEW_SOURCE_PROBES = 8
+    now = datetime.datetime.now(datetime.UTC)
+    candidates: list[tuple] = []
+    for src_row in new_src_rows[:MAX_NEW_SOURCE_PROBES]:
+        exclusions = []
+        if ctx.consumed_ids:
+            exclusions.append(Content.id.notin_(ctx.consumed_ids))
+        src_articles = list(
+            (
+                await session.scalars(
+                    select(Content)
+                    .options(selectinload(Content.source))
+                    .where(
+                        Content.source_id == src_row.source_id,
+                        Content.published_at > seven_days_ago,
+                        *exclusions,
+                    )
+                    .order_by(Content.published_at.desc())
+                    .limit(MAX_CAROUSEL_ITEMS)
+                )
+            ).all()
+        )
+        items = src_articles[:MAX_CAROUSEL_ITEMS]
+        if len(items) < MIN_NEW_SOURCE_ITEMS:
+            continue
+        # Cooldown post-add 6 h — laisse les articles remonter dans le main feed
+        # avant de pousser un carrousel « Récemment ajouté ».
+        source_age_seconds = (now - src_row.added_at).total_seconds()
+        if source_age_seconds < 6 * 3600:
+            continue
+        candidates.append((src_row, items, source_age_seconds))
+
+    if not candidates:
+        return None
+
+    seed = randomization.compute_seed(str(ctx.user_id), "daily")
+    src_row, items, _age = randomization.seeded_shuffle(candidates, seed)[0]
+    badge = {"code": "new_source", "label": "Nouvelle source", "emoji": "\U0001f195"}
+    return CarouselContent(
+        carousel_type="new_source",
+        title=f"Récemment ajouté : {src_row.name}",
+        emoji="\U0001f195",
+        items=items,
+        badges=[badge] * len(items),
+    )
+
+
+async def build_quiet_sources(ctx: CarouselBuildContext) -> CarouselContent | None:
+    """« Tes sources discrètes » — dernier article des sources suivies peu actives.
+
+    Sonde LATERAL ... LIMIT 3 sur une short session capée 8s/5s (PYTHON-5N), puis
+    round-robin seedé à l'heure. Tout le bloc est fail-soft : une erreur DB SKIP
+    le carrousel (renvoie None) au lieu de remonter.
+    """
+    QUIET_SOURCE_MAX_RECENT = 3  # < 3 articles en 30 jours = « discrète »
+    now = datetime.datetime.now(datetime.UTC)
+    thirty_days_ago = now - datetime.timedelta(days=30)
+    sixty_days_ago = now - datetime.timedelta(days=60)
+
+    quiet_articles: list[Content] = []
+    try:
+        probe = (
+            select(Content.id)
+            .where(
+                Content.source_id == UserSource.source_id,
+                Content.published_at >= thirty_days_ago,
+            )
+            .limit(QUIET_SOURCE_MAX_RECENT)
+            .lateral()
+        )
+        quiet_ids_stmt = (
+            select(UserSource.source_id)
+            .select_from(UserSource)
+            .join(Source, Source.id == UserSource.source_id)
+            .join(probe, literal(True))
+            .where(
+                UserSource.user_id == ctx.user_id,
+                UserSource.state.in_(FOLLOWED_SOURCE_STATES),
+                Source.is_active.is_(True),
+            )
+            .group_by(UserSource.source_id)
+            .having(func.count() < QUIET_SOURCE_MAX_RECENT)
+        )
+        async with ctx.session_maker(
+            statement_timeout_ms=8_000, idle_in_tx_timeout_ms=5_000
+        ) as quiet_s:
+            quiet_source_ids = list((await quiet_s.scalars(quiet_ids_stmt)).all())
+            if quiet_source_ids:
+                conds = [
+                    Content.source_id.in_(quiet_source_ids),
+                    Content.published_at >= sixty_days_ago,
+                ]
+                if ctx.consumed_ids:
+                    conds.append(Content.id.notin_(ctx.consumed_ids))
+                latest_per_source = (
+                    select(Content)
+                    .options(selectinload(Content.source))
+                    .where(*conds)
+                    .distinct(Content.source_id)
+                    .order_by(Content.source_id, Content.published_at.desc())
+                )
+                quiet_articles = list((await quiet_s.scalars(latest_per_source)).all())
+        seed = randomization.compute_seed(str(ctx.user_id), "hourly")
+        quiet_articles = randomization.seeded_shuffle(quiet_articles, seed)[
+            :MAX_CAROUSEL_ITEMS
+        ]
+    except Exception as exc:
+        logger.warning(
+            "carousel_quiet_sources_skipped",
+            error=str(exc),
+            exc_type=type(exc).__name__,
+        )
+        return None
+
+    if len(quiet_articles) < MIN_DISPLAY_ITEMS:
+        return None
+    badges = [
+        {"code": "quiet_source", "label": a.source.name, "emoji": "\U0001f50d"}
+        for a in quiet_articles
+    ]
+    return CarouselContent(
+        carousel_type="quiet_sources",
+        title="Tes sources discrètes",
+        emoji="\U0001f92b",
+        items=quiet_articles,
+        badges=badges,
+    )
+
+
+async def build_community(ctx: CarouselBuildContext) -> CarouselContent | None:
+    """« Recos de la communauté » 🌻 — unifié via `get_top_recommendations`.
+
+    Tri decay (`SUM(1/(1+heures/48))`) = récence + nombre de tournesols. Badge
+    « 🌻 N » si ≥ 2 tournesols, sinon « Reco communauté ».
+    """
+    service = CommunityRecommendationService(ctx.session)
+    recs = await service.get_top_recommendations(
+        limit=MAX_CAROUSEL_ITEMS,
+        exclude_ids=ctx.consumed_ids or None,
+    )
+    if len(recs) < MIN_CAROUSEL_ITEMS:
+        return None
+
+    items = [r["content"] for r in recs]
+    badges = []
+    for r in recs:
+        sf_count = int(r.get("sunflower_count", 0))
+        label = f"\U0001f33b {sf_count}" if sf_count >= 2 else "Reco communauté"
+        badges.append({"code": "community", "label": label, "emoji": "\U0001f33b"})
+    return CarouselContent(
+        carousel_type="community",
+        title="Recos de la communauté",
+        emoji="\U0001f33b",
+        items=items,
+        badges=badges,
+    )
+
+
+async def build_saved(ctx: CarouselBuildContext) -> CarouselContent | None:
+    """« Plus tard, c'est maintenant ! » — articles sauvegardés non consommés."""
+    saved_articles = list(
+        (
+            await ctx.session.scalars(
+                select(Content)
+                .options(selectinload(Content.source))
+                .join(
+                    UserContentStatus,
+                    UserContentStatus.content_id == Content.id,
+                )
+                .where(
+                    UserContentStatus.user_id == ctx.user_id,
+                    UserContentStatus.is_saved.is_(True),
+                    UserContentStatus.status != ContentStatus.CONSUMED,
+                )
+                .order_by(
+                    desc(
+                        func.coalesce(
+                            UserContentStatus.saved_at,
+                            UserContentStatus.created_at,
+                        )
+                    )
+                )
+                .limit(MAX_CAROUSEL_ITEMS)
+            )
+        ).all()
+    )
+
+    items = saved_articles[:MAX_CAROUSEL_ITEMS]
+    if len(items) < MIN_CAROUSEL_ITEMS:
+        return None
+
+    badges = []
+    for item in items:
+        ct = item.content_type
+        if ct == ContentType.YOUTUBE:
+            badges.append(
+                {
+                    "code": "saved_video",
+                    "label": "Vidéo sauvegardée",
+                    "emoji": "\U0001f4cc",
+                }
+            )
+        elif ct == ContentType.PODCAST:
+            badges.append(
+                {
+                    "code": "saved_audio",
+                    "label": "Audio sauvegardé",
+                    "emoji": "\U0001f4cc",
+                }
+            )
+        else:
+            badges.append(
+                {
+                    "code": "saved_article",
+                    "label": "Article sauvegardé",
+                    "emoji": "\U0001f4cc",
+                }
+            )
+    return CarouselContent(
+        carousel_type="saved",
+        title="Plus tard, c’est maintenant !",
+        emoji="\U0001f4cc",
+        items=items,
+        badges=badges,
+    )
+
+
+@dataclass(frozen=True)
+class CarouselSpec:
+    """Un type de carrousel Phase B : code, seuil d'émission, builder."""
+
+    code: str
+    min_items: int
+    build: Callable[[CarouselBuildContext], Awaitable[CarouselContent | None]]
+
+
+# Registre ordonné par priorité métier (base positions). L'ordre pilote à la fois
+# l'éligibilité (priorité) et la rotation `pick_essentiel_type`.
+PHASE_B_SPECS: tuple[CarouselSpec, ...] = (
+    CarouselSpec("quiet_sources", MIN_DISPLAY_ITEMS, build_quiet_sources),
+    CarouselSpec("saved", MIN_CAROUSEL_ITEMS, build_saved),
+    CarouselSpec("new_source", MIN_DISPLAY_ITEMS, build_new_source),
+    CarouselSpec("community", MIN_CAROUSEL_ITEMS, build_community),
+)
+
+MIN_ITEMS_BY_CODE: dict[str, int] = {
+    spec.code: spec.min_items for spec in PHASE_B_SPECS
+}

--- a/packages/api/app/services/recommendation/carousel_selection_service.py
+++ b/packages/api/app/services/recommendation/carousel_selection_service.py
@@ -1,15 +1,19 @@
 """Sélection partagée des carrousels Phase B + rotation date-seedée (Story 32.1).
 
 Deux surfaces (Flâner `GET /api/feed/` et l'Essentiel `GET /api/essentiel`)
-partagent :
+coordonnent le carrousel mis en avant **sans état DB** :
 
-- `build_phase_b(ctx)` : construit tous les carrousels Phase B éligibles. Ne fait
-  QUE l'exclusion des articles consommés → **surface-indépendant** (les deux
-  surfaces obtiennent le même ensemble éligible).
-- `pick_essentiel_type(user, date, eligible)` : choisit de façon déterministe le
-  type mis en avant dans l'Essentiel. Comme l'ensemble éligible est
-  surface-indépendant et le seed ne dépend que de `(user, date)`, Flâner recalcule
-  le **même** type et l'exclut → complémentarité sans état DB.
+- `build_phase_b(ctx)` : construit TOUS les carrousels Phase B éligibles. Ne fait
+  QUE l'exclusion des articles consommés → **surface-indépendant**. Utilisé par
+  Flâner, qui rend jusqu'à 3 carrousels.
+- `pick_essentiel_type(user, date, eligible)` : type mis en avant dans l'Essentiel,
+  choisi de façon déterministe (rotation seedée `(user, date)`). Flâner recalcule
+  le **même** type et l'exclut → complémentarité.
+- `select_essentiel_carousel(ctx, date)` : variante **paresseuse** pour l'Essentiel,
+  qui ne rend qu'UN carrousel — construit les types dans l'ordre de rotation et
+  s'arrête au premier éligible (≈ 1/4 du travail DB de `build_phase_b`, sur un
+  endpoint sensible à la latence). Résultat identique au couple `build_phase_b` +
+  `pick_essentiel_type` (l'éligibilité par type est déterministe dans la requête).
 """
 
 from __future__ import annotations
@@ -24,6 +28,20 @@ from app.services.recommendation.carousel_catalog import (
     CarouselBuildContext,
     CarouselContent,
 )
+
+
+def _rotation_order(user_id: UUID | str, target_date: datetime.date) -> tuple[str, ...]:
+    """`PHASE_B_ORDER` tournée d'un offset seedé par `(user_id, target_date)`.
+
+    Source unique de la rotation, partagée par `pick_essentiel_type` (Flâner) et
+    `select_essentiel_carousel` (Essentiel) → les deux surfaces s'accordent sur le
+    même type quel que soit le contexte de requête. La rotation porte sur la liste
+    fixe (longueur constante = 4), pas sur `len(eligible)`, pour rester stable dans
+    la journée malgré une éligibilité qui varierait (consommation d'articles).
+    """
+    digest = hashlib.md5(f"{user_id}|{target_date.isoformat()}".encode()).hexdigest()
+    offset = int(digest, 16) % len(PHASE_B_ORDER)
+    return PHASE_B_ORDER[offset:] + PHASE_B_ORDER[:offset]
 
 
 async def build_phase_b(
@@ -48,23 +66,32 @@ def pick_essentiel_type(
     target_date: datetime.date,
     eligible: set[str] | dict[str, object] | list[str],
 ) -> str | None:
-    """Choix déterministe date-seedé du carrousel mis en avant dans l'Essentiel.
-
-    Rotation seedée sur la **liste fixe** `PHASE_B_ORDER` (4 types), pick du premier
-    disponible dans `eligible`. Le seed ne dépend que de `(user_id, target_date)` →
-    stable dans la journée, varie chaque jour, identique sur les deux surfaces.
-
-    Note : la rotation porte sur la liste fixe (longueur constante = 4), pas sur
-    `len(eligible)`, pour rester robuste à une éligibilité qui varierait d'un item
-    au fil de la journée (consommation d'articles).
-    """
+    """Type du carrousel mis en avant dans l'Essentiel : premier de la rotation
+    date-seedée (`_rotation_order`) présent dans `eligible`. Le seed ne dépend que
+    de `(user_id, target_date)` → identique sur les deux surfaces."""
     eligible_set = set(eligible)
-    if not eligible_set:
-        return None
-    digest = hashlib.md5(f"{user_id}|{target_date.isoformat()}".encode()).hexdigest()
-    offset = int(digest, 16) % len(PHASE_B_ORDER)
-    rotated = PHASE_B_ORDER[offset:] + PHASE_B_ORDER[:offset]
-    for code in rotated:
+    for code in _rotation_order(user_id, target_date):
         if code in eligible_set:
             return code
+    return None
+
+
+async def select_essentiel_carousel(
+    ctx: CarouselBuildContext,
+    target_date: datetime.date,
+) -> CarouselContent | None:
+    """Construit paresseusement le SEUL carrousel du jour de l'Essentiel.
+
+    Suit `_rotation_order` et retourne le premier type dont le build atteint son
+    seuil, sans construire les suivants. Équivalent à
+    `pick_essentiel_type(build_phase_b(ctx).keys())` (même définition d'éligibilité,
+    même ordre), mais évite de construire les types perdants sur un endpoint
+    sensible à la latence.
+    """
+    specs_by_code = {spec.code: spec for spec in PHASE_B_SPECS}
+    for code in _rotation_order(ctx.user_id, target_date):
+        spec = specs_by_code[code]
+        content = await spec.build(ctx)
+        if content is not None and len(content.items) >= spec.min_items:
+            return content
     return None

--- a/packages/api/app/services/recommendation/carousel_selection_service.py
+++ b/packages/api/app/services/recommendation/carousel_selection_service.py
@@ -1,0 +1,70 @@
+"""Sélection partagée des carrousels Phase B + rotation date-seedée (Story 32.1).
+
+Deux surfaces (Flâner `GET /api/feed/` et l'Essentiel `GET /api/essentiel`)
+partagent :
+
+- `build_phase_b(ctx)` : construit tous les carrousels Phase B éligibles. Ne fait
+  QUE l'exclusion des articles consommés → **surface-indépendant** (les deux
+  surfaces obtiennent le même ensemble éligible).
+- `pick_essentiel_type(user, date, eligible)` : choisit de façon déterministe le
+  type mis en avant dans l'Essentiel. Comme l'ensemble éligible est
+  surface-indépendant et le seed ne dépend que de `(user, date)`, Flâner recalcule
+  le **même** type et l'exclut → complémentarité sans état DB.
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+from uuid import UUID
+
+from app.services.recommendation.carousel_catalog import (
+    PHASE_B_ORDER,
+    PHASE_B_SPECS,
+    CarouselBuildContext,
+    CarouselContent,
+)
+
+
+async def build_phase_b(
+    ctx: CarouselBuildContext,
+) -> dict[str, CarouselContent]:
+    """Construit tous les carrousels Phase B éligibles (surface-indépendant).
+
+    Retourne `{code: CarouselContent}` pour les types qui atteignent leur seuil
+    d'émission. Les items peuvent contenir des articles promus ailleurs (Phase A) :
+    c'est à l'appelant de les post-filtrer via `CarouselContent.excluding`.
+    """
+    contents: dict[str, CarouselContent] = {}
+    for spec in PHASE_B_SPECS:
+        content = await spec.build(ctx)
+        if content is not None and len(content.items) >= spec.min_items:
+            contents[spec.code] = content
+    return contents
+
+
+def pick_essentiel_type(
+    user_id: UUID | str,
+    target_date: datetime.date,
+    eligible: set[str] | dict[str, object] | list[str],
+) -> str | None:
+    """Choix déterministe date-seedé du carrousel mis en avant dans l'Essentiel.
+
+    Rotation seedée sur la **liste fixe** `PHASE_B_ORDER` (4 types), pick du premier
+    disponible dans `eligible`. Le seed ne dépend que de `(user_id, target_date)` →
+    stable dans la journée, varie chaque jour, identique sur les deux surfaces.
+
+    Note : la rotation porte sur la liste fixe (longueur constante = 4), pas sur
+    `len(eligible)`, pour rester robuste à une éligibilité qui varierait d'un item
+    au fil de la journée (consommation d'articles).
+    """
+    eligible_set = set(eligible)
+    if not eligible_set:
+        return None
+    digest = hashlib.md5(f"{user_id}|{target_date.isoformat()}".encode()).hexdigest()
+    offset = int(digest, 16) % len(PHASE_B_ORDER)
+    rotated = PHASE_B_ORDER[offset:] + PHASE_B_ORDER[:offset]
+    for code in rotated:
+        if code in eligible_set:
+            return code
+    return None

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -22,6 +22,7 @@ from app.services.recommendation.carousel_catalog import (
     MIN_ITEMS_BY_CODE,
     PHASE_B_ORDER,
     CarouselBuildContext,
+    fetch_consumed_ids,
 )
 from app.services.recommendation.carousel_selection_service import (
     build_phase_b,
@@ -1432,22 +1433,11 @@ class RecommendationService:
         used_group_keys: set[str] = set()  # Prevent same group in hot + deep
         today = datetime.date.today()
 
-        # T2: Fetch consumed content IDs to exclude from carousels
+        # T2: Fetch consumed content IDs to exclude from carousels (règle partagée
+        # avec l'Essentiel — cf. `carousel_catalog.fetch_consumed_ids`).
         consumed_ids: set[UUID] = set()
         if user_id is not None:
-            consumed_rows = (
-                (
-                    await self.session.execute(
-                        select(UserContentStatus.content_id).where(
-                            UserContentStatus.user_id == user_id,
-                            UserContentStatus.status == ContentStatus.CONSUMED,
-                        )
-                    )
-                )
-                .scalars()
-                .all()
-            )
-            consumed_ids = set(consumed_rows)
+            consumed_ids = await fetch_consumed_ids(self.session, user_id)
 
         # Daily seed for deterministic randomization (stable within a day per user)
         daily_seed: int | None = None
@@ -1678,7 +1668,7 @@ class RecommendationService:
             # Le seed de rotation est daté en heure de Paris (comme l'Essentiel)
             # pour que les deux surfaces choisissent le même type près de minuit.
             essentiel_type = pick_essentiel_type(
-                user_id, today_paris(), set(phase_b_contents.keys())
+                user_id, today_paris(), phase_b_contents
             )
             logger.info(
                 "carousels_phase_b_built",

--- a/packages/api/app/services/recommendation_service.py
+++ b/packages/api/app/services/recommendation_service.py
@@ -9,7 +9,7 @@ from typing import Any
 from uuid import UUID
 
 import structlog
-from sqlalchemy import case, desc, func, literal, select
+from sqlalchemy import case, desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -18,6 +18,16 @@ from app.models.content import Content, UserContentStatus
 from app.models.enums import ContentStatus, ContentType, FeedFilterMode, InterestState
 from app.models.source import Source, UserSource
 from app.models.user import UserProfile, UserSubtopic
+from app.services.recommendation.carousel_catalog import (
+    MIN_ITEMS_BY_CODE,
+    PHASE_B_ORDER,
+    CarouselBuildContext,
+)
+from app.services.recommendation.carousel_selection_service import (
+    build_phase_b,
+    pick_essentiel_type,
+)
+from app.utils.time import today_paris
 
 logger = structlog.get_logger()
 FOLLOWED_SOURCE_STATES = (InterestState.FOLLOWED, InterestState.FAVORITE)
@@ -1649,423 +1659,57 @@ class RecommendationService:
             budget_remaining=max_carousels - len(carousels),
         )
         if user_id is not None:
-            # --- new_source: articles from THE most recently added source (T3) ---
-            if len(carousels) < max_carousels:
-                MIN_NEW_SOURCE_ITEMS = 2  # T3B: lowered from 3
-                seven_days_ago = datetime.datetime.now(
-                    datetime.UTC
-                ) - datetime.timedelta(days=7)
-                new_src_rows = (
-                    await self.session.execute(
-                        select(
-                            UserSource.source_id,
-                            Source.name,
-                            UserSource.added_at,
-                        )
-                        .join(Source, Source.id == UserSource.source_id)
-                        .where(
-                            UserSource.user_id == user_id,
-                            UserSource.state.in_(FOLLOWED_SOURCE_STATES),
-                            UserSource.added_at > seven_days_ago,
-                        )
-                        .order_by(UserSource.added_at.desc())  # T3A: most recent first
-                    )
-                ).all()
-
-                logger.info(
-                    "carousel_new_source_query",
-                    new_sources_found=len(new_src_rows),
-                    source_names=[r.name for r in new_src_rows[:5]],
-                )
-                # Rotation jour à jour : au lieu de s'arrêter à la première
-                # source valide (toujours la plus récente → carrousel figé), on
-                # collecte TOUTES les sources récentes valides puis on en tire UNE
-                # seedée par le jour. Variété jour à jour, stable dans la journée.
-                # Borne de coût : on ne sonde que les 8 sources les plus récentes
-                # (1 requête article par source).
-                MAX_NEW_SOURCE_PROBES = 8
-                now = datetime.datetime.now(datetime.UTC)
-                candidates: list[tuple[object, list[Content]]] = []
-                for src_row in new_src_rows[:MAX_NEW_SOURCE_PROBES]:
-                    # T2: exclude promoted + consumed articles
-                    exclusions = []
-                    if promoted_ids:
-                        exclusions.append(Content.id.notin_(promoted_ids))
-                    if consumed_ids:
-                        exclusions.append(Content.id.notin_(consumed_ids))
-                    src_articles = list(
-                        (
-                            await self.session.scalars(
-                                select(Content)
-                                .options(selectinload(Content.source))
-                                .where(
-                                    Content.source_id == src_row.source_id,
-                                    Content.published_at > seven_days_ago,
-                                    *exclusions,
-                                )
-                                .order_by(Content.published_at.desc())
-                                .limit(MAX_CAROUSEL_ITEMS)
-                            )
-                        ).all()
-                    )
-
-                    items = src_articles[:MAX_CAROUSEL_ITEMS]
-                    if len(items) < MIN_NEW_SOURCE_ITEMS:
-                        continue
-
-                    # Cooldown post-add 6 h — laisse les articles de la source
-                    # remonter naturellement dans le main feed avant de pousser
-                    # un carrousel "Récemment ajouté".
-                    source_age_seconds = (now - src_row.added_at).total_seconds()
-                    if source_age_seconds < 6 * 3600:
-                        continue
-
-                    candidates.append((src_row, items, source_age_seconds))
-
-                if candidates:
-                    from app.services.recommendation.randomization import (
-                        compute_seed,
-                        seeded_shuffle,
-                    )
-
-                    seed = compute_seed(str(user_id), "daily")
-                    src_row, items, source_age_seconds = seeded_shuffle(
-                        candidates, seed
-                    )[0]
-
-                    position = self._jitter_carousel_position(
-                        "new_source", user_id, today
-                    )
-
-                    logger.info(
-                        "carousel_new_source_selected",
-                        source_name=src_row.name,
-                        article_count=len(items),
-                        position=position,
-                        source_age_hours=round(source_age_seconds / 3600, 1),
-                        candidate_count=len(candidates),
-                    )
-                    badge = {
-                        "code": "new_source",
-                        "label": "Nouvelle source",
-                        "emoji": "\U0001f195",
+            # Phase B unifiée (Story 32.1) : les 4 carrousels DB-driven
+            # (`quiet_sources`/`saved`/`new_source`/`community`) sont construits
+            # par le catalogue partagé avec l'Essentiel. Chaque build n'exclut
+            # QUE les articles *consommés* → l'ensemble éligible est
+            # surface-indépendant. Le type mis en avant dans l'Essentiel du jour
+            # est retiré ici pour garantir la complémentarité cross-surface sans
+            # état DB (cf. carousel_selection_service.pick_essentiel_type).
+            ctx = CarouselBuildContext(
+                session=self.session,
+                session_maker=self._session_maker,
+                user_id=user_id,
+                consumed_ids=consumed_ids,
+            )
+            phase_b_contents = await build_phase_b(ctx)
+            # Le seed de rotation est daté en heure de Paris (comme l'Essentiel)
+            # pour que les deux surfaces choisissent le même type près de minuit.
+            essentiel_type = pick_essentiel_type(
+                user_id, today_paris(), set(phase_b_contents.keys())
+            )
+            logger.info(
+                "carousels_phase_b_built",
+                eligible=sorted(phase_b_contents.keys()),
+                essentiel_type=essentiel_type,
+            )
+            for code in PHASE_B_ORDER:
+                if len(carousels) >= max_carousels:
+                    break
+                if code == essentiel_type:
+                    continue  # réservé à la carte Essentiel du jour
+                content = phase_b_contents.get(code)
+                if content is None:
+                    continue
+                # Post-filtre Flâner : retire les articles déjà promus en Phase A
+                # ou dans un carrousel Phase B précédent (dédup intra-feed).
+                filtered = content.excluding(promoted_ids, MAX_CAROUSEL_ITEMS)
+                if len(filtered.items) < MIN_ITEMS_BY_CODE[code]:
+                    continue
+                carousels.append(
+                    {
+                        "carousel_type": filtered.carousel_type,
+                        "title": filtered.title,
+                        "emoji": filtered.emoji,
+                        "position": self._jitter_carousel_position(
+                            code, user_id, today
+                        ),
+                        "items": filtered.items,
+                        "badges": filtered.badges,
                     }
-                    carousels.append(
-                        {
-                            "carousel_type": "new_source",
-                            "title": f"Récemment ajouté : {src_row.name}",
-                            "emoji": "\U0001f195",
-                            "position": position,
-                            "items": items,
-                            "badges": [badge] * len(items),
-                        }
-                    )
-                    for item in items:
-                        promoted_ids.add(item.id)
-
-            # --- quiet_sources: latest article from followed low-volume sources ---
-            if len(carousels) < max_carousels:
-                QUIET_SOURCE_MAX_RECENT = 3  # < 3 articles in 30 days = "quiet"
-                now = datetime.datetime.now(datetime.UTC)
-                thirty_days_ago = now - datetime.timedelta(days=30)
-                sixty_days_ago = now - datetime.timedelta(days=60)
-
-                # PYTHON-5N fix : l'ancien agrégat `outerjoin(Content) + GROUP BY
-                # + HAVING count() < 3` matérialisait TOUTES les lignes 30j par
-                # source juste pour les compter (1721ms / 5775 lignes sur un user
-                # à 62 sources) → dérapait vers le statement_timeout 30s → 500.
-                # On sonde désormais via LATERAL ... LIMIT 3 (court-circuit dès la
-                # 3ᵉ ligne par source, Index-Only Scan → 198ms / ~186 lignes), sur
-                # une short session capée 8s/5s plutôt que `self.session` (cap 30s).
-                # Tout le bloc est gardé par un try/except : le carrousel est
-                # optionnel, donc un QueryCanceled / erreur DB le SKIP au lieu de
-                # remonter en 500.
-                quiet_articles: list[Content] = []
-                quiet_source_ids: list[UUID] = []
-                try:
-                    probe = (
-                        select(Content.id)
-                        .where(
-                            Content.source_id == UserSource.source_id,
-                            Content.published_at >= thirty_days_ago,
-                        )
-                        .limit(QUIET_SOURCE_MAX_RECENT)
-                        .lateral()
-                    )
-                    quiet_ids_stmt = (
-                        select(UserSource.source_id)
-                        .select_from(UserSource)
-                        .join(Source, Source.id == UserSource.source_id)
-                        .join(probe, literal(True))
-                        .where(
-                            UserSource.user_id == user_id,
-                            UserSource.state.in_(FOLLOWED_SOURCE_STATES),
-                            Source.is_active.is_(True),
-                        )
-                        .group_by(UserSource.source_id)
-                        .having(func.count() < QUIET_SOURCE_MAX_RECENT)
-                    )
-                    async with self._session_maker(
-                        statement_timeout_ms=8_000, idle_in_tx_timeout_ms=5_000
-                    ) as quiet_s:
-                        quiet_source_ids = list(
-                            (await quiet_s.scalars(quiet_ids_stmt)).all()
-                        )
-                        if quiet_source_ids:
-                            latest_per_source = (
-                                select(Content)
-                                .options(selectinload(Content.source))
-                                .where(
-                                    Content.source_id.in_(quiet_source_ids),
-                                    Content.published_at >= sixty_days_ago,
-                                    Content.id.notin_(promoted_ids | consumed_ids),
-                                )
-                                .distinct(Content.source_id)
-                                .order_by(
-                                    Content.source_id,
-                                    Content.published_at.desc(),
-                                )
-                            )
-                            quiet_articles = list(
-                                (await quiet_s.scalars(latest_per_source)).all()
-                            )
-                    # Round-robin au fil des refresh : au lieu de toujours
-                    # garder les 5 articles les plus récents (mêmes sources
-                    # discrètes en boucle), on shuffle déterministe seedé à
-                    # l'heure sur TOUT le pool avant de couper à 5. Granularité
-                    # "hourly" = varie au fil des refresh, stable dans la fenêtre
-                    # de cache feed 30 s.
-                    from app.services.recommendation.randomization import (
-                        compute_seed,
-                        seeded_shuffle,
-                    )
-
-                    seed = compute_seed(str(user_id), "hourly")
-                    quiet_articles = seeded_shuffle(quiet_articles, seed)[
-                        :MAX_CAROUSEL_ITEMS
-                    ]
-                except Exception as exc:
-                    logger.warning(
-                        "carousel_quiet_sources_skipped",
-                        error=str(exc),
-                        exc_type=type(exc).__name__,
-                    )
-                    quiet_articles = []
-                    quiet_source_ids = []
-
-                logger.info(
-                    "carousel_quiet_sources_query",
-                    quiet_sources_found=len(quiet_source_ids),
-                    articles_found=len(quiet_articles),
-                    min_required=MIN_DISPLAY_ITEMS,
                 )
-                if len(quiet_articles) >= MIN_DISPLAY_ITEMS:
-                    badges = [
-                        {
-                            "code": "quiet_source",
-                            "label": a.source.name,
-                            "emoji": "\U0001f50d",
-                        }
-                        for a in quiet_articles
-                    ]
-                    carousels.append(
-                        {
-                            "carousel_type": "quiet_sources",
-                            "title": "Tes sources discrètes",
-                            "emoji": "\U0001f92b",
-                            "position": self._jitter_carousel_position(
-                                "quiet_sources", user_id, today
-                            ),
-                            "items": quiet_articles,
-                            "badges": badges,
-                        }
-                    )
-                    for item in quiet_articles:
-                        promoted_ids.add(item.id)
-
-            # --- community: 🌻 sunflower recommendations with decay scoring ---
-            if len(carousels) < max_carousels:
-                seven_days_ago = datetime.datetime.now(
-                    datetime.UTC
-                ) - datetime.timedelta(days=7)
-                exclusion = Content.id.notin_(promoted_ids) if promoted_ids else True
-                consumed_excl = (
-                    Content.id.notin_(consumed_ids) if consumed_ids else True
-                )
-
-                # Decay formula: score = SUM(1 / (1 + hours_since / 48))
-                hours_since = (
-                    func.extract(
-                        "epoch",
-                        datetime.datetime.now(datetime.UTC)
-                        - UserContentStatus.liked_at,
-                    )
-                    / 3600.0
-                )
-                decay_weight = 1.0 / (1.0 + hours_since / 48.0)
-
-                community_rows = (
-                    await self.session.execute(
-                        select(
-                            Content.id,
-                            func.sum(decay_weight).label("score"),
-                            func.count(UserContentStatus.id).label("sunflower_count"),
-                        )
-                        .join(
-                            UserContentStatus,
-                            UserContentStatus.content_id == Content.id,
-                        )
-                        .where(
-                            UserContentStatus.is_liked.is_(True),
-                            UserContentStatus.liked_at >= seven_days_ago,
-                            exclusion,
-                            consumed_excl,
-                        )
-                        .group_by(Content.id)
-                        .having(func.count(UserContentStatus.id) >= 1)
-                        .order_by(func.sum(decay_weight).desc())
-                        .limit(MAX_CAROUSEL_ITEMS)
-                    )
-                ).all()
-
-                logger.info(
-                    "carousel_community_query",
-                    community_found=len(community_rows),
-                    min_required=MIN_CAROUSEL_ITEMS,
-                    scores=[round(float(r.score), 2) for r in community_rows[:5]],
-                )
-                if len(community_rows) >= MIN_CAROUSEL_ITEMS:
-                    community_ids = [r.id for r in community_rows]
-                    count_map = {r.id: int(r.sunflower_count) for r in community_rows}
-
-                    community_contents = list(
-                        (
-                            await self.session.scalars(
-                                select(Content)
-                                .options(selectinload(Content.source))
-                                .where(Content.id.in_(community_ids))
-                            )
-                        ).all()
-                    )
-                    id_order = {cid: i for i, cid in enumerate(community_ids)}
-                    items = sorted(
-                        community_contents,
-                        key=lambda c: id_order.get(c.id, 99),
-                    )
-
-                    # Badges: show 🌻 count if >= 2
-                    badges = []
-                    for item in items:
-                        sf_count = count_map.get(item.id, 0)
-                        label = (
-                            f"\U0001f33b {sf_count}"
-                            if sf_count >= 2
-                            else "Reco communauté"
-                        )
-                        badges.append(
-                            {
-                                "code": "community",
-                                "label": label,
-                                "emoji": "\U0001f33b",
-                            }
-                        )
-
-                    carousels.append(
-                        {
-                            "carousel_type": "community",
-                            "title": "Recos de la communauté",
-                            "emoji": "\U0001f33b",
-                            "position": self._jitter_carousel_position(
-                                "community", user_id, today
-                            ),
-                            "items": items,
-                            "badges": badges,
-                        }
-                    )
-                    for item in items:
-                        promoted_ids.add(item.id)
-
-            # --- saved: user's saved but unconsumed articles ---
-            if len(carousels) < max_carousels:
-                saved_articles = list(
-                    (
-                        await self.session.scalars(
-                            select(Content)
-                            .options(selectinload(Content.source))
-                            .join(
-                                UserContentStatus,
-                                UserContentStatus.content_id == Content.id,
-                            )
-                            .where(
-                                UserContentStatus.user_id == user_id,
-                                UserContentStatus.is_saved.is_(True),
-                                UserContentStatus.status != ContentStatus.CONSUMED,
-                            )
-                            .order_by(
-                                desc(
-                                    func.coalesce(
-                                        UserContentStatus.saved_at,
-                                        UserContentStatus.created_at,
-                                    )
-                                )
-                            )
-                            .limit(MAX_CAROUSEL_ITEMS)
-                        )
-                    ).all()
-                )
-
-                items = [a for a in saved_articles if a.id not in promoted_ids][
-                    :MAX_CAROUSEL_ITEMS
-                ]
-                logger.info(
-                    "carousel_saved_query",
-                    raw_count=len(saved_articles),
-                    after_exclusion=len(items),
-                    min_required=MIN_CAROUSEL_ITEMS,
-                )
-                if len(items) >= MIN_CAROUSEL_ITEMS:
-                    badges = []
-                    for item in items:
-                        ct = item.content_type
-                        if ct == ContentType.YOUTUBE:
-                            badges.append(
-                                {
-                                    "code": "saved_video",
-                                    "label": "Vidéo sauvegardée",
-                                    "emoji": "\U0001f4cc",
-                                }
-                            )
-                        elif ct == ContentType.PODCAST:
-                            badges.append(
-                                {
-                                    "code": "saved_audio",
-                                    "label": "Audio sauvegardé",
-                                    "emoji": "\U0001f4cc",
-                                }
-                            )
-                        else:
-                            badges.append(
-                                {
-                                    "code": "saved_article",
-                                    "label": "Article sauvegardé",
-                                    "emoji": "\U0001f4cc",
-                                }
-                            )
-
-                    carousels.append(
-                        {
-                            "carousel_type": "saved",
-                            "title": "Plus tard, c\u2019est maintenant !",
-                            "emoji": "\U0001f4cc",
-                            "position": self._jitter_carousel_position(
-                                "saved", user_id, today
-                            ),
-                            "items": items,
-                            "badges": badges,
-                        }
-                    )
-                    for item in items:
-                        promoted_ids.add(item.id)
+                for item in filtered.items:
+                    promoted_ids.add(item.id)
 
         # Remove promoted articles from the main feed
         if promoted_ids:

--- a/packages/api/tests/test_carousel_catalog.py
+++ b/packages/api/tests/test_carousel_catalog.py
@@ -1,0 +1,401 @@
+"""Tests DB-driven du catalogue Phase B partagé (Story 32.1).
+
+Couvre les builds extraits de `_build_carousels` vers `carousel_catalog` :
+`build_new_source`, `build_saved`, `build_community` (unifié via
+`get_top_recommendations`) et l'agrégateur `build_phase_b`. Le carrousel
+`quiet_sources` a sa propre suite (`test_feed_carousels_quiet_sources.py`).
+
+Ces tests tournent sur une vraie base de test (pas de mocks d'ordre d'appel) :
+c'est la construction réelle des requêtes qui est vérifiée, robuste au
+réordonnancement interne.
+"""
+
+import datetime
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+from app.models.content import Content, UserContentStatus
+from app.models.enums import ContentStatus, ContentType, InterestState, SourceType
+from app.models.source import Source, UserSource
+from app.services.recommendation.carousel_catalog import (
+    CarouselBuildContext,
+    build_community,
+    build_new_source,
+    build_saved,
+)
+from app.services.recommendation.carousel_selection_service import build_phase_b
+
+
+def _now():
+    return datetime.datetime.now(datetime.UTC)
+
+
+def _make_source(name: str, is_active: bool = True) -> Source:
+    return Source(
+        id=uuid4(),
+        name=name,
+        url="https://example.com",
+        feed_url=f"https://example.com/{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_active=is_active,
+        is_curated=False,
+    )
+
+
+def _make_content(
+    source: Source,
+    days_ago: float,
+    title: str = "Article",
+    content_type: ContentType = ContentType.ARTICLE,
+) -> Content:
+    return Content(
+        id=uuid4(),
+        source_id=source.id,
+        title=title,
+        url=f"https://example.com/{uuid4()}",
+        published_at=_now() - datetime.timedelta(days=days_ago),
+        content_type=content_type,
+        guid=str(uuid4()),
+    )
+
+
+def _ctx(db_session, session_maker, user_id, consumed_ids=None) -> CarouselBuildContext:
+    return CarouselBuildContext(
+        session=db_session,
+        session_maker=session_maker,
+        user_id=user_id,
+        consumed_ids=consumed_ids or set(),
+    )
+
+
+async def _add_new_source(
+    db_session, user_id, name: str, *, added_days_ago: float, article_count: int
+) -> Source:
+    """Une source suivie ajoutée récemment + N articles frais (≤ 7 j)."""
+    source = _make_source(name)
+    db_session.add(source)
+    db_session.add(
+        UserSource(
+            user_id=user_id,
+            source_id=source.id,
+            state=InterestState.FOLLOWED,
+            added_at=_now() - datetime.timedelta(days=added_days_ago),
+        )
+    )
+    for i in range(article_count):
+        db_session.add(_make_content(source, days_ago=1 + i, title=f"{name} art {i}"))
+    await db_session.commit()
+    return source
+
+
+# --------------------------------------------------------------------------
+# build_new_source
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_new_source_basic(db_session, fake_session_maker):
+    user_id = uuid4()
+    await _add_new_source(
+        db_session, user_id, "TechCrunch", added_days_ago=2, article_count=3
+    )
+
+    content = await build_new_source(_ctx(db_session, fake_session_maker, user_id))
+    assert content is not None
+    assert content.carousel_type == "new_source"
+    assert "TechCrunch" in content.title
+    assert len(content.items) == 3
+    assert all(b["code"] == "new_source" for b in content.badges)
+    assert len(content.badges) == len(content.items)
+
+
+@pytest.mark.asyncio
+async def test_build_new_source_skipped_within_cooldown(db_session, fake_session_maker):
+    """Source ajoutée il y a < 6 h → cooldown post-add → pas de carrousel."""
+    user_id = uuid4()
+    # 2 h en jours = ~0.083.
+    await _add_new_source(
+        db_session, user_id, "FreshSrc", added_days_ago=2 / 24, article_count=3
+    )
+
+    content = await build_new_source(_ctx(db_session, fake_session_maker, user_id))
+    assert content is None
+
+
+@pytest.mark.asyncio
+async def test_build_new_source_skipped_too_few_articles(
+    db_session, fake_session_maker
+):
+    user_id = uuid4()
+    await _add_new_source(
+        db_session, user_id, "Sparse", added_days_ago=2, article_count=1
+    )
+
+    content = await build_new_source(_ctx(db_session, fake_session_maker, user_id))
+    assert content is None
+
+
+@pytest.mark.asyncio
+async def test_build_new_source_rotates_by_seed(db_session, fake_session_maker):
+    """≥ 3 sources récentes éligibles : la source mise en avant dépend du seed."""
+    user_id = uuid4()
+    for name in ("Alpha", "Bravo", "Charlie"):
+        await _add_new_source(
+            db_session, user_id, name, added_days_ago=2, article_count=3
+        )
+
+    async def _title(seed_value):
+        with patch(
+            "app.services.recommendation.randomization.compute_seed",
+            return_value=seed_value,
+        ):
+            content = await build_new_source(
+                _ctx(db_session, fake_session_maker, user_id)
+            )
+        assert content is not None
+        return content.title
+
+    title0 = await _title(0)
+    title4 = await _title(4)
+    assert title0 != title4  # rotation selon le seed
+    assert await _title(0) == title0  # déterminisme intra-seed
+
+
+@pytest.mark.asyncio
+async def test_build_new_source_excludes_consumed(db_session, fake_session_maker):
+    user_id = uuid4()
+    source = _make_source("Consumable")
+    db_session.add(source)
+    db_session.add(
+        UserSource(
+            user_id=user_id,
+            source_id=source.id,
+            state=InterestState.FOLLOWED,
+            added_at=_now() - datetime.timedelta(days=2),
+        )
+    )
+    arts = [_make_content(source, days_ago=1 + i, title=f"art {i}") for i in range(3)]
+    for a in arts:
+        db_session.add(a)
+    await db_session.commit()
+
+    # Consomme 2 des 3 → sous le seuil MIN_NEW_SOURCE_ITEMS (2).
+    consumed = {arts[0].id, arts[1].id}
+    content = await build_new_source(
+        _ctx(db_session, fake_session_maker, user_id, consumed_ids=consumed)
+    )
+    assert content is None
+
+
+# --------------------------------------------------------------------------
+# build_saved
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_saved_mixed_content_badges(db_session, fake_session_maker):
+    user_id = uuid4()
+    source = _make_source("Saves")
+    db_session.add(source)
+    # Ordre saved_at décroissant contrôlé : article (récent) > vidéo > podcast.
+    art = _make_content(source, days_ago=1, title="A", content_type=ContentType.ARTICLE)
+    vid = _make_content(source, days_ago=2, title="V", content_type=ContentType.YOUTUBE)
+    pod = _make_content(source, days_ago=3, title="P", content_type=ContentType.PODCAST)
+    for c in (art, vid, pod):
+        db_session.add(c)
+    await db_session.flush()
+    for c, mins in ((art, 1), (vid, 2), (pod, 3)):
+        db_session.add(
+            UserContentStatus(
+                user_id=user_id,
+                content_id=c.id,
+                status=ContentStatus.UNSEEN,
+                is_saved=True,
+                saved_at=_now() - datetime.timedelta(minutes=mins),
+            )
+        )
+    await db_session.commit()
+
+    content = await build_saved(_ctx(db_session, fake_session_maker, user_id))
+    assert content is not None
+    assert content.carousel_type == "saved"
+    assert len(content.items) == 3
+    codes = [b["code"] for b in content.badges]
+    assert codes == ["saved_article", "saved_video", "saved_audio"]
+
+
+@pytest.mark.asyncio
+async def test_build_saved_skipped_too_few(db_session, fake_session_maker):
+    user_id = uuid4()
+    source = _make_source("OneSave")
+    db_session.add(source)
+    c = _make_content(source, days_ago=1)
+    db_session.add(c)
+    await db_session.flush()
+    db_session.add(
+        UserContentStatus(
+            user_id=user_id,
+            content_id=c.id,
+            status=ContentStatus.UNSEEN,
+            is_saved=True,
+            saved_at=_now(),
+        )
+    )
+    await db_session.commit()
+
+    content = await build_saved(_ctx(db_session, fake_session_maker, user_id))
+    assert content is None  # < MIN_CAROUSEL_ITEMS (3)
+
+
+@pytest.mark.asyncio
+async def test_build_saved_excludes_consumed_status(db_session, fake_session_maker):
+    """Un article sauvegardé mais CONSUMED ne compte pas."""
+    user_id = uuid4()
+    source = _make_source("MixedSaves")
+    db_session.add(source)
+    arts = [_make_content(source, days_ago=1 + i) for i in range(3)]
+    for a in arts:
+        db_session.add(a)
+    await db_session.flush()
+    for i, a in enumerate(arts):
+        db_session.add(
+            UserContentStatus(
+                user_id=user_id,
+                content_id=a.id,
+                # Le 3e est consommé → 2 restants < seuil.
+                status=ContentStatus.CONSUMED if i == 2 else ContentStatus.UNSEEN,
+                is_saved=True,
+                saved_at=_now() - datetime.timedelta(minutes=i),
+            )
+        )
+    await db_session.commit()
+
+    content = await build_saved(_ctx(db_session, fake_session_maker, user_id))
+    assert content is None
+
+
+# --------------------------------------------------------------------------
+# build_community (unifié via get_top_recommendations)
+# --------------------------------------------------------------------------
+
+
+async def _like(db_session, content_id, *, n: int, hours_ago: float = 1.0):
+    """N tournesols communautaires (utilisateurs distincts) sur un article."""
+    for _ in range(n):
+        db_session.add(
+            UserContentStatus(
+                user_id=uuid4(),
+                content_id=content_id,
+                status=ContentStatus.UNSEEN,
+                is_liked=True,
+                liked_at=_now() - datetime.timedelta(hours=hours_ago),
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_build_community_basic_unified(db_session, fake_session_maker):
+    user_id = uuid4()
+    source = _make_source("Community")
+    db_session.add(source)
+    arts = [_make_content(source, days_ago=1 + i, title=f"C{i}") for i in range(3)]
+    for a in arts:
+        db_session.add(a)
+    await db_session.flush()
+    # arts[0] : 3 tournesols → badge "🌻 3" ; arts[1..2] : 1 → "Reco communauté".
+    await _like(db_session, arts[0].id, n=3, hours_ago=1)
+    await _like(db_session, arts[1].id, n=1, hours_ago=2)
+    await _like(db_session, arts[2].id, n=1, hours_ago=3)
+    await db_session.commit()
+
+    content = await build_community(_ctx(db_session, fake_session_maker, user_id))
+    assert content is not None
+    assert content.carousel_type == "community"
+    assert content.title == "Recos de la communauté"
+    assert len(content.items) == 3
+    assert all(b["code"] == "community" for b in content.badges)
+    # Le plus tournesolé (arts[0]) porte le compteur "🌻 3".
+    top_badge = content.badges[0]
+    assert "3" in top_badge["label"]
+
+
+@pytest.mark.asyncio
+async def test_build_community_skipped_too_few(db_session, fake_session_maker):
+    user_id = uuid4()
+    source = _make_source("SmallCommunity")
+    db_session.add(source)
+    arts = [_make_content(source, days_ago=1 + i) for i in range(2)]
+    for a in arts:
+        db_session.add(a)
+    await db_session.flush()
+    await _like(db_session, arts[0].id, n=1)
+    await _like(db_session, arts[1].id, n=1)
+    await db_session.commit()
+
+    content = await build_community(_ctx(db_session, fake_session_maker, user_id))
+    assert content is None  # < MIN_CAROUSEL_ITEMS (3)
+
+
+@pytest.mark.asyncio
+async def test_build_community_excludes_consumed(db_session, fake_session_maker):
+    user_id = uuid4()
+    source = _make_source("ConsumedCommunity")
+    db_session.add(source)
+    arts = [_make_content(source, days_ago=1 + i) for i in range(3)]
+    for a in arts:
+        db_session.add(a)
+    await db_session.flush()
+    for a in arts:
+        await _like(db_session, a.id, n=2)
+    await db_session.commit()
+
+    # Exclut 1 des 3 → 2 restants < seuil.
+    content = await build_community(
+        _ctx(db_session, fake_session_maker, user_id, consumed_ids={arts[0].id})
+    )
+    assert content is None
+
+
+# --------------------------------------------------------------------------
+# build_phase_b (agrégateur)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_phase_b_returns_eligible_types(db_session, fake_session_maker):
+    user_id = uuid4()
+    source = _make_source("Both")
+    db_session.add(source)
+    saved_arts = [_make_content(source, days_ago=1 + i) for i in range(3)]
+    comm_arts = [_make_content(source, days_ago=1 + i, title=f"cm{i}") for i in range(3)]
+    for a in saved_arts + comm_arts:
+        db_session.add(a)
+    await db_session.flush()
+    for i, a in enumerate(saved_arts):
+        db_session.add(
+            UserContentStatus(
+                user_id=user_id,
+                content_id=a.id,
+                status=ContentStatus.UNSEEN,
+                is_saved=True,
+                saved_at=_now() - datetime.timedelta(minutes=i),
+            )
+        )
+    for a in comm_arts:
+        await _like(db_session, a.id, n=2)
+    await db_session.commit()
+
+    contents = await build_phase_b(_ctx(db_session, fake_session_maker, user_id))
+    assert set(contents.keys()) == {"saved", "community"}
+    assert len(contents["saved"].items) == 3
+    assert len(contents["community"].items) == 3
+
+
+@pytest.mark.asyncio
+async def test_build_phase_b_empty_when_no_data(db_session, fake_session_maker):
+    user_id = uuid4()
+    contents = await build_phase_b(_ctx(db_session, fake_session_maker, user_id))
+    assert contents == {}

--- a/packages/api/tests/test_carousel_selection.py
+++ b/packages/api/tests/test_carousel_selection.py
@@ -1,0 +1,203 @@
+"""Tests de la sélection partagée des carrousels (Story 32.1).
+
+Deux volets :
+- `pick_essentiel_type` : fonction pure de rotation date-seedée (déterminisme,
+  premier-disponible dans l'ordre fixe, variation jour à jour).
+- Complémentarité côté Flâner : `_build_carousels` retire bien le type réservé à
+  l'Essentiel et sert les autres (câblage `pick_essentiel_type` dans le service).
+"""
+
+import datetime
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+from app.models.content import Content, UserContentStatus
+from app.models.enums import ContentStatus, ContentType, SourceType
+from app.models.source import Source
+from app.services.recommendation.carousel_catalog import PHASE_B_ORDER
+from app.services.recommendation.carousel_selection_service import pick_essentiel_type
+from app.services.recommendation_service import RecommendationService
+
+_DATE = datetime.date(2026, 7, 30)
+
+
+# ==========================================================================
+# pick_essentiel_type — fonction pure
+# ==========================================================================
+
+
+def test_pick_empty_eligible_returns_none():
+    assert pick_essentiel_type(uuid4(), _DATE, set()) is None
+
+
+def test_pick_single_type_returns_it():
+    assert pick_essentiel_type(uuid4(), _DATE, {"community"}) == "community"
+
+
+def test_pick_is_deterministic_for_same_user_and_date():
+    user = uuid4()
+    full = set(PHASE_B_ORDER)
+    first = pick_essentiel_type(user, _DATE, full)
+    for _ in range(5):
+        assert pick_essentiel_type(user, _DATE, full) == first
+
+
+def test_pick_returns_a_valid_eligible_type():
+    user = uuid4()
+    full = set(PHASE_B_ORDER)
+    pick = pick_essentiel_type(user, _DATE, full)
+    assert pick in full
+
+
+def test_pick_first_available_in_rotation():
+    """Retirer le type choisi fait tomber sur le suivant disponible dans la
+    rotation (jamais None tant qu'il reste des éligibles)."""
+    user = uuid4()
+    remaining = set(PHASE_B_ORDER)
+    seen = []
+    while remaining:
+        pick = pick_essentiel_type(user, _DATE, remaining)
+        assert pick is not None
+        assert pick in remaining
+        seen.append(pick)
+        remaining = remaining - {pick}
+    # On a bien épuisé les 4 types, sans doublon.
+    assert sorted(seen) == sorted(PHASE_B_ORDER)
+
+
+def test_pick_varies_across_days():
+    """La rotation date-seedée ne reste pas collée sur un seul type au fil du
+    mois (offset = md5(user|date) % 4)."""
+    user = uuid4()
+    full = set(PHASE_B_ORDER)
+    picks = {
+        pick_essentiel_type(user, datetime.date(2026, 7, day), full)
+        for day in range(1, 29)
+    }
+    assert len(picks) >= 2
+
+
+def test_pick_same_eligible_same_pick_regardless_of_container_type():
+    user = uuid4()
+    as_set = pick_essentiel_type(user, _DATE, {"saved", "community"})
+    as_list = pick_essentiel_type(user, _DATE, ["saved", "community"])
+    as_dict = pick_essentiel_type(user, _DATE, {"saved": 1, "community": 2})
+    assert as_set == as_list == as_dict
+
+
+# ==========================================================================
+# Complémentarité Flâner (DB) — le type réservé est retiré du feed
+# ==========================================================================
+
+
+def _now():
+    return datetime.datetime.now(datetime.UTC)
+
+
+def _make_source(name: str) -> Source:
+    return Source(
+        id=uuid4(),
+        name=name,
+        url="https://example.com",
+        feed_url=f"https://example.com/{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_active=True,
+        is_curated=False,
+    )
+
+
+def _make_content(source: Source, days_ago: float, title: str = "Article") -> Content:
+    return Content(
+        id=uuid4(),
+        source_id=source.id,
+        title=title,
+        url=f"https://example.com/{uuid4()}",
+        published_at=_now() - datetime.timedelta(days=days_ago),
+        content_type=ContentType.ARTICLE,
+        guid=str(uuid4()),
+    )
+
+
+async def _seed_saved_and_community(db_session, user_id):
+    """Rend `saved` ET `community` éligibles (≥ 3 items chacun)."""
+    source = _make_source("Flaner")
+    db_session.add(source)
+    saved_arts = [_make_content(source, days_ago=1 + i) for i in range(3)]
+    comm_arts = [
+        _make_content(source, days_ago=1 + i, title=f"cm{i}") for i in range(3)
+    ]
+    for a in saved_arts + comm_arts:
+        db_session.add(a)
+    await db_session.flush()
+    for i, a in enumerate(saved_arts):
+        db_session.add(
+            UserContentStatus(
+                user_id=user_id,
+                content_id=a.id,
+                status=ContentStatus.UNSEEN,
+                is_saved=True,
+                saved_at=_now() - datetime.timedelta(minutes=i),
+            )
+        )
+    for a in comm_arts:
+        for _ in range(2):  # 2 tournesols communautaires
+            db_session.add(
+                UserContentStatus(
+                    user_id=uuid4(),
+                    content_id=a.id,
+                    status=ContentStatus.UNSEEN,
+                    is_liked=True,
+                    liked_at=_now() - datetime.timedelta(hours=1),
+                )
+            )
+    await db_session.commit()
+
+
+async def _flaner_types(db_session, session_maker, user_id):
+    service = RecommendationService(db_session, session_maker=session_maker)
+    service.entity_overflow = []
+    service.keyword_overflow = []
+    _, carousels = await service._build_carousels([], {}, user_id=user_id)
+    return {c["carousel_type"] for c in carousels}
+
+
+@pytest.mark.asyncio
+async def test_flaner_excludes_reserved_saved(db_session, fake_session_maker):
+    user_id = uuid4()
+    await _seed_saved_and_community(db_session, user_id)
+    with patch(
+        "app.services.recommendation_service.pick_essentiel_type",
+        return_value="saved",
+    ):
+        types = await _flaner_types(db_session, fake_session_maker, user_id)
+    assert "saved" not in types  # réservé à l'Essentiel
+    assert "community" in types  # les autres restent servis
+
+
+@pytest.mark.asyncio
+async def test_flaner_excludes_reserved_community(db_session, fake_session_maker):
+    user_id = uuid4()
+    await _seed_saved_and_community(db_session, user_id)
+    with patch(
+        "app.services.recommendation_service.pick_essentiel_type",
+        return_value="community",
+    ):
+        types = await _flaner_types(db_session, fake_session_maker, user_id)
+    assert "community" not in types
+    assert "saved" in types
+
+
+@pytest.mark.asyncio
+async def test_flaner_no_reservation_serves_both(db_session, fake_session_maker):
+    """Sans réservation (aucun type retenu), Flâner sert les deux types."""
+    user_id = uuid4()
+    await _seed_saved_and_community(db_session, user_id)
+    with patch(
+        "app.services.recommendation_service.pick_essentiel_type",
+        return_value=None,
+    ):
+        types = await _flaner_types(db_session, fake_session_maker, user_id)
+    assert {"saved", "community"} <= types

--- a/packages/api/tests/test_carousel_selection.py
+++ b/packages/api/tests/test_carousel_selection.py
@@ -16,8 +16,15 @@ import pytest
 from app.models.content import Content, UserContentStatus
 from app.models.enums import ContentStatus, ContentType, SourceType
 from app.models.source import Source
-from app.services.recommendation.carousel_catalog import PHASE_B_ORDER
-from app.services.recommendation.carousel_selection_service import pick_essentiel_type
+from app.services.recommendation.carousel_catalog import (
+    PHASE_B_ORDER,
+    CarouselBuildContext,
+)
+from app.services.recommendation.carousel_selection_service import (
+    build_phase_b,
+    pick_essentiel_type,
+    select_essentiel_carousel,
+)
 from app.services.recommendation_service import RecommendationService
 
 _DATE = datetime.date(2026, 7, 30)
@@ -201,3 +208,23 @@ async def test_flaner_no_reservation_serves_both(db_session, fake_session_maker)
     ):
         types = await _flaner_types(db_session, fake_session_maker, user_id)
     assert {"saved", "community"} <= types
+
+
+@pytest.mark.asyncio
+async def test_select_essentiel_carousel_matches_pick(db_session, fake_session_maker):
+    """La construction paresseuse de l'Essentiel (`select_essentiel_carousel`)
+    choisit le MÊME type que le couple Flâner `build_phase_b` + `pick_essentiel_type`
+    — parité qui garantit la complémentarité cross-surface."""
+    user_id = uuid4()
+    await _seed_saved_and_community(db_session, user_id)
+    ctx = CarouselBuildContext(
+        session=db_session,
+        session_maker=fake_session_maker,
+        user_id=user_id,
+        consumed_ids=set(),
+    )
+    full = await build_phase_b(ctx)
+    expected = pick_essentiel_type(user_id, _DATE, full)
+    lazy = await select_essentiel_carousel(ctx, _DATE)
+    assert lazy is not None
+    assert lazy.carousel_type == expected

--- a/packages/api/tests/test_essentiel_carousel.py
+++ b/packages/api/tests/test_essentiel_carousel.py
@@ -81,16 +81,11 @@ def _empty_response() -> EssentielResponse:
 @pytest.mark.asyncio
 async def test_enrich_attaches_carousel_when_eligible(db_session):
     user_id = uuid4()
+    # Seul `saved` est éligible → la rotation tombe forcément dessus.
     await _seed_saved(db_session, user_id, n=3)
     response = _empty_response()
 
-    with patch(
-        "app.routers.essentiel.pick_essentiel_type",
-        return_value="saved",
-    ):
-        out = await _enrich_essentiel_carousel(
-            db_session, user_id, response, today_paris()
-        )
+    out = await _enrich_essentiel_carousel(db_session, user_id, response, today_paris())
 
     assert out.carousel is not None
     assert out.carousel.carousel_type == "saved"
@@ -115,9 +110,7 @@ async def test_enrich_none_when_no_eligible_type(db_session):
     user_id = uuid4()
     # Aucune donnée Phase B → build_phase_b vide → pas de carrousel.
     response = _empty_response()
-    out = await _enrich_essentiel_carousel(
-        db_session, user_id, response, today_paris()
-    )
+    out = await _enrich_essentiel_carousel(db_session, user_id, response, today_paris())
     assert out.carousel is None
 
 
@@ -129,7 +122,7 @@ async def test_enrich_fails_open_on_exception(db_session):
     response = _empty_response()
 
     with patch(
-        "app.routers.essentiel.build_phase_b",
+        "app.routers.essentiel.select_essentiel_carousel",
         side_effect=RuntimeError("boom"),
     ):
         out = await _enrich_essentiel_carousel(

--- a/packages/api/tests/test_essentiel_carousel.py
+++ b/packages/api/tests/test_essentiel_carousel.py
@@ -1,0 +1,139 @@
+"""Tests de l'enrichissement carrousel de l'Essentiel (Story 32.1).
+
+Vérifie au niveau fonction `_enrich_essentiel_carousel` :
+- présence du carrousel du jour quand un type Phase B est éligible ;
+- skip hors édition du jour (rewind J-7) ;
+- fail-open : une exception dans la construction laisse la réponse intacte.
+"""
+
+import datetime
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+from app.models.content import Content, UserContentStatus
+from app.models.enums import ContentStatus, ContentType, SourceType
+from app.models.source import Source
+from app.routers.essentiel import _enrich_essentiel_carousel
+from app.schemas.essentiel import EssentielResponse
+from app.utils.time import today_paris
+
+
+def _now():
+    return datetime.datetime.now(datetime.UTC)
+
+
+def _make_source(name: str) -> Source:
+    return Source(
+        id=uuid4(),
+        name=name,
+        url="https://example.com",
+        feed_url=f"https://example.com/{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_active=True,
+        is_curated=False,
+    )
+
+
+def _make_content(source: Source, days_ago: float, title: str = "Article") -> Content:
+    return Content(
+        id=uuid4(),
+        source_id=source.id,
+        title=title,
+        url=f"https://example.com/{uuid4()}",
+        published_at=_now() - datetime.timedelta(days=days_ago),
+        content_type=ContentType.ARTICLE,
+        guid=str(uuid4()),
+    )
+
+
+async def _seed_saved(db_session, user_id, n: int = 3):
+    source = _make_source("EssSaves")
+    db_session.add(source)
+    arts = [_make_content(source, days_ago=1 + i) for i in range(n)]
+    for a in arts:
+        db_session.add(a)
+    await db_session.flush()
+    for i, a in enumerate(arts):
+        db_session.add(
+            UserContentStatus(
+                user_id=user_id,
+                content_id=a.id,
+                status=ContentStatus.UNSEEN,
+                is_saved=True,
+                saved_at=_now() - datetime.timedelta(minutes=i),
+            )
+        )
+    await db_session.commit()
+    return arts
+
+
+def _empty_response() -> EssentielResponse:
+    return EssentielResponse(
+        target_date=today_paris(),
+        generated_at=_now(),
+        articles=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_enrich_attaches_carousel_when_eligible(db_session):
+    user_id = uuid4()
+    await _seed_saved(db_session, user_id, n=3)
+    response = _empty_response()
+
+    with patch(
+        "app.routers.essentiel.pick_essentiel_type",
+        return_value="saved",
+    ):
+        out = await _enrich_essentiel_carousel(
+            db_session, user_id, response, today_paris()
+        )
+
+    assert out.carousel is not None
+    assert out.carousel.carousel_type == "saved"
+    assert len(out.carousel.items) == 3
+    assert out.carousel.badges  # badges alignés
+
+
+@pytest.mark.asyncio
+async def test_enrich_skips_when_not_today(db_session):
+    """Édition passée (rewind) → aucun carrousel."""
+    user_id = uuid4()
+    await _seed_saved(db_session, user_id, n=3)
+    response = _empty_response()
+    yesterday = today_paris() - datetime.timedelta(days=1)
+
+    out = await _enrich_essentiel_carousel(db_session, user_id, response, yesterday)
+    assert out.carousel is None
+
+
+@pytest.mark.asyncio
+async def test_enrich_none_when_no_eligible_type(db_session):
+    user_id = uuid4()
+    # Aucune donnée Phase B → build_phase_b vide → pas de carrousel.
+    response = _empty_response()
+    out = await _enrich_essentiel_carousel(
+        db_session, user_id, response, today_paris()
+    )
+    assert out.carousel is None
+
+
+@pytest.mark.asyncio
+async def test_enrich_fails_open_on_exception(db_session):
+    """Une exception dans la construction ne remonte jamais et laisse la
+    réponse inchangée (surface additive)."""
+    user_id = uuid4()
+    response = _empty_response()
+
+    with patch(
+        "app.routers.essentiel.build_phase_b",
+        side_effect=RuntimeError("boom"),
+    ):
+        out = await _enrich_essentiel_carousel(
+            db_session, user_id, response, today_paris()
+        )
+
+    assert out.carousel is None  # fail-open : pas de crash, pas de carrousel

--- a/packages/api/tests/test_feed_carousels.py
+++ b/packages/api/tests/test_feed_carousels.py
@@ -1,13 +1,31 @@
 """Tests unitaires pour _build_carousels — promotion overflow → carrousels."""
 
 import json
-import pytest
 from collections import namedtuple
-from datetime import UTC, datetime, timedelta
-from uuid import uuid4, UUID
-from unittest.mock import MagicMock, AsyncMock, patch
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
 
 from app.services.recommendation_service import RecommendationService
+
+
+@pytest.fixture(autouse=True)
+def _no_essentiel_reservation():
+    """Story 32.1 — ces tests vérifient la CONSTRUCTION Phase B de Flâner.
+
+    La réservation d'un type pour la carte Essentiel du jour
+    (`pick_essentiel_type`) est orthogonale, couverte par des tests dédiés
+    (`test_carousel_selection.py`). On la neutralise ici : le type réservé
+    dépend d'un `md5(user_id|date)` sur un `user_id` aléatoire, donc sans ce
+    patch un scénario mono-type serait vidé de façon flaky.
+    """
+    with patch(
+        "app.services.recommendation_service.pick_essentiel_type",
+        return_value=None,
+    ):
+        yield
 
 
 class MockSource:
@@ -78,12 +96,14 @@ def _make_entity_group(
     """Helper: build an entity overflow dict matching the real format."""
     sources = []
     for i in range(num_sources):
-        sources.append({
-            "source_id": uuid4(),
-            "source_name": f"Source {i}",
-            "source_logo_url": None,
-            "article_count": max(1, hidden_count // num_sources),
-        })
+        sources.append(
+            {
+                "source_id": uuid4(),
+                "source_name": f"Source {i}",
+                "source_logo_url": None,
+                "article_count": max(1, hidden_count // num_sources),
+            }
+        )
 
     # Add entity JSON to representative for display name resolution
     entity_json = json.dumps({"name": entity_name.title(), "type": "PERSON"})
@@ -112,12 +132,14 @@ def _make_keyword_group(
     """Helper: build a keyword overflow dict matching the real format."""
     sources = []
     for i in range(num_sources):
-        sources.append({
-            "source_id": uuid4(),
-            "source_name": f"Source {i}",
-            "source_logo_url": None,
-            "article_count": max(1, hidden_count // num_sources),
-        })
+        sources.append(
+            {
+                "source_id": uuid4(),
+                "source_name": f"Source {i}",
+                "source_logo_url": None,
+                "article_count": max(1, hidden_count // num_sources),
+            }
+        )
     return {
         "keyword": keyword.title(),
         "filter_keyword": keyword.lower(),
@@ -336,7 +358,9 @@ class TestBuildCarouselsBudgetAndRemoval:
         service.keyword_overflow = keyword_groups
 
         _, carousels = await service._build_carousels(
-            [], pre_regroup_map, max_carousels=3,
+            [],
+            pre_regroup_map,
+            max_carousels=3,
         )
         assert len(carousels) <= 3
 
@@ -426,319 +450,6 @@ def _mock_execute_result(rows):
     return mock_result
 
 
-class TestBuildCarouselsNewSource:
-    @pytest.mark.asyncio
-    async def test_new_source_carousel_basic(self):
-        service = _setup_service_with_no_overflow()
-        user_id = uuid4()
-        src_id = uuid4()
-
-        # Mock: UserSource query returns 1 new source (added 2 days ago → position 3)
-        two_days_ago = datetime.now(UTC) - timedelta(days=2)
-        src_rows = [_SourceRow(source_id=src_id, name="TechCrunch", added_at=two_days_ago)]
-        # Mock: Content query returns 4 articles from that source
-        articles = [
-            MockContent(
-                title=f"New article {i}",
-                source=MockSource(name="TechCrunch", source_id=src_id),
-            )
-            for i in range(4)
-        ]
-        # Force source_id to match
-        for a in articles:
-            a.source_id = src_id
-
-        execute_calls = 0
-
-        async def mock_execute(stmt):
-            nonlocal execute_calls
-            execute_calls += 1
-            # 1: consumed_ids → empty
-            if execute_calls == 1:
-                return _mock_execute_result([])
-            if execute_calls == 2:
-                return _mock_execute_result(src_rows)  # new_source
-            return _mock_execute_result([])  # quiet_sources + community (empty)
-
-        service.session.execute = AsyncMock(side_effect=mock_execute)
-        service.session.scalars = AsyncMock(
-            return_value=_mock_scalars_result(articles),
-        )
-
-        _, carousels = await service._build_carousels(
-            [], {}, user_id=user_id,
-        )
-
-        new_src = [c for c in carousels if c["carousel_type"] == "new_source"]
-        assert len(new_src) == 1
-        c = new_src[0]
-        assert "TechCrunch" in c["title"]
-        assert c["position"] >= 5  # MIN_CAROUSEL_POSITION enforced
-        assert c["badges"][0]["code"] == "new_source"
-        assert len(c["items"]) == 4
-
-    @pytest.mark.asyncio
-    async def test_new_source_skipped_when_too_few_articles(self):
-        service = _setup_service_with_no_overflow()
-        user_id = uuid4()
-        src_id = uuid4()
-
-        two_days_ago = datetime.now(UTC) - timedelta(days=2)
-        src_rows = [_SourceRow(source_id=src_id, name="TechCrunch", added_at=two_days_ago)]
-        articles = [
-            MockContent(
-                title="Only one",
-                source=MockSource(name="TechCrunch", source_id=src_id),
-            )
-        ]
-        articles[0].source_id = src_id
-
-        execute_calls = 0
-
-        async def mock_execute(stmt):
-            nonlocal execute_calls
-            execute_calls += 1
-            if execute_calls == 1:
-                return _mock_execute_result([])  # consumed_ids
-            if execute_calls == 2:
-                return _mock_execute_result(src_rows)  # new_source
-            return _mock_execute_result([])  # quiet_sources + community
-
-        service.session.execute = AsyncMock(side_effect=mock_execute)
-        service.session.scalars = AsyncMock(
-            return_value=_mock_scalars_result(articles),
-        )
-
-        _, carousels = await service._build_carousels(
-            [], {}, user_id=user_id,
-        )
-
-        assert not any(c["carousel_type"] == "new_source" for c in carousels)
-
-    @pytest.mark.asyncio
-    async def test_new_source_rotates_by_seed(self):
-        """≥3 sources récentes valides : la source mise en avant change selon le
-        seed (déterminisme jour à jour), et un seul carrousel new_source sort."""
-        user_id = uuid4()
-        src_ids = [uuid4() for _ in range(3)]
-        names = ["Alpha", "Bravo", "Charlie"]
-        two_days_ago = datetime.now(UTC) - timedelta(days=2)
-        src_rows = [
-            _SourceRow(source_id=sid, name=name, added_at=two_days_ago)
-            for sid, name in zip(src_ids, names, strict=True)
-        ]
-
-        def _build_service():
-            service = _setup_service_with_no_overflow()
-            articles = [
-                MockContent(
-                    title=f"Article {i}",
-                    source=MockSource(name="Alpha", source_id=src_ids[0]),
-                )
-                for i in range(3)
-            ]
-
-            execute_calls = 0
-
-            async def mock_execute(stmt):
-                nonlocal execute_calls
-                execute_calls += 1
-                if execute_calls == 1:
-                    return _mock_execute_result([])  # consumed_ids
-                if execute_calls == 2:
-                    return _mock_execute_result(src_rows)  # new_source
-                return _mock_execute_result([])  # quiet_sources + community
-
-            service.session.execute = AsyncMock(side_effect=mock_execute)
-            # Chaque sonde par source renvoie les mêmes 3 articles → 3 candidats.
-            service.session.scalars = AsyncMock(
-                return_value=_mock_scalars_result(articles),
-            )
-            return service
-
-        async def _selected_title(seed_value):
-            service = _build_service()
-            with patch(
-                "app.services.recommendation.randomization.compute_seed",
-                return_value=seed_value,
-            ):
-                _, carousels = await service._build_carousels(
-                    [], {}, user_id=user_id,
-                )
-            new_src = [c for c in carousels if c["carousel_type"] == "new_source"]
-            assert len(new_src) == 1  # toujours un seul carrousel new_source
-            return new_src[0]["title"]
-
-        # seed 0 → Alpha, seed 4 → Charlie (cf. shuffle Gumbel déterministe)
-        title_seed0 = await _selected_title(0)
-        title_seed4 = await _selected_title(4)
-        assert "Alpha" in title_seed0
-        assert "Charlie" in title_seed4
-        assert title_seed0 != title_seed4  # rotation selon le seed
-
-        # Déterminisme : même seed ⇒ même source
-        assert await _selected_title(0) == title_seed0
-
-    @pytest.mark.asyncio
-    async def test_new_source_skipped_when_no_new_sources(self):
-        service = _setup_service_with_no_overflow()
-        user_id = uuid4()
-
-        # All queries return empty
-        async def mock_execute(stmt):
-            return _mock_execute_result([])
-
-        service.session.execute = AsyncMock(side_effect=mock_execute)
-        service.session.scalars = AsyncMock(
-            return_value=_mock_scalars_result([]),
-        )
-
-        _, carousels = await service._build_carousels(
-            [], {}, user_id=user_id,
-        )
-
-        assert not any(c["carousel_type"] == "new_source" for c in carousels)
-
-
-class TestBuildCarouselsCommunity:
-    @pytest.mark.asyncio
-    async def test_community_carousel_basic(self):
-        service = _setup_service_with_no_overflow()
-        user_id = uuid4()
-
-        # Mock community: 4 🌻 articles with decay scores and sunflower counts
-        community_articles = [MockContent(title=f"Community {i}") for i in range(4)]
-        community_rows = [
-            _CommunityRow(id=a.id, score=5.0 - i, sunflower_count=5 - i)
-            for i, a in enumerate(community_articles)
-        ]
-
-        call_count = 0
-
-        async def mock_execute(stmt):
-            nonlocal call_count
-            call_count += 1
-            # 1: consumed_ids, 2: new_source → empty. quiet_sources tourne
-            # désormais sur une short session dédiée (PYTHON-5N), plus sur
-            # self.session.execute → la requête community est l'appel #3.
-            if call_count <= 2:
-                return _mock_execute_result([])
-            # 3: community query
-            return _mock_execute_result(community_rows)
-
-        service.session.execute = AsyncMock(side_effect=mock_execute)
-        service.session.scalars = AsyncMock(
-            return_value=_mock_scalars_result(community_articles),
-        )
-
-        _, carousels = await service._build_carousels(
-            [], {}, user_id=user_id,
-        )
-
-        community = [c for c in carousels if c["carousel_type"] == "community"]
-        assert len(community) == 1
-        c = community[0]
-        assert c["title"] == "Recos de la communauté"
-        assert c["position"] >= 5  # MIN_CAROUSEL_POSITION enforced; slot shuffled
-        assert c["badges"][0]["code"] == "community"
-        assert len(c["items"]) == 4
-
-    @pytest.mark.asyncio
-    async def test_community_skipped_when_too_few_results(self):
-        service = _setup_service_with_no_overflow()
-        user_id = uuid4()
-
-        # Only 2 community items (below MIN_CAROUSEL_ITEMS=3)
-        community_articles = [MockContent(title=f"Community {i}") for i in range(2)]
-        community_rows = [
-            _CommunityRow(id=a.id, score=1.0, sunflower_count=1)
-            for a in community_articles
-        ]
-
-        call_count = 0
-
-        async def mock_execute(stmt):
-            nonlocal call_count
-            call_count += 1
-            # 1: consumed_ids, 2: new_source → empty. quiet_sources tourne
-            # désormais sur une short session dédiée (PYTHON-5N), plus sur
-            # self.session.execute → la requête community est l'appel #3.
-            if call_count <= 2:
-                return _mock_execute_result([])
-            # 3: community
-            return _mock_execute_result(community_rows)
-
-        service.session.execute = AsyncMock(side_effect=mock_execute)
-        service.session.scalars = AsyncMock(
-            return_value=_mock_scalars_result(community_articles),
-        )
-
-        _, carousels = await service._build_carousels(
-            [], {}, user_id=user_id,
-        )
-
-        assert not any(c["carousel_type"] == "community" for c in carousels)
-
-
-class TestBuildCarouselsSaved:
-    @pytest.mark.asyncio
-    async def test_saved_carousel_with_mixed_content_types(self):
-        service = _setup_service_with_no_overflow()
-        user_id = uuid4()
-
-        saved_items = [
-            MockContent(title="Saved article", content_type="article"),
-            MockContent(title="Saved video", content_type="youtube"),
-            MockContent(title="Saved podcast", content_type="podcast"),
-        ]
-
-        # All execute calls return empty (consumed_ids, new_source, quiet_sources, community)
-        async def mock_execute(stmt):
-            return _mock_execute_result([])
-
-        service.session.execute = AsyncMock(side_effect=mock_execute)
-        service.session.scalars = AsyncMock(
-            return_value=_mock_scalars_result(saved_items),
-        )
-
-        _, carousels = await service._build_carousels(
-            [], {}, user_id=user_id,
-        )
-
-        saved = [c for c in carousels if c["carousel_type"] == "saved"]
-        assert len(saved) == 1
-        c = saved[0]
-        assert c["title"] == "Plus tard, c\u2019est maintenant !"
-        assert c["position"] >= 5  # MIN_CAROUSEL_POSITION enforced; slot shuffled
-        assert len(c["items"]) == 3
-
-        # Verify per-item badges
-        assert c["badges"][0]["code"] == "saved_article"
-        assert c["badges"][1]["code"] == "saved_video"
-        assert c["badges"][2]["code"] == "saved_audio"
-
-    @pytest.mark.asyncio
-    async def test_saved_skipped_when_too_few(self):
-        service = _setup_service_with_no_overflow()
-        user_id = uuid4()
-
-        saved_items = [MockContent(title="Only one saved")]
-
-        async def mock_execute(stmt):
-            return _mock_execute_result([])
-
-        service.session.execute = AsyncMock(side_effect=mock_execute)
-        service.session.scalars = AsyncMock(
-            return_value=_mock_scalars_result(saved_items),
-        )
-
-        _, carousels = await service._build_carousels(
-            [], {}, user_id=user_id,
-        )
-
-        assert not any(c["carousel_type"] == "saved" for c in carousels)
-
-
 class TestBuildCarouselsPhaseB_Integration:
     @pytest.mark.asyncio
     async def test_no_phase_b_without_user_id(self):
@@ -747,44 +458,6 @@ class TestBuildCarouselsPhaseB_Integration:
 
         _, carousels = await service._build_carousels([], {})
         assert carousels == []
-
-    @pytest.mark.asyncio
-    async def test_phase_b_respects_max_carousels(self):
-        """Phase B carousels don't exceed max_carousels budget."""
-        service = _setup_service_with_no_overflow()
-        user_id = uuid4()
-
-        # new_source returns enough articles
-        src_id = uuid4()
-        two_days_ago = datetime.now(UTC) - timedelta(days=2)
-        src_rows = [_SourceRow(source_id=src_id, name="Src", added_at=two_days_ago)]
-        articles = [MockContent(title=f"Art {i}") for i in range(5)]
-        for a in articles:
-            a.source_id = src_id
-
-        execute_calls = 0
-
-        async def mock_execute(stmt):
-            nonlocal execute_calls
-            execute_calls += 1
-            # 1: consumed_ids → empty
-            if execute_calls == 1:
-                return _mock_execute_result([])
-            if execute_calls == 2:
-                return _mock_execute_result(src_rows)  # new_source
-            return _mock_execute_result([])  # quiet_sources + community
-
-        service.session.execute = AsyncMock(side_effect=mock_execute)
-        service.session.scalars = AsyncMock(
-            return_value=_mock_scalars_result(articles),
-        )
-
-        # max_carousels=1 → only new_source should fit
-        _, carousels = await service._build_carousels(
-            [], {}, user_id=user_id, max_carousels=1,
-        )
-        assert len(carousels) == 1
-        assert carousels[0]["carousel_type"] == "new_source"
 
 
 # ================================================================
@@ -855,10 +528,14 @@ class TestDailyJitter:
         service.keyword_overflow = []
 
         _, carousels1 = await service._build_carousels(
-            [], pre_regroup_map, user_id=user_id,
+            [],
+            pre_regroup_map,
+            user_id=user_id,
         )
         _, carousels2 = await service._build_carousels(
-            [], pre_regroup_map, user_id=user_id,
+            [],
+            pre_regroup_map,
+            user_id=user_id,
         )
 
         pos1 = [c["position"] for c in carousels1]
@@ -880,7 +557,9 @@ class TestDailyJitter:
         positions = set()
         for _ in range(20):
             _, carousels = await service._build_carousels(
-                [], pre_regroup_map, user_id=uuid4(),
+                [],
+                pre_regroup_map,
+                user_id=uuid4(),
             )
             if carousels:
                 positions.add(carousels[0]["position"])
@@ -905,7 +584,9 @@ class TestDailyJitter:
         MIN_POS = 5
         for _ in range(20):
             _, carousels = await service._build_carousels(
-                [], pre_regroup_map, user_id=uuid4(),
+                [],
+                pre_regroup_map,
+                user_id=uuid4(),
             )
             for c in carousels:
                 pos = c["position"]
@@ -945,7 +626,8 @@ class TestProbabilisticHotCluster:
         selected_keys = set()
         for seed in range(100):
             cluster_key, _, articles = find_hot_cluster(
-                all_articles, seed=seed,
+                all_articles,
+                seed=seed,
             )
             if cluster_key:
                 selected_keys.add(cluster_key)

--- a/packages/api/tests/test_feed_carousels_quiet_sources.py
+++ b/packages/api/tests/test_feed_carousels_quiet_sources.py
@@ -17,6 +17,23 @@ from app.models.source import Source, UserSource
 from app.services.recommendation_service import RecommendationService
 
 
+@pytest.fixture(autouse=True)
+def _no_essentiel_reservation():
+    """Story 32.1 — ces tests vérifient la CONSTRUCTION Phase B de Flâner.
+
+    La réservation d'un type pour la carte Essentiel du jour
+    (`pick_essentiel_type`) est une préoccupation orthogonale, couverte par des
+    tests dédiés (`test_carousel_selection.py`). On la neutralise ici : le type
+    réservé dépend d'un `md5(user_id|date)` sur un `user_id` aléatoire, donc sans
+    ce patch un scénario mono-type serait vidé de façon flaky.
+    """
+    with patch(
+        "app.services.recommendation_service.pick_essentiel_type",
+        return_value=None,
+    ):
+        yield
+
+
 def _now():
     return datetime.datetime.now(datetime.UTC)
 


### PR DESCRIPTION
# Story 32.1 — Carrousels semi-éditorialisés partagés Essentiel ⇄ Flâner

## Quoi / Pourquoi
Les carrousels d'articles semi-éditorialisés (« Plus tard, c'est maintenant ! », « Tes
sources discrètes », « Recos de la communauté », « Récemment ajouté : X ») n'apparaissaient
que dans **Flâner** (`GET /api/feed/`). Les power-users qui ne visitent que **l'Essentiel**
(la Tournée du jour) ne les voyaient jamais.

Cette PR affiche **chaque jour un carrousel différent** en fin de Tournée, **mutualisé** avec
Flâner (même composant, même logique reco), avec **complémentarité** : le type mis en avant
dans l'Essentiel n'est pas re-servi dans Flâner le même jour. La sélection statique devient
une **rotation dynamique date-seedée, sans état DB**.

## Backend
- **Nouveau** `carousel_catalog.py` : extraction (quasi verbatim) de la Phase B de
  `_build_carousels` (`quiet_sources`/`saved`/`new_source`/`community`). `community` **unifié**
  via `CommunityRecommendationService.get_top_recommendations` (decay = récence + tournesols).
  Builds **surface-indépendants** (exclusion `consumed_ids` seulement).
- **Nouveau** `carousel_selection_service.py` : `build_phase_b` + `pick_essentiel_type`
  (rotation `md5(user|date_paris) % 4` sur la liste fixe `PHASE_B_ORDER`, premier disponible).
- `recommendation_service._build_carousels` rewiré : construit la Phase B via le catalogue,
  retire le type réservé à l'Essentiel, post-filtre `promoted_ids` (dédup intra-Flâner).
- `routers/essentiel.py` : `_enrich_essentiel_carousel` **fail-open + today-only** (patron
  `_enrich_community_carousel`) ; champ `carousel: CarouselInfo | None` sur `EssentielResponse`.
- **0 migration** (1 head Alembic inchangé).

## Front (mobile)
- `CarouselSection extends FluxSection` (auto-portée, hors-cap, non déplaçable) ; branche
  ajoutée dans chaque `switch` exhaustif du type scellé (models/provider/screen/utils/section_block).
- `EssentielRepository` parse `carousel` → `FeedCarouselData` ; threadé jusqu'au provider ;
  inséré directement en fin de `_compose` (comme `AlertsSection`) ; rendu `FeedCarousel` ;
  early-return fit ; ancre invitation recalée (ignore le carrousel de fin).

## Delta de comportement (borné, assumé)
- Flâner sert désormais **≤ 3** types Phase B/jour (le 4e est réservé à l'Essentiel du jour).
- Flâner exclut `promoted_ids` en post-filtre Python (au lieu de la requête) → un carrousel peut
  être rarement plus fin en cas de chevauchement Phase A↔B.
- `community` bascule sur le tri decay de `get_top_recommendations` (équivalent au bloc inline).

## Tests
- Backend : `test_carousel_catalog.py` (DB), `test_carousel_selection.py` (rotation +
  complémentarité), `test_essentiel_carousel.py` (fail-open, today-only) ; extraction des
  tests carrousel existants. Suite complète **verte** (2702 passed).
- Front : `flutter analyze` **0 error/warning** sur le périmètre ; tests flux_continu.

## Notes reviewer
- Base mergée sur `origin/main` (récupère le fix `firstPreparingIndex` #1036 + story 30.4).
- Aucune migration ; surface purement additive côté Essentiel (fail-open).
