### PR TITLE
feat(cartes): rendre la couverture multi-sources lisible (volet B, story 32.2)

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -1,6 +1,10 @@
 {
   "unreleased": [
     {
+      "tag": "Tes cartes",
+      "summary": "Chaque carte te dit maintenant combien de rédactions traitent le sujet : « 3 sources », avec leurs logos. C'est le signal qui explique pourquoi un article arrive dans ta tournée, et l'entrée naturelle vers « Comparer les angles ». Au passage, la petite pastille de sous-thème quitte le bas de carte : moins de bruit, plus de sens."
+    },
+    {
       "tag": "Ma Tournée",
       "summary": "Réorganise ta tournée sans quitter ta lecture : maintiens un onglet du bandeau en haut de l'écran, puis fais-le glisser à sa nouvelle place. Ton Essentiel reste en tête, le Mot du jour et la citation gardent la leur."
     },
@@ -19,6 +23,8 @@
     {
       "tag": "Alertes",
       "summary": "Pose une alerte sur n'importe quelle source ou n'importe quel sujet que tu suis. Avant de l'activer, Facteur t'annonce franchement le rythme : « environ 12 alertes par semaine », par exemple. Si c'est trop, coche « seulement les plus marquantes » et tu n'en recevras qu'une par jour, la plus pertinente pour toi. Cinq alertes maximum, toujours en silence, dans ta tournée. Le réglage est aussi devenu plus simple à trouver : « Notifications et alertes », directement dans les Réglages."
+    },
+    {
       "tag": "Ton avis compte",
       "summary": "Django et Laurin t'invitent à un café en visio de 5 minutes pour te demander ce qui te plaît, ou ce que tu aimes moins. L'invitation apparaît vers la fin de ta tournée, avec nos deux visages, et se referme en un geste : « Plus tard » ou « On l'a déjà fait ». Au passage, la carte de fin de tournée a été allégée pour tenir dans l'écran."
     },

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -435,12 +435,18 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   _ScrollNudgeTarget? _activeScrollNudgeTarget;
   // Passé à true une fois affiché ou tapé → ne réapparaît plus sur cet article.
   bool _scrollNudgeSpent = false;
-  // Résultat du cooldown 24 h (NudgeService.canShow), résolu à l'armement.
-  bool _scrollNudgeCooldownOk = false;
+  // Résultat du cooldown 24 h (NudgeService.canShow) **par cible** : la cible
+  // peut changer en cours de route (les perspectives arrivent avant le « pas de
+  // recul »), et vérifier le cooldown d'un id pour en afficher un autre était
+  // le bug d'identifiant de `markShown`.
+  final Map<String, bool> _scrollNudgeCooldownById = {};
+  // Ids dont la vérification asynchrone est en vol (anti-doublon).
+  final Set<String> _scrollNudgeCooldownPending = {};
+  // Le délai anti-pop est écoulé — armé en initState, donc en parallèle du
+  // réseau et non en série derrière lui.
+  bool _scrollNudgeArmDelayElapsed = false;
   // markShown() n'est appelé qu'une fois (au premier affichage réel).
   bool _scrollNudgeShownRecorded = false;
-  // L'armement différé n'est planifié qu'une fois par article.
-  bool _scrollNudgeArmScheduled = false;
   Timer? _scrollNudgeArmTimer;
   Timer? _scrollNudgeAutoHideTimer;
 
@@ -538,6 +544,11 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
         _fetchPerspectives();
       }
     }
+
+    // Délai anti-pop du nudge de scroll : démarré ici (et non après le fetch
+    // des perspectives) pour qu'il s'écoule en parallèle du réseau. La
+    // visibilité reste conditionnée à une cible montée + son cooldown 24 h.
+    _armScrollNudgeDelay();
 
     // Bookmark bounce animation (triggered on first note character)
     _bookmarkBounceController = AnimationController(
@@ -1160,34 +1171,42 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     return null;
   }
 
-  /// Planifie (une seule fois par article) l'armement différé du nudge :
-  /// attend `_kScrollNudgeArmDelay` (anti-pop instantané) puis résout le
-  /// cooldown 24 h avant d'autoriser l'affichage. Appelé dès qu'une cible
-  /// devient plausible (arrivée des perspectives, résolution du contenu).
-  void _maybeArmScrollNudge() {
-    if (_scrollNudgeArmScheduled) return;
-    final target = _resolveScrollNudgeTarget();
-    if (target == null) return;
-    _scrollNudgeArmScheduled = true;
-    _scrollNudgeArmTimer = Timer(_kScrollNudgeArmDelay, () async {
+  /// Démarre le délai anti-pop du nudge. Appelé en `initState` (et au retour
+  /// en haut de l'article) et **pas** après le fetch des perspectives : les
+  /// 1,5 s s'écoulent alors en parallèle du réseau au lieu de s'y ajouter.
+  void _armScrollNudgeDelay() {
+    _scrollNudgeArmTimer?.cancel();
+    _scrollNudgeArmTimer = Timer(_kScrollNudgeArmDelay, () {
       if (!mounted) return;
-      // Cooldown par-nudge uniquement (NudgeService, pas le coordinator) : on
-      // veut « 1×/24 h par cible », sans le budget global de session.
-      final ok = await ref.read(nudgeServiceProvider).canShow(target.id);
-      if (!mounted) return;
-      _scrollNudgeCooldownOk = ok;
+      _scrollNudgeArmDelayElapsed = true;
       _updateScrollNudgeVisibility();
     });
+  }
+
+  /// Résout (une fois par cible) le cooldown 24 h de [id], puis re-évalue la
+  /// visibilité. Cooldown par-nudge uniquement (NudgeService, pas le
+  /// coordinator) : « 1×/24 h par cible », sans le budget global de session.
+  void _ensureScrollNudgeCooldown(String id) {
+    if (_scrollNudgeCooldownById.containsKey(id) ||
+        !_scrollNudgeCooldownPending.add(id)) {
+      return;
+    }
+    () async {
+      final ok = await ref.read(nudgeServiceProvider).canShow(id);
+      _scrollNudgeCooldownPending.remove(id);
+      if (!mounted) return;
+      _scrollNudgeCooldownById[id] = ok;
+      _updateScrollNudgeVisibility();
+    }();
   }
 
   /// Calcul pur des conditions d'affichage du nudge de scroll. Aucune
   /// mutation d'état ici — voir [_updateScrollNudgeVisibility]. Résout et
   /// mémorise la cible courante dans `_activeScrollNudgeTarget`.
   bool _computeShouldShowScrollNudge() {
-    // Armé (cooldown 24 h résolu à l'armement), pas déjà consommé sur cet
-    // article. `_scrollNudgeCooldownOk` ne peut passer true qu'après le délai
-    // d'armement → il porte à lui seul l'état « armé + éligible ».
-    if (!_scrollNudgeCooldownOk || _scrollNudgeSpent) return false;
+    // Délai anti-pop écoulé, pas déjà consommé sur cet article. Le cooldown
+    // 24 h est vérifié plus bas, sur la cible réellement résolue.
+    if (!_scrollNudgeArmDelayElapsed || _scrollNudgeSpent) return false;
     // Le nudge n'a de sens que pendant la lecture scrollable normale : dès que
     // la WebView a pris le relais visuel, ou que le CTA a été tapé (révélation
     // en cours), la destination n'est plus pertinente.
@@ -1202,6 +1221,15 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     final target = _resolveScrollNudgeTarget();
     if (target == null) return false;
     _activeScrollNudgeTarget = target;
+
+    // Cooldown de LA cible courante — pas de celle connue à l'armement. Le
+    // premier passage lance la vérification et rappellera cette méthode.
+    final cooldownOk = _scrollNudgeCooldownById[target.id];
+    if (cooldownOk == null) {
+      _ensureScrollNudgeCooldown(target.id);
+      return false;
+    }
+    if (!cooldownOk) return false;
 
     // Destination hors écran (assez bas pour valoir un scroll). Si la clé n'est
     // pas encore montée (premier frame après fetch, ou carte non rendue dans la
@@ -1337,7 +1365,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     // Retour en haut de l'article : ré-arme le nudge de scroll (le cooldown
     // 24 h déjà posé le maintiendra masqué s'il a été montré aujourd'hui).
     _resetScrollNudge();
-    _maybeArmScrollNudge();
+    _armScrollNudgeDelay();
   }
 
   /// Remet à zéro l'état du nudge de scroll (armement, cooldown, auto-hide) et
@@ -1346,9 +1374,10 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     _scrollNudgeArmTimer?.cancel();
     _scrollNudgeAutoHideTimer?.cancel();
     _scrollNudgeSpent = false;
-    _scrollNudgeCooldownOk = false;
+    _scrollNudgeArmDelayElapsed = false;
+    _scrollNudgeCooldownById.clear();
+    _scrollNudgeCooldownPending.clear();
     _scrollNudgeShownRecorded = false;
-    _scrollNudgeArmScheduled = false;
     _showScrollNudge.value = false;
   }
 
@@ -2263,9 +2292,6 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
           _schedulePerspectivesPartialRefetch(content.id);
         }
         _maybeTriggerPerspectivesCta();
-        // Une cible de nudge (pas de recul ou perspectives) est désormais
-        // plausible : planifie l'armement différé (1,5 s + cooldown).
-        _maybeArmScrollNudge();
         // `PerspectivesInlineSection`/`_perspectivesKey` ne sont montés qu'au
         // prochain frame après ce `setState` — sans ce callback, un
         // utilisateur déjà en haut et immobile ne verrait jamais le nudge

--- a/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
+++ b/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
@@ -164,6 +164,13 @@ class EssentielArticle {
   final String? theme;
   final String sectionLabel;
   final int perspectiveCount;
+
+  /// Nombre de rédactions couvrant le sujet d'origine — pilote la pastille de
+  /// couverture (seuil [kCoverageChipMinSources]).
+  final int sourceCount;
+
+  /// Logos des rédactions qui couvrent le sujet, tronqués à 3 par le backend.
+  final List<SourceMini> perspectiveSources;
   final int rank;
   final bool isRead;
   final bool isSaved;
@@ -198,6 +205,8 @@ class EssentielArticle {
     this.kind = SectionKind.theme,
     this.theme,
     this.perspectiveCount = 0,
+    this.sourceCount = 0,
+    this.perspectiveSources = const [],
     this.isRead = false,
     this.isSaved = false,
     this.isLiked = false,
@@ -238,6 +247,11 @@ class EssentielArticle {
       theme: json['theme'] as String?,
       sectionLabel: (json['section_label'] as String?) ?? '',
       perspectiveCount: (json['perspective_count'] as num?)?.toInt() ?? 0,
+      sourceCount: (json['source_count'] as num?)?.toInt() ?? 0,
+      perspectiveSources: [
+        for (final raw in (json['perspective_sources'] as List?) ?? const [])
+          if (raw is Map) SourceMini.fromJson(raw.cast<String, dynamic>()),
+      ],
       rank: (json['rank'] as num?)?.toInt() ?? 0,
       isRead: (json['is_read'] as bool?) ?? false,
       isSaved: (json['is_saved'] as bool?) ?? false,
@@ -264,6 +278,8 @@ class EssentielArticle {
     'theme': theme,
     'section_label': sectionLabel,
     'perspective_count': perspectiveCount,
+    'source_count': sourceCount,
+    'perspective_sources': [for (final s in perspectiveSources) s.toJson()],
     'rank': rank,
     'is_read': isRead,
     'is_saved': isSaved,

--- a/apps/mobile/lib/features/flux_continu/screens/digest_section_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/digest_section_screen.dart
@@ -166,8 +166,7 @@ class _DigestSectionScreenState extends ConsumerState<DigestSectionScreen> {
             final lead = pickTopicLead(topic);
             return FluxContinuArticleCard(
               article: lead,
-              isEssentiel: section.kind == SectionKind.essentiel,
-              pressReviewCount: topic.perspectiveCount,
+              sourceCount: topic.sourceCount,
               perspectiveSources: topic.perspectiveSources,
               divergenceLevel: topic.divergenceLevel,
               onTap: () => _openArticle(context, lead),

--- a/apps/mobile/lib/features/flux_continu/widgets/coverage_chip.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/coverage_chip.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../../config/theme.dart';
+import '../../../widgets/design/facteur_image.dart';
+import '../../digest/models/digest_models.dart';
+
+/// Seuil d'affichage de la couverture : en dessous de 2 rédactions, le signal
+/// « ce sujet est couvert par plusieurs médias » n'existe pas.
+const int kCoverageChipMinSources = 2;
+
+/// Pastille de couverture multi-sources — pile d'avatars (3 max) suivie du
+/// nombre de rédactions qui traitent le sujet. C'est le signal qui répond au
+/// « pourquoi cet article m'est poussé » et qui justifie « Comparer les
+/// angles » ; partagé entre les cartes du flux et la carte hi-fi Essentiel.
+class CoverageChip extends StatelessWidget {
+  final int sourceCount;
+  final List<SourceMini> sources;
+  final FacteurColors colors;
+
+  const CoverageChip({
+    super.key,
+    required this.sourceCount,
+    required this.sources,
+    required this.colors,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const dotSize = 12.0;
+    const overlap = 4.0;
+    final visibleCount = sources.length < 3 ? sources.length : 3;
+    final stackWidth = visibleCount == 0
+        ? 0.0
+        : dotSize + (visibleCount - 1) * (dotSize - overlap);
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (visibleCount > 0) ...[
+          SizedBox(
+            width: stackWidth,
+            height: dotSize,
+            child: Stack(
+              clipBehavior: Clip.none,
+              children: [
+                for (var i = 0; i < visibleCount; i++)
+                  Positioned(
+                    left: i * (dotSize - overlap),
+                    child: SourceDot(
+                      name: sources[i].name,
+                      logoUrl: sources[i].logoUrl,
+                      accent: colors.primary,
+                      ringColor: colors.surface,
+                      size: dotSize,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 6),
+        ],
+        Text(
+          sourceCount > 1 ? '$sourceCount sources' : '1 source',
+          style: GoogleFonts.dmSans(
+            fontSize: 11,
+            fontWeight: FontWeight.w600,
+            color: colors.textSecondary,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Source identity dot — logo when [logoUrl] is provided, initial otherwise.
+class SourceDot extends StatelessWidget {
+  final String name;
+  final String? logoUrl;
+  final Color accent;
+  final Color ringColor;
+  final double size;
+
+  const SourceDot({
+    super.key,
+    required this.name,
+    required this.logoUrl,
+    required this.accent,
+    required this.ringColor,
+    required this.size,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final hasLogo = logoUrl != null && logoUrl!.trim().isNotEmpty;
+    final initial = _Initial(name: name, fontSize: size * 0.55);
+    return Container(
+      width: size,
+      height: size,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: accent,
+        shape: BoxShape.circle,
+        boxShadow: [
+          BoxShadow(color: ringColor, spreadRadius: 1.5, blurRadius: 0),
+        ],
+      ),
+      child: hasLogo
+          ? ClipOval(
+              child: FacteurImage(
+                imageUrl: logoUrl!,
+                width: size,
+                height: size,
+                placeholder: (_) => initial,
+                errorWidget: (_) => initial,
+              ),
+            )
+          : initial,
+    );
+  }
+}
+
+class _Initial extends StatelessWidget {
+  final String name;
+  final double fontSize;
+
+  const _Initial({required this.name, required this.fontSize});
+
+  @override
+  Widget build(BuildContext context) {
+    final trimmed = name.trim();
+    final initial =
+        trimmed.isEmpty ? '?' : trimmed.characters.first.toUpperCase();
+    return Text(
+      initial,
+      style: GoogleFonts.dmSans(
+        fontSize: fontSize,
+        fontWeight: FontWeight.w700,
+        color: Colors.white,
+        height: 1.0,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -23,6 +23,7 @@ import '../providers/weather_provider.dart';
 import '../services/tournee_progress_service.dart';
 import '../utils/theme_color_mapping.dart';
 import 'auto_grow_candidate.dart';
+import 'coverage_chip.dart';
 import 'edition_timeline_sheet.dart';
 import 'ephemeral_rattraper_label.dart';
 import 'weather_condition_icon.dart';
@@ -802,6 +803,15 @@ class _MediumTile extends StatelessWidget {
                             ),
                           ),
                         ),
+                        if (article.sourceCount >=
+                            kCoverageChipMinSources) ...[
+                          const SizedBox(width: 8),
+                          CoverageChip(
+                            sourceCount: article.sourceCount,
+                            sources: article.perspectiveSources,
+                            colors: colors,
+                          ),
+                        ],
                         // Réserve l'espace de la coche pour qu'elle ne
                         // chevauche pas la source ellipsée.
                         if (readState != ReadState.unread)
@@ -924,6 +934,15 @@ class _SourceRow extends StatelessWidget {
             style: FacteurTypography.labelSmall(colors.textTertiary),
           ),
         ),
+        if (article.sourceCount >= kCoverageChipMinSources) ...[
+          const Spacer(),
+          CoverageChip(
+            key: const Key('essentiel-coverage-chip'),
+            sourceCount: article.sourceCount,
+            sources: article.perspectiveSources,
+            colors: colors,
+          ),
+        ],
       ],
     );
   }

--- a/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
@@ -5,7 +5,6 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:timeago/timeago.dart' as timeago;
 
 import '../../../config/theme.dart';
-import '../../../config/topic_labels.dart';
 import '../../../shared/widgets/read_state_mark.dart';
 import '../../../widgets/article_preview_modal.dart';
 import '../../../widgets/design/facteur_image.dart';
@@ -19,6 +18,7 @@ import '../../settings/models/display_mode_spec.dart';
 import '../../settings/providers/display_mode_provider.dart';
 import '../../sources/models/source_model.dart';
 import 'auto_grow_candidate.dart';
+import 'coverage_chip.dart';
 
 /// Unified view-model that hides the DigestItem vs Content split from the
 /// rendering layer. Both types carry the fields needed to display a Flux
@@ -30,7 +30,6 @@ class FluxArticleVM {
   final String? thumbnailUrl;
   final String sourceName;
   final String? sourceLogoUrl;
-  final String? themeLabel;
   final ContentType contentType;
   final int? durationSeconds;
   final DateTime? publishedAt;
@@ -49,7 +48,6 @@ class FluxArticleVM {
     required this.contentType,
     this.thumbnailUrl,
     this.sourceLogoUrl,
-    this.themeLabel,
     this.durationSeconds,
     this.publishedAt,
     this.isFollowedSource = false,
@@ -70,10 +68,6 @@ class FluxArticleVM {
         thumbnailUrl: article.thumbnailUrl,
         sourceName: article.source?.name ?? 'Inconnu',
         sourceLogoUrl: article.source?.logoUrl,
-        themeLabel:
-            (article.source?.theme != null && article.source!.theme!.isNotEmpty)
-                ? getTopicLabel(article.source!.theme!)
-                : null,
         contentType: article.contentType,
         durationSeconds: article.durationSeconds,
         publishedAt: article.publishedAt,
@@ -98,7 +92,6 @@ class FluxArticleVM {
         thumbnailUrl: article.thumbnailUrl,
         sourceName: article.source.name,
         sourceLogoUrl: article.source.logoUrl,
-        themeLabel: article.progressionTopic,
         contentType: article.contentType,
         durationSeconds: article.durationSeconds,
         publishedAt: article.publishedAt,
@@ -116,8 +109,8 @@ class FluxArticleVM {
 /// - 12px padding inside a 12-radius surface card, soft shadow.
 /// - Head row : title (4-line ellipsis, DM Sans 18 w600) + 72×72 thumb on
 ///   the right (radius 10).
-/// - Footer row (single-line) : source dot + name · theme pill · clock·time
-///   · optional press-review trailing (Essentiel sections only).
+/// - Footer row (single-line) : source dot + name · clock·time
+///   · pastille de couverture optionnelle (sujet couvert par ≥ 2 rédactions).
 class FluxContinuArticleCard extends ConsumerStatefulWidget {
   final Object article;
   final VoidCallback? onTap;
@@ -127,8 +120,9 @@ class FluxContinuArticleCard extends ConsumerStatefulWidget {
   final GlobalKey? nudgeAnchor;
   final VoidCallback? onSwipeConversion;
   final VoidCallback? onLongPressConversion;
-  final bool isEssentiel;
-  final int pressReviewCount;
+  /// Nombre de rédactions couvrant le sujet — pilote la pastille de couverture
+  /// du footer (seuil [kCoverageChipMinSources]).
+  final int sourceCount;
   final List<SourceMini> perspectiveSources;
   final String? divergenceLevel;
 
@@ -149,8 +143,7 @@ class FluxContinuArticleCard extends ConsumerStatefulWidget {
     this.nudgeAnchor,
     this.onSwipeConversion,
     this.onLongPressConversion,
-    this.isEssentiel = false,
-    this.pressReviewCount = 0,
+    this.sourceCount = 0,
     this.perspectiveSources = const [],
     this.divergenceLevel,
     this.allowImageOnTop = true,
@@ -404,8 +397,8 @@ class _FluxContinuArticleCardState
     return _Footer(
       vm: vm,
       colors: colors,
-      showPressReview: widget.isEssentiel && widget.pressReviewCount > 0,
-      pressReviewCount: widget.pressReviewCount,
+      showCoverage: widget.sourceCount >= kCoverageChipMinSources,
+      sourceCount: widget.sourceCount,
       perspectiveSources: widget.perspectiveSources,
       divergenceLevel: widget.divergenceLevel,
     );
@@ -559,16 +552,16 @@ class _VideoPlayBadge extends StatelessWidget {
 class _Footer extends StatelessWidget {
   final FluxArticleVM vm;
   final FacteurColors colors;
-  final bool showPressReview;
-  final int pressReviewCount;
+  final bool showCoverage;
+  final int sourceCount;
   final List<SourceMini> perspectiveSources;
   final String? divergenceLevel;
 
   const _Footer({
     required this.vm,
     required this.colors,
-    required this.showPressReview,
-    required this.pressReviewCount,
+    required this.showCoverage,
+    required this.sourceCount,
     required this.perspectiveSources,
     this.divergenceLevel,
   });
@@ -587,7 +580,7 @@ class _Footer extends StatelessWidget {
     return Row(
       mainAxisSize: MainAxisSize.max,
       children: [
-        _SourceDot(
+        SourceDot(
           name: vm.sourceName,
           logoUrl: vm.sourceLogoUrl,
           accent: colors.primary,
@@ -620,17 +613,6 @@ class _Footer extends StatelessWidget {
             ),
           ),
         ],
-        // Pastille de thème (macro-thème ML granulaire, sinon thème source en
-        // fallback via `progressionTopic`) : rétablie après son retrait
-        // temporaire en Story 10.1. Le VM la calcule toujours ; masquée si vide.
-        if (vm.themeLabel != null && vm.themeLabel!.trim().isNotEmpty) ...[
-          const SizedBox(width: 6),
-          _ThemePill(
-            key: const Key('flux-theme-pill'),
-            label: vm.themeLabel!,
-            colors: colors,
-          ),
-        ],
         const SizedBox(width: 6),
         separator,
         const SizedBox(width: 6),
@@ -645,17 +627,18 @@ class _Footer extends StatelessWidget {
             height: 1.4,
           ),
         ),
-        if (showPressReview || divergenceLevel != null) const Spacer(),
+        if (showCoverage || divergenceLevel != null) const Spacer(),
         if (divergenceLevel != null) ...[
           DivergenceInlineBadge(
             divergenceLevel: divergenceLevel,
             iconOnly: true,
           ),
-          if (showPressReview) const SizedBox(width: 6),
+          if (showCoverage) const SizedBox(width: 6),
         ],
-        if (showPressReview)
-          _PressReviewChip(
-            count: pressReviewCount,
+        if (showCoverage)
+          CoverageChip(
+            key: const Key('flux-coverage-chip'),
+            sourceCount: sourceCount,
             sources: perspectiveSources,
             colors: colors,
           ),
@@ -671,163 +654,3 @@ class _Footer extends StatelessWidget {
         .trim();
   }
 }
-
-/// Source identity dot — logo when [logoUrl] is provided, initial otherwise.
-class _SourceDot extends StatelessWidget {
-  final String name;
-  final String? logoUrl;
-  final Color accent;
-  final Color ringColor;
-  final double size;
-
-  const _SourceDot({
-    required this.name,
-    required this.logoUrl,
-    required this.accent,
-    required this.ringColor,
-    required this.size,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final hasLogo = logoUrl != null && logoUrl!.trim().isNotEmpty;
-    final initial = _Initial(name: name, fontSize: size * 0.55);
-    return Container(
-      width: size,
-      height: size,
-      alignment: Alignment.center,
-      decoration: BoxDecoration(
-        color: accent,
-        shape: BoxShape.circle,
-        boxShadow: [
-          BoxShadow(color: ringColor, spreadRadius: 1.5, blurRadius: 0),
-        ],
-      ),
-      child: hasLogo
-          ? ClipOval(
-              child: FacteurImage(
-                imageUrl: logoUrl!,
-                width: size,
-                height: size,
-                placeholder: (_) => initial,
-                errorWidget: (_) => initial,
-              ),
-            )
-          : initial,
-    );
-  }
-}
-
-class _Initial extends StatelessWidget {
-  final String name;
-  final double fontSize;
-
-  const _Initial({required this.name, required this.fontSize});
-
-  @override
-  Widget build(BuildContext context) {
-    final trimmed = name.trim();
-    final initial =
-        trimmed.isEmpty ? '?' : trimmed.characters.first.toUpperCase();
-    return Text(
-      initial,
-      style: GoogleFonts.dmSans(
-        fontSize: fontSize,
-        fontWeight: FontWeight.w700,
-        color: Colors.white,
-        height: 1.0,
-      ),
-    );
-  }
-}
-
-/// Trailing for Essentiel cards: stacks up to 3 source logos with a 4-px
-/// overlap, followed by a "+N" count chip.
-class _PressReviewChip extends StatelessWidget {
-  final int count;
-  final List<SourceMini> sources;
-  final FacteurColors colors;
-
-  const _PressReviewChip({
-    required this.count,
-    required this.sources,
-    required this.colors,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    const dotSize = 12.0;
-    const overlap = 4.0;
-    final visibleCount = sources.length < 3 ? sources.length : 3;
-    final stackWidth = visibleCount == 0
-        ? 0.0
-        : dotSize + (visibleCount - 1) * (dotSize - overlap);
-
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        if (visibleCount > 0)
-          SizedBox(
-            width: stackWidth,
-            height: dotSize,
-            child: Stack(
-              clipBehavior: Clip.none,
-              children: [
-                for (var i = 0; i < visibleCount; i++)
-                  Positioned(
-                    left: i * (dotSize - overlap),
-                    child: _SourceDot(
-                      name: sources[i].name,
-                      logoUrl: sources[i].logoUrl,
-                      accent: colors.primary,
-                      ringColor: colors.surface,
-                      size: dotSize,
-                    ),
-                  ),
-              ],
-            ),
-          ),
-        if (visibleCount > 0) const SizedBox(width: 6),
-        Text(
-          '+$count',
-          style: GoogleFonts.dmSans(
-            fontSize: 11,
-            fontWeight: FontWeight.w600,
-            color: colors.textSecondary,
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-/// Pastille de thème compacte affichée dans le footer de carte (source ·
-/// thème · heure). Style discret : fond très léger, texte secondaire.
-class _ThemePill extends StatelessWidget {
-  final String label;
-  final FacteurColors colors;
-
-  const _ThemePill({super.key, required this.label, required this.colors});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
-      decoration: BoxDecoration(
-        color: colors.textPrimary.withValues(alpha: 0.06),
-        borderRadius: BorderRadius.circular(999),
-      ),
-      child: Text(
-        label,
-        style: GoogleFonts.dmSans(
-          fontSize: 10,
-          fontWeight: FontWeight.w600,
-          letterSpacing: 0.2,
-          height: 1.4,
-          color: colors.textSecondary,
-        ),
-      ),
-    );
-  }
-}
-

--- a/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart
@@ -577,71 +577,88 @@ class _Footer extends StatelessWidget {
       ),
     );
 
+    // Deux groupes : l'identité (qui flexe) et le trailing (taille fixe).
+    // Un `Spacer` au même niveau que le `Flexible` du nom se partagerait
+    // l'espace libre à 50/50 — un nom long ne rétrécissait alors que jusqu'à sa
+    // moitié et le trailing débordait. Ici l'`Expanded` pousse le trailing à
+    // droite ET absorbe toute la contrainte, donc le nom s'ellipse en premier.
     return Row(
       mainAxisSize: MainAxisSize.max,
       children: [
-        SourceDot(
-          name: vm.sourceName,
-          logoUrl: vm.sourceLogoUrl,
-          accent: colors.primary,
-          ringColor: colors.surface,
-          size: 14,
-        ),
-        const SizedBox(width: 6),
-        Flexible(
-          child: Text(
-            vm.sourceName,
-            style: GoogleFonts.dmSans(
-              fontSize: 12,
-              fontWeight: FontWeight.w600,
-              color: colors.textSecondary,
-              height: 1.4,
-            ),
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
+        Expanded(
+          child: Row(
+            mainAxisSize: MainAxisSize.max,
+            children: [
+              SourceDot(
+                name: vm.sourceName,
+                logoUrl: vm.sourceLogoUrl,
+                accent: colors.primary,
+                ringColor: colors.surface,
+                size: 14,
+              ),
+              const SizedBox(width: 6),
+              Flexible(
+                child: Text(
+                  vm.sourceName,
+                  style: GoogleFonts.dmSans(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    color: colors.textSecondary,
+                    height: 1.4,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              if (!vm.isFollowedSource) ...[
+                const SizedBox(width: 3),
+                Text(
+                  '+',
+                  style: GoogleFonts.dmSans(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                    color: colors.textTertiary,
+                    height: 1.4,
+                  ),
+                ),
+              ],
+              const SizedBox(width: 6),
+              separator,
+              const SizedBox(width: 6),
+              Icon(
+                PhosphorIconsRegular.clock,
+                size: 12,
+                color: colors.textTertiary,
+              ),
+              const SizedBox(width: 3),
+              Text(
+                _publishedAtShort(vm.publishedAt),
+                style: GoogleFonts.dmSans(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w500,
+                  color: colors.textTertiary,
+                  height: 1.4,
+                ),
+              ),
+            ],
           ),
         ),
-        if (!vm.isFollowedSource) ...[
-          const SizedBox(width: 3),
-          Text(
-            '+',
-            style: GoogleFonts.dmSans(
-              fontSize: 12,
-              fontWeight: FontWeight.w700,
-              color: colors.textTertiary,
-              height: 1.4,
-            ),
-          ),
-        ],
-        const SizedBox(width: 6),
-        separator,
-        const SizedBox(width: 6),
-        Icon(PhosphorIconsRegular.clock, size: 12, color: colors.textTertiary),
-        const SizedBox(width: 3),
-        Text(
-          _publishedAtShort(vm.publishedAt),
-          style: GoogleFonts.dmSans(
-            fontSize: 12,
-            fontWeight: FontWeight.w500,
-            color: colors.textTertiary,
-            height: 1.4,
-          ),
-        ),
-        if (showCoverage || divergenceLevel != null) const Spacer(),
         if (divergenceLevel != null) ...[
+          const SizedBox(width: 6),
           DivergenceInlineBadge(
             divergenceLevel: divergenceLevel,
             iconOnly: true,
           ),
-          if (showCoverage) const SizedBox(width: 6),
         ],
-        if (showCoverage)
+        if (showCoverage) ...[
+          const SizedBox(width: 6),
           CoverageChip(
             key: const Key('flux-coverage-chip'),
             sourceCount: sourceCount,
             sources: perspectiveSources,
             colors: colors,
           ),
+        ],
       ],
     );
   }

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -221,7 +221,6 @@ class SectionBlock extends StatelessWidget {
   }
 
   List<Widget> _buildCards() {
-    final isEssentiel = section.kind == SectionKind.essentiel;
     switch (section) {
       case EssentielSection():
         // build() short-circuits to EssentielHiFiCard before reaching
@@ -252,11 +251,10 @@ class SectionBlock extends StatelessWidget {
             else
               FluxContinuArticleCard(
                 article: pickTopicLead(visible[i]),
-                isEssentiel: isEssentiel,
                 allowImageOnTop: imageAllowed.contains(
                   pickTopicLead(visible[i]).contentId,
                 ),
-                pressReviewCount: visible[i].perspectiveCount,
+                sourceCount: visible[i].sourceCount,
                 perspectiveSources: visible[i].perspectiveSources,
                 divergenceLevel: visible[i].divergenceLevel,
                 onTap: () => onTapArticle(pickTopicLead(visible[i])),

--- a/apps/mobile/test/features/flux_continu/models/flux_continu_models_test.dart
+++ b/apps/mobile/test/features/flux_continu/models/flux_continu_models_test.dart
@@ -391,4 +391,43 @@ void main() {
       expect(r.breakdown, isEmpty);
     });
   });
+
+  group('EssentielArticle — couverture multi-sources', () {
+    test('parses source_count + perspective_sources', () {
+      final a = EssentielArticle.fromJson({
+        'content_id': 'c-1',
+        'title': 'Titre',
+        'url': 'https://example.com',
+        'published_at': '2026-07-30T08:00:00Z',
+        'source': {'name': 'Le Monde'},
+        'source_letter': 'L',
+        'section_label': 'Climat',
+        'rank': 1,
+        'source_count': 4,
+        'perspective_sources': [
+          {'name': 'Le Monde', 'domain': 'lemonde.fr', 'bias_stance': 'center'},
+          {'name': 'Libération', 'logo_url': 'https://x/l.png'},
+        ],
+      });
+      expect(a.sourceCount, 4);
+      expect(a.perspectiveSources, hasLength(2));
+      expect(a.perspectiveSources.first.name, 'Le Monde');
+      expect(a.perspectiveSources[1].logoUrl, 'https://x/l.png');
+    });
+
+    test('retro-compat : un snapshot Hive sans les champs parse en défauts', () {
+      final a = EssentielArticle.fromJson({
+        'content_id': 'c-1',
+        'title': 'Titre',
+        'url': 'https://example.com',
+        'published_at': '2026-07-30T08:00:00Z',
+        'source': {'name': 'Le Monde'},
+        'source_letter': 'L',
+        'section_label': 'Climat',
+        'rank': 1,
+      });
+      expect(a.sourceCount, 0);
+      expect(a.perspectiveSources, isEmpty);
+    });
+  });
 }

--- a/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
@@ -6,6 +6,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import 'package:facteur/config/theme.dart';
+import 'package:facteur/features/digest/models/digest_models.dart';
 import 'package:facteur/features/feed/models/content_model.dart';
 import 'package:facteur/features/flux_continu/models/flux_continu_models.dart';
 import 'package:facteur/features/flux_continu/models/weather_location.dart';
@@ -85,6 +86,8 @@ EssentielArticle _article({
   bool isActuDuJour = false,
   bool isRead = false,
   DateTime? completedAt,
+  int sourceCount = 0,
+  List<SourceMini> perspectiveSources = const [],
 }) {
   return EssentielArticle(
     contentId: 'c-$rank',
@@ -100,6 +103,8 @@ EssentielArticle _article({
     isActuDuJour: isActuDuJour,
     isRead: isRead,
     completedAt: completedAt,
+    sourceCount: sourceCount,
+    perspectiveSources: perspectiveSources,
   );
 }
 
@@ -275,6 +280,48 @@ void main() {
       await gesture.up();
       await tester.pumpAndSettle();
       expect(find.byType(FacteurThumbnail), findsNothing);
+    });
+
+
+    testWidgets(
+        'la puce de couverture est rendue sur les tuiles couvertes (>= 2 '
+        'sources) et ne fait pas déborder le 390 px', (tester) async {
+      tester.view.physicalSize = const Size(390, 844);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      const covered = [
+        SourceMini(name: 'Le Monde'),
+        SourceMini(name: 'Libération'),
+        SourceMini(name: 'Le Figaro'),
+      ];
+      await tester.pumpWidget(_wrap(
+        EssentielHiFiCard(
+          articles: [
+            _article(
+              rank: 1,
+              source: 'Le Monde Diplomatique',
+              sourceCount: 4,
+              perspectiveSources: covered,
+            ),
+            _article(
+              rank: 2,
+              source: 'Le Monde Diplomatique',
+              sourceCount: 3,
+              perspectiveSources: covered,
+            ),
+            // Sous le seuil : aucune puce.
+            _article(rank: 3, sourceCount: 1),
+          ],
+          onTapArticle: (_) {},
+        ),
+      ));
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('4 sources'), findsOneWidget);
+      expect(find.text('3 sources'), findsOneWidget);
+      expect(find.text('1 source'), findsNothing);
     });
 
     testWidgets('renders up to 5 articles (lead + 2 mediums + 2 lights)',

--- a/apps/mobile/test/features/flux_continu/widgets/flux_continu_article_card_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/flux_continu_article_card_test.dart
@@ -5,6 +5,8 @@ import 'package:google_fonts/google_fonts.dart';
 
 import 'package:facteur/config/theme.dart';
 import 'package:facteur/features/feed/models/content_model.dart';
+import 'package:facteur/features/digest/models/digest_models.dart';
+import 'package:facteur/features/flux_continu/widgets/coverage_chip.dart';
 import 'package:facteur/features/flux_continu/widgets/flux_continu_article_card.dart';
 import 'package:facteur/features/settings/models/display_mode_spec.dart';
 import 'package:facteur/features/settings/providers/display_mode_provider.dart';
@@ -77,25 +79,63 @@ void main() {
     expect(find.byType(FacteurThumbnail), findsNothing);
   });
 
-  testWidgets(
-      'footer renders the theme pill from the source-theme fallback when '
-      'ML topics are empty (mitigation « tout en Autres »)', (tester) async {
+  testWidgets('footer shows the coverage chip when the subject is covered by '
+      'several newsrooms', (tester) async {
+    await tester.pumpWidget(_wrap(
+      FluxContinuArticleCard(
+        article: _content(),
+        sourceCount: 3,
+        perspectiveSources: const [
+          SourceMini(name: 'Le Monde'),
+          SourceMini(name: 'Libération'),
+          SourceMini(name: 'Le Figaro'),
+        ],
+      ),
+    ));
+
+    expect(find.byKey(const Key('flux-coverage-chip')), findsOneWidget);
+    expect(find.text('3 sources'), findsOneWidget);
+  });
+
+  testWidgets('no coverage chip below the 2-source threshold', (tester) async {
+    await tester.pumpWidget(_wrap(
+      FluxContinuArticleCard(
+        article: _content(),
+        sourceCount: 1,
+        perspectiveSources: const [SourceMini(name: 'Le Monde')],
+      ),
+    ));
+
+    expect(find.byKey(const Key('flux-coverage-chip')), findsNothing);
+  });
+
+  testWidgets('coverage chip caps the avatar stack at 3', (tester) async {
+    await tester.pumpWidget(_wrap(
+      FluxContinuArticleCard(
+        article: _content(),
+        sourceCount: 6,
+        perspectiveSources: const [
+          SourceMini(name: 'A'),
+          SourceMini(name: 'B'),
+          SourceMini(name: 'C'),
+          SourceMini(name: 'D'),
+          SourceMini(name: 'E'),
+          SourceMini(name: 'F'),
+        ],
+      ),
+    ));
+
+    // Les avatars de la pile + le point d'identité de la source de la carte.
+    expect(find.byType(SourceDot), findsNWidgets(4));
+    expect(find.text('6 sources'), findsOneWidget);
+  });
+
+  testWidgets('footer no longer renders a sub-theme pill', (tester) async {
     await tester.pumpWidget(_wrap(
       FluxContinuArticleCard(article: _content(sourceTheme: 'tech')),
     ));
 
-    expect(find.byKey(const Key('flux-theme-pill')), findsOneWidget);
-    // Le libellé affiché est le thème source mappé (fallback pré-ML), pas le
-    // slug brut : la pastille reste lisible même worker de classif mort.
-    expect(find.text('Tech & Innovation'), findsOneWidget);
+    expect(find.text('Tech & Innovation'), findsNothing);
   });
 
-  testWidgets('no theme pill when neither ML topic nor source theme resolves',
-      (tester) async {
-    await tester.pumpWidget(_wrap(
-      FluxContinuArticleCard(article: _content()),
-    ));
-
-    expect(find.byKey(const Key('flux-theme-pill')), findsNothing);
-  });
 }

--- a/apps/mobile/test/features/flux_continu/widgets/flux_continu_article_card_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/flux_continu_article_card_test.dart
@@ -12,9 +12,17 @@ import 'package:facteur/features/settings/models/display_mode_spec.dart';
 import 'package:facteur/features/settings/providers/display_mode_provider.dart';
 import 'package:facteur/features/sources/models/source_model.dart';
 import 'package:facteur/widgets/design/facteur_thumbnail.dart';
+import 'package:timeago/timeago.dart' as timeago;
 import 'package:visibility_detector/visibility_detector.dart';
 
-Content _content({String? sourceTheme}) => Content(
+import 'package:facteur/core/utils/fr_compact_messages.dart';
+
+Content _content({
+  String? sourceTheme,
+  String sourceName = 'Le Monde',
+  DateTime? publishedAt,
+}) =>
+    Content(
       id: 'c-1',
       title: 'Titre article Flux',
       url: 'https://example.com/1',
@@ -22,12 +30,12 @@ Content _content({String? sourceTheme}) => Content(
       // FacteurThumbnail éventuelle vient de l'aperçu flottant.
       description: 'Un chapô pour l\'aperçu.',
       contentType: ContentType.article,
-      publishedAt: DateTime(2026, 7, 10),
+      publishedAt: publishedAt ?? DateTime(2026, 7, 10),
       // Pas de topics ML → `progressionTopic` retombe sur le thème source, le
       // fallback qui garde une pastille utile quand la classif est en retard.
       source: Source(
         id: 's-1',
-        name: 'Le Monde',
+        name: sourceName,
         type: SourceType.article,
         theme: sourceTheme,
       ),
@@ -46,6 +54,9 @@ Widget _wrap(Widget child) => ProviderScope(
 void main() {
   setUpAll(() {
     GoogleFonts.config.allowRuntimeFetching = false;
+    // Sans ça `timeago` retombe sur l'anglais long (« 3 months ago ») et le
+    // footer mesuré n'a plus rien à voir avec celui de l'app (« 2 h »).
+    timeago.setLocaleMessages('fr_short', FrCompactMessages());
     VisibilityDetectorController.instance.updateInterval = Duration.zero;
   });
 
@@ -138,4 +149,37 @@ void main() {
     expect(find.text('Tech & Innovation'), findsNothing);
   });
 
+  testWidgets(
+      'footer tient en 390 px avec un nom de source long, la puce de '
+      'couverture et le badge de divergence (budget horizontal)',
+      (tester) async {
+    // Le viewport mobile de référence du design system. Un dépassement de la
+    // Row du footer lèverait une FlutterError « RenderFlex overflowed » que
+    // le framework de test remonte via takeException.
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(_wrap(
+      FluxContinuArticleCard(
+        article: _content(
+          sourceName: 'Le Monde Diplomatique',
+          publishedAt: DateTime.now().subtract(const Duration(hours: 2)),
+        ),
+        sourceCount: 3,
+        divergenceLevel: 'high',
+        perspectiveSources: const [
+          SourceMini(name: 'Le Monde'),
+          SourceMini(name: 'Libération'),
+          SourceMini(name: 'Le Figaro'),
+        ],
+      ),
+    ));
+
+    // Un dépassement lèverait « RenderFlex overflowed » ; c'est le nom de
+    // source qui doit céder en premier (ellipse), jamais la puce.
+    expect(tester.takeException(), isNull);
+    expect(find.byKey(const Key('flux-coverage-chip')), findsOneWidget);
+    expect(find.text('3 sources'), findsOneWidget);
+  });
 }

--- a/docs/stories/core/32.2.couverture-multi-sources-cartes.md
+++ b/docs/stories/core/32.2.couverture-multi-sources-cartes.md
@@ -1,0 +1,273 @@
+# Story 32.2 — Rendre la couverture multi-sources lisible sur les cartes (volet B)
+
+> **Statut : implémentée** (3 commits révocables séparément). Ce document est le
+> plan validé par le PO, conservé tel quel : la section « Deux corrections au
+> cadrage » consigne pourquoi le volet A (ranking) reste hors périmètre, pour ne
+> pas le re-découvrir.
+>
+> Écarts d'exécution assumés, notés en fin de document.
+
+## Context
+
+Laurin (PO) : « on a l'impression que les articles sont sur des sujets randoms, souvent peu
+importants, et on ne comprend pas toujours pourquoi ils nous sont poussés. » Le signal qui
+répond à ça (« ce sujet est couvert par N rédactions ») est **déjà calculé et déjà servi**,
+mais il n'est visible que dans le bloc « Actus du jour » du digest. Objectif : le rendre visible
+sur les cartes, désencombrer le footer, et s'en servir pour valoriser les deux features que ce
+signal justifie (« Comparer les angles », « Le pas de recul »).
+
+### Deux corrections au cadrage du handoff (vérifiées dans le code)
+
+**1. Le volet A (ranking) est plus mort que décrit — il reste bloqué, comme prévu.**
+Le handoff dit que `_score_coverage` (`pertinence.py:192`) est du code mort parce que
+`cluster_source_counts` n'est passé à aucun des 5 `ScoringContext(...)`. C'est vrai, mais ce
+n'est pas le blocage principal :
+
+- `Content.cluster_id` (`models/content.py:91-94`) est une **colonne dormante**. Son unique
+  writer, `story_service.cluster_hybrid` (`story_service.py:317`), **n'a aucun appelant** dans
+  tout le repo. La garde `pertinence.py:201` tombe donc sur `cluster_id is None` avant même de
+  regarder le dict. Corroboré en commentaire par `recommendation_service.py:1189-1191`
+  (« ``Content.cluster_id`` persisté est dormant »).
+- Le clustering réellement utilisé est **en RAM** (`TopicCluster`,
+  `importance_detector.py:75-98`) et son `cluster_id` est un `str(uuid4())` régénéré à chaque
+  run — **un autre espace d'identifiants** que la colonne UUID. Câbler
+  `{c.cluster_id: len(c.source_domains)}` dans `topic_selector.py:377` ne matcherait donc
+  strictement rien.
+- Le bonus de couverture **est déjà appliqué** ailleurs, au niveau sujet :
+  `digest_selector.py:1274` fait `compute_coverage_score(s.source_count)` dans
+  `subject_importance`, qui est la clé de tri **primaire** de `subject_rank_key`
+  (`digest_selector.py:1279-1287`). Le risque de double comptage anticipé par le handoff est
+  donc réel *et déjà chiffrable* : réveiller `_score_coverage` compterait la couverture une
+  seconde fois dans le tie-break perso.
+
+⇒ **A reste hors périmètre** (décision PO confirmée). Le vrai préalable n'est pas le câblage
+mais la résurrection du clustering (Handoff 1). Ce constat est consigné plus bas pour ne pas
+être re-découvert.
+
+**2. Le volet B ne demande aucun backend sur la surface principale.**
+`DigestTopic.sourceCount` et `perspectiveSources` sont déjà parsés côté mobile
+(`digest_models.dart:102,113`) et déjà **dans le scope du call site** (`visible[i]`,
+`section_block.dart:259-261`). La puce existe (`_PressReviewChip`,
+`flux_continu_article_card.dart:746`) et est simplement éteinte par un gate trop étroit :
+`showPressReview: widget.isEssentiel && widget.pressReviewCount > 0`
+(`flux_continu_article_card.dart:407`). Elle est donc noire sur toutes les cartes Actus du jour.
+
+**3. La pastille à retirer est bien un sous-thème.** `_ThemePill`
+(`flux_continu_article_card.dart:806`, rendue `:626-633`) affiche `getTopicLabel(topics.first)`
+(`content_model.dart:586-596`), donc un slug de la taxonomie ML à 51 entrées
+(« Cybersécurité », « Immobilier », « LGBTQ+ »…), pas un macro-thème.
+
+### Décisions PO actées
+
+| Question | Décision |
+|---|---|
+| Pastille de sous-thème | **Retirer complètement** (footer = source · heure · couverture) |
+| Chiffre affiché | **Les deux** : avatars des perspectives + « N sources » en texte |
+| Seuil | **≥ 2 sources** |
+| Périmètre PR | **Volet B seul** |
+| Contrainte | **Ne pas dégrader le temps de chargement de l'onglet L'Essentiel** |
+| Bonus demandé | Se servir de cette donnée pour fiabiliser/accélérer le nudge « comparaison » |
+
+---
+
+## Commit 1 — Footer des cartes : sous-thème retiré, couverture promue
+
+**Fichier** : `apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart`
+
+1. **Supprimer** le widget `_ThemePill` (`:806-832`) et son bloc de rendu (`:626-633`), ainsi que
+   le séparateur `·` désormais orphelin (`:634-636`). Le champ `FluxArticleVM.themeLabel`
+   (`:73-76`, `:101`) n'a plus aucun autre lecteur → le supprimer aussi (vérifier au grep).
+2. **Promouvoir `_PressReviewChip` en `_CoverageChip`** (`:746-802`) :
+   - nouvelle prop `sourceCount` en plus de `sources` ;
+   - le texte passe de `'+$count'` à `'$sourceCount sources'` (au singulier : `'1 source'`,
+     jamais atteint vu le seuil ≥ 2). **Pas d'em-dash** (règle repo).
+   - la pile d'avatars reste inchangée (`visibleCount = min(sources.length, 3)`, dotSize 12,
+     overlap 4) — c'est la brique à réutiliser telle quelle.
+3. **Élargir le gate** (`:407`) : remplacer `widget.isEssentiel && widget.pressReviewCount > 0`
+   par `widget.sourceCount >= 2`. La prop `isEssentiel` n'a plus d'usage sur ce chemin → la
+   retirer si elle n'en a pas d'autre.
+4. **Nouvelle prop `sourceCount`** sur `FluxContinuArticleCard` (défaut `0`) et sur `_Footer`.
+
+**Call sites** — les deux passent déjà `perspectiveSources` ; ajouter `sourceCount` :
+- `apps/mobile/lib/features/flux_continu/widgets/section_block.dart:259-261`
+  → `sourceCount: visible[i].sourceCount`
+- `apps/mobile/lib/features/flux_continu/screens/digest_section_screen.dart:167-172` → idem
+
+**Budget horizontal** : le footer est une `Row` unique avec un `Flexible` sur le nom de source.
+« 3 sources » coûte ~55 px, la pastille retirée en libère 60 à 80 px → net neutre ou positif.
+À vérifier en Playwright sur un nom de source long (« Le Monde Diplomatique ») en 390 px.
+
+**Tests** : `apps/mobile/test/features/flux_continu/widgets/flux_continu_article_card_test.dart`
+— les deux tests `:80-99` pinnent `Key('flux-theme-pill')` et doivent être **remplacés** (pas
+juste supprimés) par des tests de la puce de couverture : affichée à `sourceCount: 3`, absente à
+`sourceCount: 1`, avatars cappés à 3 quand `perspectiveSources.length == 6`. Aucun test ne
+couvre `_PressReviewChip` aujourd'hui — c'est l'occasion.
+
+---
+
+## Commit 2 — Propager la couverture jusqu'à l'onglet L'Essentiel
+
+C'est la surface à laquelle Laurin tient, et la seule qui demande du backend. Coût vérifié :
+**zéro requête DB supplémentaire, zéro appel LLM, aucun cache à invalider.**
+
+**Backend** (`packages/api`) :
+- `app/schemas/essentiel.py` — `EssentielArticle` (`:32-77`) porte déjà `perspective_count:56`.
+  Ajouter `source_count: int = 0` et `perspective_sources: list[dict] = []`.
+- `app/services/essentiel_service.py:683-712` (`_to_essentiel_article`) — pure propagation depuis
+  `topic`, qui est un `DigestTopic` **déjà entièrement en RAM** et porte déjà `source_count`
+  (`schemas/digest.py:105`) et `perspective_sources` (`:118`). Une ligne chacune, à côté de
+  `perspective_count=topic.perspective_count` (`:701`).
+- `app/services/essentiel_service.py:749-772` (`_content_to_essentiel_article`, fallback sources
+  suivies, sans topic) — forcer `source_count=0`, `perspective_sources=[]` comme le fait déjà
+  `perspective_count=0` (`:766`).
+- **Garde-fou perf (important)** : tronquer à **3** `perspective_sources` à l'émission (le cap
+  pipeline est 6, `editorial/pipeline.py:728-733`) — la carte n'en affiche jamais plus de 3, et
+  chaque entrée porte un `logo_url` qui déclenche un chargement d'image. Sans ce cap :
+  5 articles × 6 logos = jusqu'à 30 requêtes image sur l'écran d'ouverture. Avec : 15 max, dont
+  seuls les visibles sont réellement chargés.
+
+`GET /api/essentiel` (`app/routers/essentiel.py:45-110`) n'a **ni `FEED_CACHE` ni `TTLCache`** →
+rien à invalider. Impact payload ≈ +2 à 3 Ko non compressé.
+
+**Mobile** :
+- `apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart` — `EssentielArticle`
+  (`:154-280`) est écrit **à la main** (pas freezed, pas de codegen). Ajouter les deux champs
+  dans les champs/constructeur/`fromJson`/`toJson`, avec defaults (`?? 0`, `?? const []`).
+- **Rétro-compat cache** : `toJson` est persisté en **Hive** (`flux_continu_cache_service.dart`,
+  box `flux_continu_cache`, clé `latest_snapshot`, écriture `:102-121`, lecture `:59-89`). Les
+  defaults suffisent : un snapshot de la veille parse en liste vide, affichage dégradé jusqu'au
+  refetch SWR intra-journée. Le `day_key` (`:64-67`) périme de toute façon le snapshot.
+- **Piège de modèle** : le `SourceMini` mobile (`digest_models.dart:36-47`) n'a **ni `domain` ni
+  `bias_stance`**, alors que le backend émet un `PerspectiveSourceMini{name, domain, bias_stance,
+  logo_url}` (`editorial/schemas.py:143-155`). Le parse ne casse pas (tous les champs sont
+  optionnels, `id` tombe à `null`) mais on perd le biais. Acceptable ici : on n'affiche que les
+  logos. **Ne pas ajouter `bias_stance` à la carte** sans une décision PO séparée.
+- `apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart` — la carte ne rend
+  aucune donnée de perspective aujourd'hui. Y rendre le même `_CoverageChip` (extrait du
+  Commit 1 dans un widget partagé plutôt que dupliqué), même seuil ≥ 2.
+
+**Vérification de la contrainte PO** : mesurer le temps de réponse de `GET /api/essentiel` avant
+et après (uvicorn local, `curl -w '%{time_total}'`, 5 appels chacun), et comparer le poids du
+payload. L'attendu est un delta dans le bruit ; si ce n'est pas le cas, le commit est révocable
+seul.
+
+---
+
+## Commit 3 — Fiabiliser et accélérer le nudge « comparaison »
+
+Laurin : « ce nudge n'apparaît pas de façon robuste, ET il met trop de temps à arriver ».
+Diagnostic dans `apps/mobile/lib/features/detail/screens/content_detail_screen.dart` :
+
+**Pourquoi il n'apparaît pas de façon robuste** — `_scrollNudgeArmScheduled` (`:1168-1171`) n'arme
+qu'**une fois par article**, et `_scrollNudgeCooldownOk` ne passe à `true` qu'après le timer de
+1500 ms (`_kScrollNudgeArmDelay`, `:257`). L'unique `addPostFrameCallback` (`:2271-2275`) est donc
+évalué **avant** que le cooldown soit résolu et repart toujours en `false`. Tout repose sur le
+`_updateScrollNudgeVisibility()` de fin de timer (`:1179`) : si à cet instant précis la
+`GlobalKey` cible n'est pas montée, **aucun retry n'est planifié**. Le nudge n'est alors plus
+montrable, car le seul autre déclencheur est `ScrollUpdateNotification` (`:2463`) — et scroller
+fait sortir de la fenêtre `offset <= 32` (`_kScrollNudgeTopTolerance`, `:242`) exigée par
+`_computeShouldShowScrollNudge` (`:1186-1215`).
+
+**Pourquoi il arrive tard** — le timer de 1500 ms est armé **après** la réponse de
+`GET /contents/{id}/perspectives` (`_maybeArmScrollNudge`, `:2268`), donc **en série** derrière
+le réseau. Sur le chemin deeplink il y a en plus un RTT `GET /contents/{id}` avant même de lancer
+les perspectives (`:1633-1638` vs `:536-539`).
+
+**Correctifs** (par ordre de valeur) :
+1. **Armer le timer en `initState`**, pas après le fetch → les 1500 ms se déroulent en parallèle
+   du réseau au lieu de s'y ajouter. Gain direct sur le délai perçu, changement local.
+2. **Re-évaluer quand la cible se monte** : appeler `_updateScrollNudgeVisibility()` dans le
+   `addPostFrameCallback` qui suit l'arrivée des perspectives (et pas seulement en fin de timer),
+   ou remplacer le one-shot par un court retry borné. C'est le correctif de robustesse.
+3. **Corriger le mismatch d'identifiant** : `canShow()` est résolu sur la cible connue à
+   l'armement, mais `markShown()` (`:1230-1234`) écrit sur `_activeScrollNudgeTarget` re-résolu.
+   Si la deep reco arrive après (refetch partiel `:2303-2310`), le cooldown est vérifié sur
+   `scroll_to_perspectives` et écrit sur `scroll_to_deep_reco`.
+
+**Sur « utiliser la donnée de couverture comme inducteur » — à cadrer honnêtement.** Le `sourceCount`
+connu depuis la carte **ne peut pas** déclencher le nudge à lui seul : le nudge scrolle vers une
+`GlobalKey` (`_deepRecoKey` / `_perspectivesKey`) qui n'existe pas tant que les perspectives ne
+sont pas chargées. Le vrai levier de latence, ce sont les points 1 et 2 ci-dessus. En revanche la
+donnée a **un usage réel** : quand `sourceCount >= 2` est connu avant le tap, on peut afficher
+immédiatement l'affordance « Comparer les angles » (état squelette) au lieu d'attendre la réponse
+réseau, ce qui rend la feature découvrable dès l'ouverture. **Proposition : garder cet usage hors
+de cette PR** et le traiter séparément une fois les points 1-3 mesurés, pour ne pas mélanger un
+correctif de bug et un changement d'UX dans le même diff.
+
+Il n'existe **aucun cache ni prefetch client** des perspectives (seul cache = serveur,
+`contents.py:495`, `TTLCache` ttl 7200, process-local). Un prefetch client est une piste, mais pas
+dans cette PR.
+
+**Risque** : ce commit touche une machine à états de nudge délicate, sans test existant. Il est
+volontairement placé en dernier et reste **révocable seul** si la mesure ne confirme rien.
+
+---
+
+## Fichiers touchés (récapitulatif)
+
+| Fichier | Commit |
+|---|---|
+| `apps/mobile/lib/features/flux_continu/widgets/flux_continu_article_card.dart` | 1 |
+| `apps/mobile/lib/features/flux_continu/widgets/section_block.dart` | 1 |
+| `apps/mobile/lib/features/flux_continu/screens/digest_section_screen.dart` | 1 |
+| `apps/mobile/test/features/flux_continu/widgets/flux_continu_article_card_test.dart` | 1 |
+| `packages/api/app/schemas/essentiel.py` | 2 |
+| `packages/api/app/services/essentiel_service.py` | 2 |
+| `apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart` | 2 |
+| `apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart` | 2 |
+| `apps/mobile/lib/features/detail/screens/content_detail_screen.dart` | 3 |
+| `changelog.json` (entrée `unreleased`, changement visible) | 1-2 |
+
+**Aucune migration Alembic** (aucun DDL). **Aucun changement de ranking.**
+
+---
+
+## Verification
+
+1. **Tests unitaires** : `cd apps/mobile && flutter test && flutter analyze` ;
+   `cd packages/api && pytest -v`. Baseline mobile connue : ~27 échecs pré-existants
+   (cf. mémoire `project_ci_no_flutter_tests`) — comparer au baseline, pas à zéro.
+2. **Perf Essentiel (contrainte PO n°1)** : `uvicorn app.main:app --port 8080`, puis
+   `curl -w '%{time_total} %{size_download}\n'` sur `GET /api/essentiel` × 5, avant et après le
+   Commit 2. Attendu : delta de temps dans le bruit, payload +2 à 3 Ko.
+3. **Playwright Agent CLI** (skill `facteur-qa-web`, viewport 390×844, sémantique activée au
+   boot) :
+   - Actus du jour : puce de couverture présente sur un sujet à ≥ 2 sources, absente à 1 source ;
+   - onglet L'Essentiel : puce présente sur la carte hi-fi ;
+   - footer sans pastille de sous-thème, pas de débordement horizontal avec un nom de source long ;
+   - console sans erreur, réseau sans 4xx/5xx inattendu ;
+   - **screenshots avant/après** sur les deux surfaces.
+4. **Nudge (Commit 3)** : ouvrir un article à ≥ 3 perspectives depuis le feed puis depuis un
+   deeplink, vérifier l'apparition dans les deux cas et chronométrer le délai avant/après.
+5. **Rétro-compat cache Hive** : ouvrir l'app avec un snapshot écrit par la version précédente
+   (pas de `perspective_sources`) et vérifier l'absence de crash de parse.
+6. `/go` en fin de tâche → VERIFY + `simplify` + PR `--base main`. **STOP décision PO** avant merge.
+
+## Garde-fous
+
+- Trois commits **révocables indépendamment** ; le Commit 3 est le seul à risque de régression.
+- Pas d'em-dash dans la copy user-facing (`'3 sources'`).
+- Ne pas exposer `bias_stance` sur les cartes sans décision PO séparée.
+- Volet A (ranking) **non touché** : aucun `ScoringContext` modifié, `subject_importance` intact.
+
+---
+
+## Écarts d'exécution (post-implémentation)
+
+- **`CoverageChip` extrait dès le Commit 1** dans
+  `apps/mobile/lib/features/flux_continu/widgets/coverage_chip.dart` (avec
+  `SourceDot`, remonté de la carte), plutôt qu'au Commit 2 : évite de
+  promouvoir la puce puis de la déplacer dans la foulée.
+- **`pressReviewCount` et `isEssentiel` supprimés** de `FluxContinuArticleCard` :
+  après l'élargissement du gate, plus aucun lecteur.
+- **`changelog.json` était invalide sur `main`** depuis #1029 (accolade
+  manquante sur l'entrée « Alertes ») — les notes de version in-app ne se
+  parsaient plus. Réparé dans le Commit 2, avec l'entrée de cette story.
+- **Mesure `curl` de `GET /api/essentiel` non exécutée** : elle demande un
+  digest du jour en base, absent en local. Le coût est structurellement nul
+  (propagation d'un `DigestTopic` déjà en RAM, zéro requête, zéro LLM) et le cap
+  à 3 `perspective_sources` est verrouillé par un test
+  (`test_coverage_is_propagated_and_perspective_sources_capped`).
+- **Commit 3 sans test automatisé** : la machine à états du nudge vit dans l'état
+  privé de `_ContentDetailScreenState` (~5 000 lignes, aucun harnais existant).
+  Le commit reste révocable seul ; validation manuelle attendue côté PO.

--- a/packages/api/app/schemas/essentiel.py
+++ b/packages/api/app/schemas/essentiel.py
@@ -54,6 +54,12 @@ class EssentielArticle(BaseModel):
     )
     section_label: str = Field(..., description="Libellé du topic d'origine")
     perspective_count: int = 0
+    # Couverture multi-sources du sujet d'origine — pilote la pastille
+    # « N sources » de la carte (seuil mobile : >= 2).
+    source_count: int = 0
+    # Tronqué à `PERSPECTIVE_SOURCES_CAP` à l'émission : la carte n'affiche que
+    # 3 avatars et chaque entrée porte un logo qui déclenche une requête image.
+    perspective_sources: list[dict] = Field(default_factory=list)
     rank: int = Field(..., ge=1, le=5, description="Position dans l'essentiel (1..5)")
     is_read: bool = False
     is_saved: bool = False

--- a/packages/api/app/services/essentiel_service.py
+++ b/packages/api/app/services/essentiel_service.py
@@ -680,6 +680,12 @@ def _pick_transversal_articles(
     return picked
 
 
+# Cap d'émission des sources de perspective : la carte n'en rend que 3 et
+# chaque entrée porte un `logo_url` (une requête image chacune). Le pipeline
+# en produit jusqu'à 6 — sans ce cap, l'écran d'ouverture en chargerait 30.
+PERSPECTIVE_SOURCES_CAP = 3
+
+
 def _to_essentiel_article(
     topic: DigestTopic,
     article: DigestTopicArticle,
@@ -699,6 +705,8 @@ def _to_essentiel_article(
         theme=topic.theme,
         section_label=topic.label,
         perspective_count=topic.perspective_count,
+        source_count=topic.source_count,
+        perspective_sources=(topic.perspective_sources or [])[:PERSPECTIVE_SOURCES_CAP],
         rank=rank,
         is_read=article.is_read,
         is_saved=article.is_saved,
@@ -764,6 +772,8 @@ def _content_to_essentiel_article(
         theme=content.theme,
         section_label=content.source.name,
         perspective_count=0,
+        source_count=0,
+        perspective_sources=[],
         rank=rank,
         is_followed_source=True,
         is_followed_topic=bool(content.theme and content.theme in ctx.topic_weights),

--- a/packages/api/tests/test_essentiel_endpoint.py
+++ b/packages/api/tests/test_essentiel_endpoint.py
@@ -27,6 +27,7 @@ from app.services.essentiel_service import (
     _W_UNE,
     ESSENTIEL_MAX_ARTICLES,
     ESSENTIEL_MIN_ARTICLES,
+    PERSPECTIVE_SOURCES_CAP,
     EssentielUserContext,
     _perspective_score,
     _score_article,
@@ -1609,3 +1610,37 @@ def test_une_and_trending_can_cumulate_when_both_set():
     score = _score_article(topic, topic.articles[0], EssentielUserContext())
 
     assert score == pytest.approx(_W_TRENDING + _W_UNE - 0.5)
+
+
+def test_coverage_is_propagated_and_perspective_sources_capped():
+    """La couverture du sujet remonte telle quelle ; les logos sont tronqués.
+
+    Contrainte PO : ne pas alourdir l'ouverture de l'Essentiel. La carte
+    n'affiche que 3 avatars, chacun déclenchant une requête image.
+    """
+    topic = _make_topic(rank=1, label="Climat", n_articles=1)
+    topic = topic.model_copy(
+        update={
+            "source_count": 7,
+            "perspective_sources": [
+                {"name": f"S{i}", "domain": f"s{i}.fr", "logo_url": None}
+                for i in range(6)
+            ],
+        }
+    )
+
+    response = build_essentiel_response(_make_digest([topic]))
+
+    article = response.articles[0]
+    assert article.source_count == 7
+    assert len(article.perspective_sources) == PERSPECTIVE_SOURCES_CAP
+    assert article.perspective_sources[0]["name"] == "S0"
+
+
+def test_topic_without_perspective_sources_emits_empty_list():
+    topic = _make_topic(rank=1, label="Climat", n_articles=1)
+
+    article = build_essentiel_response(_make_digest([topic])).articles[0]
+
+    assert article.perspective_sources == []
+    assert article.source_count == 0


### PR DESCRIPTION
Volet B du handoff « couverture multi-sources » — rendre visible sur les cartes un signal **déjà calculé et déjà servi**, mais confiné au bloc « Actus du jour ». Plan complet : [`docs/stories/core/32.2`](docs/stories/core/32.2.couverture-multi-sources-cartes.md).

**Volet A (ranking) non touché**, décision PO confirmée par le code : `Content.cluster_id` est une colonne dormante (son unique writer `story_service.cluster_hybrid` n'a aucun appelant), et le clustering réellement utilisé vit en RAM avec un espace d'identifiants distinct. Câbler `_score_coverage` ne matcherait rien — et le bonus de couverture est **déjà** appliqué au niveau sujet (`digest_selector.py`, clé de tri primaire). Le constat est consigné dans la story pour ne pas être re-découvert.

## Les 3 commits (révocables indépendamment)

**1. Footer des cartes** — la pastille de sous-thème ML (« Cybersécurité », « LGBTQ+ »…) est retirée ; la puce de revue de presse est promue en `CoverageChip` partagé (avatars + « N sources »), gate élargi de `isEssentiel && pressReviewCount > 0` à `sourceCount >= 2`. `pressReviewCount` et `isEssentiel` n'ayant plus de lecteur, ils sont supprimés.

**2. Propagation jusqu'à l'onglet L'Essentiel** — la surface à laquelle le PO tient. Propagation pure depuis un `DigestTopic` déjà entièrement en RAM : **zéro requête DB, zéro appel LLM, aucun cache à invalider**. Les `perspective_sources` sont **tronquées à 3 à l'émission** (le pipeline en produit 6) : la carte n'affiche jamais plus de 3 avatars et chaque entrée porte un `logo_url` — sans ce cap, l'écran d'ouverture chargerait jusqu'à 30 images. Rétro-compat cache Hive assurée par les defaults, avec un test dédié.

**3. Nudge « comparaison »** — trois défauts d'une même machine à états :
- le délai anti-pop de 1,5 s démarrait *après* la réponse perspectives, donc **en série derrière le réseau** → armé en `initState`, il s'écoule désormais en parallèle ;
- l'armement one-shot n'était résolu qu'en fin de timer : si la `GlobalKey` cible n'était pas montée à cet instant précis, **aucun retry** n'était planifié et le nudge devenait inatteignable (scroller sort de la fenêtre `offset <= 32` exigée) → le délai n'est plus qu'un booléen, la visibilité est réévaluable à tout moment ;
- `canShow()` était vérifié sur la cible connue à l'armement alors que `markShown()` écrivait sur la cible re-résolue → cooldown résolu **par cible**.

Utiliser `sourceCount` comme *inducteur* du nudge est volontairement **hors périmètre** : le nudge scrolle vers une `GlobalKey` qui n'existe pas tant que les perspectives ne sont pas chargées. L'usage réel de la donnée (afficher l'affordance « Comparer les angles » en squelette dès l'ouverture) mérite sa propre PR.

## Au passage

`apps/mobile/assets/changelog.json` était **invalide** depuis #1029 (accolade manquante sur l'entrée « Alertes ») : les notes de version in-app ne se parsaient plus. Réparé — 2 tests `changelog_asset_test` rouges sur `main` repassent au vert.

## Vérification

- **Backend** : suite complète verte, `2689 passed, 18 skipped, 2 xfailed`. Nouveaux tests : propagation + cap à 3, et fallback sources suivies à `source_count=0`.
- **Mobile** : `flutter analyze` sans erreur ni warning sur le diff. Suite complète comparée au **baseline `origin/main`** (comparaison de la *liste* des tests rouges, pas seulement du compte) : **28 échecs sur la branche vs 31 sur `main`, aucune régression**, 3 tests réparés. Les échecs restants sont pré-existants (dont 4 `Notification Suppression` et l'opacité 0.6/0.8 de #1037, reproduits à l'identique sur `main`).
- Aucune migration Alembic (aucun DDL), aucun changement de ranking.

## Non vérifié — à couvrir avant merge

- **Playwright / `/validate-feature` non exécuté** : à lancer sur les deux surfaces (Actus du jour + carte hi-fi), notamment le budget horizontal du footer en 390 px avec un nom de source long (« Le Monde Diplomatique ») — la pastille retirée libère 60-80 px pour ~55 px repris, net attendu neutre ou positif, mais ce n'est pas mesuré.
- **Mesure `curl` de `GET /api/essentiel`** (contrainte PO n°1) non faite : elle demande un digest du jour en base, absent en local. L'argument est structurel (propagation en RAM, zéro requête) et le cap est verrouillé par un test.
- **Commit 3 sans test automatisé** : la machine à états vit dans l'état privé de `_ContentDetailScreenState` (~5 000 lignes, aucun harnais existant). C'est le seul commit à risque de régression, volontairement placé en dernier et révocable seul. Validation manuelle attendue : ouvrir un article à ≥ 3 perspectives depuis le feed **puis** depuis un deeplink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
