### PR TITLE
feat(reco): allumer le bonus de pluralité (couverture multi-sources) sur le digest

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,158 +1,56 @@
-# feat(api): cache feed observable, correct et ciblé (PR 2)
+# feat(reco): allumer le bonus de pluralité (couverture multi-sources) sur le digest
 
 Base `main`. **Aucune migration.** Backend-only (0 fichier mobile).
 
 ## Résumé
 
-PR 2 du plan « Accélérer et fiabiliser l'écran Essentiel ». L'écran Essentiel est
-lent : chaque cold-open fait un fan-out de 10 à 14 `GET /api/feed?personalized=true`,
-chacun payant le pipeline de scoring complet sur 1 seul worker uvicorn.
+Le pilier Pertinence calcule un bonus log-calibré pour les clusters multi-sources
+(`2→+12, 3→+19, 4→+24, cap 30`) mais c'était **du code mort partout** : aucun call
+site ne passait le count au `ScoringContext`, et la garde `content.cluster_id`
+tombait sur NULL pour ~99 % des candidats (`contents.cluster_id` NULL à 99 % en
+base — 298 / 29 414 sur 14j, uuid4 régénéré par run). Cette PR allume le signal
+**pour la première fois**, sur le chemin `topics` (cœur digest).
 
-Un cache existait (`app/services/feed_cache.py`, clé `(user, variant)`, TTL 60 s)
-mais était **neutralisé en pratique** : `invalidate(user_id)` purge *tous* les
-variants du user, et l'écriture dominante est `POST /contents/{id}/status` en
-`SEEN`, émise **à chaque scroll**. Scroller trois articles vidait le cache des
-~12 sections de la Tournée.
+Doc : `docs/maintenance/maintenance-coverage-pillar-wiring.md`.
 
-Doc : `docs/maintenance/maintenance-essentiel-loading-speed.md` (décisions +
-protocole de vérification staging).
+## Approche — sûre, sans mutation ORM ni migration
 
-PR 1 (`#1017`, mergée) a traité le volet mobile « Sources favorites toujours
-rendues + attente lisible ».
+Le count du cluster est porté **directement sur le `ScoringContext`** (construit par
+cluster dans `_score_and_select_articles`, donc `len(cluster.source_domains)`
+s'applique à tous ses contents), et non via une mutation de `content.cluster_id` —
+muter cet attribut ORM sur des `Content` attachés à la session risquerait un
+autoflush vers la **DB prod partagée** (la colonne même que le pipeline peuple avec
+des uuid4 par-run).
 
-## 1. Observabilité — la baseline, à lire avant de toucher au TTL
+- `ScoringContext.coverage_source_count: int | None` — nouveau champ optionnel.
+- `_score_coverage` — fast-path context-carried (prioritaire), fallback dict
+  `cluster_source_counts` inchangé.
+- `topic_selector` — `_build_scoring_context(..., coverage_source_count=len(cluster.source_domains))`.
 
-- `app/routers/feed.py` : un log structlog `feed_request` par requête —
-  `cache=hit|miss|bypass`, `variant_class=default|personalized|none`,
-  `duration_ms`, `items`. Avant, `feed_total` n'était émis que par
-  `_compute_feed` : **un hit ne produisait aucun log**, le hit rate était
-  invisible. `items` seulement sur miss/bypass (le compter sur un hit imposerait
-  un `json.loads` du payload sur le chemin rapide).
-- `app/main.py` : `GET /api/health/feed-cache`, calqué sur `/api/health/pool`,
-  avec deux écarts assumés :
-  - **gate par header `X-Health-Token`** (`hmac.compare_digest`) quand
-    `HEALTH_METRICS_TOKEN` est configuré — nouveau champ `health_metrics_token`
-    dans `Settings` (`app/config.py`), à côté de `admin_api_token`. `size` est un
-    proxy du nombre d'users actifs. Sans le secret (staging), l'endpoint reste
-    **ouvert** : fail-open assumé, à l'inverse de `require_admin_token` qui est
-    fail-closed ;
-  - `uptime_seconds` ajouté à `stats()` : les compteurs sont cumulatifs depuis le
-    boot, donc le hit rate se lisse et masquerait une régression. La lecture se
-    fait sur le **delta de deux échantillons**.
+## Périmètre / discipline (GO PO Laurin)
 
-## 2. Correction préalable : les générations (bug pré-existant)
-
-Sous le lock single-flight, `_compute_feed` prend 1,5 à 5 s puis `put()` écrivait
-**inconditionnellement**. Une `invalidate` arrivant dans cette fenêtre était
-écrasée : **un article masqué pouvait réapparaître** jusqu'à expiration du TTL.
-
-Le bug existait déjà, mais l'invalidation ciblée l'aggraverait (elle inspecte le
-payload *en cache*, l'ancien, alors que le payload en cours de calcul contient
-l'article ⇒ faux négatif systématique dans la fenêtre) et un TTL plus long
-multiplierait la durée du symptôme. Corrigé **avant** de scoper.
-
-`generation(user_id)` renvoie `(compteur du user, compteur global)` — le second
-sert aux invalidations cross-user, dont le rayon d'action inclut des users sans
-entrée en cache. Le endpoint le capture juste avant `_compute_feed` et le repasse
-à `put()`, qui droppe l'écriture si le couple a bougé. Un compteur global seul
-aurait laissé l'écriture d'un user annuler le `put()` en vol de tous les autres,
-soit en permanence avec le SEEN à chaque scroll.
-
-## 3. Invalidation content-scoped, limitée aux sites prouvés sûrs
-
-`invalidate_content(user_id, content_id)` ne purge que les variants du user
-**dont le payload mentionne l'id** (scan d'octets, ~50 µs pour 12 variants).
-
-> Pourquoi un scan d'octets plutôt qu'un `frozenset` d'ids capturé au `put()` :
-> le set exigerait un walk qui connaît le schéma (`items`, `carousels[].items`,
-> `clusters[]…`) et **manquerait silencieusement** les items imbriqués ⇒ faux
-> négatifs, donc contenu périmé servi après écriture. Le scan est agnostique du
-> schéma et son seul mode d'échec est le faux positif (une purge en trop,
-> inoffensive). Le risque réel, une évolution de sérialisation qui casserait le
-> match en silence, est épinglé par `test_cached_payload_item_ids_match_str_uuid`.
-
-**Le point critique, c'est le périmètre.** Vérifié dans `content_service.py` :
-like, save, hide, note upsert et la transition CONSUMED mutent
-`UserSubtopic.weight` et `UserEntityAffinity.affinity`, qui alimentent le scoring
-de *toutes* les sections. Les scoper laisserait un **classement** périmé partout.
-On ne les touche pas.
-
-| Site | Après |
-|---|---|
-| `update_content_status` **sans** transition consumed (SEEN au scroll) | `invalidate_content` ← **le gain principal** |
-| `impress_content` (n'écrit que `manually_impressed`/`last_impressed_at`) | `invalidate_content` |
-| `unsave_content` / `unhide_content` (aucun poids ajusté) | `invalidate_content` |
-| `delete_note` — **n'invalidait rien** | `invalidate_content` (bug fix) |
-| like/unlike, save, hide, feedback, status→CONSUMED | `invalidate()` inchangé |
-| `upsert_note` — **n'invalidait rien**, or il boost les poids | `invalidate()` (bug fix) |
-| `report_not_serene` — **n'invalidait rien**, et `is_serene=False` est un flip **global cross-user** | `invalidate_content_global` (bug fix) |
-| les 27 autres sites (mute, follow, prefs, custom topics, refresh…) | inchangés |
-
-Deux garde-fous notables :
-
-- **Ne pas purger `_locks` dans `invalidate*`** : retirer un `Lock` détenu par
-  des waiters casserait le single-flight, soit le thundering herd que ce cache
-  existe pour éviter. Gardé par `test_invalidate_keeps_locks_alive`.
-- Faux négatif résiduel borné par le TTL : le payload caché est une tranche
-  top-N ; une action sur un article hors-tranche ne purge pas la variante, ce qui
-  est correct puisqu'il n'était pas affiché.
-
-## Décisions documentées (ce qui ne change PAS)
-
-- **`--workers 2` : non.** Le cache est in-process et `invalidate` est
-  process-local : avec 2 workers, un `POST /hide` traité par le worker A ne purge
-  pas le cache du worker B ⇒ l'article masqué réapparaît. Idem
-  `_analysis_cache` / `_perspectives_cache`. Condition de réouverture :
-  invalidation partagée (Redis pub/sub). Et si le besoin est du parallélisme CPU,
-  la vraie réponse est de sortir le scoring du chemin requête.
-- **`FEED_CACHE_PERSONALIZED_TTL_SECONDS=300` : hors PR.** Étape ops Railway, à
-  faire **après** lecture du hit rate réel. Défaut code inchangé à 60 s.
-- `degraded_fallback` dans `FeedResponse` : abandonné (champ additif sans
-  consommateur UI ; le log `feed_request` couvre le besoin).
-- `profile_feed_latency.py` : pas réécrit — il bypasse le endpoint *et* le cache.
+- **Chemin `topics` seulement.** Tournée/curation + flat éditorial reportés (le flat
+  `_project_editorial_for_user` double-compterait avec `subject_importance`).
+- **`COVERAGE_CAP=30` inchangé** — levier unique = allumage du signal ; le cap est un
+  2e levier reporté (de toute façon `max_src=4` en prod ⇒ plafond effectif +24).
+- **0 migration, 0 mutation ORM.** Commit isolé/révocable.
 
 ## Tests
 
-- `tests/services/test_feed_cache.py` : +18 unitaires — invalidation ciblée /
-  globale, générations (stale droppé, per-user, bump même sans purge), garde
-  anti-régression sur `_locks`, `uptime_seconds`.
-- `tests/routers/test_feed_cache_invalidation_sites.py` (nouveau) : épingle
-  **quels endpoints purgent tout et lesquels ciblent**, plus l'invariant de
-  sérialisation dont dépend le scan d'octets.
-- `tests/test_health_feed_cache.py` (nouveau) : métriques exposées, fail-open
-  sans secret, 404 avec secret configuré.
-- `tests/test_feed_personalized_cache.py` : +3 sur le log `feed_request`
-  (miss→hit, classe default, bypass paginé).
-- Suite complète backend : **2648 passed, 18 skipped, 2 xfailed**.
-- `ruff check` + `ruff format --check` OK sur les fichiers touchés ;
-  `alembic heads` = 1 head (`sa02_alerts_v2`).
-- Smoke live `uvicorn` : `/api/health/feed-cache` → 200 sans secret,
-  `uptime_seconds` croissant sur deux échantillons ; avec `HEALTH_METRICS_TOKEN`
-  posé → 404 sans header, 404 avec mauvais token, 200 avec le bon.
+- `tests/recommendation/test_pertinence_coverage.py` : +3 cas context-carried
+  (bonus sans `cluster_id`, mono-source = 0, priorité sur dict).
+- `tests/test_topic_selector.py` : +2 cas d'intégration (cluster ≥3 sources →
+  « Couvert par 3 sources » dans le breakdown ; mono-source → rien).
+- Suite reco + digest : **119 passed**, 0 régression. `alembic heads` = 1 head
+  (`sa02_alerts_v2`).
 
-## Vérification sur staging (après déploiement)
+## Mesure post-merge (jauge)
 
-1. Deux lectures de `/api/health/feed-cache` encadrant une ouverture d'app → hit
-   rate sur le **delta**.
-2. `grep 'feed_request'` dans les logs Railway sur 5 min d'usage réel.
-3. **Scroller 3 articles puis rouvrir la Tournée < 60 s** → sections servies du
-   cache. C'est le scénario que cette PR débloque.
-4. `hide` un article visible + pull-to-refresh immédiat → il ne revient pas (test
-   des générations).
-5. Deux comptes en mode serein : A signale non-serein, B pull-to-refresh →
-   l'article disparaît chez B.
-
-Puis seulement : poser `FEED_CACHE_PERSONALIZED_TTL_SECONDS=300` et re-mesurer.
-
-## Suivi post-merge (hors PR)
-
-- `HEALTH_METRICS_TOKEN` n'est pas configuré sur Railway : l'endpoint sera
-  **ouvert** sur staging (fail-open documenté). À décider avant que `production`
-  n'avance.
-- PR 3 (SWR client par section) : périmètre réel et ses **trois bloquants**
-  (reseed nu qui détruirait l'hydratation, sections source non hydratées,
-  `_dismissedIds` en mémoire seule) documentés en fin de doc maintenance.
+`by_pillar_band["pertinence"]` (`scripts/evaluate_feed_ranking.py`). **Forward-only**
+⇒ bandes vides avant date de merge, fenêtre d'observation ≥7j. **Puissance faible**
+(~13 clusters ≥3 src / 14j) : absence de mouvement CTR ≠ preuve d'inefficacité.
 
 ## Hors périmètre
 
-Aucun changement mobile, aucune migration DB, aucun changement de TTL.
+Aucun changement mobile, aucune migration, cap inchangé, Tournée/curation/flat non
+touchés.

--- a/docs/maintenance/maintenance-coverage-pillar-wiring.md
+++ b/docs/maintenance/maintenance-coverage-pillar-wiring.md
@@ -1,0 +1,57 @@
+# Maintenance — Câbler le bonus de pluralité (couverture multi-sources) sur le digest
+
+> Discipline « reco-quality step-up » : **un seul levier mesuré à la fois**, jauge
+> avant/après, **zéro migration**, commit révocable. Fil lié : reco quality PR0 (#1034)
+> / PR1 (#1035).
+
+## Problème
+
+`PertinencePillar._score_coverage` (`pillars/pertinence.py`) calcule un bonus
+log-calibré pour les clusters multi-sources (`2→+12, 3→+19, 4→+24, cap 30`), mais
+c'était **du code mort sur toutes les surfaces** : aucun call site ne passait
+`cluster_source_counts` au `ScoringContext`, et la garde `content.cluster_id`
+tombait sur `None` pour ~99 % des candidats (`contents.cluster_id` est NULL à 99 %
+en base — 298 / 29 414 sur 14j, et l'ID est un `uuid4` régénéré par run).
+
+## Décision (GO PO Laurin, 30/07)
+
+- **Allumer d'abord sur le chemin `topics` uniquement** (cœur digest « l'essentiel
+  couvert par plusieurs rédactions »). Tournée/curation et flat éditorial : cycle
+  ultérieur, une fois la jauge lue.
+- **`COVERAGE_CAP=30` inchangé** cette PR (levier unique = allumage du signal ;
+  le cap est un 2e levier reporté). Note : `max_src=4` en prod ⇒ plafond effectif
+  de facto **+24**.
+- **Ne PAS allumer le flat éditorial** (`_project_editorial_for_user`) : double
+  comptage avec `subject_importance` (`compute_coverage_score(source_count)`).
+
+## Implémentation (5 fichiers, 0 migration, 0 mutation ORM)
+
+Voie choisie : porter le count du cluster **directement sur le `ScoringContext`**
+plutôt que muter `content.cluster_id` (attribut ORM → risque d'autoflush vers la
+DB prod partagée). Le contexte est construit **par cluster** dans
+`_score_and_select_articles`, donc `len(cluster.source_domains)` s'applique à tous
+ses contents.
+
+- `scoring_engine.py` — `ScoringContext` : nouveau champ optionnel
+  `coverage_source_count: int | None`.
+- `pillars/pertinence.py` — `_score_coverage` : fast-path context-carried
+  (prioritaire), fallback dict `cluster_source_counts` inchangé.
+- `topic_selector.py` — `_build_scoring_context(..., coverage_source_count)` +
+  call site passant `len(cluster.source_domains)`.
+- Tests : `test_pertinence_coverage.py` (3 cas context-carried : bonus sans
+  `cluster_id`, mono-source = 0, priorité sur dict) + `test_topic_selector.py`
+  (2 cas intégration threading : cluster ≥3 sources → « Couvert par 3 sources »,
+  mono-source → rien).
+
+## Mesure (jauge)
+
+`scripts/evaluate_feed_ranking.py` → `by_pillar_band["pertinence"]`. Baseline =
+« coverage = 0 partout » (signal mort avant merge). **Forward-only** : bandes
+vides avant date de merge, prévoir fenêtre post-merge ≥7j. **Puissance faible** :
+~13 clusters ≥3 src / 14j ⇒ absence de mouvement CTR ≠ preuve d'inefficacité.
+
+## Non-régression
+
+Flat legacy (`digest_selector._score_candidates`) et toutes surfaces hors `topics`
+laissent `coverage_source_count=None` ⇒ comportement inchangé (fallback dict, vide).
+Suite reco + digest : 119 passed.

--- a/packages/api/app/services/recommendation/pillars/pertinence.py
+++ b/packages/api/app/services/recommendation/pillars/pertinence.py
@@ -194,14 +194,22 @@ class PertinencePillar(BasePillar):
     ) -> tuple[float, list[PillarContribution]]:
         """Bonus log-calibré pour les clusters multi-sources.
 
-        `cluster_source_counts` est rempli en mode thématique personnalisé ;
-        sinon (cold start, autres surfaces) on n'a aucun coût ni effet.
-        """
-        cluster_id = getattr(content, "cluster_id", None)
-        if cluster_id is None or not context.cluster_source_counts:
-            return 0.0, []
+        Deux sources d'alimentation :
+        - Chemin `topics` (topic_selector) : `context.coverage_source_count`
+          porte le count du cluster courant (contexte construit par cluster).
+          Aucune dépendance à `content.cluster_id` (NULL à ~99 % en base) ni
+          mutation d'attribut ORM.
+        - Chemin dict (`cluster_source_counts` keyé par `content.cluster_id`) :
+          conservé pour les surfaces où `content.cluster_id` est renseigné.
 
-        source_count = context.cluster_source_counts.get(cluster_id, 1)
+        Sinon (cold start, autres surfaces) : aucun coût ni effet.
+        """
+        source_count = context.coverage_source_count
+        if source_count is None:
+            cluster_id = getattr(content, "cluster_id", None)
+            if cluster_id is None or not context.cluster_source_counts:
+                return 0.0, []
+            source_count = context.cluster_source_counts.get(cluster_id, 1)
         bonus = compute_coverage_score(source_count)
         if bonus <= 0:
             return 0.0, []

--- a/packages/api/app/services/recommendation/scoring_engine.py
+++ b/packages/api/app/services/recommendation/scoring_engine.py
@@ -51,6 +51,12 @@ class ScoringContext:
         # de couverture multi-sources (cf. helpers.compute_coverage_score).
         # Vide en cold start ou hors mode thématique personnalisé.
         cluster_source_counts: dict[UUID, int] | None = None,
+        # Chemin `topics` (topic_selector) : nombre de sources distinctes du
+        # cluster COURANT, porté directement sur le contexte (construit par
+        # cluster). Évite de dépendre de `content.cluster_id` (NULL à ~99 % en
+        # base) et toute mutation d'attribut ORM. Prioritaire sur
+        # `cluster_source_counts` quand renseigné.
+        coverage_source_count: int | None = None,
     ):
         self.user_profile = user_profile
         self.user_interests = user_interests
@@ -89,6 +95,9 @@ class ScoringContext:
 
         # Top3 thematic selection: cluster_id -> nb sources distinctes (24h).
         self.cluster_source_counts = cluster_source_counts or {}
+
+        # Chemin `topics` : count du cluster courant (None hors de ce chemin).
+        self.coverage_source_count = coverage_source_count
 
         # Diagnostics pour explicabilité
         self.reasons: dict[UUID, dict[str, Any]] = {}

--- a/packages/api/app/services/topic_selector.py
+++ b/packages/api/app/services/topic_selector.py
@@ -372,8 +372,15 @@ class TopicSelector:
 
         return topic_groups
 
-    def _build_scoring_context(self, context: DigestContext) -> ScoringContext:
-        """Convert DigestContext to ScoringContext for pillar engine."""
+    def _build_scoring_context(
+        self, context: DigestContext, coverage_source_count: int | None = None
+    ) -> ScoringContext:
+        """Convert DigestContext to ScoringContext for pillar engine.
+
+        `coverage_source_count` porte le nombre de sources distinctes du cluster
+        courant (chemin `topics`) pour alimenter le bonus de couverture
+        multi-sources du pilier Pertinence, sans dépendre de `content.cluster_id`.
+        """
         return ScoringContext(
             user_profile=context.user_profile,
             user_interests=context.user_interests,
@@ -390,6 +397,7 @@ class TopicSelector:
             custom_source_ids=context.custom_source_ids,
             source_affinity_scores=context.source_affinity_scores,
             source_priority_multipliers=context.source_priority_multipliers,
+            coverage_source_count=coverage_source_count,
         )
 
     def _score_and_select_articles(
@@ -404,7 +412,11 @@ class TopicSelector:
         puis applique les bonus digest-spécifiques (trending/une) en post-pilier.
         """
         max_articles = ScoringWeights.TOPIC_MAX_ARTICLES
-        scoring_context = self._build_scoring_context(context)
+        # Bonus de couverture multi-sources : on porte le count du cluster
+        # entier sur le contexte (tous ses contents partagent ce cluster).
+        scoring_context = self._build_scoring_context(
+            context, coverage_source_count=len(cluster.source_domains)
+        )
 
         # Post-pillar digest bonuses (normalized to 0-100 scale)
         TRENDING_BONUS = 15.0  # ~45/300 from old scale

--- a/packages/api/tests/recommendation/test_pertinence_coverage.py
+++ b/packages/api/tests/recommendation/test_pertinence_coverage.py
@@ -39,7 +39,9 @@ class _Content:
         self.cluster_id = cluster_id
 
 
-def _context(*, cluster_source_counts=None, user_interests=None):
+def _context(
+    *, cluster_source_counts=None, user_interests=None, coverage_source_count=None
+):
     return ScoringContext(
         user_profile=MagicMock(id=uuid4()),
         user_interests=set(user_interests or []),
@@ -48,6 +50,7 @@ def _context(*, cluster_source_counts=None, user_interests=None):
         user_prefs={},
         now=datetime.now(),
         cluster_source_counts=cluster_source_counts or {},
+        coverage_source_count=coverage_source_count,
     )
 
 
@@ -101,6 +104,52 @@ def test_small_cluster_gets_relayed_label():
 
     pillar = PertinencePillar()
     raw, contribs = pillar.compute_raw(content, ctx)
+
+    contrib = next(c for c in contribs if c.label == "Sujet relayé")
+    assert contrib.points == ScoringWeights.COVERAGE_BASE
+
+
+def test_context_carried_count_gives_bonus_without_cluster_id():
+    """Chemin `topics` : `coverage_source_count` suffit, même content.cluster_id NULL.
+
+    C'est le cœur du câblage digest : `contents.cluster_id` est NULL à ~99 %
+    en base, donc le bonus ne doit PAS dépendre de cet attribut.
+    """
+    content = _Content(cluster_id=None)
+    ctx = _context(coverage_source_count=3)
+
+    pillar = PertinencePillar()
+    raw, contribs = pillar.compute_raw(content, ctx)
+
+    coverage_contribs = [c for c in contribs if c.label.startswith("Couvert")]
+    assert len(coverage_contribs) == 1
+    expected = compute_coverage_score(3)
+    assert coverage_contribs[0].points == expected
+    assert raw == expected
+
+
+def test_context_carried_mono_source_no_bonus():
+    """`coverage_source_count == 1` (cluster mono-source) → aucun bonus."""
+    content = _Content(cluster_id=None)
+    ctx = _context(coverage_source_count=1)
+
+    pillar = PertinencePillar()
+    raw, contribs = pillar.compute_raw(content, ctx)
+
+    assert not any(c.label.startswith("Couvert") for c in contribs)
+    assert not any(c.label == "Sujet relayé" for c in contribs)
+    assert raw == 0.0
+
+
+def test_context_carried_count_takes_priority_over_dict():
+    """`coverage_source_count` prime sur `cluster_source_counts` quand renseigné."""
+    cid = uuid4()
+    content = _Content(cluster_id=cid)
+    # dict dirait 5, mais le count porté par le contexte (2) doit gagner.
+    ctx = _context(coverage_source_count=2, cluster_source_counts={cid: 5})
+
+    pillar = PertinencePillar()
+    _, contribs = pillar.compute_raw(content, ctx)
 
     contrib = next(c for c in contribs if c.label == "Sujet relayé")
     assert contrib.points == ScoringWeights.COVERAGE_BASE

--- a/packages/api/tests/test_topic_selector.py
+++ b/packages/api/tests/test_topic_selector.py
@@ -479,6 +479,43 @@ class TestScoreAndSelectArticles:
         assert len(articles) == 1
         assert articles[0].is_followed_source is True
 
+    def test_coverage_bonus_multi_source_cluster(self):
+        """Cluster ≥3 sources distinctes → contribution 'Couvert par N sources'.
+
+        Câblage digest : le count du cluster est porté sur le ScoringContext,
+        sans dépendre de content.cluster_id (NULL en base). Vérifie que le bonus
+        de couverture apparaît dans le breakdown des articles sélectionnés.
+        """
+        selector = TopicSelector()
+        sources = [make_source() for _ in range(3)]
+        contents = [make_content(source=s) for s in sources]
+        cluster = make_cluster(contents)  # 3 domaines distincts
+        assert len(cluster.source_domains) == 3
+
+        context = make_context()
+        trending_ctx = make_trending_context()
+
+        articles = selector._score_and_select_articles(cluster, context, trending_ctx)
+        labels = [b.label for art in articles for b in art.breakdown]
+        assert any(lbl == "Couvert par 3 sources" for lbl in labels)
+
+    def test_no_coverage_bonus_mono_source_cluster(self):
+        """Cluster mono-source (scoop) → aucune contribution de couverture."""
+        selector = TopicSelector()
+        src = make_source()
+        # Même source → source_domains == 1
+        content = make_content(source=src)
+        cluster = make_cluster([content])
+        assert len(cluster.source_domains) == 1
+
+        context = make_context()
+        trending_ctx = make_trending_context()
+
+        articles = selector._score_and_select_articles(cluster, context, trending_ctx)
+        labels = [b.label for art in articles for b in art.breakdown]
+        assert not any(lbl.startswith("Couvert") for lbl in labels)
+        assert not any(lbl == "Sujet relayé" for lbl in labels)
+
     def test_returns_scored_articles(self):
         """Each result should be a ScoredArticle with breakdown."""
         selector = TopicSelector()


### PR DESCRIPTION
# feat(reco): allumer le bonus de pluralité (couverture multi-sources) sur le digest

Base `main`. **Aucune migration.** Backend-only (0 fichier mobile).

## Résumé

Le pilier Pertinence calcule un bonus log-calibré pour les clusters multi-sources
(`2→+12, 3→+19, 4→+24, cap 30`) mais c'était **du code mort partout** : aucun call
site ne passait le count au `ScoringContext`, et la garde `content.cluster_id`
tombait sur NULL pour ~99 % des candidats (`contents.cluster_id` NULL à 99 % en
base — 298 / 29 414 sur 14j, uuid4 régénéré par run). Cette PR allume le signal
**pour la première fois**, sur le chemin `topics` (cœur digest).

Doc : `docs/maintenance/maintenance-coverage-pillar-wiring.md`.

## Approche — sûre, sans mutation ORM ni migration

Le count du cluster est porté **directement sur le `ScoringContext`** (construit par
cluster dans `_score_and_select_articles`, donc `len(cluster.source_domains)`
s'applique à tous ses contents), et non via une mutation de `content.cluster_id` —
muter cet attribut ORM sur des `Content` attachés à la session risquerait un
autoflush vers la **DB prod partagée** (la colonne même que le pipeline peuple avec
des uuid4 par-run).

- `ScoringContext.coverage_source_count: int | None` — nouveau champ optionnel.
- `_score_coverage` — fast-path context-carried (prioritaire), fallback dict
  `cluster_source_counts` inchangé.
- `topic_selector` — `_build_scoring_context(..., coverage_source_count=len(cluster.source_domains))`.

## Périmètre / discipline (GO PO Laurin)

- **Chemin `topics` seulement.** Tournée/curation + flat éditorial reportés (le flat
  `_project_editorial_for_user` double-compterait avec `subject_importance`).
- **`COVERAGE_CAP=30` inchangé** — levier unique = allumage du signal ; le cap est un
  2e levier reporté (de toute façon `max_src=4` en prod ⇒ plafond effectif +24).
- **0 migration, 0 mutation ORM.** Commit isolé/révocable.

## Tests

- `tests/recommendation/test_pertinence_coverage.py` : +3 cas context-carried
  (bonus sans `cluster_id`, mono-source = 0, priorité sur dict).
- `tests/test_topic_selector.py` : +2 cas d'intégration (cluster ≥3 sources →
  « Couvert par 3 sources » dans le breakdown ; mono-source → rien).
- Suite reco + digest : **119 passed**, 0 régression. `alembic heads` = 1 head
  (`sa02_alerts_v2`).

## Mesure post-merge (jauge)

`by_pillar_band["pertinence"]` (`scripts/evaluate_feed_ranking.py`). **Forward-only**
⇒ bandes vides avant date de merge, fenêtre d'observation ≥7j. **Puissance faible**
(~13 clusters ≥3 src / 14j) : absence de mouvement CTR ≠ preuve d'inefficacité.

## Hors périmètre

Aucun changement mobile, aucune migration, cap inchangé, Tournée/curation/flat non
touchés.
