### PR TITLE
feat(reco): le clustering « Actus du jour » voit le corpus complet du jour

### DIFF
--- a/docs/bugs/bug-clustering-actus-du-jour-fragmentation.md
+++ b/docs/bugs/bug-clustering-actus-du-jour-fragmentation.md
@@ -3,8 +3,15 @@
 **Date** : 2026-07-31
 **Branche** : `claude/article-clustering-analysis-06xko0`
 **Sévérité** : **P0 — cœur de proposition de valeur**. La section « Les sujets les + couverts en France » n'affiche pas les sujets les plus couverts.
-**Statut** : Lots A et B livrés (cf. §8). Lot C (persistance) et Lot D (sémantique) à faire.
+**Statut** : Lot B livré et actif. **Lot A livré mais inerte** (code mort — cf. §10).
+Le levier de pool a été traité séparément dans
+[`maintenance-clustering-corpus-complet.md`](../maintenance/maintenance-clustering-corpus-complet.md).
+Lot C (persistance) et Lot D (sémantique) à faire.
 **Liés** : `bug-actus-du-jour-ranking.md`, `bug-clustering-consistency.md`, `bug-comparison-clustering-too-loose.md`, `bug-digest-pas-de-recul-same-event.md`
+
+> ⚠️ **Plusieurs chiffres de ce document ont été invalidés par une contre-mesure.**
+> Voir [`bug-clustering-actus-du-jour-verification.md`](bug-clustering-actus-du-jour-verification.md)
+> et le §10 ci-dessous avant de citer quoi que ce soit d'ici.
 
 ---
 
@@ -327,6 +334,10 @@ L'ordre du plan de la partie I (§5) est **caduc** : il commençait par l'algori
 levier, pas le premier.
 
 **Lot A — Découpler clustering global et personnalisation** *(le levier dominant, sans IA)*
+> ⚠️ **Livré sur la mauvaise branche de l'arbre d'appel.** `TopicSelector` n'est jamais
+> atteint en production (format `editorial` pour 100 % des digests). Le principe était
+> juste ; son application au chemin vivant est faite dans
+> [`maintenance-clustering-corpus-complet.md`](../maintenance/maintenance-clustering-corpus-complet.md).
 Calculer les clusters **une fois par cycle sur le corpus complet 24 h**, les persister
 (`contents.cluster_id`, aujourd'hui écrit par la seule pipeline éditoriale : 11 lignes sur 2 205),
 avec le vrai décompte de médias.
@@ -379,6 +390,13 @@ Nouvelle constante `TOPIC_CLUSTER_COSINE_THRESHOLD = 0.30`. `TOPIC_CLUSTER_THRES
 
 ### Résultats mesurés
 
+> ⚠️ **Ce tableau n'est pas reproductible en l'état** et sa ligne « Après » ne
+> provient pas du harness commité : `bench_clustering_bcubed.py` implémente une
+> liaison **moyenne** et un IDF **non lissé**, pas la liaison par centroïde livrée.
+> Exécuté tel quel, il donne à 0.30 : R = 0.40, Ceuta 4 médias. Chiffres remesurés
+> sur le code réel dans
+> [`bug-clustering-actus-du-jour-verification.md`](bug-clustering-actus-du-jour-verification.md) §3.1.
+
 Banc d'essai B³ sur corpus annoté (`docs/qa/scripts/bench_clustering_bcubed.py`) :
 
 | | B³ P | B³ R | B³ F1 | Ceuta | Clusters mixtes |
@@ -386,9 +404,11 @@ Banc d'essai B³ sur corpus annoté (`docs/qa/scripts/bench_clustering_bcubed.py
 | Avant (Jaccard 0.45 glouton) | 1.00 | 0.31 | 0.47 | 2 médias | 0 |
 | **Après (cosinus IDF 0.30, centroïde)** | **1.00** | **0.47** | **0.64** | **9 médias** | **0** |
 
-La précision reste parfaite : Gaza, Ukraine et Iran restent séparés malgré « Trump » partout — pas de
-régression « Texas ». Performance : **0,45 s pour 2 200 articles** (1,4 s pour 4 400), une fois par
-cycle et non plus une fois par utilisateur.
+Pas de régression « Texas » : Gaza, Ukraine et Iran restent séparés malgré « Trump »
+partout — **ce point-là a été revérifié et tient**. En revanche la précision n'est
+**pas** de 1.00 à l'échelle : 0.94 sur les 81 clusters ≥ 3 médias du corpus complet
+(cf. §5 du document de vérification). Performance : **0,45 s pour 2 200 articles**
+(1,4 s pour 4 400), une fois par cycle et non plus une fois par utilisateur.
 
 ### Non livré
 
@@ -410,3 +430,29 @@ Scripts de l'analyse (corpus réel extrait de production, algorithme importé de
 - Simulation de l'algorithme et comparaison des variantes : voir historique de la branche `claude/article-clustering-analysis-06xko0`.
 
 **Aucune modification de code applicatif n'a été faite** — ce document est un diagnostic.
+
+---
+
+## 10. Post-mortem — ce que la contre-mesure a invalidé (2026-08-01)
+
+Contre-expertise complète : [`bug-clustering-actus-du-jour-verification.md`](bug-clustering-actus-du-jour-verification.md).
+Correctif de pool : [`maintenance-clustering-corpus-complet.md`](../maintenance/maintenance-clustering-corpus-complet.md).
+
+| Affirmation de ce document | Statut après remesure |
+|---|---|
+| « Lot A livré » | ❌ **Code mort.** `_get_user_digest_format()` renvoie `"editorial"` sans condition ⇒ `TopicSelector` inatteignable. Vérifié : 1 765 digests sur 7 j, 100 % `editorial_v3`. |
+| Ligne de base « Jaccard 0.45 » | ❌ Le chemin vivant tournait à **0,40** (défaut de `ImportanceDetector`). 0,45 n'était passé que par `TopicSelector` — la branche morte. |
+| « 32 → 79 sujets » (§7.2, §7.7) | ❌ Proxy en **liaison simple**, ni l'avant ni l'après. Mesure réelle code contre code : **22 → 81**. Le proxy surestimait la base et sous-estimait l'arrivée. |
+| « KPI de 0 à ~32 » attendu du Lot A | ❌ Non atteint : le Lot A est inerte. Le pool corrigé donne **4 → 82** sur le chemin éditorial. |
+| B³ P = 1.00 | ⚠️ Vrai sur 63 articles annotés, **0,94** sur les 81 clusters ≥ 3 médias du corpus complet. |
+| « en dessous de 0,25 la précision décroche » | ⚠️ Optimiste : la falaise est **entre 0,28 et 0,25** (plus gros cluster 23 → 93 articles). |
+| Lot B (cosinus IDF + centroïde) | ✅ **Actif en production** et confirmé : le doublon Gaza de la capture fusionne bien en un sujet à 7 sources. |
+| Non-régression « Texas » | ✅ Confirmée : Gaza / Ukraine / Iran restent séparés. |
+| Gironde non résolu, plafond lexical R ≈ 0,44 | ✅ Confirmé (4 médias au mieux, ~91 clusters). |
+| §7.4 description brute, §3.2 entité seule | ✅ Écartés à raison — ne pas reproposer sans preuve nouvelle. |
+
+**Leçon de méthode.** Les deux erreurs coûteuses viennent de la même cause : avoir
+mesuré un *proxy* (composantes connexes en SQL, harness à liaison moyenne) plutôt que
+le code réellement exécuté, et n'avoir pas vérifié **quel chemin la production
+emprunte** avant d'optimiser. Le Lot C (observabilité) existait précisément pour ça,
+et il a été repoussé — c'est ce qui a permis aux deux erreurs de tenir jusqu'au merge.

--- a/docs/bugs/bug-clustering-actus-du-jour-verification.md
+++ b/docs/bugs/bug-clustering-actus-du-jour-verification.md
@@ -1,0 +1,456 @@
+# Vérification adversariale — clustering « Actus du jour »
+
+**Date** : 2026-08-01
+**Branche** : `claude/clustering-actus-verification-yz5jbl` (rebasée sur `main`)
+**Objet** : contre-expertise du diagnostic et du correctif livrés dans
+`bug-clustering-actus-du-jour-fragmentation.md` (PR #1044).
+**Posture** : aucun chiffre de l'analyse précédente n'a été repris. Tout ce qui est
+chiffré ici a été remesuré, sur données de production, en important le code livré.
+
+> **Correction de périmètre, à lire en premier.** La PR #1044, dont le titre est
+> `docs(bug): …`, a **squashé le code avec la documentation**. `topic_clustering.py`,
+> le nouveau seuil et la projection `TopicSelector` sont **déjà sur `main`**. Il ne
+> s'agit donc pas d'une revue avant merge mais d'un **constat post-déploiement**.
+
+---
+
+## 0. Verdict en une page
+
+| Question | Réponse mesurée |
+|---|---|
+| Le gain est-il « drastique » ? | **Sur le chemin réellement emprunté : non.** 2 → 4 sujets à ≥ 3 médias. Sur le corpus complet (jamais atteint) : 22 → 81, soit ×3,7. |
+| Le Lot A sert-il en prod ? | **Non — code mort, prouvé.** 1 765 digests sur 7 jours, 100 % `editorial_v3`, 0 `topics_v1`. |
+| Le Lot B sert-il en prod ? | **Oui.** C'est l'affirmation n°1 du brief qui est trop pessimiste : le chemin éditorial passe bien par `build_topic_clusters`. |
+| La pastille « N sources » a-t-elle bougé ? | **Oui**, contrairement à l'hypothèse du brief : 2/3/3/1/2 → 7/4/3/2/3. Mais elle sous-compte toujours (7 au lieu de 12 réels). |
+| Le doublon Gaza de la capture est-il corrigé ? | **Oui**, reproduit et vérifié : deux clusters à 3 et 3 sources fusionnent en un seul à 7. |
+| Ceuta ? | **Résolu** sur corpus complet (19 art. / 9 médias), **pas dans le pool de prod** (2 médias). |
+| Gironde ? | **Non résolu.** 7 art. / 4 médias au mieux, cible ≥ 6. Toujours éclaté sur 91 clusters. |
+| Précision à l'échelle ? | **0,94, pas 1,00.** 5 clusters défectueux sur 81, audités un par un. |
+| Suite de tests | **2 790 passed, 30 skipped** — vérifié, le chiffre est exact. |
+
+**Le correctif est réel et bien construit. Il est étranglé par un `LIMIT 200` qui n'a
+pas été touché.** L'ordre de priorité du plan révisé (§7.7 du diagnostic) désignait le
+bon levier dominant — mais le lot livré sous le nom « Lot A » corrige ce levier **sur
+la branche morte** de l'arbre d'appel.
+
+---
+
+## 1. §3.1 — Le Lot A ne sert à rien en prod, et c'est pire que ça
+
+### 1.1 Preuve que le chemin `topics` est mort
+
+```python
+# app/services/digest_service.py:3052-3059
+async def _get_user_digest_format(self, user_id: UUID) -> str:
+    """Legacy note: … All users now receive the same editorial format."""
+    return "editorial"
+```
+
+Aucun paramètre, aucun flag, aucune table. `effective_format` (`digest_service.py:866`)
+en dérive directement, et le batch code en dur `output_format="editorial"`
+(`digest_generation_job.py:983`). La branche `if output_format == "topics"`
+(`digest_selector.py:518`) est donc inatteignable.
+
+Confirmation en base, sur les 7 derniers jours :
+
+| `format_version` | digests |
+|---|---|
+| `editorial_v3` | **1 765** |
+| `topics_v1` | **0** |
+
+`TopicSelector.select_topics_for_user` n'a qu'un seul appelant
+(`digest_selector.py:523`), dans cette branche morte. **`_clusters_from_global()` — le
+cœur du Lot A — n'a aucun appelant vivant.**
+
+### 1.2 Le corollaire coûteux, non signalé jusqu'ici
+
+`digest_selector.py:317-339` calcule `trending_context` **avant** l'aiguillage de
+format. Ce calcul est un `build_topic_clusters()` sur **tout le corpus 24 h**
+(`_build_global_trending_context`, ligne 1890 : `select(Content).where(published_at >=
+now-24h)` — 2 351 articles mesurés).
+
+Puis la branche éditoriale (ligne 371) `return` sans jamais lire `trending_context` :
+`_project_editorial_for_user` ne le reçoit pas. **Le clustering global est calculé à
+chaque batch puis jeté.** Le Lot A a ajouté deux champs (`cluster_by_content`,
+`cluster_source_domains`) à un objet que le seul chemin vivant n'ouvre pas.
+
+### 1.3 Ce que le brief sous-estime : le Lot B, lui, est bien en production
+
+`editorial/pipeline.py:179-180` :
+
+```python
+detector = ImportanceDetector()
+clusters = detector.build_topic_clusters(contents)
+```
+
+Sans argument → le **défaut** de `__init__` s'applique, et le correctif l'a fait passer
+de `0.4` (Jaccard) à `0.30` (cosinus IDF). Le nouveau cœur de clustering est donc
+**intégralement actif sur le chemin éditorial**. C'est la nuance décisive :
+
+> **Lot A = mort. Lot B = vivant. Les deux ont été livrés ensemble et présentés comme
+> un tout ; leur sort en production est opposé.**
+
+Détail associé, qui invalide une constante de la table du diagnostic : la ligne de base
+du chemin vivant était **Jaccard 0,40**, pas 0,45. `TOPIC_CLUSTER_THRESHOLD = 0.45`
+n'était passé explicitement que par `TopicSelector` — la branche morte. Tous les
+« avant » du document d'origine mesurent donc un seuil que le chemin vivant n'a jamais
+utilisé.
+
+### 1.4 Le vrai facteur limitant, mesuré
+
+`digest_generation_job._get_global_candidates` : `ORDER BY published_at DESC LIMIT 200`,
+plus une tranche `FOLLOWED_SLICE_LIMIT = 200` sur les sources suivies.
+
+Mesuré à l'heure exacte du cron (`DIGEST_CRON_HOUR_PARIS = 7` → 05:00 UTC) :
+
+| | valeur |
+|---|---|
+| Pool éditorial effectif (union des deux tranches) | **246 articles** |
+| Corpus 24 h à la même seconde | 2 351 articles |
+| **Part du corpus vue par le clustering** | **10,5 %** |
+| Médias présents dans le pool | 64 sur **192** |
+| Fenêtre temporelle réelle du pool | **7,5 h** (sur 48 h autorisées) |
+
+La fenêtre de 7,5 h à 05:00 est l'effet du creux nocturne. En journée, le débit
+d'articles la comprime :
+
+| Heure UTC | Pool | Médias | Fenêtre réelle |
+|---|---|---|---|
+| 08:00 | 221 | 48 | **2,0 h** |
+| 11:00 | 264 | 59 | **1,8 h** |
+| 14:00 | 238 | 67 | **2,0 h** |
+| 17:00 | 242 | 72 | **1,7 h** |
+| 20:00 | 253 | 52 | 2,9 h |
+
+**L'estimation « ~2 h » du brief est confirmée** pour toute génération diurne (recalcul
+à la demande, cache miss). Le batch de 05:00 bénéficie du creux nocturne et atteint
+7,5 h — mais cela signifie qu'il **ne voit aucun article publié avant 21:32 la veille**,
+c'est-à-dire toute la journée éditoriale précédente.
+
+### 1.5 Gain réel, chemin par chemin
+
+KPI = nombre de sujets couverts par ≥ 3 médias distincts (après fold agrégateurs),
+mesuré en important `app/services/briefing/topic_clustering.py` et en rejouant
+l'algorithme antérieur extrait de `beac381e`.
+
+| | AVANT (Jaccard 0,40) | APRÈS (cosinus 0,30) | |
+|---|---|---|---|
+| **Chemin éditorial — pool réel 246 art.** | **2** | **4** | **+2** |
+| Corpus complet 24 h — 2 351 art. | 22 | **81** | ×3,7 |
+
+Sur les six heures de génération testées, le delta du chemin éditorial est **+2, +3, +2,
++2, +2, +5**. Le gain est réel et systématique, mais il se compte en unités, pas en
+ordres de grandeur — parce que le pool plafonne à 10 % du corpus.
+
+**Reproduction** : `python3.12 docs/qa/scripts/verify_clustering_prod_paths.py <corpus.json>`
+
+---
+
+## 2. La pastille « N sources » — l'hypothèse du brief est fausse, la conclusion tient
+
+Le brief supposait que la pastille venait de `perspective_count` / `PerspectiveService`.
+La chaîne réelle est :
+
+```
+curation.py:44        source_count = len(cluster.source_domains)   ← clustering éditorial
+digest_service.py:2452  source_count=subject.get("source_count", 0)
+flux_continu_models.dart:251  sourceCount: json['source_count']
+coverage_chip.dart:64   Text(sourceCount > 1 ? '$sourceCount sources' : '1 source')
+```
+
+`perspective_count` existe et transite, mais **la pastille lit `source_count`**. Elle est
+donc bel et bien alimentée par le clustering, et le Lot B l'améliore.
+
+Mesuré sur le pool éditorial réel, pastilles des 5 premiers sujets :
+
+| | pastilles |
+|---|---|
+| AVANT | `2 src` · **`3 src`** · **`3 src`** · `1 src` · `2 src` |
+| APRÈS | **`7 src`** · `4 src` · `3 src` · `2 src` · `3 src` |
+
+Les deux `3 src` de la ligne AVANT sont **les deux cartes Gaza de la capture
+utilisateur** — le doublon (A) du diagnostic, reproduit à l'identique. Après correctif
+elles fusionnent en un seul sujet à 7 sources. **Le symptôme visible est corrigé.**
+
+Mais la valeur reste fausse en tant que mesure de couverture nationale. Sur le corpus
+24 h complet, ces mêmes sujets valent :
+
+| Sujet | Pastille affichée | Couverture réelle 24 h |
+|---|---|---|
+| FIFA / boycott UEFA | absent du pool | **12 médias** |
+| Xenia Fedorova | absent du pool | **12 médias** |
+| Ceuta | 2 médias | **9 médias** |
+| Gaza / désarmement Hamas | 7 médias | 7 médias |
+
+**Verdict** : la pastille n'est plus fausse par fragmentation, elle reste fausse par
+troncature du pool. « Les sujets les + couverts en France » désigne toujours « les
+sujets les plus couverts dans les 2 dernières heures, vus par 1/3 des médias ».
+
+---
+
+## 3. Le seuil 0,30 — calibration circulaire confirmée, et marge plus étroite qu'annoncée
+
+### 3.1 Le banc d'essai livré ne contient pas l'algorithme livré
+
+`docs/qa/scripts/bench_clustering_bcubed.py` :
+
+- son `cos_idf` utilise un IDF **non lissé** (`log(N/df)`) à partir d'un fichier de DF
+  figé, là où `topic_clustering.compute_idf` lisse (`log((1+N)/(1+df))+1`) et calcule
+  l'IDF **sur le corpus local** ;
+- il applique une **liaison moyenne** (`agglo(..., linkage="average")`), là où le module
+  livré applique une **liaison par centroïde** — la note d'implémentation du §8 dit
+  explicitement que la liaison moyenne a été *essayée puis écartée* ;
+- il n'expose aucune variante centroïde.
+
+Exécuté tel quel :
+
+```
+Cosinus IDF 0.3, liaison moyenne     B³ P=1.00 R=0.40 F1=0.58 | Ceuta  4 méd. | Gironde 1 méd.
+```
+
+Le tableau « Résultats mesurés » du §8 annonce `R = 0.47`, `Ceuta 9 médias` pour le
+seuil 0,30. **Le harness commité ne peut pas produire cette ligne.** Le chiffre provient
+d'un code non versionné. Il n'est pas nécessairement faux — mon propre relevé sur corpus
+complet donne bien Ceuta à 9 médias — mais il n'est **pas reproductible en l'état**, ce
+qui est le défaut que le Lot C (observabilité) était censé fermer.
+
+### 3.2 Circularité
+
+Le corpus annoté fait 63 articles dont 21 Ceuta, **tous porteurs du mot « ceuta » dans
+le titre**. Ce corpus a servi à choisir le seuil *et* à valider le seuil. La commentaire
+de `TOPIC_CLUSTER_COSINE_THRESHOLD` cite ce même corpus comme justification.
+
+### 3.3 Sensibilité remesurée sur 2 351 articles réels
+
+| Seuil | Sujets ≥ 3 méd. | Art. trending | Ceuta méd. | Gironde méd. | **Plus gros cluster** |
+|---|---|---|---|---|---|
+| 0,22 | 107 | 773 | 13 | 15 | **118 art.** ⚠ |
+| 0,25 | 97 | 650 | 12 | 14 | **93 art.** ⚠ |
+| 0,28 | 85 | 501 | 9 | 4 | 23 art. |
+| **0,30 (livré)** | **81** | **453** | **9** | **4** | **22 art.** |
+| 0,32 | 75 | 401 | 9 | 4 | 21 art. |
+| 0,35 | 69 | 357 | 6 | 4 | 21 art. |
+| 0,40 | 53 | 266 | 6 | 4 | 20 art. |
+
+La falaise de chaînage est **entre 0,28 et 0,25** : le plus gros cluster passe de 23 à
+93 articles. Le commentaire du code dit « en dessous de 0,25 la précision décroche » —
+la mesure montre que **le décrochage est déjà consommé à 0,25**. La marge sous le seuil
+livré est de **0,02**, pas de 0,05.
+
+Les gains apparents de Ceuta (13) et Gironde (15) à 0,22 sont des artefacts : ils sont
+absorbés par le cluster géant de 118 articles, pas correctement regroupés.
+
+**Conclusion nuancée** : 0,30 est un choix défendable — il est sur le plateau stable
+0,28–0,35 — mais il est plus près du précipice que la documentation ne le laisse croire,
+et il n'a jamais été validé sur autre chose qu'un corpus d'un seul jour.
+
+---
+
+## 4. Le « 32 → 79 » — provenance invalide, chiffre conservateur
+
+Confirmé : le « 32 » et le « 79 » du §7.2 sont des **composantes connexes d'un graphe de
+paires**, c'est-à-dire une **liaison simple**, obtenue par proxy SQL. Ce n'est ni
+l'algorithme d'avant (glouton, sac fusionné) ni celui d'après (centroïde). À ne pas
+citer comme résultat du code livré.
+
+Mesure réelle, code contre code, sur le corpus complet 24 h :
+
+| Base de comparaison | Sujets ≥ 3 médias |
+|---|---|
+| Jaccard 0,45 glouton (le seuil du chemin mort) | **17** |
+| Jaccard 0,40 glouton (**le vrai défaut de prod**) | **22** |
+| Proxy composantes connexes 0,45 (chiffre cité) | 32 |
+| **Cosinus IDF 0,30 centroïde (livré)** | **81** |
+
+Le proxy **surestimait la ligne de base** (32 contre 22 réels) et **sous-estimait
+légèrement l'arrivée** (79 contre 81). Le ratio honnête sur corpus complet est donc
+**×3,7 et non ×2,5**. Le chiffre publié était mal fondé mais prudent — il faut le
+remplacer, pas seulement le retirer.
+
+Rappel : ce ×3,7 décrit une borne haute que la production n'atteint pas (cf. §1.5).
+
+---
+
+## 5. Précision à l'échelle — 0,94, pas 1,00
+
+Les 81 clusters à ≥ 3 médias produits par le code livré sur les 2 351 articles ont été
+**audités un par un**. Défauts trouvés :
+
+| # | Type | Contenu |
+|---|---|---|
+| 1 | **Fusion de sujets sans rapport** | `Atomarine: Nuclear Data Centers at Sea` + `EU launches €30B push to build 7 massive AI data centers` + `LinkedIn Won't Be Expanding Its Data Centers` — 3 sujets, liés par « data centers » (5 médias) |
+| 2 | **Fusion de sujets sans rapport** | `Galaxy Watch 9 is $40 off at Costco` + `J'ai testé la Galaxy Watch 9` + `-51 % sur le Samsung Galaxy S25` — promo, test et autre produit (3 médias) |
+| 3 | **Cluster de bruit pur** | `"J'ai vu quelqu'un jeter quelque chose et ça s'est embrasé"` + `« J'ai quelque chose à te dire »` + `« Au niveau de la performance globale… »` — trois titres-citations sans sujet commun (3 médias) |
+| 4 | **Fusion de sujets voisins** | 2 affaires Le Pen distinctes + une interview Cazeneuve (3 médias) |
+| 5 | **Boilerplate** | 20 articles : `JOURNAL DE 12H30 du jeudi 30 juillet`, `Le journal RTL de 6h du 31 juillet`, … — un gabarit, pas un sujet, et **à cheval sur 3 jours** (3 médias) |
+| — | Intrus isolé | `Le pape aime les Etats-Unis…` capté par le cluster « frappes américaines sur l'Iran » (7 médias, 1 intrus sur 7) |
+
+**Précision au niveau cluster : 76/81 = 0,94.** Le KPI effectif est donc ~76 sujets
+réels, pas 81.
+
+Le `P = 1,00` du §8 n'était pas faux — il était mesuré sur 63 articles annotés, où ces
+familles de défauts n'existent pas. **La classe de défaut n°5 (boilerplate) est
+structurelle et nouvelle** : le regroupement plus permissif fait émerger des clusters de
+gabarit (journaux radio horaires, grilles TV) qui n'existaient pas avant et qui
+comptent dans le KPI comme des sujets.
+
+La non-régression « Texas » **tient** : Gaza, Ukraine et Iran restent trois clusters
+distincts malgré « Trump » partout. C'est le point le plus risqué du correctif, et il
+passe.
+
+---
+
+## 6. Effets de bord aval — confirmés et chiffrés
+
+`is_trending` est défini par `len(cluster.source_domains) >= 3`. Sur le corpus 24 h :
+
+| | Sujets ≥ 3 méd. | **Articles marqués trending** | % du corpus |
+|---|---|---|---|
+| AVANT (Jaccard 0,40) | 22 | 91 | **3,9 %** |
+| APRÈS (cosinus 0,30) | 81 | **453** | **19,3 %** |
+
+**×5 sur le rayon d'action.** Consommateurs vivants, non revérifiés lors de la livraison :
+
+1. **`routers/feed.py:811`** — endpoint `/feed/trending`, qui renvoie
+   `[c for c in clusters if c.is_trending]`. Sa liste passe de ~22 à ~81 sujets, dont les
+   5 défectueux du §5. Changement visible pour l'utilisateur, hors périmètre annoncé.
+2. **`essentiel_service.py:366-367`** — `_W_TRENDING = 50` ajouté si `topic.is_trending`,
+   lui-même dérivé de `source_count >= 3` (`digest_service.py:2450`). Quand une minorité
+   de sujets était trending, ce +50 discriminait ; à 19 % du corpus il devient beaucoup
+   plus proche d'une constante. **Le poids n'a pas été recalibré.**
+3. **`recommendation_service.py:1243`**, **`article_clustering_service.py:98`**,
+   **`digest_selector._two_pass_selection`** (`trending_target`) — mêmes clusters, ratios
+   de sélection établis sous l'ancienne distribution.
+
+Sur le digest éditorial lui-même, l'impact est aujourd'hui **inerte** : `trending_context`
+n'y est pas lu (§1.2). Mais l'inertie vient d'un bug, pas d'un choix — le jour où le
+chemin sera rebranché, ces ratios sortiront de leur calibration sans avertissement.
+
+---
+
+## 7. Gironde — non résolu, confirmé ; Ceuta — résolu hors production
+
+Fragmentation résiduelle, corpus 24 h (nombre de clusters distincts portant le mot) :
+
+| | `gironde` | `ceuta` | `incendie` |
+|---|---|---|---|
+| AVANT | 118 | 17 | 171 |
+| APRÈS | **91** | **5** | 131 |
+
+| Sujet | AVANT | APRÈS | Cible §6 |
+|---|---|---|---|
+| Ceuta — meilleur cluster | 3 art. / 3 méd. | **19 art. / 9 méd.** | ≥ 6 méd. ✅ |
+| Gironde — meilleur cluster | 3 art. / 3 méd. | **7 art. / 4 méd.** | ≥ 6 méd. ❌ |
+
+Ceuta est traité — mais uniquement sur le corpus complet. Dans le pool de production, il
+plafonne à **2 médias** : le sujet reste invisible dans l'app. **Le Lot B résout Ceuta ;
+le pool le ré-enterre.**
+
+Gironde reste éclaté sur 91 clusters. Le meilleur (4 médias) regroupe le fil « le feu est
+contenu dans son périmètre » ; les facettes (« les mécanos au front », « des obus ont
+explosé », « la radio Ici Gironde mobilisée ») restent séparées, comme prévu. Le plafond
+lexical R ≈ 0,44 est cohérent avec ce que j'observe.
+
+**Le test embeddings n'a pas été retenté** : `huggingface.co` reste bloqué par la
+politique d'egress. Je n'ai pas cherché à contourner. Le protocole du §7.6 (Mistral
+`mistral-embed`, critère B³ R > 0,70 à P ≥ 0,95) reste la bonne porte d'entrée, et il
+est bien conditionné à une mesure préalable — c'est la partie la plus saine du document
+d'origine.
+
+---
+
+## 8. Pistes omises
+
+### 8.1 Déjà écartées par la mesure — ne pas reproposer sans preuve nouvelle
+
+- clusteriser sur `title + description` brute (§7.4 : 63,9 % → 27,4 % de paires
+  cross-média) ;
+- regroupement par entité seule (§3.2, régression « Texas ») ;
+- simple baisse du seuil Jaccard (§3.1 du diagnostic, et confirmé ici §3.3).
+
+### 8.2 Non explorées — par rendement décroissant estimé
+
+1. **Le cap à 200 — le seul levier qui change l'ordre de grandeur.** C'est la conclusion
+   n°1 de ce document. Options, de la moins à la plus invasive :
+   *(a)* relever le `LIMIT` du seul `_get_global_candidates` (le clustering coûte
+   **0,45 s pour 2 200 articles** — mesuré, ce n'est pas le goulot) ;
+   *(b)* remplacer « 200 plus récents » par « tout le corpus des N dernières heures »,
+   ce qui rend le pool indépendant du débit ;
+   *(c)* brancher le chemin éditorial sur `_build_global_trending_context`, qui
+   **clusterise déjà tout le corpus 24 h et jette le résultat**. C'est l'option la moins
+   chère : le calcul existe, il suffit de le lire.
+2. **Fenêtrage temporel.** Aucune contrainte de date n'entre dans la similarité : le
+   cluster boilerplate du §5 mélange les 29, 30 et 31 juillet. Un decay temporel ou un
+   simple blocage au-delà de N heures supprimerait cette classe de défaut et
+   réduirait le chaînage — à moindre risque qu'une baisse de seuil.
+3. **Dédoublonnage intra-source.** Signalé au §4.1 du diagnostic, jamais implémenté.
+   Le cluster à 20 articles / 3 médias en est l'illustration : 13 des 20 viennent de
+   `rtl.fr`. Garder le meilleur article par source et par sujet avant clustering
+   assainirait le décompte de `source_domains`, dont dépend directement la pastille.
+4. **`Content.entities` comme signal de *blocage*, pas de regroupement.** L'inverse de
+   la piste écartée : au lieu de fusionner sur entité partagée (régression Texas),
+   **interdire** la fusion quand deux clusters portent des entités nommées disjointes.
+   Cela viserait exactement les défauts n°1, 2 et 4 du §5 sans toucher au rappel. Les
+   entités sont peuplées à 72 % et ne servent aujourd'hui qu'à *nommer* un carrousel.
+5. **Filtre boilerplate.** Classe de défaut nouvelle et facile : les titres à gabarit
+   (`JOURNAL DE \d+H`, `Le journal RTL de …`, grilles TV) sont identifiables par regex
+   et devraient être exclus du clustering, pas seulement du rendu.
+6. **Clustering incrémental.** Aujourd'hui tout est recalculé à chaque cycle. Un
+   clustering incrémental persisté rendrait un sujet suivable dans le temps et
+   supprimerait la dépendance au débit horaire — c'est le préalable réel du Lot C.
+7. **19 articles post-datés.** `published_at > now()` sur 19 lignes (dates RSS
+   erronées) ; comme le pool est `ORDER BY published_at DESC`, ils **occupent 19 des 200
+   places** en permanence, soit ~10 % du pool. Un `AND published_at <= now()` est un
+   correctif d'une ligne.
+
+---
+
+## 9. Pièges d'environnement (coût réel constaté)
+
+| Piège | Détail |
+|---|---|
+| **`staging` ≠ `main`** | `staging` est **746 commits derrière `main`** et c'est la branche par défaut du repo GitHub. Une branche créée sans `git fetch origin main` part de code périmé. Vérifier : `git rev-list --left-right --count HEAD...origin/main`. |
+| **PR #1044 mal titrée** | Squash `docs(bug): …` contenant **tout le code**. Le titre d'une PR n'est pas un périmètre — lire `git show --stat`. |
+| **Python 3.12 obligatoire** | Le `python3` du conteneur est **3.11.15**. Utiliser `python3.12` explicitement, et `uv venv --python 3.12`. |
+| **Postgres local sur 54322** | Absent au démarrage → des dizaines de faux échecs. `initdb` **refuse de tourner en root** : passer par `su postgres` et un `PGDATA` hors du scratchpad (`/var/lib/postgresql/…`), sinon « Permission denied ». |
+| **`PYTHONPATH=.`** | Sans lui, `tests/conftest.py` échoue sur `ModuleNotFoundError: No module named 'app'` avant le premier test. |
+| **psql prod bloqué** | Le MCP Supabase est la seule voie. Ses résultats > ~190 k caractères sont **écrits sur disque** au lieu d'être renvoyés : paginer (`LIMIT 700`) et parser les fichiers hors contexte. |
+| **Hôtes bloqués par politique** | `huggingface.co` → 403 au CONNECT. Ne pas contourner ; le test embeddings reste non exécuté et déclaré comme tel. |
+
+---
+
+## 10. Reproduction
+
+```bash
+python3.12 docs/qa/scripts/verify_clustering_prod_paths.py   <corpus.json> [followed_ids]
+python3.12 docs/qa/scripts/verify_clustering_side_effects.py <corpus.json> [followed_ids]
+```
+
+Les deux scripts **importent `app/services/briefing/topic_clustering.py` tel quel** et
+rejouent l'algorithme antérieur extrait de `beac381e` — aucune réimplémentation, aucun
+proxy SQL. Le corpus est un export production
+(`{p, d, s, a, t}` = published_at, domaine, source_id, type de source, titre), extrait
+via MCP Supabase sur la fenêtre 2026-07-30 05:00 → 2026-08-01 00:00 UTC (4 380 articles
+non post-datés).
+
+Suite de tests vérifiée sur ce même environnement : **2 790 passed, 30 skipped** en 52 s.
+
+---
+
+## 11. Recommandation
+
+1. **Retirer le Lot A du périmètre « livré »** dans `bug-clustering-actus-du-jour-fragmentation.md`.
+   Il est mort tant que `_get_user_digest_format` renvoie `"editorial"`. Soit on le
+   supprime, soit on branche le chemin éditorial dessus — mais il ne doit pas rester
+   comptabilisé comme un gain.
+2. **Traiter le cap à 200**, option (c) de préférence : le clustering complet 24 h est
+   déjà calculé à chaque batch et jeté. C'est le seul changement qui fasse passer le KPI
+   de 4 à un nombre à deux chiffres.
+3. **Corriger le tableau des « Résultats mesurés » (§8)** : remplacer le `32 → 79` par
+   `22 → 81`, et signaler que le banc commité ne reproduit pas la ligne « centroïde ».
+4. **Ajouter la variante centroïde à `bench_clustering_bcubed.py`** pour que le harness
+   corresponde au code — sinon le Lot C démarre déjà en dette.
+5. **Filtrer le boilerplate et les articles post-datés** — deux correctifs courts qui
+   récupèrent ~5 faux sujets sur 81 et ~10 % du pool.
+6. **Ne pas relever le seuil sans revoir `_W_TRENDING`** : à 19,3 % d'articles trending,
+   le bonus de 50 ne discrimine plus.

--- a/docs/maintenance/maintenance-clustering-corpus-complet.md
+++ b/docs/maintenance/maintenance-clustering-corpus-complet.md
@@ -48,22 +48,42 @@ et ses deux appelants.
 | | Avant | Après |
 |---|---|---|
 | Sélection | 200 plus récents (+ 200 sources suivies) | **tout le corpus de la fenêtre** |
-| Fenêtre de regroupement | 48 h nominale, **1,7–2,9 h réelle** | **24 h** |
+| Fenêtre de regroupement | 48 h nominale, **1,7–2,9 h réelle** | **échelle 24 → 48 → 168 h** |
 | Borne | `LIMIT 200` (plafond) | `LIMIT 6000` (sécurité mémoire, jamais atteinte) |
-| Pool maigre | — | ré-élargissement à `hours_lookback` sous **200** articles |
+| Pool maigre | — | on descend l'échelle jusqu'à **200** articles utiles |
 
 Le **200 historique devient un plancher** : il ne coupe plus le corpus, il détecte
-un pool anormalement maigre (nuit de réveillon, panne d'ingestion) et déclenche un
-ré-élargissement plutôt qu'un digest vide.
+un pool anormalement maigre et fait descendre d'un barreau plutôt que de servir un
+digest famélique.
 
-**Pourquoi 24 h et pas 48 h.** « Actus du jour » est un produit quotidien : un sujet
+**Pourquoi une échelle et pas une fenêtre unique.** Les deux modes n'ont pas du tout
+la même densité, et c'est ce qui a failli passer inaperçu :
+
+| Mode | 24 h | 48 h | 168 h |
+|---|---|---|---|
+| `pour_vous` | ~2 000 | — | — |
+| `serein` (hard-filtré `is_good_news`) | **13** | **33** | **145** |
+
+Une fenêtre nominale de 24 h avec un repli unique à 48 h aurait amputé
+« Bonnes Nouvelles » de **77 % de sa matière** (145 → 33) sur le chemin on-demand,
+qui lisait jusqu'ici 168 h. L'échelle fait descendre `serein` jusqu'au dernier
+barreau et restitue exactement son comportement historique, sans élargir
+`pour_vous` d'une heure.
+
+**Pourquoi 24 h en nominal.** « Actus du jour » est un produit quotidien : un sujet
 se définit dans la journée. À 48 h, les articles de la veille se raccrochent à ceux
 du jour — observé sur les bulletins radio, qui formaient un cluster à cheval sur
 3 jours. Mesuré avant de trancher : passer de 48 h à 24 h coûte **44 articles issus
 de 27 sources** qui n'ont rien publié dans les dernières 24 h. Ces 27 sources
-restent couvertes par la tranche « sources suivies », qui garde volontairement la
-fenêtre large `hours_lookback` — c'est la garantie P1 existante, préservée telle
-quelle.
+restent couvertes par la tranche « sources suivies » (ci-dessous).
+
+**La tranche « sources suivies » (P1) ne couvre plus que le créneau que la fenêtre
+n'atteint pas** — `[now-48 h, now-24 h]` au lieu de `[now-48 h, now]`. Depuis que le
+pool nominal est exhaustif sur sa fenêtre, la requêter à nouveau sur `[0, 24 h]` ne
+rendait que des articles déjà présents : ils consommaient le `LIMIT 200` avant qu'un
+seul article de niche plus ancien n'y entre — l'exact inverse du but de la tranche.
+La garantie P1 était donc **cassée par la première version de ce correctif**, sans
+qu'aucun test ne le voie.
 
 ### 3.2 Deux exclusions d'entrée
 
@@ -81,6 +101,13 @@ quelle.
   sélection ») sauvait le cluster entier. On traite ici la cause : un bulletin
   n'entre pas dans le calcul. Il reste consultable ailleurs dans l'app ; c'est un
   filtre d'entrée du regroupement, pas une suppression de contenu.
+
+  **Taux de faux positifs mesuré** sur les 4 399 titres de production du corpus figé :
+  **39 titres écartés (0,9 %)**, dont **38 bulletins authentiques**. Le seul cas
+  discutable est une enquête en série (« … (2/3) »), qui n'est pas de l'actu chaude
+  non plus. Le risque théorique existe (`^le journal\b` attraperait « Le journal
+  Libération racheté par un fonds ») mais ne s'est pas matérialisé sur 24 h de
+  production ; il est à re-mesurer si `NEWS_BULLETIN_PATTERNS` s'élargit.
 
 ### 3.3 Les deux chemins voient enfin le même corpus
 
@@ -158,30 +185,37 @@ couverts**, de 5 à 12 médias.
 ## 5. Où regarder en prod
 
 ```
-digest_generation_global_pool_built   mode, window_hours, pool_size, source_count,
-                                      dropped_unclusterable   (chemin batch)
-digest_selector_global_pool_built     idem, chemin on-demand
-editorial_pool_widened                pool sous le plancher ⇒ fenêtre ré-élargie
-editorial_pool_truncated              ⚠ plafond de 6 000 atteint = anomalie d'ingestion
-global_trending_context_built         topics_3_plus_media = le KPI
-editorial_pipeline.clusters_built     nombre de clusters soumis à la curation
+digest_generation_global_pool_built       mode, window_hours, pool_size, source_count,
+                                          dropped_unclusterable   (chemin batch)
+digest_selector_global_pool_built         idem, chemin on-demand
+editorial_pool_ladder_exhausted           aucun barreau n'atteint le plancher — normal
+                                          pour `serein`, anormal pour `pour_vous`
+editorial_pool_truncated                  ⚠ plafond 6 000 atteint = anomalie d'ingestion
+digest_generation_followed_slice_skipped  fenêtre ≥ hours_lookback : tranche P1 sans objet
+global_trending_context_built             topics_3_plus_media = le KPI
+editorial_pipeline.clusters_built         nombre de clusters soumis à la curation
 ```
 
-Les deux derniers événements de pool sont émis par `candidate_pool.fetch_editorial_pool`,
-donc **communs aux deux chemins** — le `mode` les distingue, pas le nom.
+Les événements `editorial_pool_*` sont émis par `candidate_pool`, donc **communs aux
+deux chemins** — le `mode` les distingue, pas le nom.
 
-Signal de bonne santé attendu : `pool_size` ≈ 2 000-2 500, `source_count` ≈ 190,
-`topics_3_plus_media` entre 50 et 85. Un `pool_size` retombé à ~200 signifie que le
-ré-élargissement s'est déclenché — donc que l'ingestion a un problème.
+Signal de bonne santé attendu : `pool_size` ≈ 2 000-2 500 et `source_count` ≈ 190 en
+`pour_vous` ; `pool_size` ≈ 150 en `serein` avec `editorial_pool_ladder_exhausted`
+à chaque run (attendu — le mode n'a jamais 200 bonnes nouvelles). Un `pool_size`
+`pour_vous` retombé à ~200 signifie que l'ingestion a un problème.
+
+`topics_3_plus_media` doit se situer entre 50 et 85 en régime normal.
 
 ## 6. Pour le prochain agent — ce qui reste ouvert
 
 ### 6.1 Arbitrages que j'ai tranchés seul
 
-1. **Fenêtre 24 h.** Choisie pour la cohérence produit (§3.1), au prix de 44 articles
-   de 27 sources peu actives. Si la promesse devient « les sujets de la semaine »,
-   ce choix est à refaire — et il faudra alors un decay temporel, sinon les clusters
-   se mettront à cheval sur plusieurs jours.
+1. **Échelle `[24, 48, 168]`.** Le premier barreau est choisi pour la cohérence
+   produit (§3.1) ; les suivants existent pour `serein`. Si la promesse devient
+   « les sujets de la semaine », ce choix est à refaire — et il faudra alors un
+   decay temporel, sinon les clusters se mettront à cheval sur plusieurs jours.
+   Le plancher (200) arbitre entre les barreaux : le monter ferait descendre
+   `pour_vous` à 48 h les jours creux.
 2. **Bulletins exclus à l'entrée** plutôt que filtrés au niveau cluster. Plus radical,
    mais traite la cause. Un faux positif de `NEWS_BULLETIN_PATTERNS` fait maintenant
    disparaître un article du regroupement — les patterns sont partagés avec
@@ -246,7 +280,39 @@ ré-élargissement s'est déclenché — donc que l'ingestion a un problème.
    et `essentiel_service._W_TRENDING = 50` perd son pouvoir discriminant quand un
    cinquième du corpus est trending. **À revoir avant de toucher au seuil.**
 
-### 6.4 Ce que j'ai délibérément laissé de côté
+### 6.4 Effets induits traités ici (et pourquoi)
+
+Élargir le pool a des conséquences en dehors du digest, parce que
+`EditorialGlobalContext.cluster_data` sérialise **tous** les clusters et passe de
+~200 à ~2 350 contenus. Un consommateur en dépendait :
+
+- **`grille_selector._build_cluster_index`** n'indexe plus que les clusters
+  **multi-articles**. Le bonus `+2` qu'il alimente récompense l'appartenance à un
+  *sujet* ; avec les singletons indexés, la quasi-totalité des candidats y avait
+  droit — le bonus devenait une constante, donc sans effet sur le classement. La
+  distinction était implicite tant que `cluster_data` ne couvrait que 200 articles.
+
+### 6.5 Findings de revue écartés, avec la raison
+
+- **`defer(Content.html_content)` sur la requête de pool.** Suggéré pour alléger le
+  transfert. Mesuré : `html_content` pèse **699 kB sur 24 h** (1 kB/article), pas les
+  mégaoctets supposés. Le gain est réel mais faible, alors qu'un `defer` sur des
+  objets réhydratés puis re-sérialisés fait crasher tout accès tardif en contexte
+  async (`MissingGreenlet`). Mauvais rapport risque/gain — non appliqué.
+- **Ré-élargissement en « delta » plutôt qu'en requête complète.** L'échelle
+  re-requête toute la fenêtre à chaque barreau au lieu de ne chercher que
+  l'incrément. C'est deux à trois requêtes au lieu d'une, uniquement sur les modes
+  clairsemés. La version « delta + fusion » complique la boucle pour un gain qui ne
+  se paie que là — non appliqué, mais c'est le premier endroit à regarder si le
+  chemin on-demand `serein` devient chaud.
+- **Coût CPU superlinéaire de `cluster_documents` au plafond.** Un banc synthétique
+  à forte densité de tokens donne ~O(n²) (11 s à n=2 400, 77 s à n=6 000). Sur des
+  titres réels, la mesure est de **0,45 s pour 2 214 articles** — trois ordres de
+  grandeur d'écart, le corpus réel est creux. `EDITORIAL_CLUSTERING_MAX_ARTICLES`
+  borne donc la mémoire, pas le CPU : si l'ingestion double durablement, re-mesurer
+  avant de relever ce plafond.
+
+### 6.6 Ce que j'ai délibérément laissé de côté
 
 - Étendre le filtre bulletins aux **autres** consommateurs du clustering
   (`routers/feed.py`, `article_clustering_service`, `recommendation_service`). Ce

--- a/docs/maintenance/maintenance-clustering-corpus-complet.md
+++ b/docs/maintenance/maintenance-clustering-corpus-complet.md
@@ -1,0 +1,284 @@
+# Maintenance — le clustering « Actus du jour » voit le corpus complet
+
+**Date** : 2026-08-01
+**Branche** : `claude/clustering-actus-verification-yz5jbl`
+**Type** : Maintenance (correctif de périmètre, sans DDL ni migration)
+**Amont** : [`bug-clustering-actus-du-jour-fragmentation.md`](../bugs/bug-clustering-actus-du-jour-fragmentation.md)
+(diagnostic) · [`bug-clustering-actus-du-jour-verification.md`](../bugs/bug-clustering-actus-du-jour-verification.md)
+(contre-mesures)
+
+> **Si tu reprends ce chantier, lis d'abord le §6.** Il liste ce qui reste faux,
+> ce que je n'ai pas mesuré, et les arbitrages produits que j'ai tranchés seul et
+> qui méritent d'être rediscutés.
+
+---
+
+## 1. Le problème en une phrase
+
+La section promet « les sujets les + couverts en France », mais le regroupement qui
+produit ce classement ne voyait que **les 200 articles les plus récents** — soit
+**10,5 % du corpus 24 h**, sur une fenêtre de **1,7 à 2,9 h en journée**, issus de
+**64 médias sur 192**. Un sujet couvert par 18 médias dans la journée n'en montrait
+que 2 ou 3, et les deux plus gros sujets du jour n'atteignaient jamais la section.
+
+Le plafond n'achetait pas de la latence — **le clustering coûte 0,45 s pour 2 200
+articles**. Il achetait de la cécité.
+
+## 2. Pourquoi le correctif précédent (#1044) n'a pas suffi
+
+#1044 a livré deux lots. Ils ont eu un sort opposé, ce que le document d'origine ne
+disait pas :
+
+| Lot | Contenu | État réel |
+|---|---|---|
+| **A** | `TopicSelector._clusters_from_global()` — projeter les candidats du user sur les clusters globaux | **Code mort.** `_get_user_digest_format()` renvoie `"editorial"` sans condition ⇒ la branche `output_format == "topics"` est inatteignable. Vérifié en base : **1 765 digests sur 7 jours, 100 % `editorial_v3`, 0 `topics_v1`.** |
+| **B** | `briefing/topic_clustering.py` — cosinus IDF + agglomératif par centroïde | **Actif.** `editorial/pipeline.py:180` appelle `ImportanceDetector()` sans argument, donc le défaut passé de Jaccard 0,4 à cosinus 0,30 s'applique. |
+
+Le Lot A visait le bon levier (« le regroupement global fait autorité ») mais l'a
+branché sur la branche morte de l'arbre d'appel. **Ce correctif-ci applique le même
+principe au chemin vivant.**
+
+## 3. Ce qui change
+
+Tout tient dans un module de politique, [`app/services/editorial/candidate_pool.py`](../../packages/api/app/services/editorial/candidate_pool.py),
+et ses deux appelants.
+
+### 3.1 Le pool devient le corpus de la fenêtre
+
+| | Avant | Après |
+|---|---|---|
+| Sélection | 200 plus récents (+ 200 sources suivies) | **tout le corpus de la fenêtre** |
+| Fenêtre de regroupement | 48 h nominale, **1,7–2,9 h réelle** | **24 h** |
+| Borne | `LIMIT 200` (plafond) | `LIMIT 6000` (sécurité mémoire, jamais atteinte) |
+| Pool maigre | — | ré-élargissement à `hours_lookback` sous **200** articles |
+
+Le **200 historique devient un plancher** : il ne coupe plus le corpus, il détecte
+un pool anormalement maigre (nuit de réveillon, panne d'ingestion) et déclenche un
+ré-élargissement plutôt qu'un digest vide.
+
+**Pourquoi 24 h et pas 48 h.** « Actus du jour » est un produit quotidien : un sujet
+se définit dans la journée. À 48 h, les articles de la veille se raccrochent à ceux
+du jour — observé sur les bulletins radio, qui formaient un cluster à cheval sur
+3 jours. Mesuré avant de trancher : passer de 48 h à 24 h coûte **44 articles issus
+de 27 sources** qui n'ont rien publié dans les dernières 24 h. Ces 27 sources
+restent couvertes par la tranche « sources suivies », qui garde volontairement la
+fenêtre large `hours_lookback` — c'est la garantie P1 existante, préservée telle
+quelle.
+
+### 3.2 Deux exclusions d'entrée
+
+- **Articles post-datés** (`published_at <= now()`). 19 articles portaient une date
+  RSS future ; le pool étant trié par récence décroissante, ils occupaient en
+  permanence 19 des 200 places.
+- **Bulletins et chroniques régulières** (`drop_unclusterable`). « JOURNAL DE 8H du
+  jeudi… », « Le journal RTL de 6h… » partagent un **gabarit**, pas un sujet.
+  Élargir le pool les fait se regrouper entre eux : avant ce filtre, un cluster de
+  **20 bulletins / 3 médias** comptait comme un sujet du jour et remontait dans le
+  top curé par le LLM.
+
+  `pipeline._is_non_actu_cluster` existait déjà, mais exige que **tous** les contenus
+  du cluster soient des bulletins — un seul intrus (« Ce soir à la télé : notre
+  sélection ») sauvait le cluster entier. On traite ici la cause : un bulletin
+  n'entre pas dans le calcul. Il reste consultable ailleurs dans l'app ; c'est un
+  filtre d'entrée du regroupement, pas une suppression de contenu.
+
+### 3.3 Les deux chemins voient enfin le même corpus
+
+Le chemin batch (`digest_generation_job._get_global_candidates`) et le chemin
+on-demand (`digest_selector._fetch_editorial_global_pool`) construisaient chacun
+leur pool. Ils avaient **divergé** : le chemin on-demand n'appliquait pas
+`apply_ad_filter`, donc les articles `is_ad=True` entraient dans son clustering.
+Les deux passent désormais par `build_editorial_pool_stmt`. Sans cela, un même
+sujet n'affiche pas le même nombre de médias selon que le digest vient du batch ou
+d'un recalcul à la demande.
+
+## 4. Résultats mesurés
+
+Sur corpus de production réel (2026-07-30 05:00 → 2026-08-01 00:00 UTC, 4 380
+articles non post-datés), en important le code de production — **aucun proxy SQL,
+aucune réimplémentation**.
+
+### 4.1 Le pool
+
+| | Avant | Après |
+|---|---|---|
+| Articles | 246 | **2 332** |
+| Médias | 64 | **192** |
+| Part du corpus 24 h | 10,5 % | **99,2 %** |
+| Fenêtre réelle | 7,5 h (2,0 h en journée) | **24,0 h** |
+
+### 4.2 Le KPI produit — sujets couverts par ≥ 3 médias
+
+Algorithme identique des deux côtés : **seul le pool change**.
+
+| Heure de génération | KPI avant | KPI après | |
+|---|---|---|---|
+| 05:00 UTC (cron 07:00 Paris) | 4 | **82** | ×20 |
+| 08:00 | 6 | 71 | ×12 |
+| 11:00 | 4 | 65 | ×16 |
+| 14:00 | 4 | 64 | ×16 |
+| 17:00 | 3 | 51 | ×17 |
+| 20:00 | 8 | 54 | ×7 |
+
+### 4.3 Les sujets de référence du diagnostic
+
+| Sujet | Avant | Après | Cible §6 du diagnostic |
+|---|---|---|---|
+| Ceuta | 2 médias | **9 médias** (19 art.) | ≥ 6 ✅ |
+| Gironde | 3 médias | 4 médias (7 art.) | ≥ 6 ❌ |
+
+### 4.4 Ce que la curation LLM voit réellement
+
+C'est **la vue produit** : `curation.select_topics` trie par nombre de médias et
+tronque à `cluster_input_limit = 15`, puis le digest en retient 5. Le KPI global
+n'est qu'un indicateur ; c'est ce top 15 que l'utilisateur finit par lire.
+
+| Rang | Avant | Après |
+|---|---|---|
+| 1 | 7 méd. — Trêve à Gaza / désarmement Hamas | 12 méd. — FIFA : l'UEFA menace de boycotter la Coupe du monde |
+| 2 | 4 méd. — Anthropic AI hacked three companies | 12 méd. — Xenia Fedorova visée par un arrêté d'expulsion |
+| 3 | 3 méd. — Incendie en Gironde | 9 méd. — Croissance française à 0,2 % au 2ᵉ trimestre |
+| 4 | 3 méd. — Avalanche au Pakistan | 9 méd. — Attal débouté face à Le Pen sur « renaissance » |
+| 5 | **2 méd. — « Le journal RTL de 6h du 31 juillet »** | 8 méd. — Ceuta : l'Italie veut suspendre l'Espagne de Schengen |
+| … | rangs 12-15 à **1 média**, dont **« Mattress Firm Coupons: Save up to $700 »** | rang 15 encore à **5 médias** |
+
+Avant, la curation choisissait 5 sujets dans une liste dont la moitié basse était
+du bruit à 1 média. Après, **les 15 candidats sont tous des sujets réellement
+couverts**, de 5 à 12 médias.
+
+### 4.5 Coût
+
+| | Valeur |
+|---|---|
+| Clustering | 0,45 s pour 2 200 articles (1,4 s pour 4 400) |
+| Fréquence | 2× par batch (`pour_vous` + `serein`), puis servi depuis le cache |
+| Appels LLM | **inchangés** — `cluster_input_limit = 15` borne l'entrée de la curation quelle que soit la taille du pool |
+| Suite de tests | 2 804 passed, 30 skipped (2 790 avant, +14 nouveaux) |
+
+## 5. Où regarder en prod
+
+```
+digest_generation_global_pool_built   mode, window_hours, pool_size, source_count,
+                                      dropped_unclusterable   (chemin batch)
+digest_selector_global_pool_built     idem, chemin on-demand
+editorial_pool_widened                pool sous le plancher ⇒ fenêtre ré-élargie
+editorial_pool_truncated              ⚠ plafond de 6 000 atteint = anomalie d'ingestion
+global_trending_context_built         topics_3_plus_media = le KPI
+editorial_pipeline.clusters_built     nombre de clusters soumis à la curation
+```
+
+Les deux derniers événements de pool sont émis par `candidate_pool.fetch_editorial_pool`,
+donc **communs aux deux chemins** — le `mode` les distingue, pas le nom.
+
+Signal de bonne santé attendu : `pool_size` ≈ 2 000-2 500, `source_count` ≈ 190,
+`topics_3_plus_media` entre 50 et 85. Un `pool_size` retombé à ~200 signifie que le
+ré-élargissement s'est déclenché — donc que l'ingestion a un problème.
+
+## 6. Pour le prochain agent — ce qui reste ouvert
+
+### 6.1 Arbitrages que j'ai tranchés seul
+
+1. **Fenêtre 24 h.** Choisie pour la cohérence produit (§3.1), au prix de 44 articles
+   de 27 sources peu actives. Si la promesse devient « les sujets de la semaine »,
+   ce choix est à refaire — et il faudra alors un decay temporel, sinon les clusters
+   se mettront à cheval sur plusieurs jours.
+2. **Bulletins exclus à l'entrée** plutôt que filtrés au niveau cluster. Plus radical,
+   mais traite la cause. Un faux positif de `NEWS_BULLETIN_PATTERNS` fait maintenant
+   disparaître un article du regroupement — les patterns sont partagés avec
+   `essentiel_service` et l'`actu_matcher`, donc y toucher a une portée large.
+3. **Plancher à 200.** Valeur reprise de l'ancien plafond, pas mesurée. Si le
+   ré-élargissement se déclenche souvent en prod (cf. log), c'est ce nombre qu'il
+   faut revoir en premier.
+
+### 6.2 Ce qui reste faux ou non résolu
+
+1. **Gironde n'est toujours pas résolu** : 4 médias au mieux, cible ≥ 6, toujours
+   éclaté sur ~91 clusters. Les facettes (« les mécanos au front », « des obus ont
+   explosé », « la radio Ici Gironde mobilisée ») ne partagent aucun vocabulaire.
+   **Aucun réglage lexical ne franchira ce plafond** (R ≈ 0,44 mesuré au banc B³).
+   Seule voie : une représentation sémantique — protocole au §7.6 du diagnostic
+   (embeddings Mistral, critère B³ R > 0,70 à P ≥ 0,95). `huggingface.co` est bloqué
+   par la politique d'egress ; le test n'a jamais pu tourner. **Ne pas engager
+   `pgvector` avant d'avoir cette mesure.**
+2. **La précision du clustering est de 0,94, pas 1,00.** Audit des 81 clusters ≥ 3
+   médias : 5 défectueux (fusion « data centers » de 3 sujets distincts, promo/test
+   Galaxy Watch, 3 titres-citations sans sujet commun, 2 affaires Le Pen + une
+   interview, et le cluster de bulletins — ce dernier corrigé ici). Le `P = 1,00`
+   annoncé était mesuré sur 63 articles annotés, où ces familles n'existent pas.
+3. **Le seuil 0,30 est plus près du précipice que la doc ne le dit.** Mesuré sur
+   2 351 articles : la falaise de chaînage est **entre 0,28 et 0,25** (plus gros
+   cluster : 23 → 93 articles). Le commentaire de `TOPIC_CLUSTER_COSINE_THRESHOLD`
+   dit « en dessous de 0,25 » — c'est optimiste de deux crans. **Ne pas baisser ce
+   seuil sans rejouer `verify_clustering_side_effects.py`.**
+4. **`bench_clustering_bcubed.py` ne contient pas l'algorithme livré** : il utilise
+   une liaison *moyenne* et un IDF non lissé. Il ne peut pas reproduire la ligne
+   « centroïde » du §8 du diagnostic. Tant qu'il n'a pas de variante centroïde, le
+   Lot C (observabilité) démarre en dette.
+
+### 6.3 Pistes non explorées, par rendement estimé
+
+1. **`trending_context` est calculé puis jeté.** `digest_selector.py:317-339` lance
+   un `build_topic_clusters()` sur tout le corpus 24 h **avant** l'aiguillage de
+   format ; la branche éditoriale `return` sans jamais le lire. C'est aujourd'hui du
+   travail pur perte à chaque batch. Deux issues : le rendre paresseux
+   (`if output_format != "editorial"`), ou — mieux — **fusionner les deux calculs**,
+   puisque ce correctif fait maintenant clusteriser le même corpus deux fois.
+   C'est le prochain gain évident, et il est purement mécanique.
+2. **Dédoublonnage intra-source.** Jamais implémenté (§4.1 du diagnostic). BFMTV
+   publie ~45 titres-citations quasi dupliqués sur un même sujet. Garder le meilleur
+   article par source et par sujet assainirait `source_domains`, dont dépend
+   directement la pastille « N sources ».
+3. **`Content.entities` comme signal de *blocage*.** L'inverse de la piste écartée :
+   au lieu de fusionner sur entité partagée (régression « Texas »), **interdire** la
+   fusion quand deux clusters portent des entités nommées disjointes. Viserait
+   exactement les défauts de précision du §6.2.2 sans coûter de rappel. Les entités
+   sont peuplées à 72 % et ne servent aujourd'hui qu'à *nommer* un carrousel.
+4. **Clustering incrémental et persistance.** Tout est recalculé à chaque cycle ;
+   `contents.cluster_id` n'est écrit que pour les rares sujets retenus (11 lignes sur
+   2 205). Sans persistance, impossible de suivre un sujet dans le temps ou de
+   mesurer une régression. ⚠ **DB partagée** : `contents.cluster_id` est lu par
+   `title_annotation_service` et écrit par la pipeline éditoriale ; y toucher depuis
+   `main` change le comportement du backend `production` pendant une semaine.
+   Expand-contract obligatoire, PR dédiée.
+5. **Effets de bord aval non recalibrés.** Le nombre d'articles marqués
+   `is_trending` passe de 91 à 453 (3,9 % → 19,3 % du corpus). Conséquences non
+   traitées ici : `/feed/trending` (`routers/feed.py:811`) passe de ~22 à ~81 sujets,
+   et `essentiel_service._W_TRENDING = 50` perd son pouvoir discriminant quand un
+   cinquième du corpus est trending. **À revoir avant de toucher au seuil.**
+
+### 6.4 Ce que j'ai délibérément laissé de côté
+
+- Étendre le filtre bulletins aux **autres** consommateurs du clustering
+  (`routers/feed.py`, `article_clustering_service`, `recommendation_service`). Ce
+  serait cohérent, mais ces surfaces sont vivantes et je n'ai pas mesuré l'impact.
+- Supprimer le Lot A mort. Il ne coûte rien à l'exécution ; le supprimer ou le
+  brancher est une décision produit, pas une urgence technique.
+
+## 7. Reproduction
+
+```bash
+# Mesure avant/après sur les deux chemins + audit de chaînage
+python3.12 docs/qa/scripts/verify_clustering_prod_paths.py   <corpus.json> [followed_ids]
+# Vue curation LLM, robustesse horaire, sensibilité au seuil, effets de bord
+python3.12 docs/qa/scripts/verify_clustering_side_effects.py <corpus.json> [followed_ids]
+```
+
+Les deux scripts importent `app/services/briefing/topic_clustering.py` tel quel et
+rejouent l'algorithme antérieur extrait de `beac381e`. `editorial_pool_v2()` réplique
+la politique de `candidate_pool.py` — **si tu modifies l'une, mets l'autre à jour**,
+sinon les mesures cessent de décrire la production.
+
+Le corpus est un export production `{p, d, s, a, t}` = published_at, domaine,
+source_id, type de source, titre. Extraction via MCP Supabase (psql prod est bloqué) ;
+les résultats > ~190 k caractères sont écrits sur disque au lieu d'être renvoyés,
+donc paginer (`LIMIT 700`) et parser les fichiers.
+
+### Pièges d'environnement
+
+| Piège | Détail |
+|---|---|
+| `staging` ≠ `main` | `staging` est ~746 commits derrière `main` et c'est la branche par défaut du repo. Vérifier : `git rev-list --left-right --count HEAD...origin/main`. |
+| Python 3.12 | Le `python3` du conteneur est 3.11. Utiliser `python3.12` / `uv venv --python 3.12`. |
+| Postgres sur 54322 | Absent au démarrage ⇒ des dizaines de faux échecs. `initdb` refuse de tourner en root : passer par `su postgres` et un `PGDATA` hors du scratchpad (`/var/lib/postgresql/…`). |
+| `PYTHONPATH=.` | Sans lui, `tests/conftest.py` échoue sur `ModuleNotFoundError: No module named 'app'`. |
+| Hôtes bloqués | `huggingface.co` → 403 au CONNECT. Ne pas contourner. |

--- a/docs/qa/scripts/verify_clustering_prod_paths.py
+++ b/docs/qa/scripts/verify_clustering_prod_paths.py
@@ -1,0 +1,222 @@
+# -*- coding: utf-8 -*-
+"""Mesure avant/après du clustering sur le CODE LIVRÉ, chemin éditorial et chemin topics.
+
+Contrairement à `bench_clustering_bcubed.py` (qui réimplémente un cosinus IDF et
+une liaison *moyenne*), ce banc importe le module de production
+`app/services/briefing/topic_clustering.py` tel quel — IDF lissé, plafond de DF,
+liaison par centroïde — et rejoue l'algorithme *antérieur* (Jaccard glouton
+contre sac fusionné) à l'identique, extrait de `beac381e`.
+
+Il mesure le KPI produit — nombre de sujets couverts par >= 3 médias distincts —
+sur les deux pools qui existent réellement en production :
+
+  * `editorial`  : le pool que voit la pipeline éditoriale (`digest_generation_job
+    ._get_global_candidates`) = 200 articles les plus récents + tranche sources
+    suivies, fenêtre 48 h. C'est le SEUL chemin emprunté par le digest.
+  * `corpus24h`  : le corpus complet 24 h, borne haute théorique.
+
+Usage : python3.12 docs/qa/scripts/verify_clustering_prod_paths.py <corpus.json>
+
+Le corpus attendu est une liste JSON d'objets {p: published_at ISO, d: domaine,
+s: préfixe source_id, a: type de source, t: titre}, extraite de production.
+"""
+
+import importlib.util
+import json
+import math
+import os
+import sys
+from collections import Counter
+
+SC = os.path.dirname(os.path.abspath(__file__))
+API = os.path.join(SC, "..", "..", "..", "packages", "api", "app", "services")
+
+
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Code de production importé tel quel — aucune réimplémentation.
+ts = _load("text_similarity", os.path.join(API, "text_similarity.py"))
+tc = _load("topic_clustering", os.path.join(API, "briefing", "topic_clustering.py"))
+normalize_title, jaccard = ts.normalize_title, ts.jaccard_similarity
+
+MIN_TOKENS = 3
+MAX_TOKENS = 15  # ScoringWeights.TOPIC_CLUSTER_MAX_TOKENS, supprimée par le correctif
+AGGREGATOR_TYPES = {"reddit"}
+FOLLOWED = set(sys.argv[2].split(",")) if len(sys.argv) > 2 else set()
+
+
+# --------------------------------------------------------------------------
+# Algorithme ANTÉRIEUR — copie fidèle de importance_detector.build_topic_clusters
+# à beac381e (glouton, une passe, Jaccard contre le sac de tokens fusionné).
+# --------------------------------------------------------------------------
+def cluster_before(token_sets, threshold):
+    raw = []
+    for i, tokens in enumerate(token_sets):
+        if not tokens:
+            continue
+        if len(tokens) < MIN_TOKENS:
+            raw.append({"tokens": set(tokens), "idx": [i]})
+            continue
+        matched, best = None, 0.0
+        for c in raw:
+            sim = jaccard(tokens, c["tokens"])
+            if sim > best and sim >= threshold:
+                best, matched = sim, c
+        if matched:
+            matched["idx"].append(i)
+            merged = matched["tokens"] | tokens
+            if len(merged) <= MAX_TOKENS:
+                matched["tokens"] = merged
+        else:
+            raw.append({"tokens": set(tokens), "idx": [i]})
+    return [c["idx"] for c in raw]
+
+
+def cluster_after(token_sets, threshold):
+    """Code livré, appelé directement."""
+    return tc.cluster_documents(token_sets, threshold=threshold, min_tokens=MIN_TOKENS)
+
+
+# --------------------------------------------------------------------------
+# Phase 2 métier : fold agrégateurs + décompte de domaines (identique aux deux)
+# --------------------------------------------------------------------------
+def domains_of(group, rows):
+    primary = {rows[i]["d"] for i in group if rows[i]["a"] not in AGGREGATOR_TYPES}
+    agg = {rows[i]["d"] for i in group if rows[i]["a"] in AGGREGATOR_TYPES}
+    return primary or agg
+
+
+def metrics(groups, rows):
+    doms = [domains_of(g, rows) for g in groups]
+    sizes = [len(g) for g in groups]
+    n = sum(sizes)
+    biggest = max(range(len(groups)), key=lambda k: len(doms[k])) if groups else None
+    return {
+        "articles": n,
+        "clusters": len(groups),
+        "topics_3plus_media": sum(1 for d in doms if len(d) >= 3),
+        "topics_5plus_media": sum(1 for d in doms if len(d) >= 5),
+        "multi_article": sum(1 for s in sizes if s >= 2),
+        "singleton_rate": round(100.0 * sum(1 for s in sizes if s == 1) / n, 1) if n else 0.0,
+        "grouped_rate": round(100.0 * sum(s for s in sizes if s >= 2) / n, 1) if n else 0.0,
+        "max_media": max((len(d) for d in doms), default=0),
+        "max_articles": max(sizes, default=0),
+        "_groups": groups,
+        "_doms": doms,
+        "_biggest": biggest,
+    }
+
+
+def topic_media(groups, rows, needle):
+    """Meilleur cluster contenant `needle` : (articles, médias)."""
+    best = (0, 0)
+    for g in groups:
+        hits = [i for i in g if needle in rows[i]["t"].lower()]
+        if not hits:
+            continue
+        d = len({rows[i]["d"] for i in hits})
+        if d > best[1] or (d == best[1] and len(hits) > best[0]):
+            best = (len(hits), d)
+    return best
+
+
+# --------------------------------------------------------------------------
+# Reconstruction des pools de production
+# --------------------------------------------------------------------------
+def editorial_pool(rows, gen, lookback_h=48, cap=200, followed_cap=200):
+    """Réplique digest_generation_job._get_global_candidates."""
+    lo = gen - lookback_h * 3600
+    win = [r for r in rows if lo <= r["_ts"] <= gen]
+    win.sort(key=lambda r: r["_ts"], reverse=True)
+    recency = win[:cap]
+    seen = {id(r) for r in recency}
+    if FOLLOWED:
+        fol = [r for r in win if r["s"] in FOLLOWED][:followed_cap]
+        return recency + [r for r in fol if id(r) not in seen]
+    return recency
+
+
+def corpus_window(rows, gen, hours):
+    lo = gen - hours * 3600
+    return [r for r in rows if lo <= r["_ts"] <= gen]
+
+
+def run(label, rows):
+    tokens = [normalize_title(r["t"]) for r in rows]
+    out = {}
+    for name, groups in (
+        ("AVANT  Jaccard 0.40 glouton (défaut prod réel)", cluster_before(tokens, 0.40)),
+        ("AVANT  Jaccard 0.45 glouton (chemin topics)", cluster_before(tokens, 0.45)),
+        ("APRÈS  cosinus IDF 0.30 centroïde (livré)", cluster_after(tokens, 0.30)),
+    ):
+        m = metrics(groups, rows)
+        out[name] = m
+    print(f"\n### {label} — {len(rows)} articles, {len({r['d'] for r in rows})} médias")
+    hdr = f"  {'variante':<46} {'sujets>=3méd':>12} {'>=5méd':>7} {'groupés%':>9} {'maxméd':>7} {'maxart':>7}"
+    print(hdr)
+    for name, m in out.items():
+        print(
+            f"  {name:<46} {m['topics_3plus_media']:>12} {m['topics_5plus_media']:>7} "
+            f"{m['grouped_rate']:>8}% {m['max_media']:>7} {m['max_articles']:>7}"
+        )
+    for needle in ("ceuta", "gironde"):
+        line = f"  sujet « {needle} » (art./méd.)".ljust(48)
+        for name, m in out.items():
+            a, d = topic_media(m["_groups"], rows, needle)
+            line += f"{a}/{d}".rjust(13)
+        print(line)
+    return out
+
+
+def chaining_audit(m, rows, top=5):
+    """Inspection des plus gros clusters : détection de chaînage à l'œil nu."""
+    order = sorted(range(len(m["_groups"])), key=lambda k: len(m["_groups"][k]), reverse=True)
+    for k in order[:top]:
+        g = m["_groups"][k]
+        print(f"\n  -- cluster {len(g)} art. / {len(m['_doms'][k])} médias --")
+        for i in g[:14]:
+            print(f"     [{rows[i]['d']:<28}] {rows[i]['t'][:96]}")
+        if len(g) > 14:
+            print(f"     ... +{len(g) - 14} autres")
+
+
+def main():
+    import datetime as dt
+
+    rows = json.load(open(sys.argv[1], encoding="utf-8"))
+    for r in rows:
+        r["_ts"] = dt.datetime.fromisoformat(r["p"]).replace(tzinfo=dt.UTC).timestamp()
+    gen = dt.datetime(2026, 7, 31, 5, 0, tzinfo=dt.UTC).timestamp()  # cron 07:00 Paris
+
+    print("=" * 118)
+    print("CLUSTERING — MESURE AVANT/APRÈS SUR LE CODE LIVRÉ (topic_clustering.py importé)")
+    print(f"Génération simulée : 2026-07-31 05:00 UTC (cron 07:00 Paris)")
+    print("KPI = nombre de sujets couverts par >= 3 médias distincts (après fold agrégateurs)")
+    print("=" * 118)
+
+    pool = editorial_pool(rows, gen)
+    ed = run("CHEMIN ÉDITORIAL — pool réel de la pipeline (le seul emprunté en prod)", pool)
+
+    c24 = corpus_window(rows, gen, 24)
+    full = run("CORPUS COMPLET 24 h — borne haute, non atteinte en prod", c24)
+
+    print(f"\n### Couverture du pool éditorial")
+    print(f"  pool éditorial          : {len(pool)} articles, {len({r['d'] for r in pool})} médias")
+    print(f"  corpus 24 h             : {len(c24)} articles, {len({r['d'] for r in c24})} médias")
+    print(f"  part du corpus vue      : {100.0 * len(pool) / len(c24):.1f} %")
+    span = (max(r["_ts"] for r in pool) - min(r["_ts"] for r in pool)) / 3600
+    print(f"  fenêtre réelle du pool  : {span:.1f} h (contre 48 h autorisées)")
+
+    print("\n" + "=" * 118)
+    print("AUDIT DE CHAÎNAGE — plus gros clusters produits par le code livré sur 24 h")
+    print("=" * 118)
+    chaining_audit(full["APRÈS  cosinus IDF 0.30 centroïde (livré)"], c24)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/qa/scripts/verify_clustering_prod_paths.py
+++ b/docs/qa/scripts/verify_clustering_prod_paths.py
@@ -23,10 +23,9 @@ s: préfixe source_id, a: type de source, t: titre}, extraite de production.
 
 import importlib.util
 import json
-import math
 import os
+import re
 import sys
-from collections import Counter
 
 SC = os.path.dirname(os.path.abspath(__file__))
 API = os.path.join(SC, "..", "..", "..", "packages", "api", "app", "services")
@@ -102,8 +101,12 @@ def metrics(groups, rows):
         "topics_3plus_media": sum(1 for d in doms if len(d) >= 3),
         "topics_5plus_media": sum(1 for d in doms if len(d) >= 5),
         "multi_article": sum(1 for s in sizes if s >= 2),
-        "singleton_rate": round(100.0 * sum(1 for s in sizes if s == 1) / n, 1) if n else 0.0,
-        "grouped_rate": round(100.0 * sum(s for s in sizes if s >= 2) / n, 1) if n else 0.0,
+        "singleton_rate": round(100.0 * sum(1 for s in sizes if s == 1) / n, 1)
+        if n
+        else 0.0,
+        "grouped_rate": round(100.0 * sum(s for s in sizes if s >= 2) / n, 1)
+        if n
+        else 0.0,
         "max_media": max((len(d) for d in doms), default=0),
         "max_articles": max(sizes, default=0),
         "_groups": groups,
@@ -146,11 +149,42 @@ def corpus_window(rows, gen, hours):
     return [r for r in rows if lo <= r["_ts"] <= gen]
 
 
+# Gabarits de bulletins/chroniques — miroir de `NEWS_BULLETIN_PATTERNS`, restreint
+# aux formes présentes dans le corpus mesuré. Sert à simuler `drop_unclusterable`.
+_BULLETIN = re.compile(
+    r"^\s*(journal de \d{1,2}\s?h|le journal\b|journal (rtl|rfi|bfm|europe|france)\b"
+    r"|revue de presse\b|les titres\b|jt (de|du)\b|flash (info|actu)\b)",
+    re.I,
+)
+
+
+def editorial_pool_v2(rows, gen, window_h=24, cap=6000, min_pool=200, fallback_h=48):
+    """Réplique la politique de `editorial/candidate_pool.py` après correctif.
+
+    Tout le corpus de la fenêtre, sans plafond top-N, sans article post-daté,
+    sans bulletin. Le plafond historique de 200 devient un plancher.
+    """
+
+    def _slice(hours):
+        lo = gen - hours * 3600
+        win = [r for r in rows if lo <= r["_ts"] <= gen]
+        win.sort(key=lambda r: r["_ts"], reverse=True)
+        return win[:cap]
+
+    pool = _slice(window_h)
+    if len(pool) < min_pool:
+        pool = _slice(fallback_h)
+    return [r for r in pool if not _BULLETIN.match(r["t"])]
+
+
 def run(label, rows):
     tokens = [normalize_title(r["t"]) for r in rows]
     out = {}
     for name, groups in (
-        ("AVANT  Jaccard 0.40 glouton (défaut prod réel)", cluster_before(tokens, 0.40)),
+        (
+            "AVANT  Jaccard 0.40 glouton (défaut prod réel)",
+            cluster_before(tokens, 0.40),
+        ),
         ("AVANT  Jaccard 0.45 glouton (chemin topics)", cluster_before(tokens, 0.45)),
         ("APRÈS  cosinus IDF 0.30 centroïde (livré)", cluster_after(tokens, 0.30)),
     ):
@@ -175,7 +209,9 @@ def run(label, rows):
 
 def chaining_audit(m, rows, top=5):
     """Inspection des plus gros clusters : détection de chaînage à l'œil nu."""
-    order = sorted(range(len(m["_groups"])), key=lambda k: len(m["_groups"][k]), reverse=True)
+    order = sorted(
+        range(len(m["_groups"])), key=lambda k: len(m["_groups"][k]), reverse=True
+    )
     for k in order[:top]:
         g = m["_groups"][k]
         print(f"\n  -- cluster {len(g)} art. / {len(m['_doms'][k])} médias --")
@@ -194,28 +230,38 @@ def main():
     gen = dt.datetime(2026, 7, 31, 5, 0, tzinfo=dt.UTC).timestamp()  # cron 07:00 Paris
 
     print("=" * 118)
-    print("CLUSTERING — MESURE AVANT/APRÈS SUR LE CODE LIVRÉ (topic_clustering.py importé)")
-    print(f"Génération simulée : 2026-07-31 05:00 UTC (cron 07:00 Paris)")
-    print("KPI = nombre de sujets couverts par >= 3 médias distincts (après fold agrégateurs)")
+    print(
+        "CLUSTERING — MESURE AVANT/APRÈS SUR LE CODE LIVRÉ (topic_clustering.py importé)"
+    )
+    print("Génération simulée : 2026-07-31 05:00 UTC (cron 07:00 Paris)")
+    print(
+        "KPI = nombre de sujets couverts par >= 3 médias distincts (après fold agrégateurs)"
+    )
     print("=" * 118)
 
     pool = editorial_pool(rows, gen)
-    ed = run("CHEMIN ÉDITORIAL — pool réel de la pipeline (le seul emprunté en prod)", pool)
+    run("CHEMIN ÉDITORIAL — AVANT correctif : pool plafonné à 200 par récence", pool)
+
+    pool2 = editorial_pool_v2(rows, gen)
+    after = run(
+        "CHEMIN ÉDITORIAL — APRÈS correctif : corpus complet de la fenêtre", pool2
+    )
 
     c24 = corpus_window(rows, gen, 24)
-    full = run("CORPUS COMPLET 24 h — borne haute, non atteinte en prod", c24)
+    run("CORPUS COMPLET 24 h — référence non filtrée", c24)
 
-    print(f"\n### Couverture du pool éditorial")
-    print(f"  pool éditorial          : {len(pool)} articles, {len({r['d'] for r in pool})} médias")
-    print(f"  corpus 24 h             : {len(c24)} articles, {len({r['d'] for r in c24})} médias")
-    print(f"  part du corpus vue      : {100.0 * len(pool) / len(c24):.1f} %")
-    span = (max(r["_ts"] for r in pool) - min(r["_ts"] for r in pool)) / 3600
-    print(f"  fenêtre réelle du pool  : {span:.1f} h (contre 48 h autorisées)")
+    print("\n### Couverture du pool éditorial")
+    for label, p in (("AVANT", pool), ("APRÈS", pool2)):
+        span = (max(r["_ts"] for r in p) - min(r["_ts"] for r in p)) / 3600
+        print(
+            f"  {label} : {len(p):>5} articles | {len({r['d'] for r in p}):>3} médias | "
+            f"{100.0 * len(p) / len(c24):>5.1f} % du corpus 24 h | fenêtre {span:.1f} h"
+        )
 
     print("\n" + "=" * 118)
-    print("AUDIT DE CHAÎNAGE — plus gros clusters produits par le code livré sur 24 h")
+    print("AUDIT DE CHAÎNAGE — plus gros clusters vus par le digest APRÈS correctif")
     print("=" * 118)
-    chaining_audit(full["APRÈS  cosinus IDF 0.30 centroïde (livré)"], c24)
+    chaining_audit(after["APRÈS  cosinus IDF 0.30 centroïde (livré)"], pool2)
 
 
 if __name__ == "__main__":

--- a/docs/qa/scripts/verify_clustering_prod_paths.py
+++ b/docs/qa/scripts/verify_clustering_prod_paths.py
@@ -152,13 +152,30 @@ def corpus_window(rows, gen, hours):
 # Gabarits de bulletins/chroniques — miroir de `NEWS_BULLETIN_PATTERNS`, restreint
 # aux formes présentes dans le corpus mesuré. Sert à simuler `drop_unclusterable`.
 _BULLETIN = re.compile(
-    r"^\s*(journal de \d{1,2}\s?h|le journal\b|journal (rtl|rfi|bfm|europe|france)\b"
-    r"|revue de presse\b|les titres\b|jt (de|du)\b|flash (info|actu)\b)",
+    "|".join(
+        [
+            r"^\s*journal de \d{1,2}\s?h",
+            r"^\s*le \d{1,2}\s?/\s?\d{1,2}\b",
+            r"(^\s*|[,:]\s+)chronique du\b",
+            r"^\s*jt (de |du )",
+            r"^\s*les titres\b",
+            r"^\s*info (matin|soir)\b",
+            r"^\s*bulletin (info|météo|meteo)\b",
+            r"^\s*revue de presse\b",
+            r"^\s*flash (info|actu)\b",
+            r"^\s*le journal\b",
+            r"^\s*journal (rtl|rfi|bfm|europe|france|rmc|lcp|i-?t[eé]l[eé])\b",
+            r"^\s*l['’]\s*[ée]mission\b",
+            r"^\s*(ma|la|sa|notre)\s+chronique\b",
+            r"^\s*chronique\s*[:\-–—]",
+            r",\s*émission du (lundi|mardi|mercredi|jeudi|vendredi|samedi|dimanche)\b",
+        ]
+    ),
     re.I,
 )
 
 
-def editorial_pool_v2(rows, gen, window_h=24, cap=6000, min_pool=200, fallback_h=48):
+def editorial_pool_v2(rows, gen, ladder=(24, 48, 168), cap=6000, min_pool=200):
     """Réplique la politique de `editorial/candidate_pool.py` après correctif.
 
     Tout le corpus de la fenêtre, sans plafond top-N, sans article post-daté,
@@ -171,10 +188,11 @@ def editorial_pool_v2(rows, gen, window_h=24, cap=6000, min_pool=200, fallback_h
         win.sort(key=lambda r: r["_ts"], reverse=True)
         return win[:cap]
 
-    pool = _slice(window_h)
-    if len(pool) < min_pool:
-        pool = _slice(fallback_h)
-    return [r for r in pool if not _BULLETIN.match(r["t"])]
+    for hours in ladder:
+        pool = [r for r in _slice(hours) if not _BULLETIN.search(r["t"])]
+        if len(pool) >= min_pool:
+            break
+    return pool
 
 
 def run(label, rows):

--- a/docs/qa/scripts/verify_clustering_side_effects.py
+++ b/docs/qa/scripts/verify_clustering_side_effects.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+"""Effets de bord et sensibilité du clustering livré, sur corpus de production complet.
+
+Complète `verify_clustering_prod_paths.py` :
+
+  1. robustesse du gain selon l'heure de génération (le pool éditorial dépend du débit) ;
+  2. sensibilité au seuil, mesurée sur 2 300 articles et non sur le corpus annoté de 63 ;
+  3. rayon d'action de `is_trending` (combien d'articles deviennent trending) ;
+  4. fragmentation résiduelle d'un sujet donné (combien de clusters le portent) ;
+  5. clusters « boilerplate » (journaux radio, programmes TV) qui gonflent le KPI.
+
+Usage : python3.12 docs/qa/scripts/verify_clustering_side_effects.py <corpus.json> [followed_ids]
+"""
+
+import datetime as dt
+import importlib.util
+import json
+import os
+import re
+import sys
+
+SC = os.path.dirname(os.path.abspath(__file__))
+spec = importlib.util.spec_from_file_location(
+    "v", os.path.join(SC, "verify_clustering_prod_paths.py")
+)
+v = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(v)
+
+# Titres structurellement non-clusterisables : journaux radio horaires, grilles TV,
+# podcasts quotidiens. Ils partagent un gabarit, pas un sujet.
+BOILERPLATE = re.compile(
+    r"journal (rtl|de \d|d'information)|journal de \d+h|^journal de|"
+    r"ce soir à la télé|programme tv|revue de presse|"
+    r"l'invité de|le \d+h de|édition de \d+h",
+    re.I,
+)
+
+
+def is_boilerplate_cluster(group, rows, ratio=0.6):
+    hits = sum(1 for i in group if BOILERPLATE.search(rows[i]["t"]))
+    return len(group) >= 3 and hits / len(group) >= ratio
+
+
+def kpi(groups, rows):
+    doms = [v.domains_of(g, rows) for g in groups]
+    total = sum(1 for d in doms if len(d) >= 3)
+    junk = sum(
+        1
+        for k, g in enumerate(groups)
+        if len(doms[k]) >= 3 and is_boilerplate_cluster(g, rows)
+    )
+    trending_articles = sum(len(g) for k, g in enumerate(groups) if len(doms[k]) >= 3)
+    return total, junk, trending_articles
+
+
+def fragmentation(groups, rows, needle):
+    return sum(
+        1 for g in groups if any(needle in rows[i]["t"].lower() for i in g)
+    )
+
+
+def main():
+    rows = json.load(open(sys.argv[1], encoding="utf-8"))
+    if len(sys.argv) > 2:
+        v.FOLLOWED = set(sys.argv[2].split(","))
+    for r in rows:
+        r["_ts"] = dt.datetime.fromisoformat(r["p"]).replace(tzinfo=dt.UTC).timestamp()
+
+    base = dt.datetime(2026, 7, 31, 5, 0, tzinfo=dt.UTC).timestamp()
+
+    print("=" * 112)
+    print("1. ROBUSTESSE — le gain du chemin éditorial selon l'heure de génération")
+    print("=" * 112)
+    print(f"  {'heure UTC':<12}{'pool':>7}{'médias':>8}{'fenêtre':>10}"
+          f"{'AVANT j0.40':>13}{'APRÈS c0.30':>13}{'delta':>8}")
+    for h in (5, 8, 11, 14, 17, 20):
+        gen = dt.datetime(2026, 7, 31, h, 0, tzinfo=dt.UTC).timestamp()
+        if gen > max(r["_ts"] for r in rows if r["p"] <= "2026-08-01T00:01"):
+            continue
+        pool = v.editorial_pool(rows, gen)
+        if len(pool) < 50:
+            continue
+        tk = [v.normalize_title(r["t"]) for r in pool]
+        b, _, _ = kpi(v.cluster_before(tk, 0.40), pool)
+        a, _, _ = kpi(v.cluster_after(tk, 0.30), pool)
+        span = (max(r["_ts"] for r in pool) - min(r["_ts"] for r in pool)) / 3600
+        print(f"  {h:02d}:00{'':<7}{len(pool):>7}{len({r['d'] for r in pool}):>8}"
+              f"{span:>9.1f}h{b:>13}{a:>13}{a - b:>+8}")
+
+    c24 = v.corpus_window(rows, base, 24)
+    tk24 = [v.normalize_title(r["t"]) for r in c24]
+
+    print("\n" + "=" * 112)
+    print(f"2. SENSIBILITÉ AU SEUIL — corpus complet 24 h ({len(c24)} articles),")
+    print("   et non le corpus annoté de 63 articles ayant servi à calibrer")
+    print("=" * 112)
+    print(f"  {'seuil':<9}{'sujets>=3méd':>14}{'dont boilerplate':>19}"
+          f"{'art. trending':>15}{'ceuta méd.':>12}{'gironde méd.':>14}{'max art.':>10}")
+    for th in (0.22, 0.25, 0.28, 0.30, 0.32, 0.35, 0.40):
+        g = v.cluster_after(tk24, th)
+        total, junk, tart = kpi(g, c24)
+        _, cd = v.topic_media(g, c24, "ceuta")
+        _, gd = v.topic_media(g, c24, "gironde")
+        mx = max(len(x) for x in g)
+        star = "  <-- livré" if abs(th - 0.30) < 1e-9 else ""
+        print(f"  {th:<9}{total:>14}{junk:>19}{tart:>15}{cd:>12}{gd:>14}{mx:>10}{star}")
+
+    print("\n" + "=" * 112)
+    print("3. RAYON D'ACTION DE is_trending — corpus 24 h complet")
+    print("   (`DigestSelector._build_global_trending_context`, calculé chaque batch)")
+    print("=" * 112)
+    for name, th, fn in (
+        ("AVANT  Jaccard 0.40", 0.40, v.cluster_before),
+        ("APRÈS  cosinus 0.30", 0.30, v.cluster_after),
+    ):
+        g = fn(tk24, th)
+        total, junk, tart = kpi(g, c24)
+        print(f"  {name:<22} sujets>=3méd={total:>4}   articles marqués trending="
+              f"{tart:>5} ({100.0 * tart / len(c24):.1f} % du corpus)")
+
+    print("\n" + "=" * 112)
+    print("4. FRAGMENTATION RÉSIDUELLE — nombre de clusters distincts portant le sujet")
+    print("=" * 112)
+    for name, th, fn in (
+        ("AVANT  Jaccard 0.40", 0.40, v.cluster_before),
+        ("APRÈS  cosinus 0.30", 0.30, v.cluster_after),
+    ):
+        g = fn(tk24, th)
+        parts = "   ".join(
+            f"{n}={fragmentation(g, c24, n)}" for n in ("gironde", "ceuta", "incendie")
+        )
+        print(f"  {name:<22} {parts}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/qa/scripts/verify_clustering_side_effects.py
+++ b/docs/qa/scripts/verify_clustering_side_effects.py
@@ -54,9 +54,23 @@ def kpi(groups, rows):
 
 
 def fragmentation(groups, rows, needle):
-    return sum(
-        1 for g in groups if any(needle in rows[i]["t"].lower() for i in g)
+    return sum(1 for g in groups if any(needle in rows[i]["t"].lower() for i in g))
+
+
+def llm_input_view(rows, threshold, limit=15):
+    """Les `limit` clusters que la curation LLM voit réellement.
+
+    `curation.select_topics` trie par nombre de médias et tronque à
+    `cluster_input_limit` (15). C'est donc CE classement — pas le KPI global —
+    qui détermine ce que l'utilisateur lit. Le digest en retient 5.
+    """
+    tk = [v.normalize_title(r["t"]) for r in rows]
+    g = v.cluster_after(tk, threshold)
+    m = v.metrics(g, rows)
+    order = sorted(
+        range(len(g)), key=lambda k: (len(m["_doms"][k]), len(g[k])), reverse=True
     )
+    return [(len(m["_doms"][k]), len(g[k]), rows[g[k][0]]["t"]) for k in order[:limit]]
 
 
 def main():
@@ -69,23 +83,45 @@ def main():
     base = dt.datetime(2026, 7, 31, 5, 0, tzinfo=dt.UTC).timestamp()
 
     print("=" * 112)
-    print("1. ROBUSTESSE — le gain du chemin éditorial selon l'heure de génération")
+    print("0. CE QUE LA CURATION LLM VOIT — top 15 clusters (cluster_input_limit),")
+    print("   dont elle retient 5 pour le digest. C'est la vue produit.")
     print("=" * 112)
-    print(f"  {'heure UTC':<12}{'pool':>7}{'médias':>8}{'fenêtre':>10}"
-          f"{'AVANT j0.40':>13}{'APRÈS c0.30':>13}{'delta':>8}")
+    for label, pool in (
+        ("AVANT correctif — pool plafonné à 200", v.editorial_pool(rows, base)),
+        ("APRÈS correctif — corpus de la fenêtre", v.editorial_pool_v2(rows, base)),
+    ):
+        print(f"\n  {label} ({len(pool)} articles) :")
+        for i, (d, a, title) in enumerate(llm_input_view(pool, 0.30), 1):
+            print(f"    {i:>2}. [{d:>2} méd. / {a:>2} art.] {title[:84]}")
+
+    print("\n" + "=" * 112)
+    print(
+        "1. ROBUSTESSE — sujets >= 3 médias vus par le digest, selon l'heure de génération"
+    )
+    print("   (algorithme identique des deux côtés : seul le pool change)")
+    print("=" * 112)
+    print(
+        f"  {'heure':<8}{'pool AVANT':>11}{'méd.':>6}{'fenêtre':>9}{'KPI':>6}"
+        f"{'  |':>3}{'pool APRÈS':>11}{'méd.':>6}{'fenêtre':>9}{'KPI':>6}{'gain':>7}"
+    )
     for h in (5, 8, 11, 14, 17, 20):
         gen = dt.datetime(2026, 7, 31, h, 0, tzinfo=dt.UTC).timestamp()
         if gen > max(r["_ts"] for r in rows if r["p"] <= "2026-08-01T00:01"):
             continue
-        pool = v.editorial_pool(rows, gen)
-        if len(pool) < 50:
+        old, new = v.editorial_pool(rows, gen), v.editorial_pool_v2(rows, gen)
+        if len(old) < 50:
             continue
-        tk = [v.normalize_title(r["t"]) for r in pool]
-        b, _, _ = kpi(v.cluster_before(tk, 0.40), pool)
-        a, _, _ = kpi(v.cluster_after(tk, 0.30), pool)
-        span = (max(r["_ts"] for r in pool) - min(r["_ts"] for r in pool)) / 3600
-        print(f"  {h:02d}:00{'':<7}{len(pool):>7}{len({r['d'] for r in pool}):>8}"
-              f"{span:>9.1f}h{b:>13}{a:>13}{a - b:>+8}")
+        cells = []
+        for pool in (old, new):
+            tk = [v.normalize_title(r["t"]) for r in pool]
+            k, _, _ = kpi(v.cluster_after(tk, 0.30), pool)
+            span = (max(r["_ts"] for r in pool) - min(r["_ts"] for r in pool)) / 3600
+            cells.append((len(pool), len({r["d"] for r in pool}), span, k))
+        (n1, m1, s1, k1), (n2, m2, s2, k2) = cells
+        print(
+            f"  {h:02d}:00{'':<3}{n1:>11}{m1:>6}{s1:>8.1f}h{k1:>6}{'  |':>3}"
+            f"{n2:>11}{m2:>6}{s2:>8.1f}h{k2:>6}{f'x{k2 / max(k1, 1):.0f}':>7}"
+        )
 
     c24 = v.corpus_window(rows, base, 24)
     tk24 = [v.normalize_title(r["t"]) for r in c24]
@@ -94,8 +130,10 @@ def main():
     print(f"2. SENSIBILITÉ AU SEUIL — corpus complet 24 h ({len(c24)} articles),")
     print("   et non le corpus annoté de 63 articles ayant servi à calibrer")
     print("=" * 112)
-    print(f"  {'seuil':<9}{'sujets>=3méd':>14}{'dont boilerplate':>19}"
-          f"{'art. trending':>15}{'ceuta méd.':>12}{'gironde méd.':>14}{'max art.':>10}")
+    print(
+        f"  {'seuil':<9}{'sujets>=3méd':>14}{'dont boilerplate':>19}"
+        f"{'art. trending':>15}{'ceuta méd.':>12}{'gironde méd.':>14}{'max art.':>10}"
+    )
     for th in (0.22, 0.25, 0.28, 0.30, 0.32, 0.35, 0.40):
         g = v.cluster_after(tk24, th)
         total, junk, tart = kpi(g, c24)
@@ -115,8 +153,10 @@ def main():
     ):
         g = fn(tk24, th)
         total, junk, tart = kpi(g, c24)
-        print(f"  {name:<22} sujets>=3méd={total:>4}   articles marqués trending="
-              f"{tart:>5} ({100.0 * tart / len(c24):.1f} % du corpus)")
+        print(
+            f"  {name:<22} sujets>=3méd={total:>4}   articles marqués trending="
+            f"{tart:>5} ({100.0 * tart / len(c24):.1f} % du corpus)"
+        )
 
     print("\n" + "=" * 112)
     print("4. FRAGMENTATION RÉSIDUELLE — nombre de clusters distincts portant le sujet")

--- a/packages/api/app/jobs/digest_generation_job.py
+++ b/packages/api/app/jobs/digest_generation_job.py
@@ -539,10 +539,10 @@ class DigestGenerationJob:
 
         from app.models.content import Content
         from app.services.editorial.candidate_pool import (
-            EDITORIAL_CLUSTERING_WINDOW_HOURS,
             build_editorial_pool_stmt,
-            drop_unclusterable,
+            clustering_window_hours,
             fetch_editorial_pool,
+            finalize_pool,
         )
 
         # Content.published_at is stored as tz-aware, so the comparison
@@ -550,9 +550,7 @@ class DigestGenerationJob:
         now = datetime.datetime.now(UTC)
 
         try:
-            candidates = await fetch_editorial_pool(
-                session, mode, fallback_hours=self.hours_lookback, now=now
-            )
+            candidates = await fetch_editorial_pool(session, mode, now=now)
         except Exception as e:
             logger.error(
                 "digest_generation_global_candidates_failed",
@@ -562,15 +560,39 @@ class DigestGenerationJob:
             return []
 
         if not followed_source_ids:
-            return drop_unclusterable(candidates)
+            return finalize_pool(
+                candidates, mode, "digest_generation_global_pool_built"
+            )
 
-        # Tranche "sources suivies" : mêmes filtres, fenêtre plus large que celle
-        # du regroupement (une source de niche ne publie pas tous les jours),
-        # bornée, puis dédupliquée contre la tranche récence.
+        # Tranche "sources suivies" (P1) : une source de niche qui ne publie pas
+        # tous les jours doit quand même entrer dans le clustering.
+        #
+        # Elle ne couvre QUE l'antériorité que la fenêtre de regroupement n'atteint
+        # pas. Depuis que le pool nominal est exhaustif sur sa fenêtre, requêter à
+        # nouveau [0, window] ne rendrait que des articles déjà présents : ils
+        # consommeraient le `LIMIT` avant que le moindre article de niche plus
+        # ancien n'y entre — soit exactement l'inverse du but de cette tranche.
+        window_hours = clustering_window_hours()
+        if window_hours >= self.hours_lookback:
+            # La fenêtre de regroupement couvre déjà tout ce que cette tranche
+            # irait chercher : son intervalle serait vide. Cas atteignable en
+            # remontant `clustering_window_ladder_hours` dans le YAML.
+            logger.info(
+                "digest_generation_followed_slice_skipped",
+                mode=mode,
+                reason="window_covers_lookback",
+                window_hours=window_hours,
+                hours_lookback=self.hours_lookback,
+            )
+            return finalize_pool(
+                candidates, mode, "digest_generation_global_pool_built"
+            )
+
+        window_start = now - timedelta(hours=window_hours)
         seen_ids = {c.id for c in candidates}
         followed_stmt = (
             build_editorial_pool_stmt(
-                mode, now - timedelta(hours=self.hours_lookback), now
+                mode, now - timedelta(hours=self.hours_lookback), window_start
             )
             .where(Content.source_id.in_(followed_source_ids))
             .order_by(Content.published_at.desc())
@@ -596,16 +618,11 @@ class DigestGenerationJob:
                 recency_count=len(candidates),
                 followed_added=len(followed_articles),
             )
-        pool = drop_unclusterable(candidates + followed_articles)
-        logger.info(
+        return finalize_pool(
+            candidates + followed_articles,
+            mode,
             "digest_generation_global_pool_built",
-            mode=mode,
-            window_hours=EDITORIAL_CLUSTERING_WINDOW_HOURS,
-            pool_size=len(pool),
-            source_count=len({c.source_id for c in pool}),
-            dropped_unclusterable=len(candidates) + len(followed_articles) - len(pool),
         )
-        return pool
 
     async def _prune_old_highlights(
         self,

--- a/packages/api/app/jobs/digest_generation_job.py
+++ b/packages/api/app/jobs/digest_generation_job.py
@@ -515,11 +515,17 @@ class DigestGenerationJob:
         Falls back to a broad recent-content query so the pipeline never
         cold-paths because of one unlucky user.
 
-        En plus de la tranche "top-200 par récence" (user-agnostique), on
-        unionne une tranche bornée d'articles récents des sources suivies du
-        batch (P1) : sans elle, les sources de niche sont systématiquement
-        évincées par les gros volumes mainstream et n'entrent jamais dans le
-        clustering. Les deux tranches passent les mêmes filtres ad/good-news.
+        Le pool est **tout le corpus de la fenêtre de regroupement**, et non plus
+        les 200 articles les plus récents : le décompte « N médias couvrent ce
+        sujet » n'a de sens que sur la couverture réelle du jour. La politique
+        (fenêtre, filtres, bornes) vit dans `editorial/candidate_pool.py` — elle
+        est partagée avec le chemin on-demand pour que les deux voient le même
+        corpus. Cf. `docs/maintenance/maintenance-clustering-corpus-complet.md`.
+
+        On unionne une tranche bornée d'articles des sources suivies du batch
+        (P1) sur la fenêtre `hours_lookback`, plus large : sans elle, une source
+        de niche qui ne publie pas tous les jours sort du clustering. Les deux
+        tranches passent les mêmes filtres ad/good-news.
 
         Args:
             session: Async SQLAlchemy session.
@@ -531,42 +537,22 @@ class DigestGenerationJob:
         """
         from datetime import UTC, timedelta
 
-        from sqlalchemy.orm import selectinload
-
         from app.models.content import Content
-        from app.models.source import Source
+        from app.services.editorial.candidate_pool import (
+            EDITORIAL_CLUSTERING_WINDOW_HOURS,
+            build_editorial_pool_stmt,
+            drop_unclusterable,
+            fetch_editorial_pool,
+        )
 
         # Content.published_at is stored as tz-aware, so the comparison
         # value must also be tz-aware (and utcnow() is deprecated in 3.12).
-        cutoff = datetime.datetime.now(UTC) - timedelta(hours=self.hours_lookback)
+        now = datetime.datetime.now(UTC)
 
-        def _base_stmt():
-            # Serein filter references Source.theme so we need an explicit join.
-            # The join is harmless for pour_vous (every Content has a Source) but
-            # we keep it behind the mode branch to match existing behaviour.
-            stmt = select(Content).options(selectinload(Content.source))
-            if mode == "serein":
-                # Mode "Bonnes nouvelles" : hard-filter is_good_news=True. Pool
-                # potentiellement plus restreint que l'ancien serein, c'est voulu.
-                from app.services.recommendation.filter_presets import (
-                    apply_good_news_filter,
-                )
-
-                stmt = stmt.join(Source, Content.source_id == Source.id)
-                stmt = apply_good_news_filter(stmt)
-            else:
-                # Mode pour_vous : apply_good_news_filter inclut déjà apply_ad_filter,
-                # mais pour_vous n'y passe pas — sans ce filtre, les pubs Frandroid
-                # (is_ad=True) remontent dans le clustering éditorial.
-                from app.services.recommendation.filter_presets import apply_ad_filter
-
-                stmt = apply_ad_filter(stmt)
-            return stmt.where(Content.published_at >= cutoff)
-
-        recency_stmt = _base_stmt().order_by(Content.published_at.desc()).limit(200)
         try:
-            result = await session.execute(recency_stmt)
-            candidates = list(result.scalars().all())
+            candidates = await fetch_editorial_pool(
+                session, mode, fallback_hours=self.hours_lookback, now=now
+            )
         except Exception as e:
             logger.error(
                 "digest_generation_global_candidates_failed",
@@ -576,13 +562,16 @@ class DigestGenerationJob:
             return []
 
         if not followed_source_ids:
-            return candidates
+            return drop_unclusterable(candidates)
 
-        # Tranche "sources suivies" : mêmes filtres + cutoff, bornée, puis
-        # dédupliquée contre la tranche récence (un article peut déjà y figurer).
+        # Tranche "sources suivies" : mêmes filtres, fenêtre plus large que celle
+        # du regroupement (une source de niche ne publie pas tous les jours),
+        # bornée, puis dédupliquée contre la tranche récence.
         seen_ids = {c.id for c in candidates}
         followed_stmt = (
-            _base_stmt()
+            build_editorial_pool_stmt(
+                mode, now - timedelta(hours=self.hours_lookback), now
+            )
             .where(Content.source_id.in_(followed_source_ids))
             .order_by(Content.published_at.desc())
             .limit(self.FOLLOWED_SLICE_LIMIT)
@@ -607,7 +596,16 @@ class DigestGenerationJob:
                 recency_count=len(candidates),
                 followed_added=len(followed_articles),
             )
-        return candidates + followed_articles
+        pool = drop_unclusterable(candidates + followed_articles)
+        logger.info(
+            "digest_generation_global_pool_built",
+            mode=mode,
+            window_hours=EDITORIAL_CLUSTERING_WINDOW_HOURS,
+            pool_size=len(pool),
+            source_count=len({c.source_id for c in pool}),
+            dropped_unclusterable=len(candidates) + len(followed_articles) - len(pool),
+        )
+        return pool
 
     async def _prune_old_highlights(
         self,

--- a/packages/api/app/services/digest_selector.py
+++ b/packages/api/app/services/digest_selector.py
@@ -1078,33 +1078,39 @@ class DigestSelector:
         sinon les users dont les sources suivies ne couvrent pas le mode
         (cas typique du serein) reçoivent un digest vide.
 
-        Returns: liste de Contents (≤200) ; vide si la requête échoue.
-        """
-        cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
-            hours=hours_lookback
-        )
-        stmt = select(Content).options(selectinload(Content.source))
-        if mode == "serein":
-            from app.services.recommendation.filter_presets import (
-                apply_good_news_filter,
-            )
+        La politique de pool (fenêtre, filtres, bornes) est partagée avec le
+        chemin batch via `editorial/candidate_pool.py` : les deux doivent voir le
+        même corpus, sinon un même sujet n'affiche pas le même nombre de médias
+        selon que le digest vient du batch ou d'un recalcul à la demande.
 
-            stmt = stmt.join(Source, Content.source_id == Source.id)
-            stmt = apply_good_news_filter(stmt)
-        stmt = (
-            stmt.where(Content.published_at >= cutoff)
-            .order_by(Content.published_at.desc())
-            .limit(200)
+        Returns: le corpus de la fenêtre de regroupement ; vide si la requête échoue.
+        """
+        from app.services.editorial.candidate_pool import (
+            EDITORIAL_CLUSTERING_WINDOW_HOURS,
+            drop_unclusterable,
+            fetch_editorial_pool,
         )
+
         try:
-            result = await self.session.execute(stmt)
-            return list(result.scalars().all())
+            contents = await fetch_editorial_pool(
+                self.session, mode, fallback_hours=hours_lookback
+            )
         except SQLAlchemyError:
             logger.exception(
                 "digest_selector_global_pool_failed",
                 mode=mode,
             )
             return []
+
+        pool = drop_unclusterable(contents)
+        logger.info(
+            "digest_selector_global_pool_built",
+            mode=mode,
+            window_hours=EDITORIAL_CLUSTERING_WINDOW_HOURS,
+            pool_size=len(pool),
+            source_count=len({c.source_id for c in pool}),
+        )
+        return pool
 
     async def _rehydrate_editorial_clusters(self, global_ctx: object) -> list:
         """Reconstruit les `TopicCluster` (avec Content chargés) depuis `cluster_data`.

--- a/packages/api/app/services/digest_selector.py
+++ b/packages/api/app/services/digest_selector.py
@@ -402,10 +402,7 @@ class DigestSelector:
                             # is_good_news + followed-sources peut être vide).
                             # Cf. bug-digest-pipeline-fallbacks.md C5.
                             global_pool_candidates = (
-                                await self._fetch_editorial_global_pool(
-                                    mode=mode,
-                                    hours_lookback=hours_lookback,
-                                )
+                                await self._fetch_editorial_global_pool(mode=mode)
                             )
                             compute_candidates = global_pool_candidates or candidates
 
@@ -1064,11 +1061,7 @@ class DigestSelector:
 
         return candidates
 
-    async def _fetch_editorial_global_pool(
-        self,
-        mode: str,
-        hours_lookback: int,
-    ) -> list[Content]:
+    async def _fetch_editorial_global_pool(self, mode: str) -> list[Content]:
         """Pool global pour la pipeline éditoriale on-demand.
 
         Pendant le batch, ``digest_generation_job._get_global_candidates``
@@ -1086,15 +1079,12 @@ class DigestSelector:
         Returns: le corpus de la fenêtre de regroupement ; vide si la requête échoue.
         """
         from app.services.editorial.candidate_pool import (
-            EDITORIAL_CLUSTERING_WINDOW_HOURS,
-            drop_unclusterable,
             fetch_editorial_pool,
+            finalize_pool,
         )
 
         try:
-            contents = await fetch_editorial_pool(
-                self.session, mode, fallback_hours=hours_lookback
-            )
+            contents = await fetch_editorial_pool(self.session, mode)
         except SQLAlchemyError:
             logger.exception(
                 "digest_selector_global_pool_failed",
@@ -1102,15 +1092,7 @@ class DigestSelector:
             )
             return []
 
-        pool = drop_unclusterable(contents)
-        logger.info(
-            "digest_selector_global_pool_built",
-            mode=mode,
-            window_hours=EDITORIAL_CLUSTERING_WINDOW_HOURS,
-            pool_size=len(pool),
-            source_count=len({c.source_id for c in pool}),
-        )
-        return pool
+        return finalize_pool(contents, mode, "digest_selector_global_pool_built")
 
     async def _rehydrate_editorial_clusters(self, global_ctx: object) -> list:
         """Reconstruit les `TopicCluster` (avec Content chargés) depuis `cluster_data`.

--- a/packages/api/app/services/editorial/candidate_pool.py
+++ b/packages/api/app/services/editorial/candidate_pool.py
@@ -41,6 +41,20 @@ Cf. `docs/bugs/bug-clustering-actus-du-jour-fragmentation.md` (diagnostic) et
   sélection ») suffisait à sauver le cluster entier. On traite ici la cause : un
   bulletin n'entre pas dans le calcul. Il reste évidemment consultable ailleurs dans
   l'app — c'est un filtre d'entrée du clustering, pas une suppression de contenu.
+
+## Portée exacte — ce module ne couvre PAS tout le clustering
+
+Le filtre s'applique au pool **éditorial**, donc au digest. `build_topic_clusters`
+a d'autres appelants qui construisent leur propre pool et gardent le défaut décrit
+ci-dessus (un cluster de bulletins lu comme un sujet « trending ») :
+
+- `digest_selector._build_global_trending_context` — requête brute, alimente `is_trending` ;
+- `routers/feed.py` — endpoint `/feed/trending` ;
+- `article_clustering_service.find_hot_cluster` — carrousel « actu chaude ».
+
+Les traiter revient à pousser l'exclusion dans `ImportanceDetector` lui-même, ce qui
+change le comportement de trois surfaces vivantes non mesurées — chantier distinct,
+tracé au §6.4 de `docs/maintenance/maintenance-clustering-corpus-complet.md`.
 """
 
 import datetime
@@ -48,27 +62,66 @@ import datetime
 import structlog
 from sqlalchemy import Select, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.models.content import Content
 from app.models.source import Source
+from app.services.editorial.config import load_editorial_config
+from app.services.recommendation.filter_presets import (
+    apply_ad_filter,
+    apply_good_news_filter,
+    is_news_bulletin_title,
+)
 
 logger = structlog.get_logger()
 
-# Fenêtre de regroupement. « Actus du jour » est un produit quotidien : un sujet se
-# définit dans la journée. Une fenêtre plus large laisse des articles de la veille
-# se raccrocher à ceux du jour et fabrique des clusters à cheval sur plusieurs
-# jours (observé sur les bulletins radio, sur 3 jours).
-EDITORIAL_CLUSTERING_WINDOW_HOURS = 24
+# --- Bornes de sécurité (code, pas configuration) ---------------------------
+#
+# Ces deux-là ne sont pas des réglages produit : ce sont des garde-fous. Les
+# fenêtres, elles, sont dans `editorial_config.yaml` avec les autres réglages du
+# pipeline — voir `clustering_window_hours` / `clustering_fallback_hours`.
 
-# Si la fenêtre nominale rend un pool anormalement maigre (nuit de réveillon,
-# panne d'ingestion), on ré-élargit à la fenêtre de repli plutôt que de produire un
-# digest vide. Valeur = l'ancien plafond, qui devient donc un **plancher**.
+# Plancher de pool. En dessous, la fenêtre est ré-élargie plutôt que de produire
+# un digest maigre. Valeur = l'ancien plafond `LIMIT 200`, qui devient donc son
+# exact contraire.
 EDITORIAL_CLUSTERING_MIN_POOL = 200
 
-# Borne de sécurité mémoire, pas de qualité : ~2 400 articles/24 h en régime
-# normal, on garde une marge ×2,5 avant de tronquer. Une troncature ici serait un
-# signal d'anomalie d'ingestion — elle est loguée par les appelants.
+# Borne mémoire : ~2 400 articles/24 h en régime normal, marge ×2,5 avant de
+# tronquer. Une troncature signale une anomalie d'ingestion, pas un réglage à
+# ajuster — d'où le `logger.warning`.
 EDITORIAL_CLUSTERING_MAX_ARTICLES = 6000
+
+
+def clustering_window_ladder() -> tuple[int, ...]:
+    """Fenêtres candidates, de la plus étroite à la plus large.
+
+    On garde la première qui atteint `EDITORIAL_CLUSTERING_MIN_POOL`, sinon la
+    dernière. Une échelle plutôt qu'une fenêtre unique parce que les deux modes
+    n'ont pas du tout la même densité :
+
+    - `pour_vous` : ~2 000 articles/24 h ⇒ la fenêtre nominale suffit toujours.
+      « Actus du jour » est un produit quotidien, et au-delà de 24 h les articles
+      de la veille se raccrochent à ceux du jour (observé sur les bulletins radio,
+      clusters à cheval sur 3 jours).
+    - `serein` : hard-filtré sur `is_good_news`, soit **13 articles/24 h, 33 sur
+      48 h, 145 sur 168 h** (mesuré en production). S'arrêter à 48 h amputerait
+      « Bonnes Nouvelles » de 77 % de sa matière — l'échelle le fait descendre
+      jusqu'à 168 h, ce qui était exactement son comportement historique.
+
+    **La fenêtre appartient au module, pas aux appelants.** Elle a d'abord été
+    câblée sur leur `hours_lookback` — mais ce paramètre veut dire « jusqu'où
+    remonter pour les candidats personnalisés » et vaut 48 h côté batch, 168 h
+    côté on-demand : les deux chemins se seraient élargis différemment dans le
+    seul cas où ce module existe pour garantir qu'ils voient le même corpus.
+    """
+    ladder = tuple(load_editorial_config().pipeline.clustering_window_ladder_hours)
+    # Une échelle décroissante ferait « ré-élargir » vers un pool plus petit.
+    return tuple(sorted(ladder)) if ladder else (24,)
+
+
+def clustering_window_hours() -> int:
+    """Fenêtre nominale — le premier barreau de l'échelle."""
+    return clustering_window_ladder()[0]
 
 
 def build_editorial_pool_stmt(
@@ -88,13 +141,6 @@ def build_editorial_pool_stmt(
         Un ``Select`` sur ``Content`` (source *eager-loaded*), sans tri ni limite :
         c'est à l'appelant de les poser selon sa tranche.
     """
-    from sqlalchemy.orm import selectinload
-
-    from app.services.recommendation.filter_presets import (
-        apply_ad_filter,
-        apply_good_news_filter,
-    )
-
     stmt = select(Content).options(selectinload(Content.source))
     if mode == "serein":
         # Mode « Bonnes nouvelles » : hard-filter is_good_news. `apply_good_news_filter`
@@ -113,7 +159,6 @@ def build_editorial_pool_stmt(
 async def fetch_editorial_pool(
     session: AsyncSession,
     mode: str,
-    fallback_hours: int,
     now: datetime.datetime | None = None,
 ) -> list[Content]:
     """Corpus de la fenêtre de regroupement, ré-élargi si le pool est maigre.
@@ -126,15 +171,16 @@ async def fetch_editorial_pool(
     Args:
         session: session async.
         mode: ``"serein"`` ou autre (cf. `build_editorial_pool_stmt`).
-        fallback_hours: fenêtre de repli quand le pool nominal est trop maigre.
         now: borne haute, injectable pour les tests. Défaut : maintenant, UTC.
 
     Returns:
-        Les contenus bruts de la fenêtre, **sans** `drop_unclusterable` : les
-        appelants qui unionnent d'autres tranches doivent filtrer une seule fois,
-        à la fin.
+        Les contenus de la fenêtre retenue, déjà passés par `drop_unclusterable` —
+        le plancher doit se mesurer sur ce qui ira réellement au clustering, pas
+        sur le brut. Les appelants qui unionnent d'autres tranches refiltrent le
+        tout via `finalize_pool` (le filtre est idempotent).
     """
     now = now or datetime.datetime.now(datetime.UTC)
+    ladder = clustering_window_ladder()
 
     async def _fetch(hours: int) -> list[Content]:
         stmt = (
@@ -142,23 +188,26 @@ async def fetch_editorial_pool(
             .order_by(Content.published_at.desc())
             .limit(EDITORIAL_CLUSTERING_MAX_ARTICLES)
         )
-        return list((await session.execute(stmt)).scalars().all())
+        return drop_unclusterable(list((await session.execute(stmt)).scalars().all()))
 
-    contents = await _fetch(EDITORIAL_CLUSTERING_WINDOW_HOURS)
-
-    if len(contents) < EDITORIAL_CLUSTERING_MIN_POOL:
-        # Nuit creuse / panne d'ingestion : mieux vaut une fenêtre plus large
-        # qu'un digest vide.
-        widened = await _fetch(fallback_hours)
+    # On descend l'échelle jusqu'à atteindre le plancher. Une seule requête dans
+    # le cas nominal ; les barreaux suivants ne servent qu'aux modes clairsemés
+    # (`serein`) et aux creux d'ingestion. Re-requêter la fenêtre entière plutôt
+    # que le seul delta garde la boucle lisible pour un coût qui ne se paie que
+    # sur ces cas-là.
+    contents: list[Content] = []
+    for hours in ladder:
+        contents = await _fetch(hours)
+        if len(contents) >= EDITORIAL_CLUSTERING_MIN_POOL:
+            break
+    else:
         logger.info(
-            "editorial_pool_widened",
+            "editorial_pool_ladder_exhausted",
             mode=mode,
-            window_hours=EDITORIAL_CLUSTERING_WINDOW_HOURS,
-            fallback_hours=fallback_hours,
-            before=len(contents),
-            after=len(widened),
+            widest_window_hours=ladder[-1],
+            pool_size=len(contents),
+            floor=EDITORIAL_CLUSTERING_MIN_POOL,
         )
-        contents = widened
 
     if len(contents) >= EDITORIAL_CLUSTERING_MAX_ARTICLES:
         # Jamais atteint en régime normal (~2 400 art./24 h) : signale une
@@ -172,6 +221,26 @@ async def fetch_editorial_pool(
     return contents
 
 
+def finalize_pool(contents: list[Content], mode: str, event: str) -> list[Content]:
+    """Applique `drop_unclusterable` et loge le pool servi au clustering.
+
+    Dernière étape commune aux deux chemins, après que chacun a unioné ses
+    éventuelles tranches supplémentaires. Vit ici pour la même raison que le
+    reste : la duplication de cette séquence est ce qui avait laissé les deux
+    appelants diverger.
+    """
+    pool = drop_unclusterable(contents)
+    logger.info(
+        event,
+        mode=mode,
+        window_hours=clustering_window_hours(),
+        pool_size=len(pool),
+        source_count=len({c.source_id for c in pool}),
+        dropped_unclusterable=len(contents) - len(pool),
+    )
+    return pool
+
+
 def drop_unclusterable(contents: list[Content]) -> list[Content]:
     """Retire les contenus qui ne portent pas de sujet regroupable.
 
@@ -182,7 +251,6 @@ def drop_unclusterable(contents: list[Content]) -> list[Content]:
     Un titre absent ou non-textuel est conservé : ce filtre écarte ce qu'il
     reconnaît, il n'est pas une garde de validation.
     """
-    from app.services.recommendation.filter_presets import is_news_bulletin_title
 
     def _keep(content: Content) -> bool:
         title = getattr(content, "title", None)

--- a/packages/api/app/services/editorial/candidate_pool.py
+++ b/packages/api/app/services/editorial/candidate_pool.py
@@ -1,0 +1,191 @@
+"""Politique du pool d'articles soumis au clustering éditorial.
+
+Un seul endroit décide **quels articles le clustering « Actus du jour » a le droit
+de voir**. Deux appelants en dépendent et doivent rester alignés :
+
+- `digest_generation_job._get_global_candidates` (chemin batch, 1× par cycle) ;
+- `digest_selector._fetch_editorial_global_pool` (chemin on-demand, cache miss).
+
+## Pourquoi ce module existe
+
+La section promet « les sujets les + couverts en France ». Ce décompte n'a de sens
+que si le regroupement voit **la couverture réelle du jour**. Or les deux appelants
+plafonnaient leur pool à `LIMIT 200` par récence, ce qui — mesuré sur production —
+donnait 246 articles, soit **10,5 % du corpus 24 h**, issus de 64 médias sur 192,
+sur une fenêtre de **1,7 à 2,9 h en journée**. Un sujet couvert par 18 médias dans
+la journée n'en montrait que 2 ou 3, et les deux plus gros sujets du jour
+n'atteignaient jamais la section.
+
+Le clustering n'est pas le goulot : **0,45 s pour 2 200 articles**. Le plafond
+n'achetait donc pas de la latence, il achetait de la cécité. Il est remplacé ici par
+une fenêtre temporelle explicite et une borne de sécurité très au-dessus du volume
+réel.
+
+Cf. `docs/bugs/bug-clustering-actus-du-jour-fragmentation.md` (diagnostic) et
+`docs/bugs/bug-clustering-actus-du-jour-verification.md` (mesures).
+
+## Ce que le pool exclut, et pourquoi
+
+- **Articles post-datés** (`published_at > now()`). 19 articles portaient une date
+  RSS future ; comme le pool est trié par récence décroissante, ils occupaient en
+  permanence 19 des 200 places. Le tri les remonte toujours en tête, donc le garde
+  reste utile même sans plafond.
+- **Bulletins et chroniques régulières** (« JOURNAL DE 8H du jeudi… », « Le journal
+  RTL de 6h… »). Ces titres partagent un **gabarit**, pas un sujet : élargir le pool
+  les fait se regrouper entre eux et fabriquer de faux « sujets » à 3 médias. Mesuré
+  avant ce filtre : un cluster de 20 bulletins / 3 médias, à cheval sur 3 jours,
+  comptait comme un sujet du jour.
+
+  `pipeline._is_non_actu_cluster` existait déjà mais exige que **tous** les contenus
+  du cluster soient des bulletins — un seul intrus (« Ce soir à la télé : notre
+  sélection ») suffisait à sauver le cluster entier. On traite ici la cause : un
+  bulletin n'entre pas dans le calcul. Il reste évidemment consultable ailleurs dans
+  l'app — c'est un filtre d'entrée du clustering, pas une suppression de contenu.
+"""
+
+import datetime
+
+import structlog
+from sqlalchemy import Select, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.content import Content
+from app.models.source import Source
+
+logger = structlog.get_logger()
+
+# Fenêtre de regroupement. « Actus du jour » est un produit quotidien : un sujet se
+# définit dans la journée. Une fenêtre plus large laisse des articles de la veille
+# se raccrocher à ceux du jour et fabrique des clusters à cheval sur plusieurs
+# jours (observé sur les bulletins radio, sur 3 jours).
+EDITORIAL_CLUSTERING_WINDOW_HOURS = 24
+
+# Si la fenêtre nominale rend un pool anormalement maigre (nuit de réveillon,
+# panne d'ingestion), on ré-élargit à la fenêtre de repli plutôt que de produire un
+# digest vide. Valeur = l'ancien plafond, qui devient donc un **plancher**.
+EDITORIAL_CLUSTERING_MIN_POOL = 200
+
+# Borne de sécurité mémoire, pas de qualité : ~2 400 articles/24 h en régime
+# normal, on garde une marge ×2,5 avant de tronquer. Une troncature ici serait un
+# signal d'anomalie d'ingestion — elle est loguée par les appelants.
+EDITORIAL_CLUSTERING_MAX_ARTICLES = 6000
+
+
+def build_editorial_pool_stmt(
+    mode: str,
+    cutoff: datetime.datetime,
+    now: datetime.datetime,
+) -> Select:
+    """Requête de base du pool de clustering éditorial, filtres métier compris.
+
+    Args:
+        mode: ``"serein"`` applique le filtre bonne-nouvelle (qui inclut déjà le
+            filtre pub) ; tout autre mode applique le seul filtre pub.
+        cutoff: borne basse de publication.
+        now: borne haute — écarte les articles post-datés.
+
+    Returns:
+        Un ``Select`` sur ``Content`` (source *eager-loaded*), sans tri ni limite :
+        c'est à l'appelant de les poser selon sa tranche.
+    """
+    from sqlalchemy.orm import selectinload
+
+    from app.services.recommendation.filter_presets import (
+        apply_ad_filter,
+        apply_good_news_filter,
+    )
+
+    stmt = select(Content).options(selectinload(Content.source))
+    if mode == "serein":
+        # Mode « Bonnes nouvelles » : hard-filter is_good_news. `apply_good_news_filter`
+        # inclut déjà `apply_ad_filter`, d'où le join explicite sur Source (le filtre
+        # référence `Source.theme`).
+        stmt = stmt.join(Source, Content.source_id == Source.id)
+        stmt = apply_good_news_filter(stmt)
+    else:
+        # `pour_vous` ne passe pas par le filtre bonne-nouvelle : sans ce filtre
+        # explicite, les articles `is_ad=True` entrent dans le clustering.
+        stmt = apply_ad_filter(stmt)
+
+    return stmt.where(Content.published_at >= cutoff, Content.published_at <= now)
+
+
+async def fetch_editorial_pool(
+    session: AsyncSession,
+    mode: str,
+    fallback_hours: int,
+    now: datetime.datetime | None = None,
+) -> list[Content]:
+    """Corpus de la fenêtre de regroupement, ré-élargi si le pool est maigre.
+
+    C'est ici — et pas chez les appelants — que vivent la fenêtre, le
+    ré-élargissement et la borne de sécurité : les deux chemins (batch et
+    on-demand) doivent voir le même corpus, et dupliquer cette séquence chez
+    chacun est précisément ce qui les avait laissés diverger.
+
+    Args:
+        session: session async.
+        mode: ``"serein"`` ou autre (cf. `build_editorial_pool_stmt`).
+        fallback_hours: fenêtre de repli quand le pool nominal est trop maigre.
+        now: borne haute, injectable pour les tests. Défaut : maintenant, UTC.
+
+    Returns:
+        Les contenus bruts de la fenêtre, **sans** `drop_unclusterable` : les
+        appelants qui unionnent d'autres tranches doivent filtrer une seule fois,
+        à la fin.
+    """
+    now = now or datetime.datetime.now(datetime.UTC)
+
+    async def _fetch(hours: int) -> list[Content]:
+        stmt = (
+            build_editorial_pool_stmt(mode, now - datetime.timedelta(hours=hours), now)
+            .order_by(Content.published_at.desc())
+            .limit(EDITORIAL_CLUSTERING_MAX_ARTICLES)
+        )
+        return list((await session.execute(stmt)).scalars().all())
+
+    contents = await _fetch(EDITORIAL_CLUSTERING_WINDOW_HOURS)
+
+    if len(contents) < EDITORIAL_CLUSTERING_MIN_POOL:
+        # Nuit creuse / panne d'ingestion : mieux vaut une fenêtre plus large
+        # qu'un digest vide.
+        widened = await _fetch(fallback_hours)
+        logger.info(
+            "editorial_pool_widened",
+            mode=mode,
+            window_hours=EDITORIAL_CLUSTERING_WINDOW_HOURS,
+            fallback_hours=fallback_hours,
+            before=len(contents),
+            after=len(widened),
+        )
+        contents = widened
+
+    if len(contents) >= EDITORIAL_CLUSTERING_MAX_ARTICLES:
+        # Jamais atteint en régime normal (~2 400 art./24 h) : signale une
+        # anomalie d'ingestion plutôt qu'un réglage à ajuster.
+        logger.warning(
+            "editorial_pool_truncated",
+            mode=mode,
+            cap=EDITORIAL_CLUSTERING_MAX_ARTICLES,
+        )
+
+    return contents
+
+
+def drop_unclusterable(contents: list[Content]) -> list[Content]:
+    """Retire les contenus qui ne portent pas de sujet regroupable.
+
+    Aujourd'hui : les bulletins et chroniques régulières (cf. docstring du module).
+    Le prédicat est partagé avec `pipeline._is_non_actu_cluster` et l'`actu_matcher`,
+    donc un pattern ajouté à `NEWS_BULLETIN_PATTERNS` vaut pour les trois.
+
+    Un titre absent ou non-textuel est conservé : ce filtre écarte ce qu'il
+    reconnaît, il n'est pas une garde de validation.
+    """
+    from app.services.recommendation.filter_presets import is_news_bulletin_title
+
+    def _keep(content: Content) -> bool:
+        title = getattr(content, "title", None)
+        return not isinstance(title, str) or not is_news_bulletin_title(title)
+
+    return [c for c in contents if _keep(c)]

--- a/packages/api/app/services/editorial/config.py
+++ b/packages/api/app/services/editorial/config.py
@@ -28,6 +28,14 @@ class PipelineConfig:
     # stepping back, not another same-day dispatch from a deep source.
     # See docs/bugs/bug-digest-pas-de-recul-same-event.md.
     deep_min_age_hours: int = 24
+    # Fenêtres successives du clustering éditorial, de la plus étroite à la plus
+    # large. On retient la première qui atteint EDITORIAL_CLUSTERING_MIN_POOL,
+    # sinon la dernière. 24 h suffit largement à `pour_vous` (~2 000 articles) ;
+    # `serein` est hard-filtré sur is_good_news (~13 articles/24 h) et descend
+    # donc jusqu'à 168 h — ce qui était son comportement historique.
+    # Cf. app/services/editorial/candidate_pool.py et
+    # docs/maintenance/maintenance-clustering-corpus-complet.md.
+    clustering_window_ladder_hours: tuple[int, ...] = (24, 48, 168)
 
 
 @dataclass(frozen=True)

--- a/packages/api/app/services/editorial/pipeline.py
+++ b/packages/api/app/services/editorial/pipeline.py
@@ -82,6 +82,13 @@ def _is_non_actu_cluster(cluster: TopicCluster) -> bool:
     a passé la curation. Réutilise les prédicats partagés avec l'actu_matcher.
     Un cluster mixte (au moins un contenu d'actu chaude) reste éligible.
     Cf. bug-actus-du-jour-ranking.md (Partie B).
+
+    Note : depuis que `candidate_pool.drop_unclusterable` écarte les bulletins
+    **à l'entrée** du clustering, la branche `is_news_bulletin_title` de ce `all()`
+    ne peut plus se déclencher pour les appelants qui passent par
+    `fetch_editorial_pool` — elle reste un filet pour ceux qui construiraient leur
+    pool autrement. La branche denylist, elle, fait toujours le travail : aucune
+    source denylistée n'est filtrée en amont.
     """
     from app.services.recommendation.filter_presets import (
         is_denylisted_editorial_source,

--- a/packages/api/app/services/grille_selector.py
+++ b/packages/api/app/services/grille_selector.py
@@ -118,13 +118,28 @@ def _window(text: str, surface: str) -> str:
 def _build_cluster_index(
     editorial_ctx: EditorialGlobalContext | None,
 ) -> dict[str, int]:
-    """content_id (str) → rang du cluster qui le contient (plus petit = mieux)."""
+    """content_id (str) → rang du cluster qui le contient (plus petit = mieux).
+
+    **Seuls les clusters multi-articles sont indexés.** Le bonus qui en dépend
+    récompense un mot appartenant à un *sujet* du jour ; un singleton n'en est
+    pas un. La distinction était implicite tant que `cluster_data` venait d'un
+    pool plafonné à 200 articles : peu de contenus y figuraient, donc le bonus
+    discriminait de fait. Depuis que le clustering éditorial voit tout le corpus
+    du jour (~2 350 articles, cf. `editorial/candidate_pool.py`), indexer les
+    singletons ferait toucher le bonus à la quasi-totalité des candidats — il
+    deviendrait une constante, donc sans effet sur le classement.
+    """
     index: dict[str, int] = {}
     if editorial_ctx is None:
         return index
-    for rank, cluster in enumerate(editorial_ctx.cluster_data):
-        for cid in cluster.get("content_ids", []):
+    rank = 0
+    for cluster in editorial_ctx.cluster_data:
+        content_ids = cluster.get("content_ids", [])
+        if len(content_ids) < 2:
+            continue
+        for cid in content_ids:
             index.setdefault(str(cid), rank)
+        rank += 1
     return index
 
 

--- a/packages/api/config/editorial_config.yaml
+++ b/packages/api/config/editorial_config.yaml
@@ -17,6 +17,13 @@ pipeline:
   # publiée par une source deep) ne sera pas promue en mise en perspective.
   # Cf. docs/bugs/bug-digest-pas-de-recul-same-event.md.
   deep_min_age_hours: 24
+  # Fenêtres successives du clustering éditorial, de la plus étroite à la plus
+  # large. On garde la première qui atteint le plancher de pool, sinon la
+  # dernière. « Actus du jour » est quotidien, donc 24 h en nominal : au-delà,
+  # les articles de la veille se raccrochent à ceux du jour. Mais « Bonnes
+  # Nouvelles » est hard-filtré sur is_good_news (~13 articles/24 h contre
+  # ~2 000 pour pour_vous) et a besoin de descendre jusqu'à 168 h.
+  clustering_window_ladder_hours: [24, 48, 168]
 
 cost:
   max_llm_calls_per_batch: 10   # Safety cap LLM calls

--- a/packages/api/tests/test_digest_generation_job.py
+++ b/packages/api/tests/test_digest_generation_job.py
@@ -17,6 +17,20 @@ from app.services.editorial.schemas import (
 )
 
 
+def _content(title="Un titre d'actualité ordinaire", source_id=None):
+    """Content factory for pool tests — a real `title` str, unlike a bare Mock()."""
+    return Mock(id=uuid4(), source_id=source_id or uuid4(), title=title)
+
+
+def _result(items):
+    """Wrap rows the way `session.execute(...).scalars().all()` expects."""
+    scalars = MagicMock()
+    scalars.all = MagicMock(return_value=items)
+    res = MagicMock()
+    res.scalars = MagicMock(return_value=scalars)
+    return res
+
+
 def _make_editorial_result(n_subjects=2):
     """Build a minimal EditorialPipelineResult for testing."""
     now = datetime.datetime.now(datetime.UTC)
@@ -421,25 +435,19 @@ class TestFollowedSourceSlice:
 
     @pytest.mark.asyncio
     async def test_followed_slice_unioned_and_deduped(self, job):
-        """A followed-source article past the top-200 cut is added, deduped."""
+        """A followed-source article outside the clustering window is added, deduped."""
 
         followed_src = uuid4()
         # recency slice: c1 (other source), c2 (followed, already present)
-        c1 = Mock(id=uuid4(), source_id=uuid4())
-        c2 = Mock(id=uuid4(), source_id=followed_src)
+        c1 = _content(source_id=uuid4())
+        c2 = _content(source_id=followed_src)
         # followed slice query returns c2 (dup) + c3 (new, older niche article)
-        c3 = Mock(id=uuid4(), source_id=followed_src)
-
-        def _result(items):
-            scalars = MagicMock()
-            scalars.all = MagicMock(return_value=items)
-            res = MagicMock()
-            res.scalars = MagicMock(return_value=scalars)
-            return res
+        c3 = _content(source_id=followed_src)
 
         mock_session = AsyncMock()
+        # Pool under EDITORIAL_CLUSTERING_MIN_POOL ⇒ widened re-fetch, then followed.
         mock_session.execute = AsyncMock(
-            side_effect=[_result([c1, c2]), _result([c2, c3])]
+            side_effect=[_result([c1, c2]), _result([c1, c2]), _result([c2, c3])]
         )
 
         result = await job._get_global_candidates(
@@ -449,9 +457,8 @@ class TestFollowedSourceSlice:
         ids = [c.id for c in result]
         # c1, c2 from recency + c3 from followed slice (c2 deduped).
         assert ids == [c1.id, c2.id, c3.id]
-        assert mock_session.execute.await_count == 2
-        # Second query (followed slice) filters on source_id and keeps cutoff.
-        followed_stmt = mock_session.execute.await_args_list[1].args[0]
+        # Last query (followed slice) filters on source_id and keeps the cutoff.
+        followed_stmt = mock_session.execute.await_args_list[-1].args[0]
         compiled = str(
             followed_stmt.compile(compile_kwargs={"literal_binds": False})
         ).lower()
@@ -460,19 +467,85 @@ class TestFollowedSourceSlice:
 
     @pytest.mark.asyncio
     async def test_no_followed_slice_when_empty(self, job):
-        """Without followed sources, only the recency slice query runs."""
-        scalars = MagicMock()
-        scalars.all = MagicMock(return_value=[Mock(id=uuid4(), source_id=uuid4())])
-        res = MagicMock()
-        res.scalars = MagicMock(return_value=scalars)
+        """Without followed sources, no source_id-filtered query runs."""
         mock_session = AsyncMock()
-        mock_session.execute = AsyncMock(return_value=res)
+        mock_session.execute = AsyncMock(return_value=_result([_content()]))
 
         result = await job._get_global_candidates(
             mock_session, followed_source_ids=set()
         )
         assert len(result) == 1
+        for call in mock_session.execute.await_args_list:
+            compiled = str(
+                call.args[0].compile(compile_kwargs={"literal_binds": False})
+            ).lower()
+            assert "contents.source_id in" not in compiled
+
+    @pytest.mark.asyncio
+    async def test_pool_is_the_whole_window_not_a_top_n_slice(self, job):
+        """Le pool n'est plus plafonné à 200 : un corpus complet passe entier.
+
+        C'est la garantie produit de « les sujets les + couverts en France » — le
+        décompte de médias d'un sujet doit porter sur la couverture du jour, pas
+        sur les 200 articles les plus récents (mesuré : 10,5 % du corpus 24 h).
+        Cf. docs/maintenance/maintenance-clustering-corpus-complet.md.
+        """
+        corpus = [_content() for _ in range(2400)]
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=_result(corpus))
+
+        result = await job._get_global_candidates(mock_session)
+
+        assert len(result) == 2400
+        # Pool au-dessus du plancher ⇒ pas de ré-élargissement.
         assert mock_session.execute.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_thin_pool_widens_to_fallback_window(self, job):
+        """Nuit creuse / panne d'ingestion : on ré-élargit plutôt que de rendre peu."""
+        thin = [_content() for _ in range(10)]
+        wide = [_content() for _ in range(300)]
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(side_effect=[_result(thin), _result(wide)])
+
+        result = await job._get_global_candidates(mock_session)
+
+        assert len(result) == 300
+        assert mock_session.execute.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_pool_excludes_future_dated_articles(self, job):
+        """Des dates RSS futures trustaient la tête du tri par récence."""
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=_result([_content()]))
+
+        await job._get_global_candidates(mock_session)
+
+        compiled = str(
+            mock_session.execute.await_args_list[0]
+            .args[0]
+            .compile(compile_kwargs={"literal_binds": False})
+        ).lower()
+        assert "contents.published_at <=" in compiled
+
+    @pytest.mark.asyncio
+    async def test_pool_drops_news_bulletins(self, job):
+        """Les bulletins partagent un gabarit, pas un sujet : hors clustering.
+
+        Sans ce filtre, élargir le pool fabrique un faux « sujet » : 20 journaux
+        radio de 3 médias, à cheval sur 3 jours, comptés comme un sujet du jour.
+        """
+        keep = _content(title="Trêve à Gaza : accord sur le désarmement du Hamas")
+        drops = [
+            _content(title="JOURNAL DE 8H du jeudi 30 juillet 2026"),
+            _content(title="Le journal RTL de 6h du 31 juillet 2026"),
+        ]
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=_result([keep, *drops]))
+
+        result = await job._get_global_candidates(mock_session)
+
+        assert [c.id for c in result] == [keep.id]
 
 
 class TestBatchFollowedSourceIds:
@@ -717,9 +790,7 @@ class TestEditorialModeFailureRollback:
 
         with (
             patch.object(job_mod, "DigestSelector") as mock_sel_cls,
-            patch.object(
-                job_mod, "state_mark_pending", new_callable=AsyncMock
-            ),
+            patch.object(job_mod, "state_mark_pending", new_callable=AsyncMock),
             patch.object(
                 job_mod, "apply_session_timeouts", new_callable=AsyncMock
             ) as mock_apply,

--- a/packages/api/tests/test_digest_generation_job.py
+++ b/packages/api/tests/test_digest_generation_job.py
@@ -444,10 +444,16 @@ class TestFollowedSourceSlice:
         # followed slice query returns c2 (dup) + c3 (new, older niche article)
         c3 = _content(source_id=followed_src)
 
+        # Pool sous EDITORIAL_CLUSTERING_MIN_POOL ⇒ toute l'échelle de fenêtres est
+        # parcourue, puis la tranche « sources suivies ».
+        from app.services.editorial.candidate_pool import clustering_window_ladder
+
         mock_session = AsyncMock()
-        # Pool under EDITORIAL_CLUSTERING_MIN_POOL ⇒ widened re-fetch, then followed.
         mock_session.execute = AsyncMock(
-            side_effect=[_result([c1, c2]), _result([c1, c2]), _result([c2, c3])]
+            side_effect=[
+                *([_result([c1, c2])] * len(clustering_window_ladder())),
+                _result([c2, c3]),
+            ]
         )
 
         result = await job._get_global_candidates(
@@ -464,6 +470,35 @@ class TestFollowedSourceSlice:
         ).lower()
         assert "contents.source_id in" in compiled
         assert "contents.published_at >=" in compiled
+
+    @pytest.mark.asyncio
+    async def test_followed_slice_only_covers_what_the_window_misses(self, job):
+        """La tranche « sources suivies » borne sa requête AVANT la fenêtre nominale.
+
+        Le pool nominal est désormais exhaustif sur sa fenêtre. Si la tranche
+        suivie re-requêtait [0, fenêtre], son `LIMIT` serait consommé par des
+        articles déjà présents — dédupliqués juste après en Python — et aucun
+        article de niche plus ancien n'entrerait : l'exact inverse du but de
+        cette tranche (garantie P1).
+        """
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(
+            side_effect=[_result([_content()]), _result([_content()]), _result([])]
+        )
+
+        await job._get_global_candidates(
+            mock_session, followed_source_ids={uuid4()}
+        )
+
+        followed_stmt = mock_session.execute.await_args_list[-1].args[0]
+        params = followed_stmt.compile().params
+        # Fenêtre de la tranche suivie : [now-48h, now-24h] — bornée en haut par
+        # le début de la fenêtre de regroupement, pas par `now`.
+        span_hours = (params["published_at_2"] - params["published_at_1"]).total_seconds() / 3600
+        assert 20 < span_hours < 28, (
+            "la tranche suivie doit couvrir le créneau que la fenêtre de "
+            f"regroupement n'atteint pas, pas la refaire ; span={span_hours}h"
+        )
 
     @pytest.mark.asyncio
     async def test_no_followed_slice_when_empty(self, job):

--- a/packages/api/tests/test_editorial_candidate_pool.py
+++ b/packages/api/tests/test_editorial_candidate_pool.py
@@ -17,10 +17,12 @@ import pytest
 from app.services.editorial.candidate_pool import (
     EDITORIAL_CLUSTERING_MAX_ARTICLES,
     EDITORIAL_CLUSTERING_MIN_POOL,
-    EDITORIAL_CLUSTERING_WINDOW_HOURS,
     build_editorial_pool_stmt,
+    clustering_window_hours,
+    clustering_window_ladder,
     drop_unclusterable,
     fetch_editorial_pool,
+    finalize_pool,
 )
 
 
@@ -145,7 +147,7 @@ class TestFetchEditorialPool:
         corpus = [_content(f"Sujet {i}") for i in range(2400)]
         session = _session(corpus)
 
-        result = await fetch_editorial_pool(session, "pour_vous", fallback_hours=48)
+        result = await fetch_editorial_pool(session, "pour_vous")
 
         assert len(result) == 2400
         assert session.execute.await_count == 1
@@ -154,41 +156,132 @@ class TestFetchEditorialPool:
     async def test_thin_pool_refetches_on_fallback_window(self):
         session = _session([_content("a")] * 10, [_content("b")] * 300)
 
-        result = await fetch_editorial_pool(session, "pour_vous", fallback_hours=48)
+        result = await fetch_editorial_pool(session, "pour_vous")
 
         assert len(result) == 300
         assert session.execute.await_count == 2
 
     @pytest.mark.asyncio
-    async def test_returns_rows_unfiltered(self):
-        """`drop_unclusterable` appartient à l'appelant : il unionne d'abord."""
-        rows = [_content("JOURNAL DE 8H du jeudi 30 juillet 2026")] * 250
-        session = _session(rows)
+    async def test_floor_is_measured_after_filtering(self):
+        """Le plancher porte sur ce qui ira au clustering, pas sur le brut.
 
-        result = await fetch_editorial_pool(session, "pour_vous", fallback_hours=48)
+        250 lignes dont 250 bulletins, c'est un pool vide : il faut descendre
+        l'échelle, pas s'arrêter en croyant le plancher atteint.
+        """
+        bulletins = [_content("JOURNAL DE 8H du jeudi 30 juillet 2026")] * 250
+        real = [_content(f"Sujet {i}") for i in range(300)]
+        session = _session(bulletins, real)
 
-        assert len(result) == 250
+        result = await fetch_editorial_pool(session, "pour_vous")
+
+        assert len(result) == 300
+        assert session.execute.await_count == 2
 
     @pytest.mark.asyncio
-    async def test_query_is_capped_for_memory_safety(self):
+    async def test_query_is_capped_for_memory_safety_not_for_selection(self):
+        """La borne doit valoir MAX_ARTICLES, pas un top-N déguisé.
+
+        Assertion sur la valeur réellement liée à la requête : une version qui
+        se contentait de chercher la constante dans le SQL après l'y avoir
+        substituée elle-même passait avec un `.limit(200)` réintroduit.
+        """
         session = _session([_content("a")] * 250)
 
-        await fetch_editorial_pool(session, "pour_vous", fallback_hours=48)
+        await fetch_editorial_pool(session, "pour_vous")
 
-        sql = _compiled(session.execute.await_args_list[0].args[0])
-        assert f"limit {EDITORIAL_CLUSTERING_MAX_ARTICLES}" in sql.replace(
-            ":param_1", str(EDITORIAL_CLUSTERING_MAX_ARTICLES)
+        params = session.execute.await_args_list[0].args[0].compile().params
+        limits = [v for k, v in params.items() if k.startswith("param")]
+        assert limits == [EDITORIAL_CLUSTERING_MAX_ARTICLES]
+        assert EDITORIAL_CLUSTERING_MAX_ARTICLES > 10 * EDITORIAL_CLUSTERING_MIN_POOL
+
+    @pytest.mark.asyncio
+    async def test_windows_come_from_the_module_not_the_caller(self):
+        """L'échelle appartient au module, pas à l'appelant.
+
+        Elle a d'abord été câblée sur le `hours_lookback` de chaque appelant :
+        48 h côté batch, **168 h** côté on-demand (`select_for_user`). Les deux
+        chemins se seraient élargis différemment dans le seul cas dégradé où ce
+        module existe pour garantir qu'ils voient le même corpus.
+        """
+        now = datetime.datetime(2026, 7, 31, 5, 0, tzinfo=datetime.UTC)
+        session = _session(*([[_content("a")] * 5] * len(clustering_window_ladder())))
+
+        await fetch_editorial_pool(session, "pour_vous", now=now)
+
+        cutoffs = [
+            call.args[0].compile().params["published_at_1"]
+            for call in session.execute.await_args_list
+        ]
+        assert [round((now - c).total_seconds() / 3600) for c in cutoffs] == list(
+            clustering_window_ladder()
         )
 
+    @pytest.mark.asyncio
+    async def test_sparse_mode_walks_down_to_the_widest_window(self):
+        """« Bonnes Nouvelles » n'a jamais 200 articles — mesuré : 13/24 h, 33/48 h, 145/168 h.
 
-class TestConstants:
+        S'arrêter au deuxième barreau amputerait le mode de 77 % de sa matière.
+        L'échelle doit descendre jusqu'au bout plutôt que de rendre un pool
+        maigre, ce qui restitue son comportement historique (fenêtre 168 h).
+        """
+        session = _session(
+            [_content("a")] * 13, [_content("b")] * 33, [_content("c")] * 145
+        )
+
+        result = await fetch_editorial_pool(session, "serein")
+
+        assert len(result) == 145
+        assert session.execute.await_count == len(clustering_window_ladder())
+
+
+class TestOnDemandCallerUsesTheSharedPolicy:
+    """`digest_selector._fetch_editorial_global_pool` — chemin on-demand.
+
+    Il n'avait aucun test à son niveau, alors que c'est lui qui sert un
+    utilisateur en cache miss et que c'est lui qui avait divergé du batch
+    (pas de filtre pub, fenêtre pilotée par le `hours_lookback` de l'appelant).
+    """
+
+    @pytest.mark.asyncio
+    async def test_applies_window_ad_filter_and_bulletin_drop(self):
+        from app.services.digest_selector import DigestSelector
+
+        keep = _content("Trêve à Gaza : accord sur le désarmement du Hamas")
+        rows = [keep, _content("JOURNAL DE 8H du jeudi 30 juillet 2026")]
+
+        selector = DigestSelector(_session(rows, rows, rows))
+        pool = await selector._fetch_editorial_global_pool(mode="pour_vous")
+
+        assert [c.id for c in pool] == [keep.id]
+        where = _compiled(selector.session.execute.await_args_list[0].args[0]).split(
+            " where ", 1
+        )[1]
+        assert "contents.is_ad = false" in where
+        assert "contents.published_at <=" in where
+
+
+class TestFinalizePool:
+    def test_filters_once_and_reports_what_it_dropped(self):
+        keep = _content("Trêve à Gaza : accord sur le désarmement du Hamas")
+        drop = _content("JOURNAL DE 8H du jeudi 30 juillet 2026")
+
+        assert finalize_pool([keep, drop], "pour_vous", "test_event") == [keep]
+
+
+class TestWindows:
     def test_window_is_daily(self):
         """« Actus du jour » est un produit quotidien : un sujet se définit dans la journée.
 
         Une fenêtre plus large laisse les articles de la veille se raccrocher à
         ceux du jour (observé sur les bulletins radio, clusters à cheval sur 3 jours).
         """
-        assert EDITORIAL_CLUSTERING_WINDOW_HOURS == 24
+        assert clustering_window_hours() == 24
+
+    def test_ladder_is_ascending(self):
+        """Sinon « ré-élargir » rétrécirait le pool. Trié à la lecture du YAML."""
+        ladder = clustering_window_ladder()
+        assert list(ladder) == sorted(ladder)
+        assert ladder[0] == clustering_window_hours()
 
     def test_former_cap_is_now_a_floor(self):
         """Le 200 historique plafonnait le pool ; il ne sert plus qu'à détecter un pool maigre."""

--- a/packages/api/tests/test_editorial_candidate_pool.py
+++ b/packages/api/tests/test_editorial_candidate_pool.py
@@ -1,0 +1,196 @@
+"""Tests de la politique du pool de clustering éditorial.
+
+Ce module est le point unique qui décide *quels articles le regroupement
+« Actus du jour » a le droit de voir*. Les deux appelants (batch et on-demand)
+doivent en dépendre, sinon un même sujet n'affiche pas le même nombre de médias
+selon l'origine du digest.
+
+Cf. `docs/maintenance/maintenance-clustering-corpus-complet.md`.
+"""
+
+import datetime
+from unittest.mock import AsyncMock, MagicMock, Mock
+from uuid import uuid4
+
+import pytest
+
+from app.services.editorial.candidate_pool import (
+    EDITORIAL_CLUSTERING_MAX_ARTICLES,
+    EDITORIAL_CLUSTERING_MIN_POOL,
+    EDITORIAL_CLUSTERING_WINDOW_HOURS,
+    build_editorial_pool_stmt,
+    drop_unclusterable,
+    fetch_editorial_pool,
+)
+
+
+def _compiled(stmt) -> str:
+    """SQL compilé, sur une seule ligne — le compilateur insère des sauts de ligne
+    avant FROM/WHERE, qui casseraient une recherche de sous-chaîne."""
+    sql = str(stmt.compile(compile_kwargs={"literal_binds": False})).lower()
+    return " ".join(sql.split())
+
+
+def _content(title):
+    return Mock(id=uuid4(), source_id=uuid4(), title=title)
+
+
+class TestPoolStatement:
+    def test_window_is_bounded_on_both_sides(self):
+        """La borne haute écarte les articles post-datés.
+
+        19 articles portaient une date RSS future ; le pool étant trié par
+        récence décroissante, ils remontaient systématiquement en tête.
+        """
+        now = datetime.datetime.now(datetime.UTC)
+        stmt = build_editorial_pool_stmt(
+            "pour_vous", now - datetime.timedelta(hours=24), now
+        )
+        sql = _compiled(stmt)
+        assert "contents.published_at >=" in sql
+        assert "contents.published_at <=" in sql
+
+    def test_pour_vous_filters_ads(self):
+        """`pour_vous` ne passe pas par le filtre bonne-nouvelle : filtre pub explicite.
+
+        Sans lui, les articles `is_ad=True` entraient dans le clustering du chemin
+        on-demand, qui ne l'appliquait pas — divergence avec le chemin batch.
+        """
+        now = datetime.datetime.now(datetime.UTC)
+        # `is_good_news` figure dans la liste des colonnes du SELECT : c'est la
+        # clause WHERE qu'il faut inspecter, pas la requête entière.
+        where = _compiled(
+            build_editorial_pool_stmt(
+                "pour_vous", now - datetime.timedelta(hours=24), now
+            )
+        ).split(" where ", 1)[1]
+        assert "contents.is_ad = false" in where
+        assert "is_good_news" not in where
+
+    def test_serein_filters_good_news(self):
+        now = datetime.datetime.now(datetime.UTC)
+        sql = _compiled(
+            build_editorial_pool_stmt("serein", now - datetime.timedelta(hours=24), now)
+        )
+        assert "contents.is_good_news = true" in sql
+
+    def test_statement_carries_no_limit(self):
+        """La borne appartient à l'appelant : le module ne plafonne pas en douce."""
+        now = datetime.datetime.now(datetime.UTC)
+        sql = _compiled(
+            build_editorial_pool_stmt(
+                "pour_vous", now - datetime.timedelta(hours=24), now
+            )
+        )
+        assert "limit" not in sql
+
+
+class TestDropUnclusterable:
+    def test_drops_news_bulletins(self):
+        """Un bulletin partage un gabarit, pas un sujet.
+
+        `pipeline._is_non_actu_cluster` existait déjà mais exige que *tous* les
+        contenus du cluster soient des bulletins : un seul intrus sauvait un
+        cluster de 19 journaux radio. On traite ici la cause.
+        """
+        keep = _content("Trêve à Gaza : accord sur le désarmement du Hamas")
+        dropped = [
+            _content("JOURNAL DE 8H du jeudi 30 juillet 2026"),
+            _content("Le journal RTL de 6h du 31 juillet 2026"),
+            _content("JOURNAL DE 12H30 du jeudi 30 juillet 2026"),
+            _content("Revue de presse du matin"),
+        ]
+        assert drop_unclusterable([keep, *dropped]) == [keep]
+
+    def test_keeps_ordinary_titles(self):
+        items = [
+            _content("Incendie en Gironde : le feu est contenu dans son périmètre"),
+            _content("La croissance française atteint 0,2 % au deuxième trimestre"),
+        ]
+        assert drop_unclusterable(items) == items
+
+    def test_tolerates_missing_or_non_string_titles(self):
+        """Filtre d'exclusion, pas garde de validation : en cas de doute on garde."""
+        odd = [Mock(id=uuid4(), title=None), Mock(id=uuid4(), spec=["id"])]
+        assert len(drop_unclusterable(odd)) == 2
+
+    def test_empty_pool_stays_empty(self):
+        assert drop_unclusterable([]) == []
+
+
+def _session(*batches):
+    """Session mock rendant une liste de rows par appel successif à execute()."""
+
+    def _res(items):
+        scalars = MagicMock()
+        scalars.all = MagicMock(return_value=items)
+        res = MagicMock()
+        res.scalars = MagicMock(return_value=scalars)
+        return res
+
+    session = Mock()
+    session.execute = AsyncMock(side_effect=[_res(b) for b in batches])
+    return session
+
+
+class TestFetchEditorialPool:
+    """La politique (fenêtre, ré-élargissement, borne) appartient au module.
+
+    Elle vivait en double chez les deux appelants, ce qui les avait laissés
+    diverger — le chemin on-demand n'appliquait pas le filtre pub.
+    """
+
+    @pytest.mark.asyncio
+    async def test_full_window_in_one_query(self):
+        corpus = [_content(f"Sujet {i}") for i in range(2400)]
+        session = _session(corpus)
+
+        result = await fetch_editorial_pool(session, "pour_vous", fallback_hours=48)
+
+        assert len(result) == 2400
+        assert session.execute.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_thin_pool_refetches_on_fallback_window(self):
+        session = _session([_content("a")] * 10, [_content("b")] * 300)
+
+        result = await fetch_editorial_pool(session, "pour_vous", fallback_hours=48)
+
+        assert len(result) == 300
+        assert session.execute.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_returns_rows_unfiltered(self):
+        """`drop_unclusterable` appartient à l'appelant : il unionne d'abord."""
+        rows = [_content("JOURNAL DE 8H du jeudi 30 juillet 2026")] * 250
+        session = _session(rows)
+
+        result = await fetch_editorial_pool(session, "pour_vous", fallback_hours=48)
+
+        assert len(result) == 250
+
+    @pytest.mark.asyncio
+    async def test_query_is_capped_for_memory_safety(self):
+        session = _session([_content("a")] * 250)
+
+        await fetch_editorial_pool(session, "pour_vous", fallback_hours=48)
+
+        sql = _compiled(session.execute.await_args_list[0].args[0])
+        assert f"limit {EDITORIAL_CLUSTERING_MAX_ARTICLES}" in sql.replace(
+            ":param_1", str(EDITORIAL_CLUSTERING_MAX_ARTICLES)
+        )
+
+
+class TestConstants:
+    def test_window_is_daily(self):
+        """« Actus du jour » est un produit quotidien : un sujet se définit dans la journée.
+
+        Une fenêtre plus large laisse les articles de la veille se raccrocher à
+        ceux du jour (observé sur les bulletins radio, clusters à cheval sur 3 jours).
+        """
+        assert EDITORIAL_CLUSTERING_WINDOW_HOURS == 24
+
+    def test_former_cap_is_now_a_floor(self):
+        """Le 200 historique plafonnait le pool ; il ne sert plus qu'à détecter un pool maigre."""
+        assert EDITORIAL_CLUSTERING_MIN_POOL == 200
+        assert EDITORIAL_CLUSTERING_MAX_ARTICLES > 10 * EDITORIAL_CLUSTERING_MIN_POOL

--- a/packages/api/tests/test_grille_selector.py
+++ b/packages/api/tests/test_grille_selector.py
@@ -168,12 +168,33 @@ def test_build_cluster_index_keeps_lowest_rank():
     cid = str(uuid4())
     ctx = _ctx(
         clusters=[
-            {"content_ids": [cid]},
-            {"content_ids": [cid]},
+            {"content_ids": [cid, str(uuid4())]},
+            {"content_ids": [cid, str(uuid4())]},
         ]
     )
     index = _build_cluster_index(ctx)
     assert index[cid] == 0
+
+
+def test_build_cluster_index_skips_singletons():
+    """Le bonus éditorial récompense l'appartenance à un *sujet*, pas au corpus.
+
+    `cluster_data` couvrait ~200 articles quand le pool éditorial était plafonné ;
+    il couvre désormais tout le corpus du jour (~2 350). Indexer les singletons
+    ferait toucher le +2 à la quasi-totalité des candidats — une constante, donc
+    sans effet sur le classement. Cf. editorial/candidate_pool.py.
+    """
+    solo, paired = str(uuid4()), str(uuid4())
+    ctx = _ctx(
+        clusters=[
+            {"content_ids": [solo]},
+            {"content_ids": [paired, str(uuid4())]},
+        ]
+    )
+    index = _build_cluster_index(ctx)
+    assert solo not in index
+    # Le rang reste dense : le singleton ignoré ne consomme pas de rang.
+    assert index[paired] == 0
 
 
 def test_subject_label_words_normalized():


### PR DESCRIPTION
## What

Le regroupement qui produit « les sujets les + couverts en France » travaille désormais sur **tout le corpus de la journée** au lieu des 200 articles les plus récents.

- Nouveau module `app/services/editorial/candidate_pool.py` : point unique décidant quels articles le clustering éditorial a le droit de voir (échelle de fenêtres, filtres, bornes).
- Les deux chemins — batch et on-demand — y passent tous les deux. Ils avaient divergé : le second n'appliquait pas le filtre pub.
- L'ancien `LIMIT 200` devient un **plancher** : on descend une échelle de fenêtres `[24, 48, 168] h` jusqu'à l'atteindre. Borne mémoire à 6 000, jamais atteinte.
- Deux exclusions d'entrée : articles post-datés, bulletins / chroniques régulières.

Le PR contient aussi la **contre-expertise** qui l'a motivé (`docs/bugs/bug-clustering-actus-du-jour-verification.md`) et annote le diagnostic d'origine des chiffres invalidés par la remesure.

## Why

Mesuré en production, le regroupement voyait :

| | Avant | Après |
|---|---|---|
| Articles | 246 | **2 330** |
| Médias | 64 | **192** |
| Part du corpus 24 h | 10,5 % | **99,1 %** |
| Fenêtre réelle | 7,5 h (2,0 h en journée) | **24,0 h** |

Un sujet couvert par 18 médias n'en affichait que 2 ou 3. Le plafond n'achetait pas de la latence — le clustering coûte **0,45 s pour 2 200 articles** — il achetait de la cécité.

### Résultat, algorithme inchangé — seul le pool change

Sujets couverts par ≥ 3 médias, selon l'heure de génération : **4 → 82** au cron (×7 à ×20 selon l'heure). Ceuta passe de **2 à 9 médias**.

Ce que la curation LLM reçoit (les 15 clusters de `cluster_input_limit`, dont elle retient 5) : avant, la moitié basse était à 1 média — dont « Le journal RTL de 6h du 31 juillet » et « Mattress Firm Coupons: Save up to $700 ». Après, le 15ᵉ candidat est encore à 5 médias.

**Coût LLM inchangé** : `cluster_input_limit` borne l'entrée de la curation quelle que soit la taille du pool.

## Revue adversariale (6 passes) — 2 régressions trouvées et corrigées

Le second commit corrige deux régressions que la première version introduisait **sans qu'aucun test ne les voie** :

1. **« Bonnes Nouvelles » amputé de 77 %.** Le repli de fenêtre était câblé sur le `hours_lookback` de chaque appelant — 48 h en batch, **168 h** en on-demand — donc les deux chemins s'élargissaient différemment, dans le seul cas dégradé où ce module existe pour garantir l'inverse. Or `serein` est hard-filtré sur `is_good_news` : **13 articles sur 24 h, 33 sur 48 h, 145 sur 168 h** (mesuré). S'arrêter à 48 h faisait passer le pool on-demand de 145 à 33. → échelle `[24, 48, 168]` appartenant au module.
2. **Garantie P1 cassée.** La tranche « sources suivies » requêtait encore `[now-48h, now]` alors que le pool nominal est exhaustif sur 24 h : son `LIMIT 200` se remplissait d'articles déjà présents, dédupliqués juste après — aucun article de niche plus ancien n'entrait, l'exact inverse de son but. → elle ne couvre plus que `[now-48h, now-24h]`.

**Effet induit traité** : `grille_selector._build_cluster_index` n'indexe plus que les clusters multi-articles. `cluster_data` couvrant maintenant tout le corpus, indexer les singletons faisait toucher le bonus éditorial `+2` à la quasi-totalité des candidats — une constante, donc sans effet sur le classement.

**Durcissements** : plancher mesuré après filtrage ; fenêtres dans `editorial_config.yaml` aux côtés de `actu_max_age_hours` ; `finalize_pool` réunit filtrage et log, copiés chez les deux appelants ; garde sur une fenêtre configurée plus large que `hours_lookback`.

**Tests** : le test de borne mémoire était tautologique (il fabriquait la chaîne qu'il cherchait) et laissait passer un `.limit(200)` réintroduit — il assied désormais sur la valeur liée. Ajout d'un test au niveau du chemin on-demand, qui n'en avait aucun. Les 4 régressions de ce lot sont vérifiées **par injection de mutation** (chaque mutation confirmée `CAUGHT`).

Faux positifs du filtre bulletins mesurés sur 4 399 titres de production : **39 écartés (0,9 %), dont 38 bulletins authentiques**.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [x] Tests pass locally (`pytest` : **2 815 passed, 30 skipped** — 2 790 avant, +25)
- [x] Linting passes (`ruff check` sur les fichiers touchés : clean ; les 220 erreurs du dépôt préexistent sur `main`)
- [x] No new Python `List[]` imports (use `list[]`)
- [x] If touching auth/DB: read Safety Guardrails — **aucun DDL, aucune migration**, uniquement des `SELECT` ; `alembic heads` = 1 head
- [ ] Peer Review Conductor completed (separate workspace)

## Staging

- [ ] Deployed to staging
- [ ] Smoke test passed
- [ ] N/A (docs/config only change)

### À surveiller après déploiement

```
digest_generation_global_pool_built       pool_size ≈ 2 000-2 500, source_count ≈ 190
digest_selector_global_pool_built         idem, chemin on-demand
editorial_pool_ladder_exhausted           normal pour `serein`, anormal pour `pour_vous`
editorial_pool_truncated                  ⚠ plafond 6 000 = anomalie d'ingestion
digest_generation_followed_slice_skipped  fenêtre ≥ hours_lookback : tranche P1 sans objet
global_trending_context_built             topics_3_plus_media attendu entre 50 et 85
```

## Réserves explicites

Détaillées dans [`docs/maintenance/maintenance-clustering-corpus-complet.md`](``https://github.com/boujonlaurin-dotcom/facteur/blob/claude/clustering-actus-verification-yz5jbl/docs/maintenance/maintenance-clustering-corpus-complet.md``) §6, pour que la prochaine passe puisse les critiquer :

- **Gironde reste non résolu** (4 médias, cible ≥ 6). Plafond lexical R ≈ 0,44 ; seule voie = couche sémantique, dont le test est bloqué (`huggingface.co` en 403 par la politique d'egress).
- **Précision du clustering à 0,94, pas 1,00** — audit des 81 clusters ≥ 3 médias, 5 défectueux (dont le cluster de bulletins, corrigé ici).
- **Le seuil 0,30 est à 0,02 de la falaise de chaînage**, pas 0,05 comme le dit son commentaire.
- **Effets de bord non recalibrés** : `is_trending` passe de 3,9 % à 19,3 % du corpus (`/feed/trending`, `_W_TRENDING = 50`).
- **Findings de revue écartés, avec la raison** (§6.5) : `defer(html_content)` — mesuré à 699 kB/24 h seulement, mauvais rapport risque/gain face au `MissingGreenlet` ; ré-élargissement en delta — complique la boucle pour un gain limité aux modes clairsemés ; coût CPU superlinéaire au plafond — réel sur corpus synthétique dense, invisible sur titres réels (0,45 s / 2 214 articles).
- **`trending_context` calculé puis jeté** sur le chemin éditorial — prochain gain, purement mécanique, hors périmètre.

## Reproduction

```bash
python3.12 docs/qa/scripts/verify_clustering_prod_paths.py   <corpus.json> [followed_ids]
python3.12 docs/qa/scripts/verify_clustering_side_effects.py <corpus.json> [followed_ids]
```

Les deux bancs importent `app/services/briefing/topic_clustering.py` tel quel et rejouent l'algorithme antérieur extrait de `beac381e` — aucun proxy SQL, aucune réimplémentation.