### PR TITLE
fix(curation): socle de mesure + métadonnées fausses du catalogue de sources

### DIFF
--- a/docs/bugs/bug-curation-essentiel-personnalisation-baseline.md
+++ b/docs/bugs/bug-curation-essentiel-personnalisation-baseline.md
@@ -1,0 +1,92 @@
+# Baseline « qualité de la curation » — figée le 2026-08-01
+
+Mesures de référence **avant** tout changement, à rejouer à l'identique après
+chaque PR du lot :
+
+```bash
+psql "$DATABASE_URL_RO" -X -f docs/qa/scripts/baseline_curation.sql
+```
+
+Diagnostic : [`bug-curation-essentiel-personnalisation.md`](bug-curation-essentiel-personnalisation.md).
+
+Fenêtre : 30 jours glissants au 2026-08-01. Périmètre : `daily_digest`,
+`format_version = 'editorial_v3'`. `rank` 1-5 = ce que la carte « Ton Essentiel »
+affiche ; 6-10 = généré puis tronqué, jamais vu.
+
+> **Prérequis appliqué le 2026-08-01** : `ALTER ROLE claude_analytics_ro BYPASSRLS;`
+> Avant ça, `daily_digest` / `contents` / `user_content_status` renvoyaient
+> **0 ligne** au rôle analytics (RLS) — la jauge tournait sans erreur et
+> rapportait un CTR vide. Vérifié après application : 20 135 / 73 282 / 5 561
+> lignes visibles, et le rôle **reste en lecture seule** (`permission denied`
+> sur `UPDATE`).
+
+## Les 5 métriques de pilotage
+
+| # | Métrique | Baseline 01/08/2026 | Cible après P0+P1 |
+|---|---|---|---|
+| M1 | Slots top-5 quasi-universels (`pour_vous`) | **80,8 %** | < 60 % |
+| M2 | Slots top-5 issus d'une source suivie | **16,3 %** | ≥ 35 % |
+| M3 | Part de `society` dans les slots top-5 | **42,7 %** | < 30 % |
+| M4 | Part des 5 pourvoyeurs dans les slots top-5 | **62,8 %** | < 45 % |
+| M5 | CTR global top-5 | **1,41 %** (348 / 24 595) | ne pas dégrader |
+
+## Détail
+
+**M1 — personnalisation réelle.** Un slot est « quasi-universel » si l'article
+est dans le top-5 d'au moins 50 % des users servis ce jour-là.
+
+| Mode | Slots | Quasi-universels | Réellement personnels (< 10 %) |
+|---|---|---|---|
+| `pour_vous` | 18 355 | **80,8 %** | **4,2 %** |
+| `serein` | 6 240 | **85,3 %** | **0,9 %** |
+
+**M2 — la personnalisation est sous la ligne de flottaison.**
+
+| Zone | Slots | % source suivie | % mono-source |
+|---|---|---|---|
+| rang 1-5 (affiché) | 24 595 | **16,3 %** | 36,2 % |
+| rang 6-10 (jamais vu) | 23 134 | **37,4 %** | 94,9 % |
+
+**M3 — thèmes du top-5.** `society` 42,7 % · `environment` 17,1 % ·
+`culture` 11,5 % · `international` 10,8 % · `tech` 9,5 % · `sport` 2,9 % ·
+`science` 1,8 % · `custom` 1,4 % · **`politics` 1,3 %** · `economy` 1,0 %.
+
+**M4/M5 — pourvoyeurs et CTR.**
+
+| Groupe | Slots | % top-5 | Lus | CTR |
+|---|---|---|---|---|
+| Les 5 pourvoyeurs | 15 457 | **62,8 %** | 192 | **1,24 %** |
+| Tout le reste | 9 138 | 37,2 % | 156 | **1,71 %** |
+| Source **suivie** | 4 019 | 16,3 % | 144 | **3,58 %** |
+| Source non suivie | 20 576 | 83,7 % | 204 | **0,99 %** |
+| **Global top-5** | **24 595** | | **348** | **1,41 %** |
+
+**M7 — `selection_reason` : taux d'accès au top-5.**
+
+| Raison | Top-5 | Total | % atteint |
+|---|---|---|---|
+| Traité par 3 sources | 1 343 | 1 343 | **100 %** |
+| Couvert par 2 sources | 10 249 | 11 424 | **89,7 %** |
+| Couvert par 1 sources | 7 286 | 21 228 | 34,3 % |
+| **Source suivie** | 1 608 | 9 471 | **17,0 %** |
+
+## Corrections apportées au plan par la mesure
+
+1. **La colonne « CTR top-5 » du §4 du plan est fausse.** Elle donnait
+   Ouest-France à 0,02 %, Home Fil actu / France Info / CNEWS à 0,00 %. Mesuré :
+   1,10 % / 1,08 % / 1,42 % / 1,83 %. C'était arithmétiquement impossible — avec
+   62,8 % des slots à ~0 %, le CTR global ne pouvait pas être à 1,41 %.
+   **L'écart réel est de 1,24 % contre 1,71 %, soit ×1,4 — pas un effondrement.**
+   L'argument de B-2 tient sur la **composition** (62,8 % de la surface héros à
+   5 sources qui n'apportent pas de couverture thématique, cf. test de survie
+   à 68-88 %), **pas** sur un CTR nul.
+2. **Le vrai gradient est ailleurs** et il est net : **source suivie 3,58 %
+   contre 0,99 %, soit ×3,6.** C'est la mesure qui porte tout le dossier.
+3. Les qualitatives battent les pourvoyeurs d'environ ×2 : La Croix 3,01 %,
+   Le Monde 2,43 %, Courrier International 2,15 %.
+
+## Réserve de puissance
+
+348 lectures sur 24 595 slots. Toute comparaison de CTR entre deux variantes se
+lira à **±5 pp** au mieux. **Les métriques M1-M4 sont déterministes** et se
+lisent dès le premier batch : c'est sur elles qu'il faut juger, pas sur M5.

--- a/docs/bugs/bug-curation-essentiel-personnalisation.md
+++ b/docs/bugs/bug-curation-essentiel-personnalisation.md
@@ -1,0 +1,179 @@
+# Bug — « Ton Essentiel » n'est pas personnalisé (et paraît anecdotique)
+
+- **Statut** : diagnostic figé, lot de PR en cours
+- **Ouvert le** : 2026-08-01
+- **Baseline** : [`bug-curation-essentiel-personnalisation-baseline.md`](bug-curation-essentiel-personnalisation-baseline.md)
+  (+ requêtes rejouables : `docs/qa/scripts/baseline_curation.sql`)
+- **Antécédent direct** : [`bug-actus-du-jour-ranking.md`](bug-actus-du-jour-ranking.md)
+  — c'est le **même pendule**, vu depuis l'autre extrémité.
+
+## Les deux griefs PO
+
+1. « mon intérêt pour l'IA ne remonte pas dans les 1ers articles »
+2. « le contenu semble anecdotique, voire random — pas des news importantes »
+
+Ils ont **une seule cause mécanique**, et elle est en amont d'`essentiel_service`.
+
+## Le verdict mesuré
+
+Sur 30 j (132 users, `format_version = 'editorial_v3'`) :
+
+| Métrique | Valeur |
+|---|---|
+| Slots du top-5 quasi-universels (`pour_vous`) | **80,8 %** |
+| Slots du top-5 réellement personnels (< 10 % des users) | **4,2 %** |
+| Slots du top-5 issus d'une source suivie | **16,3 %** |
+| Slots du rang **6-10** issus d'une source suivie (tronqués, jamais vus) | **37,4 %** |
+| CTR d'un slot **source suivie** | **3,58 %** |
+| CTR d'un slot source non suivie | **0,99 %** |
+
+> La carte s'appelle « Ton Essentiel », le mode s'appelle `pour_vous`. Dans les
+> faits c'est le **même journal pour tout le monde** — et le tri relègue le
+> personnel en 6-10, que la carte tronque, alors qu'il **convertit 3,6× mieux**.
+
+## Le mécanisme, en code (commit `71e81f90`)
+
+**a) Le pool éditorial est user-agnostique.**
+`app/services/editorial/candidate_pool.py:build_editorial_pool_stmt` — aucune
+jointure `user_*`. En batch, le pool *personnalisé* de `_get_candidates`
+(`digest_selector.py:876-1022`) est **calculé pour chaque user puis jeté** :
+`digest_selector.py:406-407`, `compute_candidates = global_pool_candidates or candidates`.
+
+**b) `cluster_input_limit: 15`** (`config/editorial_config.yaml:6`) — seuls les
+15 clusters les plus couverts atteignent le LLM. Un sujet IA couvert par 1-2
+médias n'y entre jamais.
+
+**c) La personnalisation est un tie-breaker de 3ᵉ rang.**
+`digest_selector.py:1296-1305` :
+```python
+return (is_multi, subject_importance(s), subject_perso(s))
+```
+`subject_importance` est **continu** (couverture + récence + polarisation) → il
+n'y a jamais d'égalité, donc `subject_perso` **ne départage jamais**. La
+docstring l'assume : *« La personnalisation ne sert plus qu'à départager. »*
+
+Confirmé par les `selection_reason` persistés : « Couvert par 2 sources » atteint
+le top-5 dans **89,7 %** des cas, « Source suivie » dans **17,0 %**.
+
+## Pourquoi « anecdotique » : `source_count` mesure la redondance
+
+Cinq sources raflent **62,8 %** des slots héros : Ouest-France (19,6 %),
+Home Fil actu (15,8 %), France Info (14,9 %), CNEWS (6,4 %), Europe 1 (6,1 %).
+Elles réécrivent les mêmes dépêches, forment donc mécaniquement les plus gros
+clusters, et gagnent le concours de taille. `source_count` est censé dire
+« N rédactions indépendantes ont jugé ce sujet important » ; 5 reprises d'une
+dépêche AFP, c'est 5 domaines mais **~1 jugement éditorial**.
+
+Côté thèmes : `society` (faits divers, incidents locaux, météo) pèse **42,7 %**
+des slots héros pour 10,5 % du corpus, quand `politics` tombe à **1,3 %**.
+
+> ⚠️ **Correction au rapport d'origine** : sa colonne « CTR top-5 » donnait ces
+> 5 sources à 0,00-0,02 %. C'est faux (et arithmétiquement impossible). Mesuré :
+> **1,24 % contre 1,71 %** pour le reste, soit ×1,4. L'argument tient sur la
+> **composition** — 62,8 % de la surface pour une couverture thématique qui
+> survit à 68-88 % sans elles — **pas** sur un CTR nul. Le vrai gradient du
+> dossier est ailleurs : **source suivie ×3,6**.
+
+## Le cadrage : c'est un pendule, pas un bug
+
+[`bug-actus-du-jour-ranking.md`](bug-actus-du-jour-ranking.md) documente une
+décision PO validée de juin 2026, dont le grief était **l'exact inverse**
+(« un sujet 11 sources se retrouve 10ème »). Le correctif a basculé à 100 %
+couverture.
+
+> Le système est passé de **100 % perso** à **0 % perso**. Les deux positions
+> sont des **tris purs** ; une **somme pondérée** n'a jamais existé. C'est
+> l'explication de « trois cycles sans amélioration ressentie ».
+
+La cible n'est donc ni « revenir à la perso » ni « réserver des slots », mais :
+
+```
+score_sujet = w_importance · norm(importance) + w_perso · norm(perso)
+              ↑ chantier A          ↑ chantier B         ↑ chantier C
+                                    (corpus)             (apprentissage)
+```
+
+**Les deux termes sont aujourd'hui faux et le mélange n'existe pas.** A sans B
+pondère de la redondance ; A sans C pondère du bruit.
+
+## Séquence
+
+| # | PR | Contenu | Statut |
+|---|---|---|---|
+| 0 | — | `BYPASSRLS` + figer la baseline | ✅ **fait le 01/08** |
+| 1 | PR 1 | **B-1** métadonnées sources (script idempotent) | 🟡 cette PR |
+| 2 | PR 2 | **B-2** fold couverture + dry-run comparatif du top-15 | à venir |
+| 3 | PR 3 | **C-1** stopper la fabrication d'intérêts + unicité `(user_id, topic_slug)` | à venir |
+| 4 | PR 4 | **A** score mixte, `is_multi` retiré, poids en env, bump `editorial_v4` | à venir |
+| 5 | PR 5 | **A** pool personnalisé rebranché (`digest_selector.py:406-407`) | à venir |
+| 6 | PR 6 | **C-2** taux appris lissés vers le prior population | à venir |
+
+---
+
+## PR 1 — B-1 : réparer les métadonnées du catalogue
+
+Livrable : `packages/api/scripts/fix_source_metadata.py` (dry-run par défaut,
+`--apply --allow-prod` gardé, idempotent, table de corrections explicite et
+relue — pas d'heuristique).
+
+### Ce que ça corrige
+
+13 sources, toutes des médias français taggés `language = 'en'` par un titre de
+flux en anglais. Dont :
+
+| Source | Correction | Art./30 j |
+|---|---|---|
+| `Home Fil actu - actualités` → **`BFMTV`** | nom + `en`→`fr` | 4 803 |
+| L'Équipe | `en`→`fr`, `culture`→**`sport`** | 3 065 |
+| Libération - Politique | `en`→`fr`, `custom`→**`politics`** | 1 347 |
+| CNEWS | `en`→`fr` | 1 318 |
+| Society (society.fr) | `en`→`fr`, `tech`→**`society`** | 22 |
+
+### ⚠️ Portée réelle — la prémisse du plan d'origine était fausse
+
+Le plan justifiait B-1 par « le pool éditorial filtre sur la langue ».
+**Vérifié : il ne filtre pas.** `build_editorial_pool_stmt`
+(`editorial/candidate_pool.py:126-156`) n'a aucune clause `language`. Le filtre
+langue vit en aval, dans le pool **personnalisé** (`digest_selector.py:1008-1009`)
+et à la projection (`essentiel_service.py:443-452`).
+
+Conséquences, à énoncer clairement :
+
+- **Ces corrections ne bougent aucune des 5 métriques de baseline aujourd'hui.**
+  C'est un **prérequis de la PR 5**, pas un levier sur le grief.
+- Le fix `theme` est, lui, actif immédiatement : `Source.theme` pilote le mute
+  de thème (`digest_selector.py:888,970`) et les presets sereins
+  (`recommendation/filter_presets.py:202,294`). Un user qui mute `sport`
+  recevait quand même les 3 065 articles/30 j de L'Équipe, rangés en `culture`.
+
+### Ce que le script **ne** fait **pas**, volontairement
+
+- **Il ne remplit pas les 206 `language IS NULL`** (64 % des sources actives).
+  `is_foreign_source(None)` vaut `False` : un NULL est **déjà** traité comme FR.
+  Renseigner la colonne rendrait *nouvellement invisibles* les sources
+  réellement étrangères pour les **51 users** à `hide_non_fr_sources = true`.
+  Changement de comportement produit ⇒ décision PO séparée.
+
+### Trouvaille de l'audit — à arbitrer
+
+**18 sources curées, actives, à 0 article sur 30 jours** : France Inter,
+Les Échos, Libération, Le Point, Brut, Alternatives Économiques, Fouloscopie,
+Heu?reka, Monsieur Phi, ScienceEtonnante… Ce sont exactement les sources de
+qualité censées nourrir le digest.
+
+Et il y a des **doublons** : `Le Point` et `Libération` existent chacun en deux
+entrées — la version **curée est morte**, la version **non curée est vivante**
+(et c'est celle qui était mal taggée). Le catalogue perd donc ses meilleures
+sources pendant que le fil brut de BFMTV produit 4 803 articles/30 j.
+
+> C'est un troisième angle sur « anecdotique », que ni l'un ni l'autre des
+> rapports n'avait vu. Feeds morts à réparer + doublons à fusionner : à cadrer
+> comme un chantier propre (candidat PR 2 bis), pas à bricoler dans ce script.
+
+### Vérification
+
+- `pytest tests/scripts/test_fix_source_metadata.py -v` — 22 tests, logique pure
+  (diff, idempotence, garde-fou `expected_name`, intégrité de la table).
+- Dry-run joué contre la prod en lecture seule : 13 sources à corriger, 0
+  introuvable, 0 renommée.
+- Aucune migration Alembic : DML pure sur des colonnes existantes.

--- a/docs/qa/scripts/baseline_curation.sql
+++ b/docs/qa/scripts/baseline_curation.sql
@@ -1,0 +1,122 @@
+-- Baseline « qualité de la curation » — requêtes de référence
+-- Cf. docs/bugs/bug-curation-essentiel-personnalisation.md
+--
+-- Rejouer avec :
+--   psql "$DATABASE_URL_RO" -X -f docs/qa/scripts/baseline_curation.sql
+-- Résultats figés au 01/08/2026 :
+--   docs/bugs/bug-curation-essentiel-personnalisation-baseline.md
+--
+-- Prérequis : `ALTER ROLE claude_analytics_ro BYPASSRLS;` (appliqué le 2026-08-01).
+-- Sans lui, daily_digest / contents / user_content_status renvoient 0 ligne
+-- (RLS) et toutes les métriques ci-dessous sortent vides SANS erreur.
+--
+-- Fenêtre : 30 jours glissants. `rank` 1-5 = ce que la carte « Ton Essentiel »
+-- affiche réellement ; 6-10 = généré puis tronqué, jamais vu.
+
+\set ON_ERROR_STOP on
+\timing off
+
+CREATE TEMP VIEW slots AS
+SELECT
+    d.user_id,
+    d.target_date,
+    d.mode,
+    (s ->> 'rank')::int                              AS rank,
+    s ->> 'theme'                                    AS theme,
+    (s -> 'actu_article' ->> 'content_id')::uuid     AS content_id,
+    (s -> 'actu_article' ->> 'source_id')::uuid      AS source_id,
+    s -> 'actu_article' ->> 'source_name'            AS source_name,
+    (s -> 'actu_article' ->> 'is_user_source')::bool AS is_user_source,
+    s ->> 'selection_reason'                         AS selection_reason,
+    (s ->> 'source_count')::int                      AS source_count
+FROM daily_digest d,
+     LATERAL jsonb_array_elements(d.items -> 'subjects') s
+WHERE d.target_date >= CURRENT_DATE - 30
+  AND d.format_version = 'editorial_v3'
+  AND jsonb_typeof(s -> 'actu_article') = 'object';
+
+CREATE TEMP VIEW top5 AS SELECT * FROM slots WHERE rank BETWEEN 1 AND 5;
+
+\echo '=== M1 — Slots du top-5 quasi-universels vs réellement personnels ==='
+-- Un slot est « quasi-universel » si l'article qui l'occupe est présent dans le
+-- top-5 d'au moins 50 % des utilisateurs servis ce jour-là dans ce mode ;
+-- « personnel » s'il l'est chez moins de 10 %.
+WITH day_users AS (
+    SELECT target_date, mode, COUNT(DISTINCT user_id) AS users_total
+    FROM top5 GROUP BY 1, 2
+),
+art_share AS (
+    SELECT t.target_date, t.mode, t.content_id,
+           COUNT(DISTINCT t.user_id)::float / du.users_total AS share
+    FROM top5 t JOIN day_users du USING (target_date, mode)
+    GROUP BY t.target_date, t.mode, t.content_id, du.users_total
+)
+SELECT t.mode,
+       COUNT(*)                                                        AS slots,
+       ROUND((100.0 * AVG((a.share >= 0.50)::int))::numeric, 1)        AS pct_quasi_universels,
+       ROUND((100.0 * AVG((a.share <  0.10)::int))::numeric, 1)        AS pct_personnels
+FROM top5 t JOIN art_share a USING (target_date, mode, content_id)
+GROUP BY t.mode ORDER BY t.mode;
+
+\echo ''
+\echo '=== M2 — Personnalisation affichee (1-5) vs tronquee (6-10) ==='
+SELECT CASE WHEN rank <= 5 THEN '1-5 (affiche)' ELSE '6-10 (jamais vu)' END AS zone,
+       COUNT(*)                                                     AS slots,
+       ROUND((100.0 * AVG(is_user_source::int))::numeric, 1)        AS pct_source_suivie,
+       ROUND((100.0 * AVG((source_count = 1)::int))::numeric, 1)    AS pct_mono_source
+FROM slots WHERE rank BETWEEN 1 AND 10
+GROUP BY 1 ORDER BY 1;
+
+\echo ''
+\echo '=== M3 — Repartition des themes dans le top-5 ==='
+SELECT COALESCE(theme, '(null)')                                  AS theme,
+       COUNT(*)                                                   AS slots,
+       ROUND((100.0 * COUNT(*) / SUM(COUNT(*)) OVER ())::numeric, 1) AS pct_top5
+FROM top5 GROUP BY 1 ORDER BY 2 DESC;
+
+\echo ''
+\echo '=== M4 — Pourvoyeurs : part du top-5 et CTR ==='
+SELECT s.source_name,
+       COUNT(*)                                                      AS slots,
+       ROUND((100.0 * COUNT(*) / SUM(COUNT(*)) OVER ())::numeric, 2) AS pct_top5,
+       COUNT(ucs.content_id)                                         AS lus,
+       ROUND((100.0 * COUNT(ucs.content_id) / COUNT(*))::numeric, 2) AS ctr_pct
+FROM top5 s
+LEFT JOIN user_content_status ucs
+       ON ucs.user_id = s.user_id
+      AND ucs.content_id = s.content_id
+      AND ucs.status = 'consumed'
+GROUP BY s.source_name ORDER BY 2 DESC LIMIT 15;
+
+\echo ''
+\echo '=== M5 — CTR du top-5 : source suivie vs non suivie ==='
+SELECT CASE WHEN s.is_user_source THEN 'source suivie' ELSE 'source non suivie' END AS zone,
+       COUNT(*)                                                      AS slots,
+       COUNT(ucs.content_id)                                         AS lus,
+       ROUND((100.0 * COUNT(ucs.content_id) / COUNT(*))::numeric, 2) AS ctr_pct
+FROM top5 s
+LEFT JOIN user_content_status ucs
+       ON ucs.user_id = s.user_id
+      AND ucs.content_id = s.content_id
+      AND ucs.status = 'consumed'
+GROUP BY 1 ORDER BY 1;
+
+\echo ''
+\echo '=== M6 — CTR global du top-5 (metrique de non-regression) ==='
+SELECT COUNT(*)                                                      AS slots,
+       COUNT(ucs.content_id)                                         AS lus,
+       ROUND((100.0 * COUNT(ucs.content_id) / COUNT(*))::numeric, 2) AS ctr_pct
+FROM top5 s
+LEFT JOIN user_content_status ucs
+       ON ucs.user_id = s.user_id
+      AND ucs.content_id = s.content_id
+      AND ucs.status = 'consumed';
+
+\echo ''
+\echo '=== M7 — selection_reason : taux d acces au top-5 ==='
+SELECT selection_reason,
+       COUNT(*) FILTER (WHERE rank <= 5)                             AS top5,
+       COUNT(*)                                                      AS total,
+       ROUND((100.0 * COUNT(*) FILTER (WHERE rank <= 5) / COUNT(*))::numeric, 1) AS pct_atteint_top5
+FROM slots WHERE rank BETWEEN 1 AND 10
+GROUP BY 1 HAVING COUNT(*) >= 200 ORDER BY 3 DESC;

--- a/packages/api/scripts/fix_source_metadata.py
+++ b/packages/api/scripts/fix_source_metadata.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""Correction des métadonnées fausses du catalogue de sources (chantier B-1).
+
+Contexte : `docs/bugs/bug-curation-essentiel-personnalisation.md` §B-1. Trois
+familles d'erreurs, toutes écrites à la création de la source (titre RSS mal
+parsé + `SourceService._guess_theme()` sur un flux dont le titre est en
+anglais) :
+
+  - **`language`** : des médias français taggés `'en'`. `is_foreign_source()`
+    (`app/services/language_user_filter.py:42-50`) les traite alors comme
+    étrangers et les masque pour les 51 utilisateurs à
+    `hide_non_fr_sources = true`, sauf s'ils suivent la source.
+  - **`theme`** : L'Équipe classée `culture` (donc invisible au mute `sport`),
+    Libération-Politique en `custom`, Society (society.fr) en `tech`.
+    `Source.theme` pilote le mute de thème (`digest_selector.py:888,970`) et
+    les presets sereins (`recommendation/filter_presets.py:202,294`).
+  - **`name`** : `Home Fil actu - actualités` est le fil brut 24/7 de BFMTV,
+    entré avec le titre RSS de la page d'accueil. C'est la seule entrée BFMTV
+    du catalogue et elle pèse 15,8 % des slots héros.
+
+**Portée réelle, à ne pas surestimer** : le pool de clustering éditorial
+(`editorial/candidate_pool.py:build_editorial_pool_stmt`) n'applique **aucun**
+filtre langue. Ces corrections ne changent donc **pas** la composition du top-5
+aujourd'hui. Elles sont un **prérequis** du chantier A (PR 5), qui rebranche le
+pool personnalisé — lequel, lui, filtre sur la langue
+(`digest_selector.py:1008-1009`).
+
+Ce que ce script ne fait **pas**, volontairement :
+
+  - **Il ne remplit pas les 206 `language IS NULL`.** `is_foreign_source(None)`
+    vaut `False` : un NULL est déjà traité comme FR. Renseigner la colonne
+    rendrait donc *nouvellement invisibles* les sources réellement étrangères
+    pour les 51 utilisateurs concernés. C'est un changement de comportement
+    produit, pas de l'hygiène — décision PO séparée.
+  - **Il ne touche pas aux sources ambiguës.** La table ci-dessous est une liste
+    explicite et relue, pas une heuristique : chaque ligne porte son URL comme
+    preuve et un `expected_name` qui bloque l'écriture si la source a été
+    renommée depuis l'audit.
+
+Garde-fous (calqués sur `fix_basket_usa_theme.py` / `apply_source_reclassification.py`) :
+  - **Dry-run par défaut** ; `--apply` gardé, `--allow-prod` requis hors DB de test.
+  - **Idempotent** : re-run sans changement = no-op, code de sortie 0.
+  - Audit non mutant : imprime les anomalies laissées de côté (NULL language,
+    sources curées à 0 article/30 j).
+
+Usage :
+    cd packages/api
+    python3 scripts/fix_source_metadata.py                        # dry-run + audit
+    python3 scripts/fix_source_metadata.py --apply --allow-prod   # prod (gated PO)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlalchemy import func, select, update
+
+from app.config import get_settings
+from app.database import async_session_maker, engine
+from app.models.content import Content
+from app.models.source import Source
+from scripts.cleanup_orphan_sources import _is_test_db
+
+# Colonnes que ce script s'autorise à écrire. Toute autre clé dans une
+# `Correction` est un bug de programmation, pas une donnée à appliquer.
+MUTABLE_FIELDS: tuple[str, ...] = ("name", "language", "theme")
+
+
+@dataclass(frozen=True)
+class Correction:
+    """Une correction relue à la main, avec sa preuve.
+
+    `expected_name` est un garde-fou : si le nom en base ne correspond plus,
+    la source a été renommée depuis l'audit et on refuse d'écrire à l'aveugle.
+    """
+
+    source_id: str
+    expected_name: str
+    evidence: str
+    name: str | None = None
+    language: str | None = None
+    theme: str | None = None
+
+    def desired(self) -> dict[str, str]:
+        """Les champs à écrire, sans les `None` (= « ne pas toucher »)."""
+        return {
+            f: getattr(self, f)
+            for f in MUTABLE_FIELDS
+            if getattr(self, f, None) is not None
+        }
+
+
+# --------------------------------------------------------------------------
+# Table des corrections. Relue le 2026-08-01 contre la prod (`DATABASE_URL_RO`).
+# Chaque ligne : URL de la source comme preuve de la langue, volume 30 j pour
+# situer l'enjeu. Seules les sources françaises **non ambiguës** y figurent.
+# --------------------------------------------------------------------------
+CORRECTIONS: tuple[Correction, ...] = (
+    Correction(
+        source_id="f88f4548-eca5-4c85-92c7-301d8434c701",
+        expected_name="Home Fil actu - actualités",
+        evidence="bfmtv.com/rss/news-24-7 — fil 24/7 de BFMTV, 4 803 art./30 j, "
+        "nom = titre RSS de la home mal parsé ; seule entrée BFMTV du catalogue",
+        name="BFMTV",
+        language="fr",
+    ),
+    Correction(
+        source_id="ae1e5e0f-dd3c-40e7-86dd-31cd14710002",
+        expected_name="L'Équipe - L'actualité du sport en continu.",
+        evidence="dwh.lequipe.fr — 3 065 art./30 j ; classée `culture`, donc "
+        "invisible au mute `sport` alors que c'est un média 100 % sport",
+        language="fr",
+        theme="sport",
+    ),
+    Correction(
+        source_id="df46726f-26ee-4469-9bf2-08245304cea5",
+        expected_name="Libération - Politique",
+        evidence="liberation.fr — 1 347 art./30 j ; `custom` alors que le flux "
+        "est la rubrique Politique",
+        language="fr",
+        theme="politics",
+    ),
+    Correction(
+        source_id="f07f88dc-ddc5-4dbe-b951-1bf90e89eb86",
+        expected_name="CNEWS",
+        evidence="cnews.fr — 1 318 art./30 j",
+        language="fr",
+    ),
+    Correction(
+        source_id="b8e4dfb0-87e5-434e-b54c-a59c49ce2fdc",
+        expected_name="The Conversation",
+        evidence="theconversation.com/fr — édition française, 250 art./30 j",
+        language="fr",
+    ),
+    Correction(
+        source_id="e6a87c97-22dc-470b-bec7-99aea5d610b5",
+        expected_name="POLITIS",
+        evidence="politis.fr — 71 art./30 j",
+        language="fr",
+    ),
+    Correction(
+        source_id="460f4601-47a8-4e66-be60-e03c6dbb150d",
+        expected_name="JeuxOnline.info",
+        evidence="jeuxonline.info — 59 art./30 j",
+        language="fr",
+    ),
+    Correction(
+        source_id="41497cf6-4b3d-4959-a7dd-33f501f867b4",
+        expected_name="Le Point",
+        evidence="lepoint.fr — 50 art./30 j",
+        language="fr",
+    ),
+    Correction(
+        source_id="31af28bd-7d05-4c64-af96-9ee47fee6f5e",
+        expected_name="Contexte - European Political News and Policy Insights",
+        evidence="contexte.com — média français, 48 art./30 j ; le titre du flux "
+        "est en anglais, d'où le mauvais tag",
+        language="fr",
+    ),
+    Correction(
+        source_id="2cb53520-5701-4ffa-8379-24657e615405",
+        expected_name="RSS Reggae.fr - les news",
+        evidence="reggae.fr — 32 art./30 j",
+        language="fr",
+    ),
+    Correction(
+        source_id="ec765de2-835c-4e57-a192-19d6e0b18d75",
+        expected_name="FrenchWeb",
+        evidence="frenchweb.fr — 29 art./30 j",
+        language="fr",
+    ),
+    Correction(
+        source_id="26b05d76-4fda-45d2-b5ec-4548c8c77650",
+        expected_name="Society",
+        evidence="society.fr — 22 art./30 j ; magazine société classé `tech`",
+        language="fr",
+        theme="society",
+    ),
+    Correction(
+        source_id="188eb0f7-031a-4e78-96f0-b77f035a6f42",
+        expected_name="HugoDécrypte - Grands formats",
+        evidence="chaîne YouTube française, 20 art./30 j",
+        language="fr",
+    ),
+)
+
+
+@dataclass
+class Write:
+    source_id: str
+    name: str
+    changes: dict[str, tuple[str | None, str]]  # champ -> (avant, après)
+
+
+@dataclass
+class Plan:
+    writes: list[Write] = field(default_factory=list)
+    noop: list[str] = field(default_factory=list)  # déjà à la bonne valeur
+    missing: list[str] = field(default_factory=list)  # id absent de la base
+    renamed: list[str] = field(default_factory=list)  # expected_name ne colle plus
+
+
+def compute_changes(
+    corrections: tuple[Correction, ...] | list[Correction],
+    current: dict[str, dict[str, str | None]],
+) -> Plan:
+    """Diff pur entre la table de corrections et l'état lu en base.
+
+    `current` : source_id (str) -> {"name", "language", "theme"}.
+    Aucune I/O : c'est la fonction couverte par les tests.
+    """
+    plan = Plan()
+    for corr in corrections:
+        row = current.get(corr.source_id)
+        if row is None:
+            plan.missing.append(f"{corr.expected_name} ({corr.source_id})")
+            continue
+        # Le nom en base doit être celui de l'audit — ou déjà celui qu'on veut
+        # écrire, sinon le renommage rendrait le script non rejouable.
+        if row.get("name") not in {corr.expected_name, corr.name or corr.expected_name}:
+            plan.renamed.append(
+                f"{corr.source_id} : attendu « {corr.expected_name} », "
+                f"trouvé « {row.get('name')} »"
+            )
+            continue
+
+        changes = {
+            fld: (row.get(fld), value)
+            for fld, value in corr.desired().items()
+            if row.get(fld) != value
+        }
+        if not changes:
+            plan.noop.append(corr.expected_name)
+            continue
+        plan.writes.append(
+            Write(source_id=corr.source_id, name=corr.expected_name, changes=changes)
+        )
+    return plan
+
+
+async def _load_current(session) -> dict[str, dict[str, str | None]]:
+    ids = [UUID(c.source_id) for c in CORRECTIONS]
+    result = await session.execute(
+        select(Source.id, Source.name, Source.language, Source.theme).where(
+            Source.id.in_(ids)
+        )
+    )
+    return {
+        str(r.id): {"name": r.name, "language": r.language, "theme": r.theme}
+        for r in result
+    }
+
+
+async def _audit(session) -> None:
+    """Anomalies volontairement **non** corrigées ici — à arbitrer séparément."""
+    null_lang = await session.scalar(
+        select(func.count())
+        .select_from(Source)
+        .where(Source.is_active.is_(True), Source.language.is_(None))
+    )
+    active = await session.scalar(
+        select(func.count()).select_from(Source).where(Source.is_active.is_(True))
+    )
+    print("-" * 78)
+    print("AUDIT (non muté — décisions séparées) :")
+    print(
+        f"  • language IS NULL : {null_lang}/{active} sources actives. "
+        "NON rempli par ce script : `is_foreign_source(None)` vaut False, donc "
+        "un NULL est déjà traité comme FR. Renseigner la colonne masquerait "
+        "nouvellement les sources étrangères pour les users à "
+        "`hide_non_fr_sources = true`."
+    )
+
+    cutoff = datetime.now(UTC) - timedelta(days=30)
+    dead = await session.execute(
+        select(Source.name, Source.id)
+        .outerjoin(
+            Content,
+            (Content.source_id == Source.id) & (Content.published_at >= cutoff),
+        )
+        .where(Source.is_active.is_(True), Source.is_curated.is_(True))
+        .group_by(Source.id, Source.name)
+        .having(func.count(Content.id) == 0)
+        .order_by(Source.name)
+    )
+    rows = list(dead)
+    print(f"  • {len(rows)} source(s) curée(s) et active(s) à 0 article/30 j :")
+    for r in rows[:20]:
+        print(f"      - {r.name} ({r.id})")
+    if len(rows) > 20:
+        print(f"      … et {len(rows) - 20} autres")
+    print("-" * 78)
+
+
+def _render(plan: Plan) -> None:
+    print(f"\n{len(plan.writes)} source(s) à corriger :")
+    for w in plan.writes:
+        print(f"  • {w.name} ({w.source_id})")
+        for fld, (before, after) in sorted(w.changes.items()):
+            print(f"      {fld} : {before!r} -> {after!r}")
+    if plan.noop:
+        print(f"\n{len(plan.noop)} déjà à jour (no-op) : {', '.join(plan.noop)}")
+    if plan.renamed:
+        print(f"\n{len(plan.renamed)} IGNORÉE(S) — renommée(s) depuis l'audit :")
+        for line in plan.renamed:
+            print(f"  ! {line}")
+    if plan.missing:
+        print(f"\n{len(plan.missing)} INTROUVABLE(S) en base :")
+        for line in plan.missing:
+            print(f"  ! {line}")
+
+
+async def run(apply: bool, allow_prod: bool) -> int:
+    settings = get_settings()
+    db_url = settings.database_url or ""
+    is_test = _is_test_db(db_url)
+    print(
+        f"DB cible : {db_url.split('@')[-1] if '@' in db_url else db_url}  (test={is_test})"
+    )
+    if apply and not is_test and not allow_prod:
+        print("\nABORT : --apply contre une DB non-test sans --allow-prod (gated PO).")
+        return 2
+
+    async with async_session_maker() as session:
+        try:
+            current = await _load_current(session)
+            plan = compute_changes(CORRECTIONS, current)
+            _render(plan)
+            await _audit(session)
+
+            if plan.missing or plan.renamed:
+                print(
+                    "\nABORT : la table de corrections ne colle plus à la base "
+                    "(source introuvable ou renommée). Relire avant d'appliquer."
+                )
+                return 2
+            if not plan.writes:
+                print("\n(no-op — toutes les corrections sont déjà en base.)")
+                return 0
+            if not apply:
+                print("\n(dry-run — aucune mutation. Relance avec --apply.)")
+                return 0
+
+            for w in plan.writes:
+                await session.execute(
+                    update(Source)
+                    .where(Source.id == UUID(w.source_id))
+                    .values(**{f: after for f, (_, after) in w.changes.items()})
+                )
+            await session.commit()
+            print(f"\nAPPLIQUÉ : {len(plan.writes)} source(s) corrigée(s).")
+            return 0
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await engine.dispose()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply", action="store_true", help="exécute (défaut: dry-run)"
+    )
+    parser.add_argument(
+        "--allow-prod", action="store_true", help="autorise --apply hors DB de test"
+    )
+    args = parser.parse_args()
+    sys.exit(asyncio.run(run(apply=args.apply, allow_prod=args.allow_prod)))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/api/tests/scripts/test_fix_source_metadata.py
+++ b/packages/api/tests/scripts/test_fix_source_metadata.py
@@ -1,0 +1,124 @@
+"""Tests pour scripts/fix_source_metadata.py.
+
+Couvre la logique **pure** (`compute_changes`, sans DB) : diff champ par champ,
+no-op idempotent, garde-fou `expected_name`, source introuvable, et l'intégrité
+de la table `CORRECTIONS` elle-même (pas de doublon, pas de champ hors
+`MUTABLE_FIELDS`, chaque ligne porte au moins une correction et une preuve).
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from scripts.fix_source_metadata import (
+    CORRECTIONS,
+    MUTABLE_FIELDS,
+    Correction,
+    compute_changes,
+)
+
+
+def _corr(sid: str, **kwargs) -> Correction:
+    kwargs.setdefault("expected_name", "Src")
+    kwargs.setdefault("evidence", "preuve")
+    return Correction(source_id=sid, **kwargs)
+
+
+def _current(sid: str, *, name="Src", language=None, theme="society"):
+    return {sid: {"name": name, "language": language, "theme": theme}}
+
+
+def test_diff_only_reports_fields_that_actually_change():
+    sid = str(uuid4())
+    plan = compute_changes(
+        [_corr(sid, language="fr", theme="sport")],
+        _current(sid, language="en", theme="sport"),
+    )
+    assert len(plan.writes) == 1
+    # `theme` est déjà bon -> absent du diff ; seul `language` est écrit.
+    assert plan.writes[0].changes == {"language": ("en", "fr")}
+
+
+def test_noop_when_already_correct_is_idempotent():
+    sid = str(uuid4())
+    plan = compute_changes(
+        [_corr(sid, language="fr", theme="sport")],
+        _current(sid, language="fr", theme="sport"),
+    )
+    assert plan.writes == []
+    assert plan.noop == ["Src"]
+
+
+def test_null_language_is_a_real_change():
+    sid = str(uuid4())
+    plan = compute_changes([_corr(sid, language="fr")], _current(sid, language=None))
+    assert plan.writes[0].changes == {"language": (None, "fr")}
+
+
+def test_rename_writes_name_field():
+    sid = str(uuid4())
+    plan = compute_changes(
+        [_corr(sid, expected_name="Home Fil actu", name="BFMTV", language="fr")],
+        _current(sid, name="Home Fil actu", language="en"),
+    )
+    assert plan.writes[0].changes["name"] == ("Home Fil actu", "BFMTV")
+
+
+def test_expected_name_mismatch_is_refused_not_written():
+    """Garde-fou : la source a été renommée depuis l'audit -> on n'écrit pas."""
+    sid = str(uuid4())
+    plan = compute_changes(
+        [_corr(sid, expected_name="Ancien nom", language="fr")],
+        _current(sid, name="Nouveau nom", language="en"),
+    )
+    assert plan.writes == []
+    assert len(plan.renamed) == 1
+    assert "Ancien nom" in plan.renamed[0]
+
+
+def test_missing_source_is_reported_not_written():
+    plan = compute_changes([_corr(str(uuid4()), language="fr")], {})
+    assert plan.writes == []
+    assert len(plan.missing) == 1
+
+
+def test_desired_ignores_untouched_fields():
+    c = _corr(str(uuid4()), language="fr")
+    assert c.desired() == {"language": "fr"}
+
+
+# --- intégrité de la table livrée -----------------------------------------
+
+
+def test_corrections_table_has_no_duplicate_ids():
+    ids = [c.source_id for c in CORRECTIONS]
+    assert len(ids) == len(set(ids))
+
+
+@pytest.mark.parametrize("corr", CORRECTIONS, ids=lambda c: c.expected_name)
+def test_each_correction_is_actionable_and_documented(corr: Correction):
+    desired = corr.desired()
+    assert desired, f"{corr.expected_name} ne corrige aucun champ"
+    assert set(desired) <= set(MUTABLE_FIELDS)
+    assert corr.evidence.strip(), f"{corr.expected_name} n'a pas de preuve"
+
+
+def test_table_applied_twice_is_a_noop():
+    """Idempotence de bout en bout sur la vraie table : après application, un
+    second run ne produit plus aucune écriture."""
+    after = {
+        c.source_id: {
+            "name": c.name or c.expected_name,
+            "language": None,
+            "theme": None,
+        }
+        | c.desired()
+        for c in CORRECTIONS
+    }
+    plan = compute_changes(CORRECTIONS, after)
+    assert plan.writes == []
+    assert plan.renamed == []
+    assert plan.missing == []
+    assert len(plan.noop) == len(CORRECTIONS)


### PR DESCRIPTION
# fix(curation): socle de mesure + métadonnées fausses du catalogue de sources

Base `main`. **Aucune migration.** Backend-only (0 fichier mobile).

## Contexte

Premier livrable du lot « qualité de la curation ». Deux griefs PO — « mon
intérêt pour l'IA ne remonte pas dans les 1ers articles » et « le contenu semble
anecdotique » — ont une seule cause mécanique, en amont d'`essentiel_service`.
Cette PR pose le **socle de mesure** et corrige les **métadonnées fausses du
catalogue**.

Diagnostic complet : `docs/bugs/bug-curation-essentiel-personnalisation.md`.

## 1. La baseline, figée et rejouable

`docs/qa/scripts/baseline_curation.sql` +
`docs/bugs/bug-curation-essentiel-personnalisation-baseline.md`.

Prérequis appliqué en prod le 01/08 : `ALTER ROLE claude_analytics_ro BYPASSRLS;`
Avant ça, `daily_digest` / `contents` / `user_content_status` renvoyaient **0
ligne** au rôle analytics — la jauge CTR tournait **sans erreur** et rapportait un
CTR vide. Vérifié après : 20 135 / 73 282 / 5 561 lignes visibles, et le rôle
**reste en lecture seule** (`permission denied` sur `UPDATE`).

| Métrique | Baseline 01/08 | Cible P0+P1 |
|---|---|---|
| Slots top-5 quasi-universels (`pour_vous`) | **80,8 %** | < 60 % |
| Slots top-5 issus d'une source suivie | **16,3 %** | ≥ 35 % |
| Part de `society` dans le top-5 | **42,7 %** | < 30 % |
| Part des 5 pourvoyeurs dans le top-5 | **62,8 %** | < 45 % |
| CTR global top-5 | **1,41 %** | ne pas dégrader |

Le gradient qui porte tout le dossier : **un slot issu d'une source suivie
convertit à 3,58 % contre 0,99 %** — et n'obtient que 16,3 % du top-5, pendant que
**37,4 %** de la personnalisation est reléguée en rang 6-10, que la carte tronque.

## 2. `scripts/fix_source_metadata.py`

Dry-run par défaut, `--apply --allow-prod` gardé, idempotent, table de corrections
**explicite et relue** (pas d'heuristique), garde-fou `expected_name` qui refuse
d'écrire si une source a été renommée depuis l'audit.

13 sources, toutes des médias français taggés `language = 'en'` par un titre de
flux en anglais :

| Source | Correction | Art./30 j |
|---|---|---|
| `Home Fil actu - actualités` → **`BFMTV`** | nom + `en`→`fr` | 4 803 |
| L'Équipe | `en`→`fr`, `culture`→**`sport`** | 3 065 |
| Libération - Politique | `en`→`fr`, `custom`→**`politics`** | 1 347 |
| CNEWS | `en`→`fr` | 1 318 |
| Society (society.fr) | `en`→`fr`, `tech`→**`society`** | 22 |

## Trois choses que la mesure a corrigées dans le plan d'origine

1. **La prémisse de B-1 était fausse.** Le plan justifiait le fix `language` par
   « le pool éditorial filtre sur la langue ». Vérifié : `build_editorial_pool_stmt`
   (`editorial/candidate_pool.py:126-156`) n'a **aucune** clause `language`.
   ⇒ Ces corrections **ne bougent aucune métrique de baseline aujourd'hui** ;
   c'est un **prérequis de la PR 5** (rebranchement du pool personnalisé, qui lui
   filtre sur la langue, `digest_selector.py:1008-1009`). Le fix `theme` est en
   revanche actif tout de suite : un user qui mute `sport` recevait quand même les
   3 065 art./30 j de L'Équipe, rangés en `culture`.

2. **La colonne « CTR top-5 » du §4 du plan était fausse** — elle donnait les 5
   pourvoyeurs à 0,00-0,02 %, arithmétiquement impossible avec un CTR global à
   1,41 %. Mesuré : **1,24 % contre 1,71 %** pour le reste, soit ×1,4. L'argument
   de B-2 tient sur la **composition** (62,8 % de la surface héros pour une
   couverture qui survit à 68-88 % sans elles), **pas** sur un CTR nul.

3. **Trouvaille nouvelle : 18 sources curées, actives, à 0 article/30 j** — France
   Inter, Les Échos, Libération, Le Point, Brut, Alternatives Économiques,
   Fouloscopie, Heu?reka, Monsieur Phi, ScienceEtonnante… Et des **doublons** :
   `Le Point` et `Libération` existent en deux entrées, la **curée est morte**, la
   **non curée est vivante** (et mal taggée). Le catalogue perd ses meilleures
   sources pendant que le fil brut de BFMTV produit 4 803 articles/30 j.
   ⇒ Troisième angle sur « anecdotique », vu par aucun des deux rapports. À cadrer
   en chantier propre, **pas** bricolé dans ce script.

## Ce que le script ne fait pas, volontairement

**Il ne remplit pas les 206 `language IS NULL`** (64 % des sources actives).
`is_foreign_source(None)` vaut `False` : un NULL est **déjà** traité comme FR.
Renseigner la colonne rendrait *nouvellement invisibles* les sources réellement
étrangères pour les **51 users** à `hide_non_fr_sources = true`. Changement de
comportement produit ⇒ décision PO séparée, pas de l'hygiène.

## Tests

- `tests/scripts/test_fix_source_metadata.py` — **22 tests** : diff champ par
  champ, idempotence de bout en bout sur la vraie table, garde-fou
  `expected_name`, source introuvable, intégrité de la table livrée.
- Dry-run joué **contre la prod en lecture seule** : 13 sources à corriger, 0
  introuvable, 0 renommée.
- `docs/qa/scripts/baseline_curation.sql` rejoué : 7 blocs, aucune erreur.
- Suite backend complète + `ruff check` / `ruff format` OK.
- **Aucune migration Alembic** (DML pure), **aucun fichier existant modifié** —
  la PR est purement additive.

## Après merge

`python3 scripts/fix_source_metadata.py --apply --allow-prod` — étape PO
post-merge, comme pour `apply_source_reclassification.py`.

## Suite du lot

PR 2 (B-2 fold couverture) · PR 3 (C-1 fabrication d'intérêts + unicité) ·
PR 4-5 (A : score mixte pondéré, `is_multi` retiré, pool perso rebranché) ·
PR 6 (C-2 taux lissés).
