### PR TITLE
feat(premium): soutien à prix libre (Stripe + Premium in-app)

### DIFF
--- a/apps/landing/emails/soutien-magic-link.html
+++ b/apps/landing/emails/soutien-magic-link.html
@@ -1,0 +1,157 @@
+<!--
+  Facteur · Email « Magic Link » de soutien (option c)
+  ====================================================
+  SOURCE DE VÉRITÉ VERSIONNÉE. Ce fichier n'est pas servi par nginx.
+  Il se colle dans : Supabase → Authentication → Email Templates → « Magic Link ».
+
+  Objet suggéré (champ « Subject heading » de Supabase) :
+      Merci pour ta demande de soutien
+
+  Variable Supabase utilisée : {{ .ConfirmationURL }} (le lien de connexion,
+  dont le redirect_to pointe vers https://facteur.app/soutenir?t=<token>).
+
+  Contraintes respectées :
+    - HTML email : layout en <table>, styles inline, pas de CSS externe/variables.
+    - Polices web (Fraunces) chargées pour les clients qui les supportent
+      (Apple Mail), avec repli Georgia/serif partout ailleurs (Gmail, Outlook).
+    - Palette manifeste : crème #faf8f5, encre #2C2A29, orange #d4652a.
+    - Ton sobre (pas de fausse lettre personnifiée), aucune em-dash « — ».
+-->
+<!DOCTYPE html>
+<html lang="fr" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="light only">
+  <meta name="supported-color-schemes" content="light only">
+  <title>Rejoindre Facteur</title>
+  <!--[if !mso]><!-->
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700&display=swap" rel="stylesheet">
+  <!--<![endif]-->
+  <style>
+    a { text-decoration: none; }
+    @media only screen and (max-width: 620px) {
+      .fct-card { width: 100% !important; border-radius: 0 !important; }
+      .fct-pad { padding-left: 24px !important; padding-right: 24px !important; }
+    }
+  </style>
+</head>
+<body style="margin:0; padding:0; background-color:#faf8f5; -webkit-text-size-adjust:100%; -ms-text-size-adjust:100%;">
+  <!-- Préheader (masqué) : première ligne visible dans l'aperçu boîte mail. -->
+  <div style="display:none; max-height:0; overflow:hidden; opacity:0; mso-hide:all;">
+    Ton lien pour rejoindre Facteur et soutenir une info libre. Il t'attend une heure.
+  </div>
+
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#faf8f5;">
+    <tr>
+      <td align="center" style="padding:32px 16px 40px 16px;">
+
+        <!-- Carte -->
+        <table role="presentation" class="fct-card" width="560" cellpadding="0" cellspacing="0" border="0" style="width:560px; max-width:560px; background-color:#ffffff; border:1px solid #eadfce; border-radius:16px; overflow:hidden;">
+
+          <!-- Marque -->
+          <tr>
+            <td class="fct-pad" style="padding:32px 44px 0 44px;">
+              <span style="font-family:'Fraunces',Georgia,serif; font-weight:700; font-size:20px; letter-spacing:-0.4px; color:#2C2A29;">Facteur</span>
+            </td>
+          </tr>
+
+          <!-- Titre -->
+          <tr>
+            <td class="fct-pad" style="padding:20px 44px 0 44px;">
+              <h1 style="margin:0; font-family:'Fraunces',Georgia,'Times New Roman',serif; font-weight:600; font-size:26px; line-height:1.24; color:#2C2A29; letter-spacing:-0.3px;">
+                Merci pour ta demande de soutien.
+              </h1>
+            </td>
+          </tr>
+
+          <!-- Corps -->
+          <tr>
+            <td class="fct-pad" style="padding:18px 44px 0 44px;">
+              <p style="margin:0 0 16px 0; font-family:Helvetica,Arial,sans-serif; font-size:16px; line-height:1.62; color:#3a3735;">
+                Facteur ne pourra exister et rester indépendant que grâce à vos donations.
+              </p>
+              <p style="margin:0 0 16px 0; font-family:Helvetica,Arial,sans-serif; font-size:16px; line-height:1.62; color:#3a3735;">
+                Nous sommes et resterons une application ouverte, sans pub ni actionnaire
+                pour orienter l'information. L'info qu'on te livre ne tient que si celles
+                et ceux qui y croient la financent. Et elle coûte cher à produire :
+                collecte des articles, stockage, calculs des préférences utilisateurs,
+                pipelines IA pour les analyses et les évaluations&hellip;
+              </p>
+              <p style="margin:0 0 4px 0; font-family:Helvetica,Arial,sans-serif; font-size:16px; line-height:1.62; color:#3a3735;">
+                En nous rejoignant, tu t'ajoutes aux premiers
+                <strong style="color:#2C2A29;">Fact&middot;eur&middot;isses</strong> qui
+                façonnent ce projet, à un moment charnière pour notre démocratie et pour
+                notre pays. Et pour cela, nous t'en sommes d'avance infiniment reconnaissants.
+              </p>
+            </td>
+          </tr>
+
+          <!-- CTA -->
+          <tr>
+            <td class="fct-pad" align="left" style="padding:24px 44px 6px 44px;">
+              <!--[if mso]>
+              <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{ .ConfirmationURL }}" style="height:52px;v-text-anchor:middle;width:280px;" arcsize="50%" fillcolor="#d4652a" strokecolor="#d4652a">
+                <w:anchorlock/>
+                <center style="color:#ffffff;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:bold;">Choisir mon soutien</center>
+              </v:roundrect>
+              <![endif]-->
+              <!--[if !mso]><!-->
+              <a href="{{ .ConfirmationURL }}" target="_blank" style="display:inline-block; background-color:#d4652a; color:#ffffff; font-family:Helvetica,Arial,sans-serif; font-size:16px; font-weight:700; line-height:52px; text-align:center; padding:0 34px; border-radius:100px;">
+                Choisir mon soutien &rarr;
+              </a>
+              <!--<![endif]-->
+            </td>
+          </tr>
+
+          <!-- Signature -->
+          <tr>
+            <td class="fct-pad" style="padding:20px 44px 0 44px;">
+              <p style="margin:0; font-family:Helvetica,Arial,sans-serif; font-size:16px; font-weight:600; color:#2C2A29;">
+                Django &amp; Laurin
+              </p>
+            </td>
+          </tr>
+
+          <!-- Réassurance -->
+          <tr>
+            <td class="fct-pad" style="padding:14px 44px 0 44px;">
+              <p style="margin:0; font-family:Helvetica,Arial,sans-serif; font-size:13.5px; line-height:1.6; color:#7a7570;">
+                Le paiement sécurisé par Stripe &middot; c'est résiliable en un geste et
+                sans engagement &middot; tu soutiens le montant que tu veux, aussi longtemps
+                que tu le veux.
+              </p>
+            </td>
+          </tr>
+
+          <!-- Séparateur -->
+          <tr>
+            <td class="fct-pad" style="padding:26px 44px 0 44px;">
+              <div style="height:1px; line-height:1px; font-size:1px; background-color:#eadfce;">&nbsp;</div>
+            </td>
+          </tr>
+
+          <!-- Pied de page -->
+          <tr>
+            <td class="fct-pad" style="padding:20px 44px 34px 44px;">
+              <p style="margin:0 0 10px 0; font-family:Helvetica,Arial,sans-serif; font-size:12.5px; line-height:1.6; color:#9a938c;">
+                Ce lien t'attend pendant une heure. Le bouton ne s'ouvre pas ?
+                Copie cette adresse dans ton navigateur :
+              </p>
+              <p style="margin:0 0 16px 0; font-family:'Courier Prime','Courier New',monospace; font-size:12px; line-height:1.5; word-break:break-all;">
+                <a href="{{ .ConfirmationURL }}" target="_blank" style="color:#a24a1e; text-decoration:underline;">{{ .ConfirmationURL }}</a>
+              </p>
+              <p style="margin:0; font-family:Helvetica,Arial,sans-serif; font-size:12.5px; line-height:1.6; color:#9a938c;">
+                Tu n'as rien demandé ? Ignore simplement cet email : personne ne
+                pourra se connecter à ta place, et il n'y aura aucune suite.
+              </p>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/apps/landing/nginx.conf.template
+++ b/apps/landing/nginx.conf.template
@@ -9,6 +9,14 @@ server {
         try_files /methodologie.html =404;
     }
 
+    location = /soutenir {
+        try_files /soutenir.html =404;
+    }
+
+    location = /soutenir-merci {
+        try_files /soutenir-merci.html =404;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/apps/landing/public/index.html
+++ b/apps/landing/public/index.html
@@ -657,6 +657,7 @@
             </div>
             <div class="footer__links">
                 <a href="/blog.html" class="footer__link">Blog</a>
+                <a href="/soutenir" class="footer__link">Soutenir</a>
                 <a href="/premium.html" class="footer__link">Premium</a>
                 <a href="/methodologie" class="footer__link">Méthodologie</a>
                 <a href="/politique-confidentialite.html" class="footer__link">Politique de confidentialité</a>

--- a/apps/landing/public/js/soutenir.js
+++ b/apps/landing/public/js/soutenir.js
@@ -1,0 +1,172 @@
+/* Facteur Landing - Soutien à prix libre (Stripe)
+ *
+ * Flow : la page reçoit soit un token signé `?t=` (parcours app -> email -> web),
+ * soit rien (visiteur anonyme -> on demande l'email). Au submit :
+ *   POST /api/checkout/create-stripe-session { token|email, amount_cents }
+ *   -> redirection vers l'URL Stripe Checkout hébergée.
+ * Bornes montant alignées sur stripe_support_min_cents / _max_cents (2 / 100 EUR).
+ */
+(function () {
+    'use strict';
+
+    var API_URL = 'https://facteur-production.up.railway.app';
+    var MIN_CENTS = 200;
+    var MAX_CENTS = 10000;
+
+    var token = new URLSearchParams(window.location.search).get('t');
+
+    var amountBtns = Array.prototype.slice.call(document.querySelectorAll('.amt'));
+    var customInput = document.getElementById('custom-amount');
+    var emailRow = document.getElementById('email-row');
+    var emailInput = document.getElementById('email');
+    var submitBtn = document.getElementById('submit');
+    var errorEl = document.getElementById('error');
+
+    // Sans token signé, on a besoin de l'email pour relier le soutien au compte.
+    if (!token && emailRow) emailRow.hidden = false;
+
+    function showError(msg) {
+        if (!errorEl) return;
+        errorEl.textContent = msg;
+        errorEl.hidden = false;
+    }
+
+    function clearError() {
+        if (errorEl) errorEl.hidden = true;
+    }
+
+    function selectPreset(btn) {
+        amountBtns.forEach(function (b) { b.classList.remove('amt--on'); });
+        btn.classList.add('amt--on');
+        if (customInput) customInput.value = '';
+    }
+
+    amountBtns.forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            clearError();
+            selectPreset(btn);
+        });
+    });
+
+    if (customInput) {
+        customInput.addEventListener('input', function () {
+            clearError();
+            // Une saisie custom désélectionne les presets.
+            if (customInput.value) {
+                amountBtns.forEach(function (b) { b.classList.remove('amt--on'); });
+            }
+        });
+    }
+
+    function selectedAmountCents() {
+        var euros;
+        if (customInput && customInput.value) {
+            euros = parseFloat(customInput.value.replace(',', '.'));
+        } else {
+            var on = document.querySelector('.amt--on');
+            euros = on ? parseFloat(on.getAttribute('data-amount')) : NaN;
+        }
+        if (!isFinite(euros)) return NaN;
+        return Math.round(euros * 100);
+    }
+
+    // Mur des soutiens : n'affiche QUE les messages modérés (published côté API).
+    // La section reste masquée s'il n'y en a aucun. Rendu via textContent -> pas
+    // d'injection HTML depuis un texte utilisateur.
+    function loadWall() {
+        fetch(API_URL + '/api/checkout/support-messages')
+            .then(function (r) { return r.ok ? r.json() : []; })
+            .then(function (list) {
+                if (!Array.isArray(list) || !list.length) return;
+                var wall = document.getElementById('wall');
+                var host = document.getElementById('wall-list');
+                if (!wall || !host) return;
+                list.forEach(function (m) {
+                    var card = document.createElement('div');
+                    card.style.cssText =
+                        'background:#fff;border:1px solid #eadfce;border-radius:14px;padding:16px 18px';
+                    var p = document.createElement('p');
+                    p.style.cssText =
+                        'margin:0;font-size:15px;line-height:1.55;color:#3a3735';
+                    p.textContent = m.message;
+                    card.appendChild(p);
+                    if (m.display_name) {
+                        var n = document.createElement('p');
+                        n.style.cssText =
+                            'margin:8px 0 0;font-size:13px;color:#8a847f';
+                        n.textContent = m.display_name;
+                        card.appendChild(n);
+                    }
+                    host.appendChild(card);
+                });
+                wall.hidden = false;
+            })
+            .catch(function () { /* le mur est optionnel : on ignore les erreurs */ });
+    }
+    loadWall();
+
+    submitBtn.addEventListener('click', function () {
+        clearError();
+
+        var amountCents = selectedAmountCents();
+        if (isNaN(amountCents)) {
+            showError('Choisis ou saisis un montant.');
+            return;
+        }
+        if (amountCents < MIN_CENTS || amountCents > MAX_CENTS) {
+            showError('Le montant doit être compris entre 2 et 100 euros par mois.');
+            return;
+        }
+
+        var payload = { amount_cents: amountCents };
+        if (token) {
+            payload.token = token;
+        } else {
+            var email = (emailInput && emailInput.value || '').trim();
+            if (!email) {
+                showError('Indique ton email pour continuer.');
+                return;
+            }
+            payload.email = email;
+        }
+
+        var msgEl = document.getElementById('message');
+        var msg = (msgEl && msgEl.value || '').trim();
+        if (msg) payload.message = msg;
+
+        var originalLabel = submitBtn.textContent;
+        submitBtn.disabled = true;
+        submitBtn.textContent = '...';
+
+        fetch(API_URL + '/api/checkout/create-stripe-session', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        })
+            .then(function (res) {
+                if (!res.ok) {
+                    return res.json().then(function (data) {
+                        throw new Error((data && data.detail) || 'Erreur');
+                    });
+                }
+                return res.json();
+            })
+            .then(function (data) {
+                if (data && data.url) {
+                    window.location.href = data.url;
+                } else {
+                    throw new Error('Réponse invalide');
+                }
+            })
+            .catch(function (err) {
+                var msg = 'Impossible de démarrer le paiement. Réessaie ?';
+                if (err && /expired|invalid/i.test(err.message)) {
+                    msg = 'Ton lien a expiré. Reviens dans l\'app et redemande un lien.';
+                }
+                showError(msg);
+                submitBtn.textContent = originalLabel;
+                submitBtn.disabled = false;
+                if (window.console) console.warn('create-stripe-session failed', err);
+            });
+    });
+})();

--- a/apps/landing/public/soutenir-merci.html
+++ b/apps/landing/public/soutenir-merci.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="fr">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Facteur · Merci pour ton soutien</title>
+    <meta name="robots" content="noindex">
+    <link rel="canonical" href="https://facteur.app/soutenir-merci">
+    <link rel="icon" type="image/png" href="favicon.png">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+        href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700&family=DM+Sans:wght@400;600;700&display=swap"
+        rel="stylesheet">
+    <style>
+    :root{
+      --font-serif:'Fraunces',Georgia,serif;
+      --font-sans:'DM Sans',system-ui,-apple-system,sans-serif;
+      --acc:#d4652a;
+      --acc-ink:color-mix(in srgb,var(--acc) 78%,black);
+    }
+    body{margin:0;background:#faf8f5;color:#2C2A29;font-family:var(--font-sans);-webkit-font-smoothing:antialiased;min-height:100vh;display:grid;place-items:center;padding:24px}
+    .card{max-width:520px;width:100%;background:#fff;border:1px solid #eadfce;border-radius:18px;padding:clamp(28px,6vw,44px);text-align:center}
+    </style>
+</head>
+
+<body>
+  <div class="card">
+    <img src="favicon.png" alt="Logo Facteur" style="width:40px;height:40px;border-radius:10px;margin:0 auto 18px;display:block">
+    <h1 style="font-family:var(--font-serif);font-weight:600;font-size:clamp(26px,5vw,34px);line-height:1.18;letter-spacing:-0.4px;margin:0">
+      Merci, ton soutien est en route.
+    </h1>
+    <p style="font-size:17px;line-height:1.6;color:#5D5B5A;margin:16px 0 0">
+      Tu comptes maintenant parmi les premiers Fact&middot;eur&middot;isses. Ton
+      accès s'active dans quelques instants : rouvre l'application Facteur, il t'y
+      attend.
+    </p>
+    <p style="font-size:14px;line-height:1.6;color:#8a847f;margin:22px 0 0">
+      Django &amp; Laurin
+    </p>
+  </div>
+</body>
+
+</html>

--- a/apps/landing/public/soutenir.html
+++ b/apps/landing/public/soutenir.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="fr">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Facteur · Soutenir une info libre</title>
+    <meta name="description"
+        content="Soutiens Facteur à prix libre : une info ouverte, sans pub ni actionnaire. Tu choisis ton montant mensuel, résiliable en un geste.">
+    <meta property="og:title" content="Facteur · Soutenir une info libre">
+    <meta property="og:description"
+        content="Une info ouverte, sans pub ni actionnaire. Tu choisis ton montant mensuel, résiliable en un geste.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://facteur.app/soutenir">
+    <meta name="robots" content="noindex">
+    <link rel="canonical" href="https://facteur.app/soutenir">
+
+    <link rel="icon" type="image/png" href="favicon.png">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+        href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700&family=DM+Sans:wght@400;600;700&family=Courier+Prime:wght@400;700&display=swap"
+        rel="stylesheet">
+
+    <style>
+    :root{
+      --font-serif:'Fraunces',Georgia,serif;
+      --font-sans:'DM Sans',system-ui,-apple-system,sans-serif;
+      --font-mono:'Courier Prime','Courier New',monospace;
+      --acc:#d4652a;
+      --acc-ink:color-mix(in srgb,var(--acc) 78%,black);
+      --cream:#faf8f5;
+      --ink:#2C2A29;
+    }
+    *{box-sizing:border-box}
+    html{overflow-x:clip}
+    body{margin:0;background:var(--cream);color:var(--ink);font-family:var(--font-sans);-webkit-font-smoothing:antialiased}
+    a{color:var(--acc-ink)}
+    a:focus-visible,button:focus-visible,input:focus-visible{outline:2px solid var(--acc);outline-offset:2px}
+    ::selection{background:color-mix(in srgb,var(--acc) 22%,transparent)}
+    [hidden]{display:none!important}
+
+    .wrap{max-width:620px;margin:0 auto;padding:0 20px}
+    .card{background:#fff;border:1px solid #eadfce;border-radius:18px;padding:clamp(24px,5vw,40px)}
+
+    .amounts{display:flex;gap:10px;margin:0 0 14px}
+    .amt{flex:1;font-family:var(--font-sans);font-weight:700;font-size:18px;color:var(--ink);background:var(--cream);border:1.5px solid #eadfce;border-radius:12px;padding:16px 8px;cursor:pointer;transition:border-color 140ms,background 140ms,transform 140ms}
+    .amt:hover{border-color:color-mix(in srgb,var(--acc) 45%,#eadfce)}
+    .amt--on{border-color:var(--acc);background:color-mix(in srgb,var(--acc) 8%,#fff);color:var(--acc-ink)}
+
+    .field{width:100%;font-family:var(--font-sans);font-size:16px;color:var(--ink);background:var(--cream);border:1.5px solid #eadfce;border-radius:12px;padding:14px 16px;transition:border-color 140ms}
+    .field:focus{border-color:var(--acc);outline:none;background:#fff}
+    .label{display:block;font-weight:600;font-size:14px;margin:0 0 7px}
+
+    .custom{position:relative}
+    .custom .field{padding-right:88px}
+    .custom__unit{position:absolute;right:16px;top:50%;transform:translateY(-50%);font-size:14px;color:#8a847f;pointer-events:none}
+
+    .btn{width:100%;font-family:var(--font-sans);font-weight:700;font-size:16px;color:#fff;background:var(--acc);border:none;border-radius:100px;padding:16px 22px;cursor:pointer;transition:opacity 140ms}
+    .btn:hover{opacity:0.93}
+    .btn:disabled{opacity:0.6;cursor:default}
+
+    .error{margin:0 0 14px;font-size:13.5px;line-height:1.5;color:#C0392B;background:color-mix(in srgb,#C0392B 8%,white);border-radius:10px;padding:11px 14px}
+    .note{font-size:13px;line-height:1.6;color:#8a847f}
+    </style>
+</head>
+
+<body>
+
+<nav style="position:sticky;top:0;z-index:50;background:rgba(250,248,245,0.96);border-bottom:1px solid #eadfce">
+  <div class="wrap" style="max-width:1080px;padding:11px 20px;display:flex;align-items:center;gap:10px">
+    <a href="/" style="display:inline-flex;align-items:center;gap:10px;text-decoration:none;color:var(--ink)">
+      <span aria-hidden="true" style="color:var(--acc-ink);font-size:17px;line-height:1">&larr;</span>
+      <img src="favicon.png" alt="Logo Facteur" style="width:26px;height:26px;border-radius:7px;display:block">
+      <span style="font-family:var(--font-serif);font-weight:700;letter-spacing:-0.5px;font-size:19px">Facteur</span>
+    </a>
+  </div>
+</nav>
+
+<header class="wrap" style="padding-top:clamp(40px,7vw,72px);padding-bottom:8px;text-align:center">
+  <span style="font-family:var(--font-mono);font-weight:700;font-size:12px;letter-spacing:2.5px;text-transform:uppercase;color:var(--acc-ink)">Soutenir Facteur</span>
+  <h1 style="font-family:var(--font-serif);font-weight:600;font-size:clamp(28px,5.5vw,40px);line-height:1.15;letter-spacing:-0.5px;margin:14px 0 0">
+    Une info libre ne tient que si on la finance ensemble.
+  </h1>
+  <p style="max-width:520px;margin:16px auto 0;font-size:17px;line-height:1.6;color:#5D5B5A">
+    Facteur est et restera une application ouverte, sans pub ni actionnaire pour
+    orienter l'information. Tu choisis ton montant, chaque mois, aussi longtemps
+    que tu le veux.
+  </p>
+</header>
+
+<main class="wrap" style="padding-top:28px;padding-bottom:56px;display:grid;gap:22px">
+
+  <section style="display:grid;gap:14px">
+    <p style="margin:0;font-size:16px;line-height:1.65;color:#3a3735">
+      L'info qu'on te livre coûte cher à produire : collecte des articles,
+      stockage, calcul de tes préférences, pipelines IA pour les analyses et les
+      évaluations. En nous rejoignant, tu deviens <strong>Fact&middot;eur&middot;isse</strong>
+      et tu fais vivre une information indépendante.
+    </p>
+  </section>
+
+  <section class="card">
+    <p class="label" style="font-size:15px;margin-bottom:12px">Ton soutien mensuel</p>
+
+    <div class="amounts" role="group" aria-label="Montant mensuel">
+      <button type="button" class="amt" data-amount="3">3 &euro;</button>
+      <button type="button" class="amt amt--on" data-amount="5">5 &euro;</button>
+      <button type="button" class="amt" data-amount="10">10 &euro;</button>
+    </div>
+
+    <label class="custom" style="display:block;margin-bottom:16px">
+      <span class="label">Autre montant</span>
+      <input id="custom-amount" class="field" type="number" min="2" max="100" step="1"
+        inputmode="numeric" placeholder="Ex. 20" aria-label="Autre montant en euros par mois">
+      <span class="custom__unit">&euro; / mois</span>
+    </label>
+
+    <div id="email-row" hidden style="margin-bottom:16px">
+      <label class="label" for="email">Ton email</label>
+      <input id="email" class="field" type="email" placeholder="toi@exemple.fr" autocomplete="email">
+      <p class="note" style="margin:8px 0 0">On l'utilise pour relier ton soutien à ton compte Facteur.</p>
+    </div>
+
+    <div style="margin-bottom:16px">
+      <label class="label" for="message">Ajoute un mot <span style="font-weight:400;color:#8a847f">(optionnel)</span></label>
+      <textarea id="message" class="field" rows="3" maxlength="280"
+        placeholder="Pourquoi tu soutiens Facteur ?" style="resize:vertical"></textarea>
+      <p class="note" style="margin:8px 0 0">Il pourra apparaître sur notre site, après relecture.</p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <button id="submit" class="btn" type="button">Choisir mon soutien &rarr;</button>
+
+    <p class="note" style="margin:16px 0 0;text-align:center">
+      Paiement sécurisé par Stripe &middot; résiliable en un geste, sans engagement.
+    </p>
+  </section>
+
+  <section id="wall" hidden style="display:grid;gap:14px">
+    <h2 style="font-family:var(--font-serif);font-weight:600;font-size:22px;letter-spacing:-0.3px;text-align:center;margin:8px 0 0">
+      Ils soutiennent Facteur
+    </h2>
+    <div id="wall-list" style="display:grid;gap:12px"></div>
+  </section>
+
+</main>
+
+<footer style="border-top:1px solid #eadfce;background:var(--cream)">
+  <div class="wrap" style="max-width:1080px;padding:26px 20px;display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:14px">
+    <a href="/" style="display:inline-flex;align-items:center;gap:9px;text-decoration:none;color:var(--ink)">
+      <img src="favicon.png" alt="" style="width:22px;height:22px;border-radius:6px;display:block">
+      <span style="font-family:var(--font-serif);font-weight:700;letter-spacing:-0.5px;font-size:17px">Facteur</span>
+    </a>
+    <p style="margin:0;font-family:var(--font-mono);font-size:12px;color:#959392">Sans pub &middot; sans actionnaire &middot; <a href="/" style="color:#959392">facteur.app</a></p>
+  </div>
+</footer>
+
+<script src="js/soutenir.js?v=1"></script>
+</body>
+
+</html>

--- a/apps/mobile/lib/features/premium/premium_refresh.dart
+++ b/apps/mobile/lib/features/premium/premium_refresh.dart
@@ -1,0 +1,54 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:purchases_flutter/purchases_flutter.dart';
+
+import '../../config/constants.dart';
+import 'premium_provider.dart';
+
+/// Rafraîchit l'entitlement `premium` après un checkout web (parcours soutien).
+///
+/// Le grant côté serveur est asynchrone (webhook Stripe -> entitlement
+/// promotionnel RevenueCat), donc au retour dans l'app l'info peut ne pas être
+/// encore à jour. On invalide le cache RevenueCat puis on poll brièvement
+/// (3 essais, backoff 1/2/4 s) jusqu'à voir l'entitlement actif, avant de
+/// réinvalider `customerInfoProvider` pour que le gating se rafraîchisse.
+///
+/// No-op sur web ou si RevenueCat n'est pas configuré (jamais d'appel SDK sur
+/// un singleton non initialisé, cf. [customerInfoProvider]).
+Future<void> refreshPremiumAfterCheckout(WidgetRef ref) async {
+  if (kIsWeb || !RevenueCatConstants.isConfigured(isIOS: Platform.isIOS)) {
+    return;
+  }
+
+  try {
+    await Purchases.invalidateCustomerInfoCache();
+  } catch (_) {
+    // SDK indisponible : on abandonne silencieusement (dégrade en non-premium).
+    return;
+  }
+
+  const delays = [
+    Duration(seconds: 1),
+    Duration(seconds: 2),
+    Duration(seconds: 4),
+  ];
+  for (final delay in delays) {
+    await Future<void>.delayed(delay);
+    try {
+      final info = await Purchases.getCustomerInfo();
+      if (info.entitlements.active.containsKey(
+        RevenueCatConstants.entitlementId,
+      )) {
+        break;
+      }
+    } catch (_) {
+      // Réseau/SDK flaky : on retente au prochain palier.
+    }
+  }
+
+  // Force le stream à réémettre l'état frais (le gating lit customerInfoProvider).
+  ref.invalidate(customerInfoProvider);
+}

--- a/apps/mobile/lib/features/soutien/screens/soutien_screen.dart
+++ b/apps/mobile/lib/features/soutien/screens/soutien_screen.dart
@@ -1,10 +1,15 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../config/theme.dart';
 import '../../../widgets/design/facteur_stamp.dart';
+import '../../premium/premium_provider.dart';
+import '../../premium/premium_refresh.dart';
 import '../soutien_copy.dart';
 import '../widgets/checkout_cta_button.dart';
 import '../widgets/founder_photos.dart';
@@ -12,8 +17,39 @@ import '../widgets/price_row.dart';
 
 /// Porte 1 du système de monétisation : l'écran Soutien, incarné par les
 /// fondateurs. Lettre 2 §, carte bonus, réassurances, prix, CTA email.
-class SoutienScreen extends StatelessWidget {
+///
+/// Le soutien se finalise sur le web (option c : email -> page prix libre ->
+/// Stripe). Au retour dans l'app (reprise), on rafraîchit l'entitlement premium
+/// pour refléter le grant serveur asynchrone sans que l'utilisateur ait à
+/// relancer l'app.
+class SoutienScreen extends ConsumerStatefulWidget {
   const SoutienScreen({super.key});
+
+  @override
+  ConsumerState<SoutienScreen> createState() => _SoutienScreenState();
+}
+
+class _SoutienScreenState extends ConsumerState<SoutienScreen> {
+  late final AppLifecycleListener _lifecycleListener;
+
+  @override
+  void initState() {
+    super.initState();
+    _lifecycleListener = AppLifecycleListener(onResume: _onResume);
+  }
+
+  void _onResume() {
+    // Déjà premium : rien à rafraîchir (évite un poll SDK inutile à chaque
+    // reprise de l'écran).
+    if (ref.read(isPremiumProvider)) return;
+    unawaited(refreshPremiumAfterCheckout(ref));
+  }
+
+  @override
+  void dispose() {
+    _lifecycleListener.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/docs/stories/core/premium.2.soutien-prix-libre.md
+++ b/docs/stories/core/premium.2.soutien-prix-libre.md
@@ -1,0 +1,206 @@
+# premium.2 — Soutien à prix libre (page web propre + Stripe + Premium in-app)
+
+> Type : **Feature**. Base de toutes les PR : `main` (staging continu).
+> Arbitrage store-review retenu par le PO : **option (c)** (cf. plus bas).
+
+## Objectif
+
+Remplacer le détour « magic-link brut Supabase -> RevenueCat Web Billing prix
+fixe » par :
+
+1. Une **page web Facteur propre** (`/soutenir`) présentant la mission (info de
+   qualité, indépendante, sans peur ni urgence).
+2. Un **abonnement à prix libre** (montant choisi par l'utilisateur, mensuel)
+   via **Stripe en direct**.
+3. Une reconnaissance **Premium automatique dans l'app** dès paiement validé, via
+   un **entitlement RevenueCat « promotionnel »** posé par le backend -> zéro
+   changement du gating mobile (`isPremiumProvider` lit déjà l'entitlement
+   `premium` du SDK).
+
+## Arbitrage store-review : OPTION (c) — validée PO
+
+App Store 3.1.1 (et équivalent Google Play) interdit d'ouvrir un paiement externe
+pour débloquer du contenu premium. Le parcours email existait précisément pour
+l'éviter. **Décision : (c) on garde le flux magic-link email** (l'app ne pointe
+jamais directement vers un paiement), **mais** :
+
+- Le **template email Supabase par défaut** (« Follow this link to login ») est
+  remplacé par un **email propre, à notre ton** (source de vérité versionnée :
+  `apps/landing/emails/soutien-magic-link.html`, collée dans Supabase Auth ->
+  Email Templates -> Magic Link).
+- Le magic link **redirige désormais vers `/soutenir`** (prix libre Stripe) au
+  lieu de `pay.rev.cat` (prix fixe RevenueCat).
+
+Conséquence sur le découpage : **PR4 (mobile) conserve `send-link` +
+`link_sent_screen`** (pas de suppression, pas d'ouverture directe de paiement) ;
+seules la copy/le CTA et le refresh premium au retour changent. **PR5** se limite
+à retirer les bouts RevenueCat Web Billing (`*_WEB_BILLING_BASE_URL`, page-pont
+`checkout-redirect.html`, `_build_bridge_url`), pas le canal email.
+
+## État de l'existant réutilisé
+
+- Premium = entitlement RevenueCat `premium`, lu par le SDK mobile
+  (`premium_provider.dart`). `user_subscriptions` = miroir analytics (webhook).
+- Couplage identité : `main.dart:378` `Purchases.logIn(userId)` avec user_id
+  Supabase = app_user_id RevenueCat -> un paiement web est reconnu dans l'app.
+- `SubscriptionService` : pattern idempotent (`last_event_id`,
+  `_is_duplicate_event`), `_get_or_create_subscription` -> étendu pour Stripe.
+- `checkout.py` : `_supabase_admin_*` + `_supabase_send_magic_link` +
+  `_build_bridge_url` -> réutilisés (magic link conservé, redirect_to changé).
+- In-app browser store-safe déjà en place (`LaunchMode.inAppBrowserView`), JWT
+  Bearer attaché à toutes les requêtes Dio.
+- Landing = nginx statique `apps/landing/public/` ; modèle de ton =
+  `methodologie.html` (Fraunces + palette crème/orange).
+
+## Corrections d'hypothèses (importantes)
+
+- Stripe `custom_unit_amount` NE marche PAS en subscription : montant saisi sur
+  la page, **validé serveur** (min/max), passé en `unit_amount` fixe dans un
+  `price_data` récurrent inline.
+- Head Alembic réel = `sa02_alerts_v2` -> `st01_stripe_support` chaîne dessus
+  (**vérifié : `alembic heads` == 1**).
+- `stripe` n'était pas une dépendance (ajoutée PR1). `revenuecat_api_key`
+  (config) inutilisé ; le grant promotionnel exige une **clé secrète v1 RC**
+  dédiée (`revenuecat_rest_api_key`).
+- Ne PAS réutiliser `supabase_jwt_secret` pour le lien signé -> secret dédié
+  `checkout_link_secret` (HS256).
+- Bug latent hors scope (à ne PAS corriger ici) : `subscription.py:38` (test)
+  appelle `service.sync_with_revenuecat(...)` inexistant.
+
+## Découpage en PR (chacune `--base main`)
+
+### PR1 — Fondations (migration additive + config + dépendance) — LIVRÉE ✅
+- `alembic/versions/st01_stripe_support_columns.py` (`down_revision="sa02_alerts_v2"`,
+  additif/nullable) : colonnes `stripe_customer_id`, `stripe_subscription_id`,
+  `support_amount_cents`, `provider` sur `user_subscriptions` + index sur les 2
+  ids Stripe ; table `stripe_events(event_id PK, event_type, received_at)`.
+- `app/models/subscription.py` : 4 colonnes nullable + modèle `StripeEvent`.
+- `app/config.py` : `stripe_secret_key`, `stripe_webhook_secret`,
+  `stripe_support_product_id`, `stripe_currency="eur"`,
+  `stripe_support_min_cents=200`, `stripe_support_max_cents=10000`,
+  `checkout_link_secret`, `revenuecat_rest_api_key`,
+  `revenuecat_entitlement_id="premium"`, `public_web_base_url`.
+- `requirements.txt` : `stripe==11.4.1`.
+- **Vérifié** : `alembic heads` == `st01_stripe_support` ; upgrade+downgrade+re-upgrade
+  contre une DB vide OK ; 47 tests subscription/checkout verts.
+
+### PR2 — Backend Stripe (env-gated : 503 si `stripe_secret_key` vide) — LIVRÉE ✅
+> Fait : `checkout_token.py`, `revenuecat_grant_service.py`, `stripe_service.py`
+> (appels SDK bloquants en threadpool), handlers Stripe dans
+> `subscription_service.py` (grant tz-safe : bug d'offset UTC corrigé),
+> `create-stripe-session` + cutover env-gated de `send-link`, routeur
+> `stripe_webhooks.py` (idempotence `stripe_events` = INSERT/ON CONFLICT dans la
+> même tx, rollback re-traitable). 24 tests neufs + 10 subscription verts, ruff OK.
+
+- `services/checkout_token.py` : `mint`/`verify` HS256 (`checkout_link_secret`),
+  claims `{sub,email,aud:"soutenir",iat,exp}`.
+- `services/revenuecat_grant_service.py` : `grant_premium(app_user_id,end_time_ms)`
+  / `revoke_premium(app_user_id)` (REST v1 promotional / revoke_promotionals).
+- `services/stripe_service.py` : `create_support_subscription_session(...)`
+  (mode=subscription, price_data inline récurrent, validation min/max,
+  idempotency_key) + `construct_event(payload,sig)`.
+- `subscription_service.py` : handlers `checkout.session.completed` /
+  `invoice.paid` (-> `grant_premium`, end_time = period_end + 3 j) /
+  `customer.subscription.deleted` (-> `revoke_premium`) /
+  `invoice.payment_failed` (-> `past_due`), idempotents via `stripe_events`.
+- `routers/checkout.py` : `POST /create-stripe-session` (non-auth ; branche
+  token OU email passwordless) -> `{url}`.
+- **Option (c)** : `send-link` **conservé**, mais `redirect_to` devient
+  `{public_web_base_url}/soutenir?t=<checkout_token>` (plus RevenueCat).
+- `routers/stripe_webhooks.py` (monté `/api/webhooks/stripe`, clone de
+  `webhooks.py`) : `construct_event` (401 si invalide), idempotence
+  `stripe_events` (ON CONFLICT DO NOTHING), dispatch, 200 systématique.
+
+### PR3 — Page web — LIVRÉE ✅
+> Fait : `soutenir.html` (design manifeste, copy sobre, module prix libre
+> 3/5/10 EUR + custom borné 2/100, fallback email si pas de `?t=`),
+> `js/soutenir.js` (token vs email, validation bornes, POST create-stripe-session
+> -> redirect), `soutenir-merci.html`, routes nginx `/soutenir` + `/soutenir-merci`,
+> lien « Soutenir » dans le footer `index.html`. Validé au navigateur : rendu OK,
+> toggle montant, garde bornes (pas de fetch si invalide), payload correct vers
+> l'endpoint, redirect succès. Page autonome inline -> pas de bump `?v=` global.
+
+- `apps/landing/public/soutenir.html` + `js/soutenir.js` + `soutenir-merci.html`
+  (design manifeste `methodologie.html`). Module prix libre (3/5/10 EUR + custom,
+  bornes 2 EUR/100 EUR alignées `stripe_support_*_cents`, « par mois »),
+  réassurance, fallback email si pas de `?t=`.
+- `nginx.conf.template` : `location = /soutenir` + `= /soutenir-merci`. Lien
+  « Soutenir » de `index.html` -> `/soutenir`.
+
+### PR4 — Mobile (option c) — LIVRÉE ✅
+> Fait : `send-link` + `link_sent_screen` **conservés** (store-safe, aucune
+> ouverture de paiement in-app). La copy/CTA existantes sont déjà sobres et
+> compatibles prix libre (PriceRow sans montant, note « tu soutiens quand tu
+> veux ») -> pas de churn inutile. Ajout : helper `premium_refresh.dart`
+> (`refreshPremiumAfterCheckout` = invalidate cache RC + poll 1/2/4 s +
+> invalidate `customerInfoProvider`) ; `SoutienScreen` passé en
+> `ConsumerStatefulWidget` avec `AppLifecycleListener` -> refresh premium au
+> `resume` (guardé si déjà premium). `flutter analyze` OK. Test unitaire du
+> helper non pertinent (wrapper sur singleton natif RC, no-op hors config) ;
+> validation réelle = smoke device (APK non buildable ici, pas de JDK).
+
+### PR4 (plan initial) — Mobile
+- `send-link` + `link_sent_screen` **conservés** (store-safe).
+- Copy/CTA soutien alignés « prix libre » ; icône `heart`/`handHeart`.
+- Refresh premium au retour : `SoutienScreen` -> `AppLifecycleListener`, sur
+  `resumed` `refreshPremiumAfterCheckout()` = `invalidateCustomerInfoCache()` +
+  `getCustomerInfo()` avec poll court (3 essais 1/2/4 s).
+
+### PR5 — Nettoyage (après validation prod Stripe)
+- Retirer `*_WEB_BILLING_BASE_URL`, `_build_bridge_url`,
+  `checkout-redirect.html`, page-pont. **Conserver** `send-link` /
+  `_supabase_send_magic_link` (canal email = mitigation store).
+
+## Email « Magic Link » (option c) — livrable clé PO
+
+`apps/landing/emails/soutien-magic-link.html` (source versionnée, à coller dans
+Supabase). Objet suggéré : « Merci pour ta demande de soutien ». Ton **sobre**
+(copy validée PO : pas de fausse lettre personnifiée, argument coût/indépendance,
+signé « Django & Laurin » sans fioriture), palette crème/orange, Fraunces->Georgia,
+sans em-dash, `{{ .ConfirmationURL }}`.
+
+## Mot de soutien (mur public modéré) — LIVRÉE ✅
+Le soutien peut laisser un « mot » optionnel sur `/soutenir` (280 car. max).
+Pipeline : champ web -> `create-stripe-session {message}` -> metadata de session
+Stripe -> persisté au webhook `checkout.session.completed` dans
+`supporter_messages` (migration **st02**, `down_revision="st01_stripe_support"`),
+**`published=false` par défaut = modération avant tout affichage public**.
+Lecture publique : `GET /api/checkout/support-messages` (uniquement `published`).
+Affichage : section « Ils soutiennent Facteur » sur `/soutenir`, **masquée tant
+qu'aucun message publié** (rendu `textContent` = pas d'injection HTML).
+
+> ⚠️ **Décision PO en attente** : (a) garder la modération manuelle (aucun outil
+> d'admin pour l'instant : publier = passer `published=true` en base), ou (b)
+> auto-publier (risque spam/PII/abus sur une surface publique). Défaut retenu :
+> modéré. Placement du mur (page `/soutenir` vs page dédiée vs `index`) à confirmer.
+
+## Config & étapes manuelles PO
+
+1. Stripe : Product « Soutien Facteur » -> `stripe_support_product_id` ; clés
+   `sk_...` (test + live).
+2. Webhook Stripe -> `https://facteur-production.up.railway.app/api/webhooks/stripe`
+   (4 events) -> `whsec_...`.
+3. RevenueCat : clé API **secrète v1** ; vérifier entitlement `premium`.
+4. `checkout_link_secret` aléatoire fort.
+5. Env vars sur Railway **staging ET prod**.
+6. **Coller `soutenir-magic-link.html`** dans Supabase Auth -> Email Templates ->
+   Magic Link (+ objet) et ajouter `/soutenir` à l'allow-list Redirect URLs.
+
+## Tests & vérif
+
+- pytest : `test_checkout_stripe.py`, `test_stripe_webhooks.py`,
+  `test_revenuecat_grant_service.py` (cf. plan).
+- flutter : provider refresh premium (poll), copy/CTA.
+- E2E : `stripe listen` + carte test 4242, vérifier grant/revoke + idempotence.
+
+## Pièges
+
+- Grant : `end_time_ms = period_end + 3 j`, re-grant à chaque `invoice.paid`,
+  `revoke_promotionals` sur `subscription.deleted`. Webhook manqué -> retries
+  Stripe.
+- Propagation grant -> SDK : `invalidateCustomerInfoCache` + poll.
+- Sécurité : token `exp` court + `aud`, jamais loggé, absent du success_url ;
+  seul `amount_cents` vient du user et est borné ; `construct_event` anti-forge.
+- Migration DB partagée : additif nullable + table neuve ; PR1 avant tout code
+  lisant ces colonnes ; `alembic heads` == 1.
+- Clé RC bien **secrète v1** (clé SDK publique -> 401 sur `/promotional`).

--- a/packages/api/alembic/versions/st01_stripe_support_columns.py
+++ b/packages/api/alembic/versions/st01_stripe_support_columns.py
@@ -1,0 +1,79 @@
+"""stripe support (prix libre) — additive columns + stripe_events idempotency.
+
+Fondations du parcours « Soutien à prix libre » (Stripe direct + grant
+RevenueCat promotionnel). Purement ADDITIF / nullable : `main` (staging) et
+`production` (prod) partagent la DB Supabase de prod, donc cette migration doit
+pouvoir tourner sous l'ancien code prod sans rien casser (expand-contract).
+
+- `user_subscriptions` : 4 colonnes nullables décrivant le miroir Stripe.
+  `provider` reste NULL pour l'existant (RevenueCat historique) ; la nouvelle
+  chaîne écrit `'stripe'`.
+- `stripe_events` : table d'idempotence globale des webhooks Stripe (INSERT
+  ... ON CONFLICT DO NOTHING avant traitement).
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "st01_stripe_support"
+down_revision: str | None = "sa02_alerts_v2"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_subscriptions",
+        sa.Column("stripe_customer_id", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "user_subscriptions",
+        sa.Column("stripe_subscription_id", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "user_subscriptions",
+        sa.Column("support_amount_cents", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "user_subscriptions",
+        sa.Column("provider", sa.String(length=20), nullable=True),
+    )
+    op.create_index(
+        "ix_user_subscriptions_stripe_subscription_id",
+        "user_subscriptions",
+        ["stripe_subscription_id"],
+    )
+    op.create_index(
+        "ix_user_subscriptions_stripe_customer_id",
+        "user_subscriptions",
+        ["stripe_customer_id"],
+    )
+
+    op.create_table(
+        "stripe_events",
+        sa.Column("event_id", sa.String(length=255), primary_key=True),
+        sa.Column("event_type", sa.String(length=100), nullable=True),
+        sa.Column(
+            "received_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("stripe_events")
+    op.drop_index(
+        "ix_user_subscriptions_stripe_customer_id",
+        table_name="user_subscriptions",
+    )
+    op.drop_index(
+        "ix_user_subscriptions_stripe_subscription_id",
+        table_name="user_subscriptions",
+    )
+    op.drop_column("user_subscriptions", "provider")
+    op.drop_column("user_subscriptions", "support_amount_cents")
+    op.drop_column("user_subscriptions", "stripe_subscription_id")
+    op.drop_column("user_subscriptions", "stripe_customer_id")

--- a/packages/api/alembic/versions/st02_supporter_messages.py
+++ b/packages/api/alembic/versions/st02_supporter_messages.py
@@ -1,0 +1,60 @@
+"""supporter messages — mot laissé par un soutien (mur public, modéré).
+
+Table neuve, purement additive (expand-contract, DB partagée staging/prod). Le
+message est saisi sur `/soutenir`, transporté via les métadonnées Stripe, puis
+persisté ici au webhook `checkout.session.completed` (donc seulement pour un
+paiement réellement engagé). `published=false` par défaut : rien n'apparaît
+publiquement sans modération explicite.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "st02_supporter_messages"
+down_revision: str | None = "st01_stripe_support"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "supporter_messages",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "user_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=True
+        ),
+        sa.Column("message", sa.Text(), nullable=False),
+        sa.Column("display_name", sa.String(length=120), nullable=True),
+        sa.Column("stripe_session_id", sa.String(length=255), nullable=True),
+        sa.Column(
+            "published",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_supporter_messages_user_id", "supporter_messages", ["user_id"]
+    )
+    # Index partiel : le mur public ne lit que les messages publiés, récents d'abord.
+    op.create_index(
+        "ix_supporter_messages_published_created",
+        "supporter_messages",
+        ["created_at"],
+        postgresql_where=sa.text("published"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_supporter_messages_published_created", table_name="supporter_messages"
+    )
+    op.drop_index("ix_supporter_messages_user_id", table_name="supporter_messages")
+    op.drop_table("supporter_messages")

--- a/packages/api/app/config.py
+++ b/packages/api/app/config.py
@@ -71,6 +71,25 @@ class Settings(BaseSettings):
     # RevenueCat
     revenuecat_api_key: str = ""
     revenuecat_webhook_secret: str = ""
+    # Clé API SECRÈTE v1 RevenueCat (grant/revoke entitlement promotionnel).
+    # Distincte de `revenuecat_api_key` (SDK public) : une clé publique renvoie
+    # 401 sur /promotional. Utilisée par revenuecat_grant_service (PR2).
+    revenuecat_rest_api_key: str = ""
+    revenuecat_entitlement_id: str = "premium"
+
+    # Stripe — parcours « Soutien à prix libre » (env-gated : le backend Stripe
+    # renvoie 503 tant que `stripe_secret_key` est vide).
+    stripe_secret_key: str = ""
+    stripe_webhook_secret: str = ""
+    stripe_support_product_id: str = ""
+    stripe_currency: str = "eur"
+    stripe_support_min_cents: int = 200
+    stripe_support_max_cents: int = 10000
+    # Secret dédié (HS256) pour signer le lien de checkout app -> web. NE PAS
+    # réutiliser supabase_jwt_secret (l'auth réelle est ES256/JWKS).
+    checkout_link_secret: str = ""
+    # Base publique de la landing (liens web du parcours soutien).
+    public_web_base_url: str = "https://facteur.app"
 
     # RSS Sync
     rss_sync_interval_minutes: int = 30
@@ -251,6 +270,16 @@ class Settings(BaseSettings):
     def is_staging(self) -> bool:
         """Vérifie si on est en staging."""
         return self.environment == "staging"
+
+    @property
+    def support_stripe_enabled(self) -> bool:
+        """Le parcours soutien Stripe (prix libre) est-il actif ?
+
+        Une seule définition du cutover : `send_link` bascule le magic link vers
+        `/soutenir?t=<token>` (Stripe) dès que les deux secrets sont présents,
+        sinon retombe sur l'ancien pont RevenueCat Web Billing.
+        """
+        return bool(self.stripe_secret_key and self.checkout_link_secret)
 
 
 @lru_cache

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -105,6 +105,7 @@ from app.routers import (
     push_devices,
     sources,
     streaks,
+    stripe_webhooks,
     subscription,
     user_interests,
     user_sources_state,
@@ -502,6 +503,7 @@ app.include_router(
 app.include_router(streaks.router, prefix="/api/streaks", tags=["Streaks"])
 app.include_router(grille.router, prefix="/api/grille", tags=["Grille"])
 app.include_router(webhooks.router, prefix="/api/webhooks", tags=["Webhooks"])
+app.include_router(stripe_webhooks.router, prefix="/api/webhooks", tags=["Webhooks"])
 app.include_router(checkout.router, prefix="/api/checkout", tags=["Checkout"])
 app.include_router(analytics.router, prefix="/api/analytics", tags=["Analytics"])
 app.include_router(internal.router, prefix="/api/internal", tags=["Internal"])

--- a/packages/api/app/models/subscription.py
+++ b/packages/api/app/models/subscription.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import DateTime, String
+from sqlalchemy import Boolean, DateTime, Integer, String, Text, func
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -35,6 +35,14 @@ class UserSubscription(Base):
         DateTime(timezone=True), nullable=True
     )
     last_event_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    # Miroir Stripe (parcours « Soutien à prix libre »). NULL pour l'existant
+    # RevenueCat ; `provider` vaut 'stripe' pour les abonnements Stripe.
+    stripe_customer_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    stripe_subscription_id: Mapped[str | None] = mapped_column(
+        String(255), nullable=True
+    )
+    support_amount_cents: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    provider: Mapped[str | None] = mapped_column(String(20), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=datetime.utcnow
     )
@@ -62,3 +70,43 @@ class UserSubscription(Base):
             delta = self.current_period_end - datetime.utcnow()
             return max(0, delta.days)
         return 0
+
+
+class StripeEvent(Base):
+    """Idempotence globale des webhooks Stripe.
+
+    Le handler insère `event_id` en `ON CONFLICT DO NOTHING` avant de traiter :
+    un événement déjà vu (retry Stripe sur réponse non-2xx) est ignoré, ce qui
+    évite un double grant RevenueCat.
+    """
+
+    __tablename__ = "stripe_events"
+
+    event_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    event_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    received_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+class SupporterMessage(Base):
+    """Mot laissé par un soutien, destiné à un mur public (modéré).
+
+    Persisté au webhook `checkout.session.completed` (paiement engagé).
+    `published` reste False tant qu'un humain n'a pas validé le message : rien
+    n'apparaît publiquement sans modération.
+    """
+
+    __tablename__ = "supporter_messages"
+
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True)
+    user_id: Mapped[UUID | None] = mapped_column(PGUUID(as_uuid=True), nullable=True)
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    display_name: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    stripe_session_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    published: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false", default=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/packages/api/app/routers/checkout.py
+++ b/packages/api/app/routers/checkout.py
@@ -19,18 +19,29 @@ import httpx
 import sentry_sdk
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
 from app.database import get_db
 from app.dependencies import get_current_user_id
+from app.models.subscription import SupporterMessage
 from app.schemas.checkout import (
     CheckoutSendLinkRequest,
     CheckoutSendLinkResponse,
     CheckoutStartRequest,
     CheckoutStartResponse,
+    CreateStripeSessionRequest,
+    CreateStripeSessionResponse,
+    SupporterMessagePublic,
+)
+from app.services.checkout_token import (
+    CheckoutTokenError,
+    mint_checkout_token,
+    verify_checkout_token,
 )
 from app.services.posthog_client import get_posthog_client
+from app.services.stripe_service import create_support_subscription_session
 from app.services.subscription_service import SubscriptionService
 
 router = APIRouter()
@@ -304,8 +315,20 @@ async def send_link(
             detail="User email not found",
         )
 
-    checkout_url = _build_checkout_url(request.offering, user_id)
-    await _supabase_send_magic_link(email, _build_bridge_url(checkout_url))
+    # Option (c) — cutover env-gated : dès que le parcours Stripe est configuré
+    # (`stripe_secret_key` + `checkout_link_secret`), le magic link pointe vers
+    # la page « prix libre » `/soutenir?t=<token>`. Sinon on garde le pont
+    # RevenueCat Web Billing historique (repli à chaud = retirer les env vars).
+    settings = get_settings()
+    stripe_flow = settings.support_stripe_enabled
+    if stripe_flow:
+        token = mint_checkout_token(user_id, email)
+        redirect_to = (
+            f"{settings.public_web_base_url}/soutenir?{urlencode({'t': token})}"
+        )
+    else:
+        redirect_to = _build_bridge_url(_build_checkout_url(request.offering, user_id))
+    await _supabase_send_magic_link(email, redirect_to)
 
     service = SubscriptionService(db)
     await service._get_or_create_subscription(user_id)
@@ -317,6 +340,7 @@ async def send_link(
         properties={
             "offering": request.offering,
             "resend": request.resend,
+            "flow": "stripe" if stripe_flow else "revenuecat",
         },
     )
 
@@ -328,3 +352,88 @@ async def send_link(
     )
 
     return CheckoutSendLinkResponse(sent=True, email=email)
+
+
+@router.post("/create-stripe-session", response_model=CreateStripeSessionResponse)
+async def create_stripe_session(
+    request: CreateStripeSessionRequest,
+    db: AsyncSession = Depends(get_db),
+) -> CreateStripeSessionResponse:
+    """Ouvre une session Stripe Checkout à prix libre depuis la page `/soutenir`.
+
+    Non authentifié (appelé du web). L'identité vient soit du `token` signé
+    (parcours app -> email -> web), soit de l'`email` (visiteur anonyme
+    passwordless). Le montant est borné côté serveur par `stripe_service`.
+    """
+    if request.token:
+        try:
+            claims = verify_checkout_token(request.token)
+        except CheckoutTokenError as exc:
+            logger.warning("checkout.stripe_session_invalid_token", error=str(exc))
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid or expired link",
+            ) from exc
+        user_id = claims["user_id"]
+        email = claims["email"]
+        via = "token"
+    elif request.email:
+        existing_id = await _supabase_admin_lookup_user_by_email(request.email)
+        user_id = existing_id or await _supabase_admin_create_user(request.email)
+        email = request.email
+        via = "email"
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="token or email is required",
+        )
+
+    service = SubscriptionService(db)
+    await service._get_or_create_subscription(user_id)
+    await db.commit()
+
+    url = await create_support_subscription_session(
+        user_id, email, request.amount_cents, message=request.message
+    )
+
+    get_posthog_client().capture(
+        user_id=user_id,
+        event="support_session_created",
+        properties={
+            "amount_cents": request.amount_cents,
+            "via": via,
+            "has_message": bool(request.message and request.message.strip()),
+        },
+    )
+    logger.info(
+        "checkout.create_stripe_session",
+        user_id=user_id,
+        amount_cents=request.amount_cents,
+        via=via,
+    )
+    return CreateStripeSessionResponse(url=url)
+
+
+@router.get("/support-messages", response_model=list[SupporterMessagePublic])
+async def support_messages(
+    db: AsyncSession = Depends(get_db),
+) -> list[SupporterMessagePublic]:
+    """Mur public des mots de soutien : uniquement les messages **modérés**.
+
+    Non authentifié (lecture publique). Ne renvoie que `published = true` : un
+    mot reste invisible tant qu'un humain ne l'a pas validé.
+    """
+    result = await db.execute(
+        select(SupporterMessage)
+        .where(SupporterMessage.published.is_(True))
+        .order_by(SupporterMessage.created_at.desc())
+        .limit(100)
+    )
+    return [
+        SupporterMessagePublic(
+            message=row.message,
+            display_name=row.display_name,
+            created_at=row.created_at,
+        )
+        for row in result.scalars().all()
+    ]

--- a/packages/api/app/routers/stripe_webhooks.py
+++ b/packages/api/app/routers/stripe_webhooks.py
@@ -1,0 +1,85 @@
+"""Webhook Stripe — parcours « Soutien à prix libre ».
+
+Monté sur `/api/webhooks/stripe`. Vérifie la signature (`construct_event`),
+garantit l'idempotence via la table `stripe_events` (INSERT ON CONFLICT DO
+NOTHING dans la MÊME transaction que le traitement : un échec de traitement
+rollback aussi l'insertion, donc le retry Stripe re-traite ; un doublon déjà
+committé est ignoré). Répond 200 sauf signature invalide (401) ou échec de
+traitement (500 -> retry Stripe).
+"""
+
+import sentry_sdk
+import structlog
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.models.subscription import StripeEvent
+from app.services.revenuecat_grant_service import RevenueCatGrantService
+from app.services.stripe_service import construct_event
+from app.services.subscription_service import SubscriptionService
+
+router = APIRouter()
+logger = structlog.get_logger()
+
+
+@router.post("/stripe")
+async def stripe_webhook(
+    request: Request,
+    stripe_signature: str = Header(None, alias="Stripe-Signature"),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, str]:
+    """Reçoit et traite les events Stripe du parcours soutien."""
+    payload = await request.body()
+    event = construct_event(payload, stripe_signature)  # 401/503 si invalide
+
+    event_id = event["id"]
+    event_type = event["type"]
+    obj = event["data"]["object"]
+
+    logger.info("stripe.webhook_received", event_type=event_type, event_id=event_id)
+
+    # Idempotence : on tente d'insérer l'event ; s'il existe déjà (committé par
+    # une livraison précédente), on ne traite pas. L'insert n'est PAS committé
+    # tant que le traitement n'a pas réussi -> un échec rollback l'insert et le
+    # retry Stripe re-traite proprement.
+    insert_stmt = (
+        pg_insert(StripeEvent)
+        .values(event_id=event_id, event_type=event_type)
+        .on_conflict_do_nothing(index_elements=["event_id"])
+        .returning(StripeEvent.event_id)
+    )
+    inserted = (await db.execute(insert_stmt)).scalar_one_or_none()
+    if inserted is None:
+        await db.rollback()
+        logger.info("stripe.webhook_duplicate", event_id=event_id)
+        return {"status": "duplicate"}
+
+    try:
+        service = SubscriptionService(db)
+        grant = RevenueCatGrantService()
+
+        match event_type:
+            case "checkout.session.completed":
+                await service.handle_stripe_checkout_completed(obj)
+            case "invoice.paid":
+                await service.handle_stripe_invoice_paid(obj, grant)
+            case "customer.subscription.deleted":
+                await service.handle_stripe_subscription_deleted(obj, grant)
+            case "invoice.payment_failed":
+                await service.handle_stripe_payment_failed(obj)
+            case _:
+                logger.info("stripe.webhook_unhandled", event_type=event_type)
+
+        await db.commit()
+    except Exception as exc:  # noqa: BLE001 - on rollback + remonte en 500
+        await db.rollback()
+        logger.error("stripe.webhook_error", event_type=event_type, error=str(exc))
+        sentry_sdk.capture_exception(exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Webhook processing failed",
+        ) from exc
+
+    return {"status": "processed"}

--- a/packages/api/app/schemas/checkout.py
+++ b/packages/api/app/schemas/checkout.py
@@ -1,8 +1,12 @@
 """Schémas Pydantic pour le checkout web Premium."""
 
+from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
+
+# Longueur max d'un « mot » de soutien (aligné front + Stripe metadata <= 500).
+SUPPORT_MESSAGE_MAX_LEN = 280
 
 
 class CheckoutStartRequest(BaseModel):
@@ -35,3 +39,31 @@ class CheckoutSendLinkResponse(BaseModel):
 
     sent: bool
     email: EmailStr
+
+
+class CreateStripeSessionRequest(BaseModel):
+    """Création d'une session Stripe Checkout à prix libre (appelé du web).
+
+    Identité résolue soit via `token` signé (parcours app -> email -> web), soit
+    via `email` (visiteur anonyme passwordless). `amount_cents` est borné serveur.
+    """
+
+    amount_cents: int
+    token: str | None = None
+    email: EmailStr | None = None
+    # Mot optionnel laissé par le soutien (mur public, modéré avant affichage).
+    message: str | None = Field(default=None, max_length=SUPPORT_MESSAGE_MAX_LEN)
+
+
+class CreateStripeSessionResponse(BaseModel):
+    """Réponse : URL hébergée Stripe Checkout vers laquelle rediriger."""
+
+    url: str
+
+
+class SupporterMessagePublic(BaseModel):
+    """Message de soutien exposé publiquement (uniquement si `published`)."""
+
+    message: str
+    display_name: str | None = None
+    created_at: datetime

--- a/packages/api/app/services/checkout_token.py
+++ b/packages/api/app/services/checkout_token.py
@@ -1,0 +1,75 @@
+"""Token signé (HS256) pour le lien de checkout app -> web « soutien ».
+
+Porté dans le magic link Supabase (`redirect_to=/soutenir?t=<token>`) puis relu
+par `POST /api/checkout/create-stripe-session`. On NE réutilise PAS
+`supabase_jwt_secret` : l'auth réelle de l'app est ES256/JWKS, ce token est un
+canal séparé signé avec `checkout_link_secret`.
+
+Le token ne contient rien de secret (user_id + email) et ne débloque pas Premium
+par lui-même : il autorise seulement l'ouverture d'une session Stripe Checkout
+que l'utilisateur doit finaliser avec sa carte. Le montant, lui, est borné
+serveur.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from jose import JWTError, jwt
+
+from app.config import get_settings
+
+_ALGORITHM = "HS256"
+_AUDIENCE = "soutenir"
+# Le token est embarqué dans un email : il doit survivre au délai d'ouverture de
+# la boîte mail. On l'aligne (large) sur la durée de vie du magic link Supabase.
+_DEFAULT_TTL_MINUTES = 24 * 60
+
+
+class CheckoutTokenError(Exception):
+    """Token de checkout absent, invalide ou expiré."""
+
+
+def mint_checkout_token(
+    user_id: str, email: str, ttl_minutes: int | None = None
+) -> str:
+    """Signe un token portant `user_id`/`email` pour le parcours soutien."""
+    settings = get_settings()
+    if not settings.checkout_link_secret:
+        raise CheckoutTokenError("checkout_link_secret not configured")
+
+    now = datetime.now(UTC)
+    ttl = ttl_minutes if ttl_minutes is not None else _DEFAULT_TTL_MINUTES
+    claims = {
+        "sub": user_id,
+        "email": email,
+        "aud": _AUDIENCE,
+        "iat": int(now.timestamp()),
+        "exp": int((now + timedelta(minutes=ttl)).timestamp()),
+    }
+    return jwt.encode(claims, settings.checkout_link_secret, algorithm=_ALGORITHM)
+
+
+def verify_checkout_token(token: str) -> dict[str, str]:
+    """Vérifie signature/exp/aud et renvoie `{user_id, email}`.
+
+    Lève `CheckoutTokenError` sur token expiré, mauvaise audience, signature
+    invalide ou claims manquants.
+    """
+    settings = get_settings()
+    if not settings.checkout_link_secret:
+        raise CheckoutTokenError("checkout_link_secret not configured")
+
+    try:
+        payload = jwt.decode(
+            token,
+            settings.checkout_link_secret,
+            algorithms=[_ALGORITHM],
+            audience=_AUDIENCE,
+        )
+    except JWTError as exc:
+        raise CheckoutTokenError(f"invalid token: {exc}") from exc
+
+    user_id = payload.get("sub")
+    email = payload.get("email")
+    if not user_id or not email:
+        raise CheckoutTokenError("missing claims")
+    return {"user_id": user_id, "email": email}

--- a/packages/api/app/services/revenuecat_grant_service.py
+++ b/packages/api/app/services/revenuecat_grant_service.py
@@ -1,0 +1,96 @@
+"""Grant / revoke de l'entitlement Premium « promotionnel » RevenueCat (REST v1).
+
+Le miroir Stripe pose (`grant_premium`) ou retire (`revoke_premium`) l'entitlement
+`premium` côté RevenueCat ; le SDK mobile le lit ensuite -> zéro changement du
+gating (`isPremiumProvider`).
+
+Exige une clé API **secrète v1** (`revenuecat_rest_api_key`), distincte de la clé
+SDK publique (`revenuecat_api_key`) : une clé publique renvoie 401 sur
+`/promotional`.
+"""
+
+import certifi
+import httpx
+import structlog
+
+from app.config import get_settings
+
+logger = structlog.get_logger()
+
+_BASE_URL = "https://api.revenuecat.com/v1"
+# Le bundle CA ne change pas d'un appel à l'autre : le résoudre une fois à
+# l'import évite de reconstruire le contexte TLS à chaque grant/revoke.
+_CA_BUNDLE = certifi.where()
+
+
+class RevenueCatGrantError(Exception):
+    """Échec d'un appel grant/revoke RevenueCat (config absente ou HTTP non-2xx)."""
+
+
+class RevenueCatGrantService:
+    """Client mince pour les entitlements promotionnels RevenueCat."""
+
+    def __init__(self) -> None:
+        settings = get_settings()
+        self._api_key = settings.revenuecat_rest_api_key
+        self._entitlement = settings.revenuecat_entitlement_id
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self._api_key)
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    async def _post(
+        self, action: str, url: str, app_user_id: str, json: dict | None = None
+    ) -> None:
+        """POST commun grant/revoke : garde config + client + gestion du statut.
+
+        `action` sert de clé de log (`grant`/`revoke`) ; `json=None` = pas de body
+        (cas revoke).
+        """
+        if not self.is_configured:
+            logger.warning("revenuecat_grant.not_configured", action=action)
+            raise RevenueCatGrantError("revenuecat_rest_api_key not configured")
+
+        async with httpx.AsyncClient(verify=_CA_BUNDLE, timeout=10.0) as client:
+            resp = await client.post(url, headers=self._headers(), json=json)
+        if resp.status_code not in (200, 201):
+            logger.warning(
+                f"revenuecat_grant.{action}_failed",
+                status=resp.status_code,
+                body=resp.text[:500],
+                app_user_id=app_user_id,
+            )
+            raise RevenueCatGrantError(f"{action} failed: HTTP {resp.status_code}")
+
+    async def grant_premium(self, app_user_id: str, end_time_ms: int) -> None:
+        """Accorde/étend l'entitlement promotionnel jusqu'à `end_time_ms`.
+
+        Re-appeler avec un `end_time_ms` plus tardif étend la validité : c'est ce
+        qui gère le renouvellement (re-grant à chaque `invoice.paid`).
+        """
+        url = (
+            f"{_BASE_URL}/subscribers/{app_user_id}"
+            f"/entitlements/{self._entitlement}/promotional"
+        )
+        await self._post("grant", url, app_user_id, json={"end_time_ms": end_time_ms})
+        logger.info(
+            "revenuecat_grant.granted",
+            app_user_id=app_user_id,
+            end_time_ms=end_time_ms,
+        )
+
+    async def revoke_premium(self, app_user_id: str) -> None:
+        """Retire l'entitlement promotionnel (idempotent côté RevenueCat)."""
+        url = (
+            f"{_BASE_URL}/subscribers/{app_user_id}"
+            f"/entitlements/{self._entitlement}/revoke_promotionals"
+        )
+        await self._post("revoke", url, app_user_id)
+        logger.info("revenuecat_grant.revoked", app_user_id=app_user_id)

--- a/packages/api/app/services/stripe_service.py
+++ b/packages/api/app/services/stripe_service.py
@@ -1,0 +1,123 @@
+"""Service Stripe — parcours « Soutien à prix libre » (env-gated).
+
+Env-gated : lève 503 tant que `stripe_secret_key` (ou `stripe_webhook_secret`
+pour la vérif webhook) est vide. Le SDK Stripe est synchrone/bloquant : les
+appels réseau sont déportés en threadpool pour ne pas figer l'event loop.
+
+Sécurité : seul `amount_cents` vient de l'utilisateur (borné min/max serveur) ;
+la devise et le produit sont fixés côté serveur (pas de SSRF). Le
+`custom_unit_amount` de Stripe ne marche PAS en mode subscription -> le montant
+validé est passé en `unit_amount` FIXE dans un `price_data` récurrent inline.
+"""
+
+from uuid import uuid4
+
+import stripe
+import structlog
+from fastapi import HTTPException, status
+from starlette.concurrency import run_in_threadpool
+
+from app.config import get_settings
+from app.schemas.checkout import SUPPORT_MESSAGE_MAX_LEN
+
+logger = structlog.get_logger()
+
+
+def _ensure_stripe_configured() -> None:
+    settings = get_settings()
+    if not settings.stripe_secret_key:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Stripe not configured",
+        )
+    stripe.api_key = settings.stripe_secret_key
+
+
+async def create_support_subscription_session(
+    user_id: str, email: str, amount_cents: int, message: str | None = None
+) -> str:
+    """Crée une session Stripe Checkout d'abonnement à prix libre.
+
+    Renvoie l'URL hébergée Stripe. Lève 400 si le montant est hors bornes,
+    503 si Stripe n'est pas configuré. Le `message` optionnel est transporté en
+    metadata de session pour être persisté au webhook (mur des soutiens).
+    """
+    settings = get_settings()
+    _ensure_stripe_configured()
+
+    if (
+        amount_cents < settings.stripe_support_min_cents
+        or amount_cents > settings.stripe_support_max_cents
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"amount_cents must be between {settings.stripe_support_min_cents} "
+                f"and {settings.stripe_support_max_cents}"
+            ),
+        )
+
+    session_metadata = {"user_id": user_id}
+    clean_message = (message or "").strip()[:SUPPORT_MESSAGE_MAX_LEN]
+    if clean_message:
+        session_metadata["support_message"] = clean_message
+
+    session = await run_in_threadpool(
+        stripe.checkout.Session.create,
+        mode="subscription",
+        client_reference_id=user_id,
+        customer_email=email,
+        line_items=[
+            {
+                "price_data": {
+                    "currency": settings.stripe_currency,
+                    "product": settings.stripe_support_product_id,
+                    "unit_amount": amount_cents,
+                    "recurring": {"interval": "month"},
+                },
+                "quantity": 1,
+            }
+        ],
+        subscription_data={
+            "metadata": {
+                "user_id": user_id,
+                "support_amount_cents": str(amount_cents),
+            }
+        },
+        metadata=session_metadata,
+        success_url=(
+            f"{settings.public_web_base_url}/soutenir-merci"
+            "?session_id={CHECKOUT_SESSION_ID}"
+        ),
+        cancel_url=f"{settings.public_web_base_url}/soutenir",
+        idempotency_key=str(uuid4()),
+    )
+
+    logger.info(
+        "stripe.support_session_created",
+        user_id=user_id,
+        amount_cents=amount_cents,
+    )
+    return session.url
+
+
+def construct_event(payload: bytes, sig_header: str | None) -> stripe.Event:
+    """Vérifie la signature du webhook (HMAC + tolérance timestamp = anti-replay).
+
+    Lève 503 si non configuré, 401 si la signature/le payload est invalide.
+    """
+    settings = get_settings()
+    if not settings.stripe_webhook_secret:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Stripe webhook not configured",
+        )
+    try:
+        return stripe.Webhook.construct_event(
+            payload, sig_header or "", settings.stripe_webhook_secret
+        )
+    except (ValueError, stripe.error.SignatureVerificationError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid Stripe signature",
+        ) from exc

--- a/packages/api/app/services/subscription_service.py
+++ b/packages/api/app/services/subscription_service.py
@@ -1,15 +1,18 @@
 """Service abonnement."""
 
-from datetime import datetime, timedelta
+import contextlib
+from datetime import UTC, datetime, timedelta
 from uuid import UUID, uuid4
 
+import sentry_sdk
 import structlog
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.subscription import UserSubscription
+from app.models.subscription import SupporterMessage, UserSubscription
 from app.schemas.subscription import SubscriptionResponse, SubscriptionStatus
 from app.services.posthog_client import get_posthog_client
+from app.services.revenuecat_grant_service import RevenueCatGrantService
 
 logger = structlog.get_logger()
 
@@ -23,6 +26,9 @@ class SubscriptionService:
     """
 
     TRIAL_DAYS = 7
+    # Marge de grâce ajoutée à l'entitlement promotionnel RevenueCat au-delà de
+    # la fin de période Stripe : absorbe le délai des webhooks de renouvellement.
+    GRANT_GRACE_DAYS = 3
 
     def __init__(self, db: AsyncSession):
         self.db = db
@@ -251,3 +257,239 @@ class SubscriptionService:
 
         self._mark_event(subscription, event_id)
         await self.db.flush()
+
+    # ─────────────────────────────────────────────────────────────────────
+    # Stripe (parcours « Soutien à prix libre »)
+    #
+    # L'idempotence globale des webhooks Stripe est portée par la table
+    # `stripe_events` (INSERT ON CONFLICT côté routeur) : ces handlers n'ont
+    # donc pas à re-dédupliquer. Le grant/revoke RevenueCat est lui-même
+    # idempotent (re-grant = extension, revoke_promotionals = no-op si absent).
+    # ─────────────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _parse_seconds(value: int | str | None) -> datetime | None:
+        """Convertit un timestamp Stripe (secondes epoch) en datetime UTC.
+
+        Exprimé via `_parse_ms` (source unique de la conversion epoch -> datetime
+        naïf UTC) : le montant est en secondes, on repasse en ms.
+        """
+        if value is None:
+            return None
+        try:
+            return SubscriptionService._parse_ms(int(value) * 1000)
+        except (TypeError, ValueError, OSError):
+            return None
+
+    @staticmethod
+    def _invoice_period_end(invoice: dict) -> datetime | None:
+        """Fin de période facturée : ligne d'abonnement d'abord, puis fallback."""
+        lines = (invoice.get("lines") or {}).get("data") or []
+        if lines:
+            period = lines[0].get("period") or {}
+            end = SubscriptionService._parse_seconds(period.get("end"))
+            if end:
+                return end
+        return SubscriptionService._parse_seconds(invoice.get("period_end"))
+
+    async def _resolve_subscription_by_stripe(
+        self,
+        *,
+        stripe_subscription_id: str | None = None,
+        stripe_customer_id: str | None = None,
+    ) -> UserSubscription | None:
+        """Retrouve la ligne miroir via l'id d'abonnement puis de client Stripe."""
+        if stripe_subscription_id:
+            result = await self.db.execute(
+                select(UserSubscription).where(
+                    UserSubscription.stripe_subscription_id == stripe_subscription_id
+                )
+            )
+            row = result.scalar_one_or_none()
+            if row:
+                return row
+        if stripe_customer_id:
+            result = await self.db.execute(
+                select(UserSubscription).where(
+                    UserSubscription.stripe_customer_id == stripe_customer_id
+                )
+            )
+            return result.scalar_one_or_none()
+        return None
+
+    async def handle_stripe_checkout_completed(self, session: dict) -> None:
+        """`checkout.session.completed` : persiste le mapping user <-> Stripe.
+
+        Le grant Premium est posé par `handle_stripe_invoice_paid` (qui connaît la
+        période) ; ici on ne fait que relier `user_id` aux ids Stripe.
+        """
+        metadata = session.get("metadata") or {}
+        user_id = session.get("client_reference_id") or metadata.get("user_id")
+        if not user_id:
+            logger.warning("stripe.checkout_completed_missing_user")
+            sentry_sdk.capture_message(
+                "stripe.checkout_completed_missing_user", level="warning"
+            )
+            return
+
+        subscription = await self._get_or_create_subscription(user_id)
+        subscription.provider = "stripe"
+        if session.get("customer"):
+            subscription.stripe_customer_id = session["customer"]
+        if session.get("subscription"):
+            subscription.stripe_subscription_id = session["subscription"]
+
+        raw_amount = metadata.get("support_amount_cents") or session.get("amount_total")
+        if raw_amount is not None:
+            with contextlib.suppress(TypeError, ValueError):
+                subscription.support_amount_cents = int(raw_amount)
+
+        # Mot de soutien optionnel : persisté non publié (modération avant le
+        # mur public). Seuls les paiements engagés (ce webhook) laissent un mot.
+        raw_message = (metadata.get("support_message") or "").strip()
+        if raw_message:
+            self.db.add(
+                SupporterMessage(
+                    id=uuid4(),
+                    user_id=subscription.user_id,
+                    message=raw_message,
+                    stripe_session_id=session.get("id"),
+                    published=False,
+                )
+            )
+
+        self._emit(
+            subscription.user_id,
+            "support_checkout_completed",
+            {
+                "amount_cents": subscription.support_amount_cents,
+                "has_message": bool(raw_message),
+            },
+        )
+        await self.db.flush()
+
+    async def handle_stripe_invoice_paid(
+        self, invoice: dict, grant_service: RevenueCatGrantService | None = None
+    ) -> None:
+        """`invoice.paid` : passe l'abonnement `active` puis (re-)grant Premium."""
+        grant_service = grant_service or RevenueCatGrantService()
+
+        subscription_id = invoice.get("subscription")
+        customer_id = invoice.get("customer")
+        user_id = (
+            (invoice.get("subscription_details") or {}).get("metadata") or {}
+        ).get("user_id")
+
+        subscription: UserSubscription | None = None
+        if not user_id:
+            subscription = await self._resolve_subscription_by_stripe(
+                stripe_subscription_id=subscription_id,
+                stripe_customer_id=customer_id,
+            )
+            if subscription:
+                user_id = str(subscription.user_id)
+
+        if not user_id:
+            logger.warning(
+                "stripe.invoice_paid_unresolved_user",
+                subscription=subscription_id,
+                customer=customer_id,
+            )
+            sentry_sdk.capture_message(
+                "stripe.invoice_paid_unresolved_user", level="warning"
+            )
+            return
+
+        if subscription is None:
+            subscription = await self._get_or_create_subscription(user_id)
+
+        subscription.provider = "stripe"
+        if subscription_id:
+            subscription.stripe_subscription_id = subscription_id
+        if customer_id:
+            subscription.stripe_customer_id = customer_id
+        subscription.status = "active"
+        subscription.current_period_start = (
+            self._parse_seconds(invoice.get("period_start"))
+            or subscription.current_period_start
+        )
+        period_end = self._invoice_period_end(invoice)
+        if period_end:
+            subscription.current_period_end = period_end
+        await self.db.flush()
+
+        if period_end:
+            # `period_end` est un datetime naïf en UTC (cf. `_parse_seconds`) :
+            # on le rend timezone-aware avant `.timestamp()`, sinon Python
+            # l'interprète en heure locale et décale `end_time_ms` de l'offset
+            # UTC du serveur.
+            end_utc = period_end.replace(tzinfo=UTC)
+            end_time_ms = int(
+                (end_utc + timedelta(days=self.GRANT_GRACE_DAYS)).timestamp() * 1000
+            )
+            await grant_service.grant_premium(user_id, end_time_ms)
+
+        self._emit(
+            subscription.user_id,
+            "support_invoice_paid",
+            {"amount_cents": subscription.support_amount_cents},
+        )
+
+    async def handle_stripe_subscription_deleted(
+        self, sub_obj: dict, grant_service: RevenueCatGrantService | None = None
+    ) -> None:
+        """`customer.subscription.deleted` : status `cancelled` + revoke Premium."""
+        grant_service = grant_service or RevenueCatGrantService()
+
+        subscription_id = sub_obj.get("id")
+        customer_id = sub_obj.get("customer")
+        user_id = (sub_obj.get("metadata") or {}).get("user_id")
+
+        subscription: UserSubscription | None = None
+        if not user_id:
+            subscription = await self._resolve_subscription_by_stripe(
+                stripe_subscription_id=subscription_id,
+                stripe_customer_id=customer_id,
+            )
+            if subscription:
+                user_id = str(subscription.user_id)
+        else:
+            subscription = await self._get_subscription(user_id)
+
+        if not user_id:
+            logger.warning(
+                "stripe.subscription_deleted_unresolved_user",
+                subscription=subscription_id,
+            )
+            sentry_sdk.capture_message(
+                "stripe.subscription_deleted_unresolved_user", level="warning"
+            )
+            return
+
+        if subscription is not None:
+            subscription.status = "cancelled"
+            await self.db.flush()
+
+        await grant_service.revoke_premium(user_id)
+        self._emit(UUID(user_id), "support_subscription_cancelled", {})
+
+    async def handle_stripe_payment_failed(self, invoice: dict) -> None:
+        """`invoice.payment_failed` : status `past_due` (pas de revoke immédiat).
+
+        L'entitlement promotionnel expire de lui-même à `end_time_ms` si les
+        paiements ne reprennent pas ; on ne coupe pas l'accès tout de suite.
+        """
+        subscription = await self._resolve_subscription_by_stripe(
+            stripe_subscription_id=invoice.get("subscription"),
+            stripe_customer_id=invoice.get("customer"),
+        )
+        if subscription is None:
+            logger.warning(
+                "stripe.payment_failed_unresolved_user",
+                subscription=invoice.get("subscription"),
+            )
+            return
+
+        subscription.status = "past_due"
+        await self.db.flush()
+        self._emit(subscription.user_id, "support_payment_failed", {})

--- a/packages/api/requirements.txt
+++ b/packages/api/requirements.txt
@@ -20,6 +20,9 @@ passlib[bcrypt]==1.7.4
 # HTTP Client
 httpx==0.26.0
 
+# Paiements — parcours « Soutien à prix libre » (Stripe direct)
+stripe==11.4.1
+
 # Caching
 cachetools>=5.3.0
 

--- a/packages/api/tests/services/test_checkout_token.py
+++ b/packages/api/tests/services/test_checkout_token.py
@@ -1,0 +1,76 @@
+"""Tests du token signé de checkout soutien (HS256, aud, exp)."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from jose import jwt
+
+from app.config import get_settings
+from app.services.checkout_token import (
+    _ALGORITHM,
+    _AUDIENCE,
+    CheckoutTokenError,
+    mint_checkout_token,
+    verify_checkout_token,
+)
+
+_SECRET = "unit-test-checkout-secret-abc123"
+
+
+@pytest.fixture
+def secret(monkeypatch):
+    monkeypatch.setattr(get_settings(), "checkout_link_secret", _SECRET)
+    return _SECRET
+
+
+def test_roundtrip_returns_user_and_email(secret):
+    token = mint_checkout_token("user-123", "sender@facteur.app")
+    claims = verify_checkout_token(token)
+    assert claims == {"user_id": "user-123", "email": "sender@facteur.app"}
+
+
+def test_expired_token_rejected(secret):
+    token = mint_checkout_token("u", "a@b.co", ttl_minutes=-1)
+    with pytest.raises(CheckoutTokenError):
+        verify_checkout_token(token)
+
+
+def test_wrong_audience_rejected(secret):
+    forged = jwt.encode(
+        {
+            "sub": "u",
+            "email": "a@b.co",
+            "aud": "not-soutenir",
+            "exp": int((datetime.now(UTC) + timedelta(minutes=5)).timestamp()),
+        },
+        _SECRET,
+        algorithm=_ALGORITHM,
+    )
+    with pytest.raises(CheckoutTokenError):
+        verify_checkout_token(forged)
+
+
+def test_correct_audience_constant():
+    # Garde-fou : l'audience attendue reste stable (le web n'a pas à la deviner).
+    assert _AUDIENCE == "soutenir"
+
+
+def test_tampered_signature_rejected(secret):
+    token = mint_checkout_token("u", "a@b.co")
+    with pytest.raises(CheckoutTokenError):
+        verify_checkout_token(token + "tampered")
+
+
+def test_wrong_secret_rejected(secret, monkeypatch):
+    token = mint_checkout_token("u", "a@b.co")
+    monkeypatch.setattr(get_settings(), "checkout_link_secret", "another-secret")
+    with pytest.raises(CheckoutTokenError):
+        verify_checkout_token(token)
+
+
+def test_missing_secret_raises(monkeypatch):
+    monkeypatch.setattr(get_settings(), "checkout_link_secret", "")
+    with pytest.raises(CheckoutTokenError):
+        mint_checkout_token("u", "a@b.co")
+    with pytest.raises(CheckoutTokenError):
+        verify_checkout_token("whatever")

--- a/packages/api/tests/services/test_revenuecat_grant_service.py
+++ b/packages/api/tests/services/test_revenuecat_grant_service.py
@@ -1,0 +1,90 @@
+"""Tests du client grant/revoke RevenueCat (URL, headers, body, erreurs)."""
+
+import pytest
+
+from app.config import get_settings
+from app.services.revenuecat_grant_service import (
+    RevenueCatGrantError,
+    RevenueCatGrantService,
+)
+
+
+class _FakeResp:
+    def __init__(self, status_code: int = 200, text: str = ""):
+        self.status_code = status_code
+        self.text = text
+
+
+class _FakeClient:
+    """Remplace httpx.AsyncClient : enregistre les appels POST."""
+
+    def __init__(self, recorder: list, status_code: int = 200):
+        self._rec = recorder
+        self._status = status_code
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+    async def post(self, url, headers=None, json=None):
+        self._rec.append({"url": url, "headers": headers, "json": json})
+        return _FakeResp(self._status)
+
+
+def _patch_client(monkeypatch, recorder, status_code=200):
+    monkeypatch.setattr(
+        "app.services.revenuecat_grant_service.httpx.AsyncClient",
+        lambda *_a, **_k: _FakeClient(recorder, status_code),
+    )
+
+
+@pytest.fixture
+def configured(monkeypatch):
+    monkeypatch.setattr(get_settings(), "revenuecat_rest_api_key", "sk_rc_secret_v1")
+    monkeypatch.setattr(get_settings(), "revenuecat_entitlement_id", "premium")
+
+
+@pytest.mark.asyncio
+async def test_grant_posts_to_promotional(configured, monkeypatch):
+    rec: list = []
+    _patch_client(monkeypatch, rec)
+    await RevenueCatGrantService().grant_premium("app-user-1", 1_700_000_000_000)
+
+    assert len(rec) == 1
+    assert rec[0]["url"].endswith(
+        "/subscribers/app-user-1/entitlements/premium/promotional"
+    )
+    assert rec[0]["headers"]["Authorization"] == "Bearer sk_rc_secret_v1"
+    assert rec[0]["json"] == {"end_time_ms": 1_700_000_000_000}
+
+
+@pytest.mark.asyncio
+async def test_revoke_posts_to_revoke_promotionals(configured, monkeypatch):
+    rec: list = []
+    _patch_client(monkeypatch, rec)
+    await RevenueCatGrantService().revoke_premium("app-user-1")
+
+    assert len(rec) == 1
+    assert rec[0]["url"].endswith(
+        "/subscribers/app-user-1/entitlements/premium/revoke_promotionals"
+    )
+    # revoke n'envoie pas de body JSON
+    assert rec[0]["json"] is None
+
+
+@pytest.mark.asyncio
+async def test_grant_raises_on_non_2xx(configured, monkeypatch):
+    _patch_client(monkeypatch, [], status_code=401)
+    with pytest.raises(RevenueCatGrantError):
+        await RevenueCatGrantService().grant_premium("u", 1)
+
+
+@pytest.mark.asyncio
+async def test_grant_raises_when_not_configured(monkeypatch):
+    monkeypatch.setattr(get_settings(), "revenuecat_rest_api_key", "")
+    svc = RevenueCatGrantService()
+    assert svc.is_configured is False
+    with pytest.raises(RevenueCatGrantError):
+        await svc.grant_premium("u", 1)

--- a/packages/api/tests/services/test_stripe_service.py
+++ b/packages/api/tests/services/test_stripe_service.py
@@ -1,0 +1,120 @@
+"""Tests du service Stripe : bornes montant, args session, construct_event."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import stripe
+from fastapi import HTTPException
+
+from app.config import get_settings
+from app.services.stripe_service import (
+    construct_event,
+    create_support_subscription_session,
+)
+
+
+@pytest.fixture
+def stripe_configured(monkeypatch):
+    monkeypatch.setattr(get_settings(), "stripe_secret_key", "sk_test_123")
+    monkeypatch.setattr(get_settings(), "stripe_support_product_id", "prod_abc")
+    monkeypatch.setattr(get_settings(), "stripe_currency", "eur")
+    monkeypatch.setattr(get_settings(), "stripe_support_min_cents", 200)
+    monkeypatch.setattr(get_settings(), "stripe_support_max_cents", 10000)
+    monkeypatch.setattr(get_settings(), "public_web_base_url", "https://facteur.app")
+
+
+@pytest.mark.asyncio
+async def test_create_session_passes_expected_args(stripe_configured):
+    fake_create = MagicMock(
+        return_value=SimpleNamespace(url="https://checkout.stripe.com/x")
+    )
+    with patch.object(stripe.checkout.Session, "create", fake_create):
+        url = await create_support_subscription_session("user-1", "a@b.co", 500)
+
+    assert url == "https://checkout.stripe.com/x"
+    kwargs = fake_create.call_args.kwargs
+    assert kwargs["mode"] == "subscription"
+    assert kwargs["client_reference_id"] == "user-1"
+    assert kwargs["customer_email"] == "a@b.co"
+    price_data = kwargs["line_items"][0]["price_data"]
+    assert price_data["currency"] == "eur"
+    assert price_data["product"] == "prod_abc"
+    assert price_data["unit_amount"] == 500
+    assert price_data["recurring"] == {"interval": "month"}
+    assert kwargs["subscription_data"]["metadata"]["user_id"] == "user-1"
+    assert kwargs["metadata"]["user_id"] == "user-1"
+    assert "{CHECKOUT_SESSION_ID}" in kwargs["success_url"]
+    assert kwargs["idempotency_key"]  # présent
+
+
+@pytest.mark.asyncio
+async def test_amount_below_min_rejected(stripe_configured):
+    with pytest.raises(HTTPException) as exc:
+        await create_support_subscription_session("u", "a@b.co", 199)
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_amount_above_max_rejected(stripe_configured):
+    with pytest.raises(HTTPException) as exc:
+        await create_support_subscription_session("u", "a@b.co", 10001)
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_503_when_stripe_not_configured(monkeypatch):
+    monkeypatch.setattr(get_settings(), "stripe_secret_key", "")
+    with pytest.raises(HTTPException) as exc:
+        await create_support_subscription_session("u", "a@b.co", 500)
+    assert exc.value.status_code == 503
+
+
+def test_construct_event_valid(monkeypatch):
+    monkeypatch.setattr(get_settings(), "stripe_webhook_secret", "whsec_x")
+    fake_event = {"id": "evt_1", "type": "invoice.paid", "data": {"object": {}}}
+    with patch.object(
+        stripe.Webhook, "construct_event", MagicMock(return_value=fake_event)
+    ):
+        assert construct_event(b"{}", "sig") == fake_event
+
+
+def test_construct_event_invalid_signature_401(monkeypatch):
+    monkeypatch.setattr(get_settings(), "stripe_webhook_secret", "whsec_x")
+    err = stripe.error.SignatureVerificationError("bad sig", "sig-header")
+    with (
+        patch.object(stripe.Webhook, "construct_event", MagicMock(side_effect=err)),
+        pytest.raises(HTTPException) as exc,
+    ):
+        construct_event(b"{}", "bad")
+    assert exc.value.status_code == 401
+
+
+def test_construct_event_503_when_not_configured(monkeypatch):
+    monkeypatch.setattr(get_settings(), "stripe_webhook_secret", "")
+    with pytest.raises(HTTPException) as exc:
+        construct_event(b"{}", "sig")
+    assert exc.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_message_carried_in_session_metadata(stripe_configured):
+    fake_create = MagicMock(
+        return_value=SimpleNamespace(url="https://checkout.stripe.com/x")
+    )
+    with patch.object(stripe.checkout.Session, "create", fake_create):
+        await create_support_subscription_session(
+            "user-1", "a@b.co", 500, message="  Bravo pour le projet  "
+        )
+    md = fake_create.call_args.kwargs["metadata"]
+    assert md["support_message"] == "Bravo pour le projet"  # trim appliqué
+
+
+@pytest.mark.asyncio
+async def test_blank_message_omitted_from_metadata(stripe_configured):
+    fake_create = MagicMock(return_value=SimpleNamespace(url="u"))
+    with patch.object(stripe.checkout.Session, "create", fake_create):
+        await create_support_subscription_session(
+            "user-1", "a@b.co", 500, message="   "
+        )
+    assert "support_message" not in fake_create.call_args.kwargs["metadata"]

--- a/packages/api/tests/test_stripe_webhooks.py
+++ b/packages/api/tests/test_stripe_webhooks.py
@@ -1,0 +1,347 @@
+"""Tests du webhook Stripe : signature, dispatch, mapping DB, grant/revoke,
+idempotence (event rejoué -> pas de double grant)."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from app.database import get_db
+from app.main import app
+from app.models.subscription import (
+    StripeEvent,
+    SupporterMessage,
+    UserSubscription,
+)
+
+
+def _period_end_seconds(days: int = 30) -> int:
+    return int((datetime.now(UTC) + timedelta(days=days)).timestamp())
+
+
+async def _post_event(event: dict):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        return await ac.post(
+            "/api/webhooks/stripe",
+            content=b"{}",
+            headers={"Stripe-Signature": "sig"},
+        )
+
+
+@pytest.fixture
+def override_db(db_session):
+    async def _db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _db
+    try:
+        yield db_session
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.fixture
+def grant_mocks(monkeypatch):
+    grant = AsyncMock()
+    revoke = AsyncMock()
+    monkeypatch.setattr(
+        "app.services.subscription_service.RevenueCatGrantService.grant_premium",
+        grant,
+    )
+    monkeypatch.setattr(
+        "app.services.subscription_service.RevenueCatGrantService.revoke_premium",
+        revoke,
+    )
+    return grant, revoke
+
+
+def _patch_construct(event: dict):
+    return patch("app.routers.stripe_webhooks.construct_event", return_value=event)
+
+
+@pytest.mark.asyncio
+async def test_invalid_signature_returns_401(override_db):
+    with patch(
+        "app.routers.stripe_webhooks.construct_event",
+        side_effect=HTTPException(status_code=401, detail="Invalid Stripe signature"),
+    ):
+        resp = await _post_event({})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_checkout_completed_persists_mapping(override_db, grant_mocks):
+    user_id = str(uuid4())
+    event = {
+        "id": "evt_checkout_1",
+        "type": "checkout.session.completed",
+        "data": {
+            "object": {
+                "client_reference_id": user_id,
+                "customer": "cus_1",
+                "subscription": "sub_1",
+                "metadata": {"user_id": user_id, "support_amount_cents": "500"},
+                "amount_total": 500,
+            }
+        },
+    }
+    with _patch_construct(event):
+        resp = await _post_event(event)
+    assert resp.status_code == 200
+
+    row = (
+        await override_db.execute(
+            select(UserSubscription).where(UserSubscription.user_id == UUID(user_id))
+        )
+    ).scalar_one()
+    assert row.provider == "stripe"
+    assert row.stripe_customer_id == "cus_1"
+    assert row.stripe_subscription_id == "sub_1"
+    assert row.support_amount_cents == 500
+
+
+@pytest.mark.asyncio
+async def test_invoice_paid_activates_and_grants(override_db, grant_mocks):
+    grant, _revoke = grant_mocks
+    user_id = str(uuid4())
+    end_s = _period_end_seconds(30)
+    event = {
+        "id": "evt_invoice_1",
+        "type": "invoice.paid",
+        "data": {
+            "object": {
+                "subscription": "sub_1",
+                "customer": "cus_1",
+                "period_start": _period_end_seconds(0),
+                "lines": {"data": [{"period": {"end": end_s}}]},
+                "subscription_details": {"metadata": {"user_id": user_id}},
+            }
+        },
+    }
+    with _patch_construct(event):
+        resp = await _post_event(event)
+    assert resp.status_code == 200
+
+    row = (
+        await override_db.execute(
+            select(UserSubscription).where(UserSubscription.user_id == UUID(user_id))
+        )
+    ).scalar_one()
+    assert row.status == "active"
+    assert row.provider == "stripe"
+
+    grant.assert_awaited_once()
+    called_user, called_end_ms = grant.await_args.args
+    assert called_user == user_id
+    # end_time_ms = period_end + 3 j de grâce
+    expected_ms = int((end_s + 3 * 86400) * 1000)
+    assert abs(called_end_ms - expected_ms) < 2000
+
+
+@pytest.mark.asyncio
+async def test_duplicate_event_grants_only_once(override_db, grant_mocks):
+    grant, _revoke = grant_mocks
+    user_id = str(uuid4())
+    end_s = _period_end_seconds(30)
+    event = {
+        "id": "evt_invoice_dup",
+        "type": "invoice.paid",
+        "data": {
+            "object": {
+                "subscription": "sub_dup",
+                "customer": "cus_dup",
+                "lines": {"data": [{"period": {"end": end_s}}]},
+                "subscription_details": {"metadata": {"user_id": user_id}},
+            }
+        },
+    }
+    with _patch_construct(event):
+        first = await _post_event(event)
+        second = await _post_event(event)
+
+    assert first.status_code == 200
+    assert first.json()["status"] == "processed"
+    assert second.status_code == 200
+    assert second.json()["status"] == "duplicate"
+    grant.assert_awaited_once()
+
+    # une seule ligne d'idempotence enregistrée
+    events = (
+        (
+            await override_db.execute(
+                select(StripeEvent).where(StripeEvent.event_id == "evt_invoice_dup")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(events) == 1
+
+
+@pytest.mark.asyncio
+async def test_subscription_deleted_revokes(override_db, grant_mocks):
+    _grant, revoke = grant_mocks
+    user_id = str(uuid4())
+    # pré-crée la ligne miroir (comme après checkout.session.completed)
+    override_db.add(
+        UserSubscription(
+            id=uuid4(),
+            user_id=UUID(user_id),
+            status="active",
+            provider="stripe",
+            stripe_subscription_id="sub_del",
+            stripe_customer_id="cus_del",
+            trial_end=datetime.utcnow() + timedelta(days=1),
+        )
+    )
+    await override_db.flush()
+
+    event = {
+        "id": "evt_sub_deleted",
+        "type": "customer.subscription.deleted",
+        "data": {
+            "object": {
+                "id": "sub_del",
+                "customer": "cus_del",
+                "metadata": {"user_id": user_id},
+            }
+        },
+    }
+    with _patch_construct(event):
+        resp = await _post_event(event)
+    assert resp.status_code == 200
+
+    revoke.assert_awaited_once_with(user_id)
+    row = (
+        await override_db.execute(
+            select(UserSubscription).where(UserSubscription.user_id == UUID(user_id))
+        )
+    ).scalar_one()
+    assert row.status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_checkout_completed_persists_message_unpublished(override_db, grant_mocks):
+    user_id = str(uuid4())
+    event = {
+        "id": "evt_checkout_msg",
+        "type": "checkout.session.completed",
+        "data": {
+            "object": {
+                "id": "cs_msg_1",
+                "client_reference_id": user_id,
+                "customer": "cus_m",
+                "subscription": "sub_m",
+                "metadata": {
+                    "user_id": user_id,
+                    "support_amount_cents": "500",
+                    "support_message": "Merci pour ce projet.",
+                },
+            }
+        },
+    }
+    with _patch_construct(event):
+        resp = await _post_event(event)
+    assert resp.status_code == 200
+
+    msg = (
+        await override_db.execute(
+            select(SupporterMessage).where(SupporterMessage.user_id == UUID(user_id))
+        )
+    ).scalar_one()
+    assert msg.message == "Merci pour ce projet."
+    assert msg.published is False
+    assert msg.stripe_session_id == "cs_msg_1"
+
+
+@pytest.mark.asyncio
+async def test_checkout_completed_without_message_stores_none(override_db, grant_mocks):
+    user_id = str(uuid4())
+    event = {
+        "id": "evt_checkout_nomsg",
+        "type": "checkout.session.completed",
+        "data": {
+            "object": {
+                "id": "cs_nomsg",
+                "client_reference_id": user_id,
+                "metadata": {"user_id": user_id, "support_amount_cents": "300"},
+            }
+        },
+    }
+    with _patch_construct(event):
+        await _post_event(event)
+
+    rows = (
+        await override_db.execute(
+            select(SupporterMessage).where(SupporterMessage.user_id == UUID(user_id))
+        )
+    ).scalars().all()
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_support_messages_endpoint_returns_only_published(override_db):
+    override_db.add_all(
+        [
+            SupporterMessage(
+                id=uuid4(),
+                message="visible",
+                published=True,
+                created_at=datetime.now(UTC),
+            ),
+            SupporterMessage(
+                id=uuid4(),
+                message="en attente de modération",
+                published=False,
+                created_at=datetime.now(UTC),
+            ),
+        ]
+    )
+    await override_db.flush()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/checkout/support-messages")
+
+    assert resp.status_code == 200
+    messages = [m["message"] for m in resp.json()]
+    assert "visible" in messages
+    assert "en attente de modération" not in messages
+
+
+@pytest.mark.asyncio
+async def test_payment_failed_sets_past_due(override_db, grant_mocks):
+    user_id = str(uuid4())
+    override_db.add(
+        UserSubscription(
+            id=uuid4(),
+            user_id=UUID(user_id),
+            status="active",
+            provider="stripe",
+            stripe_subscription_id="sub_pf",
+            stripe_customer_id="cus_pf",
+            trial_end=datetime.utcnow() + timedelta(days=1),
+        )
+    )
+    await override_db.flush()
+
+    event = {
+        "id": "evt_payment_failed",
+        "type": "invoice.payment_failed",
+        "data": {"object": {"subscription": "sub_pf", "customer": "cus_pf"}},
+    }
+    with _patch_construct(event):
+        resp = await _post_event(event)
+    assert resp.status_code == 200
+
+    row = (
+        await override_db.execute(
+            select(UserSubscription).where(UserSubscription.user_id == UUID(user_id))
+        )
+    ).scalar_one()
+    assert row.status == "past_due"


### PR DESCRIPTION
## Quoi

Parcours **« Soutien à prix libre »** de bout en bout : page web `/soutenir`
(abonnement **Stripe** mensuel, montant choisi par l'utilisateur) → webhook
backend → entitlement RevenueCat **promotionnel** → **Premium reconnu in-app**
sans toucher au gating (`isPremiumProvider` lit déjà l'entitlement `premium`).

Remplace le détour « magic-link → RevenueCat Web Billing prix fixe ». Tout le
backend Stripe est **env-gated** : 503 tant que `stripe_secret_key` est vide,
donc no-op tant que les secrets ne sont pas posés.

## Pourquoi

Store-review **option (c)** (validée PO) : App Store 3.1.1 interdit d'ouvrir un
paiement externe depuis l'app. On **conserve le canal email magic-link**
(l'app n'ouvre jamais un paiement) ; seul le `redirect_to` du lien bascule vers
`/soutenir?t=<token>` au lieu de `pay.rev.cat`. Le prix libre + notre page
propre remplacent le prix fixe et le template Supabase par défaut.

## Contenu

**Backend** (`packages/api`)
- Migrations **additives** `st01` (colonnes `stripe_*`/`support_amount_cents`/`provider` sur `user_subscriptions` + table `stripe_events`) et `st02` (`supporter_messages`), chaînées `sa02_alerts_v2 → st01 → st02`, **1 seul head**.
- Services `stripe_service` (session Checkout abonnement, `price_data` récurrent inline, bornes serveur), `checkout_token` (HS256, secret dédié — pas `supabase_jwt_secret`), `revenuecat_grant_service` (REST v1 **secrète**, grant/revoke promotionnels).
- Routeur webhook `POST /api/webhooks/stripe` : idempotence via `stripe_events` (INSERT-on-conflict dans la tx de traitement), 4 handlers (`checkout.session.completed`, `invoice.paid` → grant `period_end + 3j`, `customer.subscription.deleted` → revoke, `invoice.payment_failed` → `past_due`).
- `POST /api/checkout/create-stripe-session` (token OU email passwordless) et `GET /api/checkout/support-messages` (mur public **modéré**, `published=false` par défaut, rendu `textContent`).

**Web** (`apps/landing`) : `/soutenir` (module prix libre 3/5/10 € + custom borné 2/100, mot optionnel, fallback email sans `?t=`), `/soutenir-merci`, routes nginx, lien footer, email Supabase versionné.

**Mobile** (`apps/mobile`) : `AppLifecycleListener` + `refreshPremiumAfterCheckout` (invalidate cache RC + poll 1/2/4 s) au retour d'app. `send-link` + `link_sent_screen` **conservés**.

## Comment ça a été vérifié

- [x] **pytest backend** : `2854 passed, 18 skipped, 2 xfailed` (dont ~33 tests neufs Stripe/webhooks/token/grant)
- [x] **Alembic** : `heads` == 1 ; `upgrade head` sur DB vide + `downgrade`/re-`upgrade` OK (chaîne complète depuis baseline)
- [x] **Smoke API locale** (curl) : `support-messages` → 200 `[]` ; `create-stripe-session` → 400 (ni token ni email) / 401 (token invalide) / 503 (Stripe non configuré) ; webhook sans signature → 503 (fail-closed)
- [x] **flutter test** : test soutien vert ; suite complète sans **nouvelle** régression (28 échecs = baseline pré-existante, fichiers hors-diff)
- [x] **flutter analyze** : 0 issue sur les fichiers touchés
- [x] **ruff** : clean
- [x] **/simplify** : dedup constante 280, prédicat `support_stripe_enabled` unique (config), consolidation grant/revoke + hoist `certifi.where()`, `_parse_seconds` via `_parse_ms`

## Zones à risque

- **DB partagée staging/prod** : migrations additives/nullable + tables neuves → safe expand-contract. Le `Dockerfile` rejoue `alembic upgrade head` au boot ; vérifié sur DB vide.
- **Endpoints non authentifiés** : `create-stripe-session` (protégé par montant borné + token signé/lookup email), `support-messages` (lecture publique `published`), webhook (signature Stripe, 503 si secret absent = fail-closed).
- Clé RevenueCat = **secrète v1** obligatoire (une clé SDK publique → 401 sur `/promotional`).

## Étapes manuelles PO (avant activation)

1. Stripe : Product « Soutien Facteur » → `stripe_support_product_id` ; clés `sk_...` (test + live).
2. Webhook Stripe → `/api/webhooks/stripe` (4 events) → `whsec_...`.
3. RevenueCat : clé API **secrète v1** (`revenuecat_rest_api_key`) ; entitlement `premium`.
4. `checkout_link_secret` aléatoire fort ; env vars Railway **staging ET prod**.
5. Coller `apps/landing/emails/soutien-magic-link.html` dans Supabase Auth → Email Templates → Magic Link, + ajouter `/soutenir` à l'allow-list Redirect URLs.

## Décisions / suites (non bloquantes)

- **Modération du mur de soutien** : défaut = **modéré** (`published=false`, aucun outil admin → publier = passer `published=true` en base). PO à trancher : garder manuel vs auto-publier ; placement du mur.
- **PR5 (nettoyage)** RevenueCat Web Billing (`*_WEB_BILLING_BASE_URL`, `checkout-redirect.html`, `_build_bridge_url`) reportée post-validation prod — **rien retiré ici**.
- Note archi (pas dans cette PR) : `stripe_events` pourrait devenir un `webhook_events(provider, event_id)` générique pour que RevenueCat adopte la même idempotence atomique (aujourd'hui `last_event_id`, plus faible).
- Copy à faire relire (léger) : personnification douce « il t'y attend » / « ce lien t'attend ». Pas d'em-dash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
