### PR TITLE
fix(couverture): compteur carte = couverture réelle + nudge scroll fiable

### DIFF
--- a/apps/mobile/assets/changelog.json
+++ b/apps/mobile/assets/changelog.json
@@ -2,6 +2,10 @@
   "unreleased": [
     {
       "tag": "Tes cartes",
+      "summary": "Le nombre de rédactions affiché sur tes cartes colle enfin à la couverture réelle : si un sujet est traité par 7 sources, la carte l'annonce au lieu de rester bloquée à 2. Et l'invitation à prendre du recul ou à comparer les points de vue réapparaît de façon fiable pendant ta lecture."
+    },
+    {
+      "tag": "Tes cartes",
       "summary": "Chaque carte te dit maintenant combien de rédactions traitent le sujet : « 3 sources », avec leurs logos. C'est le signal qui explique pourquoi un article arrive dans ta tournée, et l'entrée naturelle vers « Comparer les angles ». Au passage, la petite pastille de sous-thème quitte le bas de carte : moins de bruit, plus de sens."
     },
     {

--- a/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
+++ b/apps/mobile/lib/features/detail/screens/content_detail_screen.dart
@@ -236,11 +236,6 @@ const double _kFooterBottomMargin = 8;
 /// de l'ombre). Sans elle, un liseré fantôme resterait visible en bas.
 const double _kFooterShadowClearance = 24;
 
-/// Tolérance (px) autour de l'offset 0 en dessous de laquelle l'utilisateur
-/// est encore considéré « en haut de l'article » pour le nudge de scroll —
-/// absorbe un léger rebond d'overscroll sans faire clignoter le nudge.
-const double _kScrollNudgeTopTolerance = 32.0;
-
 /// Nombre minimal de points de vue en ligne pour que le nudge flottant
 /// « Voir plus de points de vue ? » vaille la peine d'être montré (le pas de
 /// recul, prioritaire, n'a pas de seuil : une carte suffit).
@@ -258,6 +253,109 @@ const Duration _kScrollNudgeArmDelay = Duration(milliseconds: 1500);
 
 /// Durée d'affichage avant auto-masquage : le nudge ne traîne pas à l'écran.
 const Duration _kScrollNudgeAutoHideDelay = Duration(seconds: 6);
+
+/// Délai de confirmation avant de brûler le cooldown 24 h : `markShown` n'est
+/// posé que si la pastille est **toujours** visible à l'échéance. Un flip
+/// transitoire (flash masqué aussitôt) ne doit pas éteindre le nudge pour la
+/// journée — c'était le symptôme « never shows » persistant en test.
+const Duration _kScrollNudgeConfirmDelay = Duration(milliseconds: 400);
+
+/// Type de cible du nudge de scroll, résolu par [resolveScrollNudgeTargetKind].
+/// Extrait comme fonction pure top-level pour être testable sans pomper l'écran.
+enum ScrollNudgeTargetKind { none, deepReco, perspectives }
+
+/// Décide **quelle** cible le nudge de scroll doit viser, à partir de signaux
+/// bruts. Le pas de recul (deep reco) prime sur la couverture médiatique, mais
+/// seulement si sa carte est montée dans l'arbre courant ([deepRecoMounted]) :
+/// dans la branche scroll-vers-le-site elle ne l'est pas, et prioriser une
+/// cible morte empêchait le nudge de retomber sur les perspectives. Le seuil
+/// de points de vue est **inclusif** (`>=`) pour s'aligner sur la pastille de
+/// la carte (affichée à >= 2).
+ScrollNudgeTargetKind resolveScrollNudgeTargetKind({
+  required bool showPerspectivesBand,
+  required bool isExternal,
+  required bool hasDeepReco,
+  required bool deepRecoMounted,
+  required int perspectivesCount,
+  required int minCount,
+}) {
+  if (!showPerspectivesBand || isExternal) return ScrollNudgeTargetKind.none;
+  if (hasDeepReco && deepRecoMounted) return ScrollNudgeTargetKind.deepReco;
+  if (perspectivesCount >= minCount) return ScrollNudgeTargetKind.perspectives;
+  return ScrollNudgeTargetKind.none;
+}
+
+/// Signaux d'entrée du calcul pur de visibilité du nudge de scroll. Regroupés
+/// pour que [computeScrollNudgeVisibility] reste une fonction pure testable.
+class ScrollNudgeInputs {
+  const ScrollNudgeInputs({
+    required this.armElapsed,
+    required this.spent,
+    required this.webViewActive,
+    required this.ctaTapped,
+    required this.hasActiveScrollController,
+    required this.showPerspectivesBand,
+    required this.isExternal,
+    required this.hasDeepReco,
+    required this.deepRecoMounted,
+    required this.perspectivesCount,
+    required this.minCount,
+    required this.cooldownOk,
+    required this.targetTopY,
+    required this.viewportHeight,
+    required this.minBelowFraction,
+  });
+
+  final bool armElapsed;
+  final bool spent;
+  final bool webViewActive;
+  final bool ctaTapped;
+  final bool hasActiveScrollController;
+  final bool showPerspectivesBand;
+  final bool isExternal;
+  final bool hasDeepReco;
+  final bool deepRecoMounted;
+  final int perspectivesCount;
+  final int minCount;
+
+  /// Résultat du cooldown 24 h de la cible résolue. `null` = pas encore résolu
+  /// (vérification asynchrone en vol) → le nudge attend, ne s'affiche pas.
+  final bool? cooldownOk;
+
+  /// Position écran (px) du haut de la cible. `null` = clé non montée/attachée
+  /// (premier frame après fetch, ou carte absente de la branche de layout).
+  final double? targetTopY;
+  final double viewportHeight;
+  final double minBelowFraction;
+}
+
+/// Calcul **pur** de la visibilité du nudge de scroll (aucune mutation d'état).
+/// La destination hors écran (`targetTopY > viewport * minBelowFraction`) est
+/// le seul garde-fou de position : plus de gate « uniquement tout en haut » —
+/// la fiabilité prime, l'auto-masquage + le cooldown 24 h garantissent une
+/// seule apparition par article.
+bool computeScrollNudgeVisibility(ScrollNudgeInputs i) {
+  if (!i.armElapsed || i.spent) return false;
+  if (i.webViewActive || i.ctaTapped) return false;
+  if (!i.hasActiveScrollController) return false;
+
+  final kind = resolveScrollNudgeTargetKind(
+    showPerspectivesBand: i.showPerspectivesBand,
+    isExternal: i.isExternal,
+    hasDeepReco: i.hasDeepReco,
+    deepRecoMounted: i.deepRecoMounted,
+    perspectivesCount: i.perspectivesCount,
+    minCount: i.minCount,
+  );
+  if (kind == ScrollNudgeTargetKind.none) return false;
+
+  final cooldownOk = i.cooldownOk;
+  if (cooldownOk == null || !cooldownOk) return false;
+
+  final topY = i.targetTopY;
+  if (topY == null) return false;
+  return topY > i.viewportHeight * i.minBelowFraction;
+}
 
 /// Cible résolue du nudge de scroll flottant (pas de recul prioritaire, sinon
 /// couverture médiatique). Résolue à la volée par [_resolveScrollNudgeTarget].
@@ -449,6 +547,9 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   bool _scrollNudgeShownRecorded = false;
   Timer? _scrollNudgeArmTimer;
   Timer? _scrollNudgeAutoHideTimer;
+  // Confirme la visibilité avant de brûler le cooldown 24 h (anti flip
+  // transitoire). Annulé partout où la pastille se masque.
+  Timer? _scrollNudgeConfirmTimer;
 
   bool get _showPerspectivesBand =>
       _content?.contentType == ContentType.article;
@@ -1151,24 +1252,35 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   /// `null` si aucune cible pertinente (pas un article, mode externe, ou pas
   /// assez de points de vue et pas de pas de recul).
   _ScrollNudgeTarget? _resolveScrollNudgeTarget() {
-    if (!_showPerspectivesBand || _isExternal) return null;
-    if (_perspectivesResponse?.deepRecommendation != null) {
-      return _ScrollNudgeTarget(
-        NudgeIds.scrollToDeepReco,
-        _deepRecoKey,
-        'Prendre du recul ?',
-        PhosphorIcons.binoculars(PhosphorIconsStyle.regular),
-      );
+    final kind = resolveScrollNudgeTargetKind(
+      showPerspectivesBand: _showPerspectivesBand,
+      isExternal: _isExternal,
+      hasDeepReco: _perspectivesResponse?.deepRecommendation != null,
+      // La carte deep-reco n'est montée qu'en lecture in-app : dans la branche
+      // scroll-vers-le-site sa clé n'a pas de contexte → on retombe sur les
+      // perspectives au lieu de pointer vers une cible morte.
+      deepRecoMounted: _deepRecoKey.currentContext != null,
+      perspectivesCount: _inlinePerspectives.length,
+      minCount: _kScrollNudgeMinCount,
+    );
+    switch (kind) {
+      case ScrollNudgeTargetKind.deepReco:
+        return _ScrollNudgeTarget(
+          NudgeIds.scrollToDeepReco,
+          _deepRecoKey,
+          'Prendre du recul ?',
+          PhosphorIcons.binoculars(PhosphorIconsStyle.regular),
+        );
+      case ScrollNudgeTargetKind.perspectives:
+        return _ScrollNudgeTarget(
+          NudgeIds.scrollToPerspectives,
+          _perspectivesKey,
+          'Voir plus de points de vue ?',
+          PhosphorIcons.arrowDown(PhosphorIconsStyle.regular),
+        );
+      case ScrollNudgeTargetKind.none:
+        return null;
     }
-    if (_inlinePerspectives.length > _kScrollNudgeMinCount) {
-      return _ScrollNudgeTarget(
-        NudgeIds.scrollToPerspectives,
-        _perspectivesKey,
-        'Voir plus de points de vue ?',
-        PhosphorIcons.arrowDown(PhosphorIconsStyle.regular),
-      );
-    }
-    return null;
   }
 
   /// Démarre le délai anti-pop du nudge. Appelé en `initState` (et au retour
@@ -1200,66 +1312,93 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     }();
   }
 
-  /// Calcul pur des conditions d'affichage du nudge de scroll. Aucune
-  /// mutation d'état ici — voir [_updateScrollNudgeVisibility]. Résout et
-  /// mémorise la cible courante dans `_activeScrollNudgeTarget`.
+  /// Assemble les signaux d'état et délègue la décision à la fonction pure
+  /// [computeScrollNudgeVisibility]. Deux effets de bord assumés : mémorise la
+  /// cible courante dans `_activeScrollNudgeTarget` et amorce (une fois) la
+  /// résolution asynchrone du cooldown de cette cible.
   bool _computeShouldShowScrollNudge() {
-    // Délai anti-pop écoulé, pas déjà consommé sur cet article. Le cooldown
-    // 24 h est vérifié plus bas, sur la cible réellement résolue.
-    if (!_scrollNudgeArmDelayElapsed || _scrollNudgeSpent) return false;
-    // Le nudge n'a de sens que pendant la lecture scrollable normale : dès que
-    // la WebView a pris le relais visuel, ou que le CTA a été tapé (révélation
-    // en cours), la destination n'est plus pertinente.
-    if (_isWebViewActive || _ctaTapped) return false;
-
-    // Gardes bon marché d'abord (chemin chaud du scroll) : « en haut » avant
-    // toute résolution/allocation de cible.
-    final ScrollController? active = _activeScrollController;
-    if (active == null) return false;
-    if (active.offset > _kScrollNudgeTopTolerance) return false;
-
-    final target = _resolveScrollNudgeTarget();
-    if (target == null) return false;
-    _activeScrollNudgeTarget = target;
-
-    // Cooldown de LA cible courante — pas de celle connue à l'armement. Le
-    // premier passage lance la vérification et rappellera cette méthode.
-    final cooldownOk = _scrollNudgeCooldownById[target.id];
-    if (cooldownOk == null) {
-      _ensureScrollNudgeCooldown(target.id);
+    // Gardes bon marché d'abord (chemin chaud du scroll) : on bail sur un simple
+    // booléen avant de résoudre la cible, marcher l'arbre de rendu ou lire le
+    // MediaQuery. La fonction pure re-teste ces gates, mais les court-circuiter
+    // ici évite le travail cher quand le nudge est désarmé/dépensé/masqué.
+    if (!_scrollNudgeArmDelayElapsed ||
+        _scrollNudgeSpent ||
+        _isWebViewActive ||
+        _ctaTapped ||
+        _activeScrollController == null) {
       return false;
     }
-    if (!cooldownOk) return false;
 
-    // Destination hors écran (assez bas pour valoir un scroll). Si la clé n'est
-    // pas encore montée (premier frame après fetch, ou carte non rendue dans la
-    // branche de layout courante), on traite comme "non applicable" : pas de
-    // nudge pointant vers rien.
-    final renderObject = target.key.currentContext?.findRenderObject();
-    if (renderObject is! RenderBox || !renderObject.attached) return false;
-    final topY = renderObject.localToGlobal(Offset.zero).dy;
-    final viewportHeight = MediaQuery.of(context).size.height;
-    return topY > viewportHeight * _kScrollNudgeMinBelowFraction;
+    final target = _resolveScrollNudgeTarget();
+    if (target != null) {
+      _activeScrollNudgeTarget = target;
+      // Cooldown de LA cible courante — pas de celle connue à l'armement. Le
+      // premier passage lance la vérification et rappellera cette méthode.
+      _ensureScrollNudgeCooldown(target.id);
+    }
+
+    // Position écran du haut de la cible, si sa clé est montée et attachée.
+    double? targetTopY;
+    final renderObject = target?.key.currentContext?.findRenderObject();
+    if (renderObject is RenderBox && renderObject.attached) {
+      targetTopY = renderObject.localToGlobal(Offset.zero).dy;
+    }
+
+    return computeScrollNudgeVisibility(
+      ScrollNudgeInputs(
+        armElapsed: _scrollNudgeArmDelayElapsed,
+        spent: _scrollNudgeSpent,
+        webViewActive: _isWebViewActive,
+        ctaTapped: _ctaTapped,
+        hasActiveScrollController: _activeScrollController != null,
+        showPerspectivesBand: _showPerspectivesBand,
+        isExternal: _isExternal,
+        hasDeepReco: _perspectivesResponse?.deepRecommendation != null,
+        deepRecoMounted: _deepRecoKey.currentContext != null,
+        perspectivesCount: _inlinePerspectives.length,
+        minCount: _kScrollNudgeMinCount,
+        cooldownOk: target == null
+            ? null
+            : _scrollNudgeCooldownById[target.id],
+        targetTopY: targetTopY,
+        viewportHeight: MediaQuery.of(context).size.height,
+        minBelowFraction: _kScrollNudgeMinBelowFraction,
+      ),
+    );
   }
 
   /// Recalcule et applique la visibilité du nudge de scroll. Ne fait jamais de
   /// `setState` — seule `_showScrollNudge.value` change, consommée par un
-  /// `ValueListenableBuilder<bool>` dédié dans `build()`. Au premier passage
-  /// false→true : pose le cooldown 24 h (markShown, une seule fois) et arme
-  /// l'auto-masquage.
+  /// `ValueListenableBuilder<bool>` dédié dans `build()`. Au passage false→true
+  /// arme l'auto-masquage et un timer de **confirmation** avant de brûler le
+  /// cooldown 24 h ; au passage true→false annule ce timer (le nudge n'a pas
+  /// tenu → on ne le grille pas pour la journée).
   void _updateScrollNudgeVisibility() {
     if (!mounted) return;
     final shouldShow = _computeShouldShowScrollNudge();
     if (_showScrollNudge.value == shouldShow) return;
     _showScrollNudge.value = shouldShow;
-    if (!shouldShow) return;
+    if (!shouldShow) {
+      _scrollNudgeConfirmTimer?.cancel();
+      return;
+    }
 
+    // markShown 24 h posé **après confirmation** (le nudge est toujours visible
+    // à l'échéance) : un flip transitoire aussitôt masqué ne consomme plus la
+    // journée. Le timer est annulé sur chaque masquage (branche ci-dessus,
+    // auto-hide, reset, tap).
     final target = _activeScrollNudgeTarget;
     if (target != null && !_scrollNudgeShownRecorded) {
-      _scrollNudgeShownRecorded = true;
-      // Démarre le cooldown 24 h dès le premier affichage réel → ne réapparaît
-      // plus aujourd'hui (couvre « déjà montré / cliqué »).
-      unawaited(ref.read(nudgeServiceProvider).markShown(target.id));
+      _scrollNudgeConfirmTimer?.cancel();
+      _scrollNudgeConfirmTimer = Timer(_kScrollNudgeConfirmDelay, () {
+        if (!mounted ||
+            !_showScrollNudge.value ||
+            _scrollNudgeShownRecorded) {
+          return;
+        }
+        _scrollNudgeShownRecorded = true;
+        unawaited(ref.read(nudgeServiceProvider).markShown(target.id));
+      });
     }
     // Auto-masquage : le nudge ne traîne pas à l'écran.
     _scrollNudgeAutoHideTimer?.cancel();
@@ -1267,14 +1406,16 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
       if (!mounted) return;
       _scrollNudgeSpent = true;
       _showScrollNudge.value = false;
+      _scrollNudgeConfirmTimer?.cancel();
     });
   }
 
   /// Tap sur le nudge : scrolle le contrôleur actif pour amener le haut de la
   /// destination juste sous le header, puis masque le nudge sans attendre le
   /// `ScrollUpdateNotification` résultant (sinon il resterait visible,
-  /// incongru, pendant toute l'animation). Le cooldown est déjà posé à
-  /// l'affichage.
+  /// incongru, pendant toute l'animation). Le tap est un engagement franc → on
+  /// pose le cooldown 24 h même si le timer de confirmation n'a pas encore
+  /// couru (tap dans les 400 ms suivant l'affichage).
   void _scrollToNudgeTarget(GlobalKey key) {
     final ScrollController? active = _activeScrollController;
     final renderObject = key.currentContext?.findRenderObject();
@@ -1285,6 +1426,13 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     }
 
     HapticFeedback.selectionClick();
+
+    _scrollNudgeConfirmTimer?.cancel();
+    final tapped = _activeScrollNudgeTarget;
+    if (tapped != null && !_scrollNudgeShownRecorded) {
+      _scrollNudgeShownRecorded = true;
+      unawaited(ref.read(nudgeServiceProvider).markShown(tapped.id));
+    }
 
     final topY = renderObject.localToGlobal(Offset.zero).dy;
     final desiredScreenY = _headerHeight + FacteurSpacing.space3;
@@ -1373,6 +1521,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
   void _resetScrollNudge() {
     _scrollNudgeArmTimer?.cancel();
     _scrollNudgeAutoHideTimer?.cancel();
+    _scrollNudgeConfirmTimer?.cancel();
     _scrollNudgeSpent = false;
     _scrollNudgeArmDelayElapsed = false;
     _scrollNudgeCooldownById.clear();
@@ -2015,6 +2164,7 @@ class _ContentDetailScreenState extends ConsumerState<ContentDetailScreen>
     _perspectivesRefetchTimer?.cancel();
     _scrollNudgeArmTimer?.cancel();
     _scrollNudgeAutoHideTimer?.cancel();
+    _scrollNudgeConfirmTimer?.cancel();
     _analysisSheetData.dispose();
     _bookmarkBounceController.dispose();
     _likeBounceController.dispose();

--- a/apps/mobile/lib/features/digest/models/digest_models.dart
+++ b/apps/mobile/lib/features/digest/models/digest_models.dart
@@ -119,6 +119,14 @@ class DigestTopic with _$DigestTopic {
   bool get isCovered =>
       articles.any((a) => a.isRead || a.isSaved || a.isDismissed);
 
+  /// Nombre de sources à afficher sur la carte : le plus grand entre le
+  /// compteur de ranking [sourceCount] (clustering en RAM au digest, plancher
+  /// à 2, jamais réactualisé) et [perspectiveCount] (cluster + Google News
+  /// persisté, = ce que montre le reader). `max` ne régresse jamais sous
+  /// l'affichage actuel. Bug « couverture carte » (voir bug doc).
+  int get coverageCount =>
+      sourceCount > perspectiveCount ? sourceCount : perspectiveCount;
+
   factory DigestTopic.fromJson(Map<String, dynamic> json) =>
       _$DigestTopicFromJson(json);
 }

--- a/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
+++ b/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
@@ -219,6 +219,14 @@ class EssentielArticle {
     this.isActuDuJour = false,
   });
 
+  /// Nombre de sources à afficher sur la carte : le plus grand entre le
+  /// compteur de ranking [sourceCount] (clustering en RAM au digest, plancher
+  /// à 2, jamais réactualisé) et [perspectiveCount] (cluster + Google News
+  /// persisté, = ce que montre le reader). `max` ne régresse jamais sous
+  /// l'affichage actuel. Bug « couverture carte » (voir bug doc).
+  int get coverageCount =>
+      sourceCount > perspectiveCount ? sourceCount : perspectiveCount;
+
   /// État de lecture serveur-truth (avant fusion session), miroir de
   /// [Content.readState] — l'Essentiel n'a que des articles (jamais vidéo).
   ReadState get readState => deriveReadState(

--- a/apps/mobile/lib/features/flux_continu/screens/digest_section_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/digest_section_screen.dart
@@ -166,7 +166,7 @@ class _DigestSectionScreenState extends ConsumerState<DigestSectionScreen> {
             final lead = pickTopicLead(topic);
             return FluxContinuArticleCard(
               article: lead,
-              sourceCount: topic.sourceCount,
+              sourceCount: topic.coverageCount,
               perspectiveSources: topic.perspectiveSources,
               divergenceLevel: topic.divergenceLevel,
               onTap: () => _openArticle(context, lead),

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -803,11 +803,11 @@ class _MediumTile extends StatelessWidget {
                             ),
                           ),
                         ),
-                        if (article.sourceCount >=
+                        if (article.coverageCount >=
                             kCoverageChipMinSources) ...[
                           const SizedBox(width: 8),
                           CoverageChip(
-                            sourceCount: article.sourceCount,
+                            sourceCount: article.coverageCount,
                             sources: article.perspectiveSources,
                             colors: colors,
                           ),
@@ -934,11 +934,11 @@ class _SourceRow extends StatelessWidget {
             style: FacteurTypography.labelSmall(colors.textTertiary),
           ),
         ),
-        if (article.sourceCount >= kCoverageChipMinSources) ...[
+        if (article.coverageCount >= kCoverageChipMinSources) ...[
           const Spacer(),
           CoverageChip(
             key: const Key('essentiel-coverage-chip'),
-            sourceCount: article.sourceCount,
+            sourceCount: article.coverageCount,
             sources: article.perspectiveSources,
             colors: colors,
           ),

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -273,7 +273,7 @@ class SectionBlock extends StatelessWidget {
                 allowImageOnTop: imageAllowed.contains(
                   pickTopicLead(visible[i]).contentId,
                 ),
-                sourceCount: visible[i].sourceCount,
+                sourceCount: visible[i].coverageCount,
                 perspectiveSources: visible[i].perspectiveSources,
                 divergenceLevel: visible[i].divergenceLevel,
                 onTap: () => onTapArticle(pickTopicLead(visible[i])),

--- a/apps/mobile/test/features/detail/scroll_nudge_visibility_test.dart
+++ b/apps/mobile/test/features/detail/scroll_nudge_visibility_test.dart
@@ -1,0 +1,194 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:facteur/features/detail/screens/content_detail_screen.dart';
+
+/// Base « happy path » : nudge visible. Chaque test dérive de ce cas nominal en
+/// ne changeant qu'un signal, pour isoler chaque garde-fou.
+ScrollNudgeInputs _base({
+  bool armElapsed = true,
+  bool spent = false,
+  bool webViewActive = false,
+  bool ctaTapped = false,
+  bool hasActiveScrollController = true,
+  bool showPerspectivesBand = true,
+  bool isExternal = false,
+  bool hasDeepReco = false,
+  bool deepRecoMounted = false,
+  int perspectivesCount = 2,
+  int minCount = 2,
+  bool? cooldownOk = true,
+  double? targetTopY = 3000,
+  double viewportHeight = 800,
+  double minBelowFraction = 0.85,
+}) {
+  return ScrollNudgeInputs(
+    armElapsed: armElapsed,
+    spent: spent,
+    webViewActive: webViewActive,
+    ctaTapped: ctaTapped,
+    hasActiveScrollController: hasActiveScrollController,
+    showPerspectivesBand: showPerspectivesBand,
+    isExternal: isExternal,
+    hasDeepReco: hasDeepReco,
+    deepRecoMounted: deepRecoMounted,
+    perspectivesCount: perspectivesCount,
+    minCount: minCount,
+    cooldownOk: cooldownOk,
+    targetTopY: targetTopY,
+    viewportHeight: viewportHeight,
+    minBelowFraction: minBelowFraction,
+  );
+}
+
+void main() {
+  group('computeScrollNudgeVisibility', () {
+    test('happy path (perspectives, offset ignoré, cible sous le pli) → true', () {
+      expect(computeScrollNudgeVisibility(_base()), isTrue);
+    });
+
+    test('seuil de couverture inclusif : count == minCount → true', () {
+      // Bug — la carte affiche la pastille à >= 2 ; le nudge doit s'aligner.
+      expect(
+        computeScrollNudgeVisibility(_base(perspectivesCount: 2, minCount: 2)),
+        isTrue,
+      );
+    });
+
+    test('count < minCount et pas de deep reco → false', () {
+      expect(
+        computeScrollNudgeVisibility(_base(perspectivesCount: 1, minCount: 2)),
+        isFalse,
+      );
+    });
+
+    test('délai anti-pop pas encore écoulé → false', () {
+      expect(computeScrollNudgeVisibility(_base(armElapsed: false)), isFalse);
+    });
+
+    test('déjà consommé sur cet article → false', () {
+      expect(computeScrollNudgeVisibility(_base(spent: true)), isFalse);
+    });
+
+    test('WebView active → false', () {
+      expect(computeScrollNudgeVisibility(_base(webViewActive: true)), isFalse);
+    });
+
+    test('CTA tapé (révélation en cours) → false', () {
+      expect(computeScrollNudgeVisibility(_base(ctaTapped: true)), isFalse);
+    });
+
+    test('aucun contrôleur de scroll actif → false', () {
+      expect(
+        computeScrollNudgeVisibility(_base(hasActiveScrollController: false)),
+        isFalse,
+      );
+    });
+
+    test('cooldown pas encore résolu (null) → false', () {
+      expect(computeScrollNudgeVisibility(_base(cooldownOk: null)), isFalse);
+    });
+
+    test('cooldown 24 h non ok → false', () {
+      expect(computeScrollNudgeVisibility(_base(cooldownOk: false)), isFalse);
+    });
+
+    test('clé de cible non montée (topY null) → false', () {
+      expect(computeScrollNudgeVisibility(_base(targetTopY: null)), isFalse);
+    });
+
+    test('cible near-fold (au-dessus du seuil below-fold) → false', () {
+      // topY = 600, viewport 800, fraction 0.85 → seuil 680 : 600 < 680.
+      expect(computeScrollNudgeVisibility(_base(targetTopY: 600)), isFalse);
+    });
+
+    test('deep reco monté prime, même count < minCount → true', () {
+      expect(
+        computeScrollNudgeVisibility(
+          _base(
+            hasDeepReco: true,
+            deepRecoMounted: true,
+            perspectivesCount: 0,
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test('hors de la bande perspectives (pas un article) → false', () {
+      expect(
+        computeScrollNudgeVisibility(_base(showPerspectivesBand: false)),
+        isFalse,
+      );
+    });
+
+    test('article externe → false', () {
+      expect(computeScrollNudgeVisibility(_base(isExternal: true)), isFalse);
+    });
+  });
+
+  group('resolveScrollNudgeTargetKind', () {
+    ScrollNudgeTargetKind resolve({
+      bool showPerspectivesBand = true,
+      bool isExternal = false,
+      bool hasDeepReco = false,
+      bool deepRecoMounted = false,
+      int perspectivesCount = 2,
+      int minCount = 2,
+    }) {
+      return resolveScrollNudgeTargetKind(
+        showPerspectivesBand: showPerspectivesBand,
+        isExternal: isExternal,
+        hasDeepReco: hasDeepReco,
+        deepRecoMounted: deepRecoMounted,
+        perspectivesCount: perspectivesCount,
+        minCount: minCount,
+      );
+    }
+
+    test('deep reco présent ET monté → deepReco (prioritaire)', () {
+      expect(
+        resolve(hasDeepReco: true, deepRecoMounted: true, perspectivesCount: 5),
+        ScrollNudgeTargetKind.deepReco,
+      );
+    });
+
+    test('deep reco présent mais NON monté → retombe sur perspectives', () {
+      // Bug — branche scroll-vers-le-site : la carte deep-reco n'est pas dans
+      // l'arbre ; prioriser sa cible morte bloquait tout le nudge.
+      expect(
+        resolve(
+          hasDeepReco: true,
+          deepRecoMounted: false,
+          perspectivesCount: 3,
+        ),
+        ScrollNudgeTargetKind.perspectives,
+      );
+    });
+
+    test('deep reco NON monté et count insuffisant → none', () {
+      expect(
+        resolve(
+          hasDeepReco: true,
+          deepRecoMounted: false,
+          perspectivesCount: 1,
+          minCount: 2,
+        ),
+        ScrollNudgeTargetKind.none,
+      );
+    });
+
+    test('perspectives count == minCount → perspectives', () {
+      expect(
+        resolve(perspectivesCount: 2, minCount: 2),
+        ScrollNudgeTargetKind.perspectives,
+      );
+    });
+
+    test('hors bande perspectives → none', () {
+      expect(resolve(showPerspectivesBand: false), ScrollNudgeTargetKind.none);
+    });
+
+    test('externe → none', () {
+      expect(resolve(isExternal: true), ScrollNudgeTargetKind.none);
+    });
+  });
+}

--- a/apps/mobile/test/features/flux_continu/models/flux_continu_models_test.dart
+++ b/apps/mobile/test/features/flux_continu/models/flux_continu_models_test.dart
@@ -430,4 +430,53 @@ void main() {
       expect(a.perspectiveSources, isEmpty);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // coverageCount — max(sourceCount, perspectiveCount) — bug « carte bloquée »
+  // ---------------------------------------------------------------------------
+  group('coverageCount', () {
+    EssentielArticle article({int sourceCount = 0, int perspectiveCount = 0}) {
+      return EssentielArticle(
+        contentId: 'c',
+        title: 't',
+        url: 'https://example.com',
+        publishedAt: DateTime(2026, 7, 30),
+        sourceName: 'Le Monde',
+        sourceLetter: 'L',
+        sectionLabel: 'Climat',
+        rank: 1,
+        sourceCount: sourceCount,
+        perspectiveCount: perspectiveCount,
+      );
+    }
+
+    DigestTopic topic({int sourceCount = 0, int perspectiveCount = 0}) {
+      return DigestTopic(
+        topicId: 't',
+        label: 'Topic',
+        sourceCount: sourceCount,
+        perspectiveCount: perspectiveCount,
+      );
+    }
+
+    test('EssentielArticle : perspective (reader) > source (ranking figé)', () {
+      expect(article(sourceCount: 2, perspectiveCount: 7).coverageCount, 7);
+    });
+
+    test('EssentielArticle : source >= perspective → source', () {
+      expect(article(sourceCount: 5, perspectiveCount: 3).coverageCount, 5);
+    });
+
+    test('EssentielArticle : égaux → la valeur commune', () {
+      expect(article(sourceCount: 4, perspectiveCount: 4).coverageCount, 4);
+    });
+
+    test('DigestTopic : perspective (reader) > source (ranking figé)', () {
+      expect(topic(sourceCount: 2, perspectiveCount: 8).coverageCount, 8);
+    });
+
+    test('DigestTopic : source >= perspective → source', () {
+      expect(topic(sourceCount: 6, perspectiveCount: 1).coverageCount, 6);
+    });
+  });
 }

--- a/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart
@@ -87,6 +87,7 @@ EssentielArticle _article({
   bool isRead = false,
   DateTime? completedAt,
   int sourceCount = 0,
+  int perspectiveCount = 0,
   List<SourceMini> perspectiveSources = const [],
 }) {
   return EssentielArticle(
@@ -99,7 +100,7 @@ EssentielArticle _article({
     sectionLabel: label,
     theme: theme,
     rank: rank,
-    perspectiveCount: 3,
+    perspectiveCount: perspectiveCount,
     isActuDuJour: isActuDuJour,
     isRead: isRead,
     completedAt: completedAt,
@@ -321,6 +322,48 @@ void main() {
       expect(tester.takeException(), isNull);
       expect(find.text('4 sources'), findsOneWidget);
       expect(find.text('3 sources'), findsOneWidget);
+      expect(find.text('1 source'), findsNothing);
+    });
+
+    testWidgets(
+        'la couverture affiche le plus grand entre source_count (ranking) et '
+        'perspective_count (reader) — bug carte bloquée à ~2', (tester) async {
+      tester.view.physicalSize = const Size(390, 844);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(_wrap(
+        EssentielHiFiCard(
+          // Ranking figé à 1, mais la couverture réelle (reader) = 7 : la puce
+          // doit refléter le 7, pas rester bloquée sous le seuil.
+          articles: [_article(rank: 1, sourceCount: 1, perspectiveCount: 7)],
+          onTapArticle: (_) {},
+        ),
+      ));
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('7 sources'), findsOneWidget);
+      expect(find.text('1 source'), findsNothing);
+    });
+
+    testWidgets(
+        'aucune puce quand la couverture réelle reste < 2 (source et '
+        'perspective sous le seuil)', (tester) async {
+      tester.view.physicalSize = const Size(390, 844);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(_wrap(
+        EssentielHiFiCard(
+          articles: [_article(rank: 1, sourceCount: 1, perspectiveCount: 1)],
+          onTapArticle: (_) {},
+        ),
+      ));
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      expect(find.byKey(const Key('essentiel-coverage-chip')), findsNothing);
       expect(find.text('1 source'), findsNothing);
     });
 

--- a/docs/bugs/bug-couverture-carte-count-et-nudge.md
+++ b/docs/bugs/bug-couverture-carte-count-et-nudge.md
@@ -1,0 +1,118 @@
+# Bug — couverture médiatique : compteur carte bloqué + nudge jamais affiché
+
+> Type : Bug (mobile-only). Deux régressions héritées de la story 32.2
+> (PR #1041 « pastille N sources » + nudge « comparaison », dont le Commit 3
+> avait été livré sans test, validation PO différée). Aucune migration, aucun
+> changement backend, aucun changement de ranking.
+
+## Symptômes (signalés par le PO)
+
+1. **Le chiffre « prévisualisé » sur les cartes est bloqué à ~2**, alors qu'en
+   ouvrant l'article le reader affiche 5/7/8 sources, et ce **avant même la fin
+   de la requête Google News** : la donnée existe déjà, stockée au digest.
+2. **Le nudge flottant** (« Voir plus de points de vue ? » / « Prendre du
+   recul ? » dans le reader) **ne s'affiche jamais.**
+
+## Bug 1 — cause racine
+
+Deux compteurs distincts, calculés par des chemins différents :
+
+- **Carte** → `CoverageChip` affiche `sourceCount`, issu du backend
+  `source_count = len(cluster.source_domains)` du clustering en RAM au moment
+  du digest (`editorial/pipeline.py`), avec un gate multi-source `>= 2` dans
+  `briefing/importance_detector.py` qui pose un **plancher à 2**. C'est un
+  compteur de **ranking**, jamais réactualisé.
+- **Reader** → `perspective_count` (cluster + Google News, filtré biais connu),
+  calculé ET persisté par `_process_perspectives`, = ce que le reader montre
+  immédiatement depuis le snapshot stocké.
+
+`perspective_count` est déjà propagé jusqu'à la carte sur les 3 surfaces
+(`DigestTopic`, `EssentielArticle` portent `sourceCount` **et**
+`perspectiveCount`) : la puce lisait simplement le mauvais champ.
+
+**Décision PO** : afficher `max(sourceCount, perspectiveCount)` partout, seuil
+`>= 2`. `max` ne régresse jamais sous l'affichage actuel. Ranking `source_count`
+non touché.
+
+### Fix Bug 1
+
+- Getter `coverageCount => max(sourceCount, perspectiveCount)` sur `DigestTopic`
+  (`digest_models.dart`) et `EssentielArticle` (`flux_continu_models.dart`).
+- Call sites basculés sur `coverageCount` : `section_block.dart`,
+  `digest_section_screen.dart`, `essentiel_hi_fi_card.dart` (2 sites : lead
+  `_SourceRow` + tuile inline). `CoverageChip` inchangé (le param s'appelle
+  toujours `sourceCount` mais porte le nombre de couverture, choix minimaliste).
+
+## Bug 2 — cause racine
+
+Le nudge exige que **toutes** ces conditions tiennent au même instant : arm
+1,5 s écoulé, non `spent`, pas WebView/CTA, cible résolue, cooldown 24 h ok,
+cible montée avec `topY > 0.85 * viewport`. Causes, par gravité :
+
+- **Fenêtre trop étroite (dominante)** : le gate `offset <= 32 px` (tout en
+  haut) combiné à la chaîne async (arm 1,5 s + fetch perspectives + round-trip
+  cooldown) rendait le créneau quasi inatteignable : l'utilisateur scrolle
+  avant.
+- **Blocage dur deep-reco** : `_resolveScrollNudgeTarget` priorisait le target
+  `_deepRecoKey`, **non monté** dans la branche scroll-vers-le-site (montée
+  seulement en lecture in-app). Tout article avec `deepRecommendation` résolvait
+  donc une cible morte et **ne retombait jamais** sur les perspectives.
+- **Gate de compte** `> minCount` (donc `>= 3`) alors que la carte affiche à
+  `>= 2`.
+- **Cooldown brûlé sur un show transitoire** : `markShown` (24 h/device) était
+  appelé au flip `true` sans confirmation de visibilité : un flash masqué
+  aussitôt éteignait le nudge pour la journée (symptôme « never shows »
+  persistant en test).
+
+### Fix Bug 2
+
+Fichier unique `content_detail_screen.dart` :
+
+1. Seuil de couverture inclusif : `perspectivesCount >= minCount` (aligne `>= 2`).
+2. Fallback deep-reco : la cible deep-reco ne prime que si sa carte est montée
+   (`_deepRecoKey.currentContext != null`) ; sinon on retombe sur les
+   perspectives.
+3. Suppression du gate `offset <= _kScrollNudgeTopTolerance` (et de la constante,
+   devenue morte). La visibilité repose sur le seul check below-fold
+   `topY > 0.85 * viewport`, qui masque naturellement la pastille quand la
+   section approche. `spent` + auto-hide 6 s + cooldown 24 h garantissent 1
+   apparition/article. **Décision PO : fiabilité > top-only.**
+4. `markShown` déféré derrière un timer de confirmation
+   (`_kScrollNudgeConfirmDelay = 400 ms`) : le cooldown n'est posé que si la
+   pastille est **toujours** visible à l'échéance ; le timer est annulé partout
+   où elle se masque (flip `!shouldShow`, auto-hide, reset, tap). Le tap pose le
+   cooldown immédiatement (engagement franc).
+
+### Refactor de testabilité
+
+La logique pure est extraite en deux fonctions top-level testables sans pomper
+l'écran : `resolveScrollNudgeTargetKind(...)` (sélection de cible) et
+`computeScrollNudgeVisibility(ScrollNudgeInputs)` (décision de visibilité). La
+méthode `_computeShouldShowScrollNudge` devient un adaptateur qui lit l'état et
+délègue (effets de bord assumés : mémorisation de la cible + amorçage du
+cooldown).
+
+## Tests
+
+- `test/features/detail/scroll_nudge_visibility_test.dart` : happy path +
+  garde-fous (count exact 2, near-fold, spent/webview/cta, cooldown
+  pending/false, deep-reco monté/non-monté → fallback perspectives).
+- `test/features/flux_continu/widgets/essentiel_hi_fi_card_test.dart` :
+  `perspectiveCount > sourceCount` fait afficher le plus grand ; couverture
+  réelle `< 2` cache la puce. Helper `_article` : `perspectiveCount` devient
+  paramètre (défaut 0) pour rendre les cas déterministes.
+- `test/features/flux_continu/models/flux_continu_models_test.dart` : getter
+  `coverageCount` sur `DigestTopic` et `EssentielArticle`.
+
+> Note : le plan prévoyait aussi un widget test pumpant `ContentDetailScreen`.
+> L'écran est fortement couplé (réseau, WebView, nombreux providers) ; le
+> refactor en fonctions pures couvre déterministe­ment les deux régressions de
+> fond (fenêtre + fallback deep-reco), sans la fragilité d'un pump complet. La
+> validation de bout en bout passe par Playwright (voir plan).
+
+## Garde-fous
+
+- Bug 1 (getters + call sites) et Bug 2 (edits + refactor) sont indépendants et
+  révocables.
+- Pas d'em-dash dans la copy user-facing.
+- Ranking (`source_count`, `is_multi`, `compute_coverage_score`) non touché.


### PR DESCRIPTION
## Quoi

Deux régressions mobile-only héritées de la story 32.2 (PR #1041). Aucune migration, aucun changement backend, aucun changement de ranking.

**Bug 1 — compteur carte bloqué à ~2.** La pastille de couverture lisait `sourceCount` (compteur de ranking, planché à 2, jamais réactualisé) alors que le reader affiche la couverture réelle (`perspectiveCount`), déjà persistée au digest. Fix : getter `coverageCount => max(sourceCount, perspectiveCount)` sur `DigestTopic` et `EssentielArticle` ; call sites basculés (`section_block`, `digest_section_screen`, `essentiel_hi_fi_card`). Seuil `>= 2` inchangé, `max` ne régresse jamais.

**Bug 2 — nudge scroll jamais affiché.** Fenêtre trop étroite (gate `offset <= 32px`), fallback deep-reco vers une cible non montée, gate de compte `> minCount`, cooldown brûlé sur un show transitoire. Fix dans `content_detail_screen` : seuil inclusif `>= 2`, fallback perspectives si carte deep-reco non montée, suppression du gate top-only (décision PO : fiabilité > top-only), `markShown` déféré derrière un timer de confirmation 400ms.

**Refactor de testabilité** : logique pure extraite en `resolveScrollNudgeTargetKind` et `computeScrollNudgeVisibility`, testée sans pumper l'écran. Gardes bon marché conservées en tête du chemin chaud du scroll (revue simplify).

## Pourquoi

Signalé par le PO : chiffre bloqué à 2 sur les cartes alors que le reader montre 5/7/8 sources ; nudge « prendre du recul / comparer les points de vue » invisible.

## Comment ça a été vérifié

- [x] `flutter test` sur les fichiers touchés : 92 tests OK (scroll_nudge_visibility, essentiel_hi_fi_card, flux_continu_models)
- [x] Suite complète : 1973 pass / 28 échecs pré-existants baseline (settings, bookmark, feed, perspectives… aucun sur les fichiers touchés)
- [x] `flutter analyze` sur les fichiers modifiés : aucun nouvel issue (1 warning + infos pré-existants sur origin/main)
- [x] `/simplify` passé (fix efficacité chemin chaud appliqué)
- [ ] Playwright non exécuté — la logique de fond est couverte par les fonctions pures ; validation end-to-end via Playwright possible en QA

## Zones à risque

- `content_detail_screen.dart` (reader, scroll notifications, timers) — nudge + refactor, révocable.
- Ranking (`source_count`, `is_multi`, `compute_coverage_score`) NON touché.

🤖 Generated with [Claude Code](https://claude.com/claude-code)