### PR TITLE
fix(curation): fold couverture (B-2) + arrêt de la fabrication d'intérêts (C-1)

### DIFF
--- a/.context/pr-handoff.md
+++ b/.context/pr-handoff.md
@@ -1,56 +1,130 @@
-# feat(reco): allumer le bonus de pluralité (couverture multi-sources) sur le digest
+# fix(curation): fold couverture (B-2) + arrêt de la fabrication d'intérêts (C-1)
 
-Base `main`. **Aucune migration.** Backend-only (0 fichier mobile).
+Base `main`. **Une migration Alembic** (`cq01_subtopics_uniq_muted`).
+Backend-only (0 fichier mobile).
 
-## Résumé
+## Contexte
 
-Le pilier Pertinence calcule un bonus log-calibré pour les clusters multi-sources
-(`2→+12, 3→+19, 4→+24, cap 30`) mais c'était **du code mort partout** : aucun call
-site ne passait le count au `ScoringContext`, et la garde `content.cluster_id`
-tombait sur NULL pour ~99 % des candidats (`contents.cluster_id` NULL à 99 % en
-base — 298 / 29 414 sur 14j, uuid4 régénéré par run). Cette PR allume le signal
-**pour la première fois**, sur le chemin `topics` (cœur digest).
+Deuxième livrable du lot « qualité de la curation », après PR 1 (B-1
+métadonnées, #1047). La cible du lot est
+`score = w_imp · norm(importance) + w_perso · norm(perso)` (PR 4-5). Les deux
+termes sont aujourd'hui faux : `importance` compte de la redondance (B), `perso`
+est un signal plat et fabriqué (C). **Cette PR répare les deux termes avant que
+PR 4 ne les mélange.** Elle ne change volontairement **pas** le tri.
 
-Doc : `docs/maintenance/maintenance-coverage-pillar-wiring.md`.
+Diagnostic complet : `docs/bugs/bug-curation-essentiel-personnalisation.md`.
 
-## Approche — sûre, sans mutation ORM ni migration
+## PR 2 — B-2 : ne compter que les rédactions qui portent un jugement
 
-Le count du cluster est porté **directement sur le `ScoringContext`** (construit par
-cluster dans `_score_and_select_articles`, donc `len(cluster.source_domains)`
-s'applique à tous ses contents), et non via une mutation de `content.cluster_id` —
-muter cet attribut ORM sur des `Content` attachés à la session risquerait un
-autoflush vers la **DB prod partagée** (la colonne même que le pipeline peuple avec
-des uuid4 par-run).
+`importance_detector.py` : `_is_aggregator` → `_counts_toward_coverage`, appliqué
+aux **deux** collections (`source_ids` **et** `source_domains`).
 
-- `ScoringContext.coverage_source_count: int | None` — nouveau champ optionnel.
-- `_score_coverage` — fast-path context-carried (prioritaire), fallback dict
-  `cluster_source_counts` inchangé.
-- `topic_selector` — `_build_scoring_context(..., coverage_source_count=len(cluster.source_domains))`.
+- **Critère** : `SourceType.REDDIT` **OU** (`is_curated` falsy **ET**
+  `reliability_score ∈ {low, mixed}`). Réglable sans déploiement :
+  `EDITORIAL_COVERAGE_FOLD_RELIABILITY` (défaut `low,mixed`),
+  `EDITORIAL_COVERAGE_FOLD_ENABLED` (kill switch, défaut `true`).
+- **`unknown` volontairement exclu** : « jamais évaluée » ≠ « peu fiable » ;
+  l'inclure folderait 39,5 % du corpus `politics` (déjà à 1,3 % du top-5).
 
-## Périmètre / discipline (GO PO Laurin)
+### Dry-run comparatif (prod, lecture seule, 24 h) — livrable bloquant
 
-- **Chemin `topics` seulement.** Tournée/curation + flat éditorial reportés (le flat
-  `_project_editorial_for_user` double-compterait avec `subject_importance`).
-- **`COVERAGE_CAP=30` inchangé** — levier unique = allumage du signal ; le cap est un
-  2e levier reporté (de toute façon `max_src=4` en prod ⇒ plafond effectif +24).
-- **0 migration, 0 mutation ORM.** Commit isolé/révocable.
+`scripts/dryrun_coverage_fold.py --hours 24 --tag b2-fold` (read-only, sans LLM,
+exit ≠ 0 si > 50 % du top-15 change). Résultat sur 1 565 contenus / 1 086
+clusters :
+
+- **top-15 (entrée LLM) change de 13 %** (2 sortants, 2 entrants) ;
+- **18 clusters franchissent `2→1`**, 9 franchissent `3→2` ; `4+ domaines` :
+  22 → 13 ;
+- **`politics` net = +0** (non enterré ; sortants = 1 environment, 1 culture ;
+  entrants = 1 science, 1 sport).
+
+Artefacts : `.context/dryrun_coverage_fold_b2-fold.{json,md}`.
+
+## PR 3 — C-1 : arrêter de fabriquer des intérêts
+
+Correctif **au moment de l'écriture** (une fois la ligne créée, rien ne distingue
+un intérêt déclaré d'un intérêt fabriqué) :
+
+- `_adjust_interest_weight` (lecture) → **UPDATE seul** (no-op si absent).
+- `_adjust_subtopic_weights` → paramètre `allow_create` (défaut `False`). Créent
+  seulement les signaux **explicites** : like/save/note (`content_service`),
+  feedback (`routers/contents.py`), actions digest **SAVE/LIKE**
+  (`digest_service`). Lecture (READ) et signaux négatifs = update seul.
+- **Double-comptage confirmé (§3.1)** : le tail « interest par thème source » de
+  `_adjust_subtopic_weights` fabriquait **aussi** un `user_interests` sur lecture
+  (en plus de `_adjust_interest_weight`). Il est désormais gardé par le même
+  `allow_create` → plus aucune fabrication d'intérêt sur lecture. La magnitude du
+  renforcement d'un intérêt *existant* sur lecture (0,05 + 0,03) est inchangée
+  (hors périmètre C-1, relève de PR 4).
+- Onboarding (`user_service.py`) : `db.add(UserSubtopic)` → upsert
+  `on_conflict_do_nothing` (ne casse pas sur la nouvelle contrainte).
+
+### Migration `cq01_subtopics_uniq_muted` (down_revision `sa02_alerts_v2`)
+
+1. **Dédup** `user_subtopics` sur `(user_id, topic_slug)` (garde le plus grand
+   weight) — la contrainte d'origine avait été droppée par accident
+   (`4d497ce7bcc2`).
+2. **`UNIQUE uq_user_subtopics_user_topic`** + **`INDEX ix_user_subtopics_user_id`**
+   (la table n'avait aucun index → seq scan à chaque lecture feed/digest).
+3. **`DELETE`** idempotent des `user_interests` contredisant un `muted_themes`.
+
+Idempotente, `__table_args__` posé sur le modèle. Testée : `alembic upgrade head`
+sur DB vide (chaîne complète), downgrade/re-upgrade, exactement **1 head**.
+
+**Risque expand-contract assumé** (DB partagée staging/prod) : pendant ≤ 1
+semaine, le backend `production` (ancien code) fait encore du check-then-insert ;
+une course produira une `IntegrityError` ponctuelle (mesuré **5×** sur toute la
+vie de la table) au lieu d'un doublon silencieux. Décision PO §5 : contrainte
+dans cette PR.
 
 ## Tests
 
-- `tests/recommendation/test_pertinence_coverage.py` : +3 cas context-carried
-  (bonus sans `cluster_id`, mono-source = 0, priorité sur dict).
-- `tests/test_topic_selector.py` : +2 cas d'intégration (cluster ≥3 sources →
-  « Couvert par 3 sources » dans le breakdown ; mono-source → rien).
-- Suite reco + digest : **119 passed**, 0 régression. `alembic heads` = 1 head
-  (`sa02_alerts_v2`).
+- `test_importance_detector.py::TestReliabilityFold` — 7 cas (fold low/mixed,
+  repli cluster 100 % foldé, curée medium compte, **`unknown` compte** — non-rég
+  Libération, `source_ids` **et** `source_domains`, kill switch, CSV env).
+- `test_digest_per_user_projection.py::test_rehydrated_clusters_do_not_depend_on_source_domains`
+  — invariant : cluster réhydraté n'a pas de `source_domains`, le décompte passe
+  par `source_ids` (déjà foldé en global).
+- `test_subtopic_weight_concurrency.py` (nouveau) — read n'crée pas / like crée /
+  cap 3.0 / clamp 0.1.
+- `test_interest_weight_concurrency.py` — réécrit : read n'crée pas / read
+  incrémente un existant.
+- `tests/alembic/test_cq01_subtopics_uniq_muted.py` (nouveau) — dédup garde
+  max-weight + idempotence, DELETE muté (seulement muté, idempotent, thème
+  re-déclaré préservé, no-op sans mute).
+- Non-régression `test_like_feature.py` / `test_user_service_persist.py` mis à
+  jour (`allow_create`, upsert onboarding).
+- **Suite backend complète : 2862 passed, 18 skipped, 2 xfailed.** `ruff check` OK.
 
-## Mesure post-merge (jauge)
+## Vérification C-1 (avant/après)
 
-`by_pillar_band["pertinence"]` (`scripts/evaluate_feed_ranking.py`). **Forward-only**
-⇒ bandes vides avant date de merge, fenêtre d'observation ≥7j. **Puissance faible**
-(~13 clusters ≥3 src / 14j) : absence de mouvement CTR ≠ preuve d'inefficacité.
+Bloc « C-1 » ajouté à `docs/qa/scripts/baseline_curation.sql` (M8-M11). À lancer
+via le rôle service (`claude_analytics_ro` n'a pas le `SELECT` sur
+`user_interests`/`user_subtopics`). Valeurs live prod (via MCP Supabase) :
 
-## Hors périmètre
+| # | Métrique | Avant (live 02/08) | Après |
+|---|---|---|---|
+| M8 | `user_interests` sur un thème muté | **42** (27 comptes) | **0** après migration |
+| M11 | Doublons `(user_id, topic_slug)` | **5** | **0**, impossible |
 
-Aucun changement mobile, aucune migration, cap inchangé, Tournée/curation/flat non
-touchés.
+(M8 = 53 au snapshot 02/08 ; le chiffre dérive tant que `production` fabrique
+encore — d'où le rejeu post-release ci-dessous.)
+
+## Après merge
+
+1. `alembic upgrade head` rejoué automatiquement au boot Railway (staging + prod).
+2. **Après la release hebdo suivante** : rejouer une fois le `DELETE` des thèmes
+   mutés (le temps que `production` prenne le correctif de code) :
+
+   ```sql
+   DELETE FROM user_interests ui USING user_personalization up
+   WHERE up.user_id = ui.user_id
+     AND ui.interest_slug = ANY(COALESCE(up.muted_themes, '{}'));
+   ```
+
+## Ce que cette PR ne fait pas
+
+- Ne change pas le tri (`is_multi`, `subject_rank_key`) — **PR 4**.
+- Ne rebranche pas le pool personnalisé (« l'IA » qui remonte) — **PR 5**.
+- N'atteint pas les cibles M1-M4 seule : elle rend les deux termes du futur score
+  honnêtes, le mélange c'est PR 4-5.

--- a/docs/bugs/bug-curation-essentiel-personnalisation.md
+++ b/docs/bugs/bug-curation-essentiel-personnalisation.md
@@ -101,9 +101,9 @@ pondère de la redondance ; A sans C pondère du bruit.
 | # | PR | Contenu | Statut |
 |---|---|---|---|
 | 0 | — | `BYPASSRLS` + figer la baseline | ✅ **fait le 01/08** |
-| 1 | PR 1 | **B-1** métadonnées sources (script idempotent) | 🟡 cette PR |
-| 2 | PR 2 | **B-2** fold couverture + dry-run comparatif du top-15 | à venir |
-| 3 | PR 3 | **C-1** stopper la fabrication d'intérêts + unicité `(user_id, topic_slug)` | à venir |
+| 1 | PR 1 | **B-1** métadonnées sources (script idempotent) | ✅ mergée (#1047) |
+| 2 | PR 2 | **B-2** fold couverture + dry-run comparatif du top-15 | ✅ **cette PR** |
+| 3 | PR 3 | **C-1** stopper la fabrication d'intérêts + unicité `(user_id, topic_slug)` | ✅ **cette PR** |
 | 4 | PR 4 | **A** score mixte, `is_multi` retiré, poids en env, bump `editorial_v4` | à venir |
 | 5 | PR 5 | **A** pool personnalisé rebranché (`digest_selector.py:406-407`) | à venir |
 | 6 | PR 6 | **C-2** taux appris lissés vers le prior population | à venir |
@@ -177,3 +177,87 @@ sources pendant que le fil brut de BFMTV produit 4 803 articles/30 j.
 - Dry-run joué contre la prod en lecture seule : 13 sources à corriger, 0
   introuvable, 0 renommée.
 - Aucune migration Alembic : DML pure sur des colonnes existantes.
+
+---
+
+## PR 2 — B-2 : ne compter que les rédactions qui portent un jugement
+
+Point d'insertion unique : le « fold agrégateurs » de
+`importance_detector.py`. `_is_aggregator` devient `_counts_toward_coverage`,
+appliqué aux **deux** collections (`source_ids` **et** `source_domains`).
+
+Critère : `SourceType.REDDIT` **OU** (`source.is_curated` falsy **ET**
+`reliability_score ∈ {low, mixed}`). Réglable sans déploiement via
+`EDITORIAL_COVERAGE_FOLD_RELIABILITY` (défaut `low,mixed`) et
+`EDITORIAL_COVERAGE_FOLD_ENABLED` (kill switch, défaut `true`).
+
+### Les 3 corrections mesurées au plan d'origine (§1)
+
+1. **`unknown` retiré du critère.** `unknown` = jamais évaluée, pas « peu
+   fiable ». L'inclure folderait 39,5 % du corpus `politics` (déjà à 1,3 % du
+   top-5), via `Libération - Politique` notamment. Critère restreint à
+   `low`/`mixed` ⇒ 19 sources / 9 509 art./30 j, `politics` foldé retombe à
+   29,1 % (= `society`).
+2. **Le critère n'attrape que 2 des 5 pourvoyeurs** (Home Fil actu, CNEWS) ;
+   Ouest-France / France Info / Europe 1 sont curées ⇒ **M4 < 45 % n'est pas
+   atteignable par B-2 seul**. Assainissement du terme `importance`, pas le
+   levier des cibles (PR 4-5).
+3. **Le fold s'applique à `source_ids` aussi**, pas seulement `source_domains` :
+   `routers/feed.py` lit `source_ids` et hériterait sinon d'un comptage
+   incohérent.
+
+### Dry-run comparatif (prod, lecture seule, 24 h)
+
+`scripts/dryrun_coverage_fold.py --hours 24 --tag b2-fold`. Résultat (1 565
+contenus, 1 086 clusters) : **top-15 change de 13 %** (garde-fou : abort si
+> 50 %), **18 clusters franchissent `2→1`**, 9 franchissent `3→2`,
+**`politics` net = +0** (non net-sortant). Distribution `4+ domaines` :
+22 → 13. Artefacts : `.context/dryrun_coverage_fold_b2-fold.{json,md}`.
+
+Aucune migration.
+
+---
+
+## PR 3 — C-1 : arrêter de fabriquer des intérêts
+
+Correctif **au moment de l'écriture**, pas au scoring.
+
+- `_adjust_interest_weight` (lecture) → **UPDATE seul** : une lecture ne crée
+  plus de `user_interests` sur le thème de la source.
+- `_adjust_subtopic_weights` → paramètre `allow_create` (défaut `False`). Seuls
+  les signaux **explicites** (like / save / note / feedback, actions digest
+  SAVE|LIKE) peuvent créer une ligne ; lecture et signaux négatifs = update
+  seul. **Le tail « interest par thème source » de cette fonction est gardé par
+  le même `allow_create`** — il fabriquait lui aussi un `user_interests` sur
+  lecture (double-comptage §3.1 confirmé, cf. handoff).
+- Onboarding (`user_service.py`) : `db.add(UserSubtopic)` → upsert
+  `on_conflict_do_nothing` (ne casse pas sur la nouvelle contrainte).
+
+### Migration `cq01_subtopics_uniq_muted` (head : `sa02_alerts_v2`)
+
+1. Dédup `user_subtopics` sur `(user_id, topic_slug)` (garde le plus grand
+   weight) — la contrainte d'origine avait été droppée par accident
+   (`4d497ce7bcc2`).
+2. `UNIQUE uq_user_subtopics_user_topic` + `INDEX ix_user_subtopics_user_id`
+   (la table n'avait aucun index).
+3. `DELETE` idempotent des `user_interests` contredisant un `muted_themes`
+   (53 lignes / 27 comptes au 02/08).
+
+Idempotente, testée `alembic upgrade head` sur DB vide + downgrade/re-upgrade.
+**Risque expand-contract assumé** (DB partagée) : pendant ≤ 1 semaine le backend
+`production` (ancien code) peut recréer une course doublon (mesuré 5×/vie-de-table)
+⇒ `IntegrityError` ponctuelle au lieu d'un doublon silencieux. Le `DELETE` muté
+est **à rejouer une fois après la release hebdo**.
+
+### Vérification C-1
+
+Nouvelles métriques (M8-M11) dans `docs/qa/scripts/baseline_curation.sql`
+(bloc « C-1 », à lancer via le rôle service — `claude_analytics_ro` n'a pas le
+`SELECT` sur `user_interests`/`user_subtopics`) :
+
+| # | Métrique | Avant (02/08) | Après |
+|---|---|---|---|
+| M8 | `user_interests` sur un thème muté | 53 (27 comptes) | 0 après migration |
+| M9 | Lignes `user_interests` à `1,0 < w < 1,2` | 174 / 746 | ne plus croître |
+| M10 | Users à amplitude `user_subtopics` < 0,2 | 85 / 101 | ne plus croître |
+| M11 | Doublons `(user_id, topic_slug)` | 5 | 0, impossible |

--- a/docs/qa/scripts/baseline_curation.sql
+++ b/docs/qa/scripts/baseline_curation.sql
@@ -120,3 +120,44 @@ SELECT selection_reason,
        ROUND((100.0 * COUNT(*) FILTER (WHERE rank <= 5) / COUNT(*))::numeric, 1) AS pct_atteint_top5
 FROM slots WHERE rank BETWEEN 1 AND 10
 GROUP BY 1 HAVING COUNT(*) >= 200 ORDER BY 3 DESC;
+
+-- ============================================================================
+-- Bloc C-1 (PR 3) — signal `perso` : santé de user_interests / user_subtopics.
+-- ⚠️ Ces tables ne sont PAS couvertes par le GRANT de claude_analytics_ro
+--    (BYPASSRLS ne donne pas le SELECT). Lancer ce bloc via le rôle service
+--    (MCP Supabase) ou après un `GRANT SELECT ON user_interests, user_subtopics
+--    TO claude_analytics_ro;`. Valeurs figées au 02/08/2026.
+-- ============================================================================
+
+\echo ''
+\echo '=== M8 — user_interests sur un theme MUTE (attendu 0 apres migration) ==='
+SELECT COUNT(*) AS lignes, COUNT(DISTINCT ui.user_id) AS comptes
+FROM user_interests ui
+JOIN user_personalization up ON up.user_id = ui.user_id
+WHERE ui.interest_slug = ANY(COALESCE(up.muted_themes, '{}'));
+
+\echo ''
+\echo '=== M9 — user_interests fabriques (1,0 < weight < 1,2) : ne plus croitre ==='
+SELECT COUNT(*) FILTER (WHERE weight > 1.0 AND weight < 1.2) AS fabriques,
+       COUNT(*)                                             AS total
+FROM user_interests;
+
+\echo ''
+\echo '=== M10 — users a amplitude user_subtopics < 0,2 (signal plat) ==='
+WITH amp AS (
+    SELECT user_id, MAX(weight) - MIN(weight) AS amplitude
+    FROM user_subtopics GROUP BY user_id
+)
+SELECT COUNT(*) FILTER (WHERE amplitude < 0.2) AS users_plats,
+       COUNT(*)                                AS users_total
+FROM amp;
+
+\echo ''
+\echo '=== M11 — doublons (user_id, topic_slug) dans user_subtopics (attendu 0) ==='
+SELECT COUNT(*) AS paires_en_double
+FROM (
+    SELECT user_id, topic_slug
+    FROM user_subtopics
+    GROUP BY user_id, topic_slug
+    HAVING COUNT(*) > 1
+) t;

--- a/packages/api/alembic/versions/cq01_subtopics_uniq_muted.py
+++ b/packages/api/alembic/versions/cq01_subtopics_uniq_muted.py
@@ -1,0 +1,96 @@
+"""Curation perso — hygiène user_subtopics + purge intérêts contredits (C-1).
+
+Trois opérations, dans l'ordre :
+
+1. **Dédup** ``user_subtopics`` sur ``(user_id, topic_slug)`` — garde la ligne
+   de plus grand ``weight`` (5 doublons / 4 comptes au 2026-08-02). La
+   contrainte d'unicité d'origine (``uq_user_subtopics_user_topic``) avait été
+   droppée par accident par un ``--autogenerate`` (cf. ``4d497ce7bcc2``).
+2. **Contrainte** ``UNIQUE (user_id, topic_slug)`` + **index** ``(user_id)`` —
+   rétablit l'unicité (upsert atomique) et supprime le seq scan feed/digest
+   (la table n'avait aucun index).
+3. **Purge** des lignes ``user_interests`` sur un thème que l'utilisateur a
+   explicitement **muté** (``user_personalization.muted_themes``) — 53 lignes /
+   27 comptes au 02/08. Elles étaient fabriquées passivement par
+   ``_adjust_interest_weight`` (corrigé dans la même PR) et affichées à tort
+   dans « Mes intérêts ».
+
+Idempotente (rejouable au boot des deux backends Railway) et sûre en
+expand-contract : la DB est partagée staging/prod. La contrainte n'interdit
+qu'un doublon que le vieux code ``production`` produit ~5×/vie-de-table (course
+SEEN/CONSUMED). Le DELETE muté est à **rejouer une fois après la release hebdo**
+— le temps que ``production`` prenne le correctif de code, il peut recréer
+quelques lignes.
+
+Head précédent : ``sa02_alerts_v2``. Après : 1 seul head (cq01).
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "cq01_subtopics_uniq_muted"
+down_revision: str | None = "sa02_alerts_v2"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+_TABLE = "user_subtopics"
+_UNIQUE = "uq_user_subtopics_user_topic"
+_INDEX = "ix_user_subtopics_user_id"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    # 1. Dédup préalable (garde le plus grand weight, puis le plus récent).
+    #    Idempotent : no-op au 2ᵉ passage (plus aucun rn > 1).
+    op.execute(
+        """
+        DELETE FROM user_subtopics
+        WHERE id IN (
+          SELECT id FROM (
+            SELECT id, ROW_NUMBER() OVER (
+              PARTITION BY user_id, topic_slug
+              ORDER BY weight DESC, created_at DESC
+            ) AS rn
+            FROM user_subtopics
+          ) t WHERE rn > 1
+        )
+        """
+    )
+
+    # 2a. Contrainte d'unicité (idempotent : garde sur pg_constraint).
+    uniques = {u["name"] for u in inspector.get_unique_constraints(_TABLE)}
+    if _UNIQUE not in uniques:
+        op.create_unique_constraint(_UNIQUE, _TABLE, ["user_id", "topic_slug"])
+
+    # 2b. Index sur user_id (idempotent).
+    indexes = {i["name"] for i in inspector.get_indexes(_TABLE)}
+    if _INDEX not in indexes:
+        op.create_index(_INDEX, _TABLE, ["user_id"])
+
+    # 3. Purge des intérêts contredisant un mute (idempotent : no-op si vide).
+    op.execute(
+        """
+        DELETE FROM user_interests ui
+        USING user_personalization up
+        WHERE up.user_id = ui.user_id
+          AND ui.interest_slug = ANY(COALESCE(up.muted_themes, '{}'))
+        """
+    )
+
+
+def downgrade() -> None:
+    # Le DELETE (dédup + purge muted) n'est pas réversible — on ne restaure que
+    # le schéma (index + contrainte).
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    indexes = {i["name"] for i in inspector.get_indexes(_TABLE)}
+    if _INDEX in indexes:
+        op.drop_index(_INDEX, table_name=_TABLE)
+
+    uniques = {u["name"] for u in inspector.get_unique_constraints(_TABLE)}
+    if _UNIQUE in uniques:
+        op.drop_constraint(_UNIQUE, _TABLE, type_="unique")

--- a/packages/api/alembic/versions/mg06_merge_cq01_st02.py
+++ b/packages/api/alembic/versions/mg06_merge_cq01_st02.py
@@ -1,0 +1,27 @@
+"""merge cq01 (hygiène user_subtopics + purge intérêts) et st02 (soutien Stripe).
+
+Aucun changement de schéma. Les deux révisions ont down_revision =
+"sa02_alerts_v2" (mergées sur `main` le même jour via des PRs distinctes) :
+`alembic upgrade head` n'avait plus de cible unique côté CI. Les deux
+branches ne touchent aucun objet commun (user_subtopics/user_interests d'un
+côté, colonnes Stripe/supporter_messages de l'autre), donc la révision est
+vide.
+"""
+
+from typing import Sequence, Union
+
+revision: str = "mg06_merge_cq01_st02"
+down_revision: Union[str, tuple[str, ...], None] = (
+    "cq01_subtopics_uniq_muted",
+    "st02_supporter_messages",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/packages/api/app/models/user.py
+++ b/packages/api/app/models/user.py
@@ -8,6 +8,7 @@ from sqlalchemy import (
     Enum,
     Float,
     ForeignKey,
+    Index,
     Integer,
     String,
     UniqueConstraint,
@@ -168,6 +169,15 @@ class UserSubtopic(Base):
     """User preferences for granular sub-topics (Story 4.1c)."""
 
     __tablename__ = "user_subtopics"
+    __table_args__ = (
+        # Unicité rétablie (C-1) : la contrainte d'origine avait été droppée par
+        # accident (cf. migration `4d497ce7bcc2`). Empêche les doublons et permet
+        # l'upsert atomique dans `_adjust_subtopic_weights` / l'onboarding.
+        UniqueConstraint("user_id", "topic_slug", name="uq_user_subtopics_user_topic"),
+        # La table n'avait aucun index : chaque lecture feed/digest était un
+        # seq scan sur `user_id`.
+        Index("ix_user_subtopics_user_id", "user_id"),
+    )
 
     id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True), primary_key=True, default=uuid4

--- a/packages/api/app/routers/contents.py
+++ b/packages/api/app/routers/contents.py
@@ -462,7 +462,10 @@ async def submit_article_feedback(
             if request.sentiment == "positive"
             else ScoringWeights.DISMISS_TOPIC_PENALTY
         )
-        await service._adjust_subtopic_weights(user_uuid, content_id, delta)
+        # Feedback = signal explicite → création autorisée (positif seulement).
+        await service._adjust_subtopic_weights(
+            user_uuid, content_id, delta, allow_create=True
+        )
         await service._adjust_entity_affinity(user_uuid, content_id, delta)
 
         await db.commit()

--- a/packages/api/app/services/briefing/importance_detector.py
+++ b/packages/api/app/services/briefing/importance_detector.py
@@ -12,6 +12,7 @@ Architecture: Ce module est DÉCOUPLÉ du ScoringEngine. Il consomme les contenu
 bruts et produit des clusters/flags d'importance utilisés par TopicSelector et Top3Selector.
 """
 
+import os
 from collections import Counter
 from dataclasses import dataclass, field
 from urllib.parse import urlparse
@@ -37,6 +38,10 @@ from app.services.text_similarity import (
 # une "couverture média" distincte. Cf. bug-digest-pipeline-fallbacks.md C4.
 _AGGREGATOR_SOURCE_TYPES: frozenset[SourceType] = frozenset({SourceType.REDDIT})
 
+# Fold fiabilité (B-2) : valeurs par défaut et vocabulaire « faux » des flags env.
+_DEFAULT_COVERAGE_FOLD_SCORES: frozenset[str] = frozenset({"low", "mixed"})
+_FALSEY_ENV_VALUES: frozenset[str] = frozenset({"false", "0", "no", ""})
+
 
 def _extract_domain(url: str) -> str:
     """Extrait le domaine canonique depuis une URL d'article.
@@ -52,17 +57,67 @@ def _extract_domain(url: str) -> str:
         return str(url)
 
 
-def _is_aggregator(content: Content) -> bool:
+def _coverage_fold_enabled() -> bool:
+    """Kill switch du fold fiabilité (B-2).
+
+    `EDITORIAL_COVERAGE_FOLD_ENABLED=false` restaure le comportement
+    historique : seuls les agrégateurs (Reddit) sont foldés. Lu à l'usage
+    (pas de cache) pour rester testable sans `cache_clear`.
+    """
+    raw = os.environ.get("EDITORIAL_COVERAGE_FOLD_ENABLED", "true").strip().lower()
+    return raw not in _FALSEY_ENV_VALUES
+
+
+def _coverage_fold_reliability_scores() -> frozenset[str]:
+    """Scores de fiabilité qui déclenchent le fold (défaut : low, mixed).
+
+    ⚠️ `unknown` volontairement absent du défaut : « jamais évaluée » ≠ « peu
+    fiable » — l'inclure folderait ~39,5 % du corpus `politics` (cf.
+    bug-curation-essentiel-personnalisation §1.2). Surchargeable via
+    `EDITORIAL_COVERAGE_FOLD_RELIABILITY` (CSV).
+    """
+    raw = os.environ.get("EDITORIAL_COVERAGE_FOLD_RELIABILITY", "").strip()
+    if not raw:
+        return _DEFAULT_COVERAGE_FOLD_SCORES
+    return frozenset(s.strip().lower() for s in raw.split(",") if s.strip())
+
+
+def _counts_toward_coverage(content: Content) -> bool:
+    """True si la source du contenu compte comme une couverture média distincte.
+
+    Renvoie False (le contenu ne gonfle pas `source_count`) pour :
+    - les **agrégateurs** (Reddit) — reprise, pas production éditoriale ;
+    - les **sources non curées à faible fiabilité** (`reliability_score`
+      ∈ {low, mixed}) — du volume sans jugement (BFMTV « Home Fil actu »,
+      CNEWS). `unknown` n'est PAS foldée (cf. `_coverage_fold_reliability_scores`).
+
+    Sémantique de **repli conservée** : `build_topic_clusters` ne folde ces
+    sources que si le cluster contient au moins une source qui compte ; un
+    cluster composé uniquement de sources foldées garde son décompte.
+    """
     src = getattr(content, "source", None)
     if src is None:
-        return False
+        # Source inconnue → on ne folde pas (conservateur).
+        return True
+
+    # Agrégateur (Reddit) : jamais une couverture distincte. Foldé même quand
+    # le kill switch est off (comportement historique).
     src_type = getattr(src, "type", None)
-    if src_type is None:
-        return False
-    try:
-        return SourceType(src_type) in _AGGREGATOR_SOURCE_TYPES
-    except ValueError:
-        return False
+    if src_type is not None:
+        try:
+            if SourceType(src_type) in _AGGREGATOR_SOURCE_TYPES:
+                return False
+        except ValueError:
+            pass
+
+    # Fold fiabilité (B-2) : non curée ET reliability ∈ {low, mixed}.
+    if _coverage_fold_enabled() and not bool(getattr(src, "is_curated", False)):
+        score = getattr(src, "reliability_score", None)
+        score_str = str(getattr(score, "value", score) or "").strip().lower()
+        if score_str in _coverage_fold_reliability_scores():
+            return False
+
+    return True
 
 
 # Re-exposé pour compat (anciennement défini ici)
@@ -202,24 +257,26 @@ class ImportanceDetector:
 
         for raw in raw_clusters:
             cluster_contents: list[Content] = raw["contents"]
-            # Fold agrégateurs : si le cluster a au moins une source primaire,
-            # on n'inclut pas les sources de type aggregator (Reddit) dans le
-            # compte. Sinon (cluster Reddit-only), on les conserve — un sujet
-            # repris uniquement par r/france mérite encore d'exister.
-            primary_source_ids: set[UUID] = set()
-            aggregator_source_ids: set[UUID] = set()
-            primary_source_domains: set[str] = set()
-            aggregator_source_domains: set[str] = set()
+            # Fold couverture (agrégateurs + faible fiabilité non curée, B-2) :
+            # si le cluster contient au moins une source qui compte comme
+            # couverture média distincte, on n'inclut pas les sources foldées
+            # (Reddit, ou non curée low/mixed) dans le décompte. Sinon (cluster
+            # composé uniquement de sources foldées), on les conserve — un sujet
+            # repris uniquement par r/france ou CNEWS mérite encore d'exister.
+            counted_source_ids: set[UUID] = set()
+            folded_source_ids: set[UUID] = set()
+            counted_source_domains: set[str] = set()
+            folded_source_domains: set[str] = set()
             for c in cluster_contents:
                 domain = _extract_domain(c.url)
-                if _is_aggregator(c):
-                    aggregator_source_ids.add(c.source_id)
-                    aggregator_source_domains.add(domain)
+                if _counts_toward_coverage(c):
+                    counted_source_ids.add(c.source_id)
+                    counted_source_domains.add(domain)
                 else:
-                    primary_source_ids.add(c.source_id)
-                    primary_source_domains.add(domain)
-            source_ids = primary_source_ids or aggregator_source_ids
-            source_domains = primary_source_domains or aggregator_source_domains
+                    folded_source_ids.add(c.source_id)
+                    folded_source_domains.add(domain)
+            source_ids = counted_source_ids or folded_source_ids
+            source_domains = counted_source_domains or folded_source_domains
 
             # Thème dominant : mode de content.theme, fallback source.theme
             themes: list[str] = []

--- a/packages/api/app/services/content_service.py
+++ b/packages/api/app/services/content_service.py
@@ -240,37 +240,47 @@ class ContentService:
             elif ratio < 0.1:
                 engagement_factor = 0.2
 
-        # 3. Update UserInterest — upsert atomique (Postgres ON CONFLICT)
-        # SEEN (scroll) et CONSUMED (retour WebView) arrivent quasi-simultanément
-        # pour le même (user_id, theme_slug) ; un check-then-insert classique
-        # provoquait une UniqueViolation (user_interests_user_slug_uniq).
-        # NewWeight = OldWeight + (Engagement * Rate), capé à 3.0 pour éviter
-        # l'explosion. À la création : poids 1.0 + boost (découverte de thèmes
-        # via sources généralistes). On ne touche pas `state` sur conflit pour
-        # préserver un éventuel FAVORITE.
+        # 3. Renforce UserInterest — UPDATE SEUL (C-1).
+        # Une lecture est un signal PASSIF : elle ne doit plus FABRIQUER
+        # d'intérêt. Fabriquer une ligne `state='followed'` sur le thème de la
+        # SOURCE (généraliste) empoisonnait la perso et contredisait les
+        # `muted_themes` (53 lignes / 27 comptes). On se contente donc de
+        # renforcer un intérêt déjà déclaré/appris : `UPDATE ... WHERE` no-op
+        # (rowcount 0) si la ligne n'existe pas. La création reste réservée aux
+        # signaux explicites (like/save/note, cf. `_adjust_subtopic_weights`).
+        # NewWeight = OldWeight + (Engagement * Rate), capé à 3.0.
+        # Cf. bug-curation-essentiel-personnalisation §3.1.
         learning_rate = 0.05
         boost = engagement_factor * learning_rate
 
         stmt = (
-            insert(UserInterest)
-            .values(
-                user_id=user_id,
-                interest_slug=theme_slug,
-                weight=1.0 + boost,
+            update(UserInterest)
+            .where(
+                UserInterest.user_id == user_id,
+                UserInterest.interest_slug == theme_slug,
             )
-            .on_conflict_do_update(
-                constraint="user_interests_user_slug_uniq",
-                set_={"weight": func.least(UserInterest.weight + boost, 3.0)},
-            )
+            .values(weight=func.least(UserInterest.weight + boost, 3.0))
         )
         await self.session.execute(stmt)
 
     async def _adjust_subtopic_weights(
-        self, user_id: UUID, content_id: UUID, delta: float
+        self,
+        user_id: UUID,
+        content_id: UUID,
+        delta: float,
+        *,
+        allow_create: bool = False,
     ) -> None:
         """
-        Ajuste les poids des sous-thèmes utilisateur en fonction d'un signal explicite.
+        Ajuste les poids des sous-thèmes utilisateur en fonction d'un signal.
         Réutilisé par like (+0.15) et bookmark (+0.05).
+
+        `allow_create` (défaut False) — C-1 : seuls les signaux **explicites**
+        (like/save/note/feedback, actions digest SAVE/LIKE) peuvent CRÉER une
+        ligne `user_subtopics`. Un signal passif (lecture) ou négatif ne fait
+        qu'`UPDATE` une ligne existante (no-op sinon) : on cesse de fabriquer un
+        intérêt à partir d'une simple lecture. Cf.
+        bug-curation-essentiel-personnalisation §3.1.
 
         ⚠️ Ces poids alimentent le scoring de **toutes** les sections du feed.
         Tout endpoint dont le chemin arrive ici doit donc appeler
@@ -293,23 +303,38 @@ class ContentService:
         if not content or not content.topics:
             return
 
+        # Poids borné [0.1, 3.0], partagé par les deux branches (upsert / update).
+        clamped = func.greatest(func.least(UserSubtopic.weight + delta, 3.0), 0.1)
         for topic_slug in content.topics:
-            stmt = select(UserSubtopic).where(
-                UserSubtopic.user_id == user_id,
-                UserSubtopic.topic_slug == topic_slug,
-            )
-            subtopic = await self.session.scalar(stmt)
-
-            if subtopic:
-                new_weight = subtopic.weight + delta
-                subtopic.weight = max(0.1, min(new_weight, 3.0))
-            elif delta > 0:
-                new_subtopic = UserSubtopic(
-                    user_id=user_id,
-                    topic_slug=topic_slug,
-                    weight=1.0 + delta,
+            if allow_create and delta > 0:
+                # Signal explicite positif : upsert atomique (Postgres ON
+                # CONFLICT sur la contrainte `uq_user_subtopics_user_topic`).
+                # Création à 1.0 + delta ; conflit → renforce, borné.
+                stmt = (
+                    insert(UserSubtopic)
+                    .values(
+                        user_id=user_id,
+                        topic_slug=topic_slug,
+                        weight=1.0 + delta,
+                    )
+                    .on_conflict_do_update(
+                        constraint="uq_user_subtopics_user_topic",
+                        set_={"weight": clamped},
+                    )
                 )
-                self.session.add(new_subtopic)
+                await self.session.execute(stmt)
+            else:
+                # Signal passif (lecture) ou négatif : UPDATE seul, jamais de
+                # création (C-1). No-op si la ligne n'existe pas.
+                stmt = (
+                    update(UserSubtopic)
+                    .where(
+                        UserSubtopic.user_id == user_id,
+                        UserSubtopic.topic_slug == topic_slug,
+                    )
+                    .values(weight=clamped)
+                )
+                await self.session.execute(stmt)
 
         # Also adjust interest weight for source theme
         if content.source and content.source.theme:
@@ -319,8 +344,8 @@ class ContentService:
             theme_slug = content.source.theme
             learning_rate = ScoringWeights.LIKE_INTEREST_RATE
 
-            if delta > 0:
-                # Like/bookmark : upsert atomique, poids borné [0.1, 3.0].
+            if delta > 0 and allow_create:
+                # Signal explicite (like/save/note) : upsert atomique, borné.
                 stmt = (
                     insert(UserInterest)
                     .values(
@@ -340,9 +365,11 @@ class ContentService:
                 )
                 await self.session.execute(stmt)
             else:
-                # Unlike : décrément ciblé, jamais de création de ligne (pas
-                # d'INSERT → pas de risque de conflit). No-op si l'intérêt
-                # n'existe pas.
+                # Signal passif (lecture, allow_create=False) ou négatif
+                # (unlike/dismiss) : UPDATE seul, jamais de création (C-1). Le
+                # pas suit le signe de delta. No-op si l'intérêt n'existe pas —
+                # une lecture ne FABRIQUE plus d'intérêt sur le thème source.
+                step = learning_rate if delta > 0 else -learning_rate
                 stmt = (
                     update(UserInterest)
                     .where(
@@ -351,7 +378,7 @@ class ContentService:
                     )
                     .values(
                         weight=func.greatest(
-                            func.least(UserInterest.weight - learning_rate, 3.0),
+                            func.least(UserInterest.weight + step, 3.0),
                             0.1,
                         )
                     )
@@ -480,7 +507,11 @@ class ContentService:
             if is_liked
             else -ScoringWeights.LIKE_TOPIC_BOOST
         )
-        await self._adjust_subtopic_weights(user_id, content_id, delta)
+        # Like : signal explicite → création autorisée (allow_create). Sur
+        # unlike (delta < 0) la branche update-only s'applique de toute façon.
+        await self._adjust_subtopic_weights(
+            user_id, content_id, delta, allow_create=True
+        )
         await self._adjust_entity_affinity(user_id, content_id, delta)
 
         return status
@@ -516,10 +547,13 @@ class ContentService:
         result = await self.session.scalars(stmt)
         status = result.one()
 
-        # Reinforce subtopic weights on bookmark
+        # Reinforce subtopic weights on bookmark (signal explicite → création OK)
         if is_saved:
             await self._adjust_subtopic_weights(
-                user_id, content_id, ScoringWeights.BOOKMARK_TOPIC_BOOST
+                user_id,
+                content_id,
+                ScoringWeights.BOOKMARK_TOPIC_BOOST,
+                allow_create=True,
             )
             await self._adjust_entity_affinity(
                 user_id, content_id, ScoringWeights.BOOKMARK_TOPIC_BOOST
@@ -649,9 +683,12 @@ class ContentService:
         result = await self.session.scalars(stmt)
         status = result.one()
 
-        # Reinforce subtopic weights (same as bookmark)
+        # Reinforce subtopic weights (same as bookmark, signal explicite → création OK)
         await self._adjust_subtopic_weights(
-            user_id, content_id, ScoringWeights.BOOKMARK_TOPIC_BOOST
+            user_id,
+            content_id,
+            ScoringWeights.BOOKMARK_TOPIC_BOOST,
+            allow_create=True,
         )
         await self._adjust_entity_affinity(
             user_id, content_id, ScoringWeights.BOOKMARK_TOPIC_BOOST

--- a/packages/api/app/services/digest_service.py
+++ b/packages/api/app/services/digest_service.py
@@ -1422,7 +1422,10 @@ class DigestService:
             from app.services.recommendation.scoring_config import ScoringWeights
 
             await content_service._adjust_subtopic_weights(
-                user_id, content_id, ScoringWeights.BOOKMARK_TOPIC_BOOST
+                user_id,
+                content_id,
+                ScoringWeights.BOOKMARK_TOPIC_BOOST,
+                allow_create=True,
             )
             await content_service._adjust_entity_affinity(
                 user_id, content_id, ScoringWeights.BOOKMARK_TOPIC_BOOST
@@ -1438,7 +1441,10 @@ class DigestService:
             from app.services.recommendation.scoring_config import ScoringWeights
 
             await content_service._adjust_subtopic_weights(
-                user_id, content_id, ScoringWeights.LIKE_TOPIC_BOOST
+                user_id,
+                content_id,
+                ScoringWeights.LIKE_TOPIC_BOOST,
+                allow_create=True,
             )
             await content_service._adjust_entity_affinity(
                 user_id, content_id, ScoringWeights.LIKE_TOPIC_BOOST

--- a/packages/api/app/services/user_service.py
+++ b/packages/api/app/services/user_service.py
@@ -297,13 +297,23 @@ class UserService:
         subtopic_count = 0
         if answers.subtopics:
             for topic_slug in answers.subtopics:
-                subtopic = UserSubtopic(
-                    id=uuid4(),
-                    user_id=UUID(user_id),
-                    topic_slug=topic_slug,
-                    weight=1.0,
+                # Upsert idempotent : la contrainte `uq_user_subtopics_user_topic`
+                # (C-1) ferait échouer un `db.add` brut sur double soumission
+                # concurrente. Onboarding = déclaration explicite → weight=1.0
+                # exact, on ne clobbe pas un poids existant (do_nothing).
+                stmt = (
+                    pg_insert(UserSubtopic)
+                    .values(
+                        id=uuid4(),
+                        user_id=UUID(user_id),
+                        topic_slug=topic_slug,
+                        weight=1.0,
+                    )
+                    .on_conflict_do_nothing(
+                        constraint="uq_user_subtopics_user_topic",
+                    )
                 )
-                self.db.add(subtopic)
+                await self.db.execute(stmt)
                 subtopic_count += 1
 
                 # Create UserTopicProfile only if not already followed

--- a/packages/api/scripts/dryrun_coverage_fold.py
+++ b/packages/api/scripts/dryrun_coverage_fold.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Dry-run comparatif du fold couverture (B-2) — READ-ONLY contre la prod.
+
+Rejoue `charger contenus → build_topic_clusters → sélection top-15 (entrée LLM)`
+**avec** et **sans** le fold fiabilité (`EDITORIAL_COVERAGE_FOLD_ENABLED`), sans
+appeler le LLM (la sélection des 15 clusters soumis est déterministe : elle ne
+dépend que de `len(source_domains)`, cf. `curation.select_topics`).
+
+Ce script n'écrit **rien** en base. Il produit :
+  - le diff des 15 clusters soumis au LLM (entrants / sortants / % changé) ;
+  - la distribution `source_count` avant/après + les franchissements 2→1 / 3→2 ;
+  - la répartition par thème des clusters entrants et sortants (garde-fou
+    `politics`).
+
+Garde-fou du plan : si **> 50 % du top-15 change**, le script sort un code
+retour ≠ 0 (on revoit le critère avant de merger).
+
+Usage:
+    cd packages/api && source venv/bin/activate
+    PYTHONPATH=. python scripts/dryrun_coverage_fold.py --hours 24 --tag b2-fold
+    PYTHONPATH=. python scripts/dryrun_coverage_fold.py --hours 24 --tag b2-fold --compare
+
+Sorties (comme evaluate_event_clustering.py) :
+    ../../.context/dryrun_coverage_fold_<tag>.json  (machine)
+    ../../.context/dryrun_coverage_fold_<tag>.md    (lisible)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from collections import Counter
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+# packages/api sur sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONTEXT_DIR = REPO_ROOT / ".context"
+
+# Seuil de churn bloquant (plan §2).
+CHURN_ABORT_THRESHOLD = 0.50
+
+parser = argparse.ArgumentParser(
+    description="Dry-run comparatif du fold couverture B-2 (read-only prod)"
+)
+parser.add_argument(
+    "--hours", type=int, default=24, help="Fenêtre de contenus (défaut: 24h)"
+)
+parser.add_argument("--tag", default="b2-fold", help="Nom du run (défaut: b2-fold)")
+parser.add_argument(
+    "--compare",
+    action="store_true",
+    help="Affiche le tableau détaillé cluster-par-cluster en plus du résumé",
+)
+args = parser.parse_args()
+
+# Le LLM n'est jamais appelé, mais on neutralise la clé par précaution (la
+# sélection top-15 est purement déterministe).
+os.environ["MISTRAL_API_KEY"] = ""
+
+from sqlalchemy import select  # noqa: E402
+from sqlalchemy.orm import selectinload  # noqa: E402
+
+from app.database import async_session_maker, engine  # noqa: E402
+from app.models.content import Content  # noqa: E402
+from app.models.source import Source  # noqa: E402
+from app.services.briefing.importance_detector import (  # noqa: E402
+    ImportanceDetector,
+    TopicCluster,
+)
+from app.services.editorial.config import load_editorial_config  # noqa: E402
+
+ClusterKey = frozenset
+
+
+def _cluster_key(cluster: TopicCluster) -> ClusterKey:
+    """Clé stable d'un cluster = ensemble des content.id qui le composent.
+
+    `cluster_id` est un uuid4 régénéré à chaque `build_topic_clusters`, donc
+    inutilisable pour apparier deux runs. Le clustering est déterministe sur
+    les mêmes contenus → les groupes sont identiques fold ON/OFF ; seuls les
+    décomptes de sources changent. La composition en contenus est donc la clé.
+    """
+    return frozenset(c.id for c in cluster.contents)
+
+
+def _select_top_clusters(
+    clusters: list[TopicCluster], count: int, limit: int
+) -> list[TopicCluster]:
+    """Reproduit la sélection pré-LLM de `curation.select_topics` (:220-248).
+
+    Préfère les clusters multi-source (≥2 domaines), retombe sur l'ensemble si
+    le pool multi-source est insuffisant, puis trie par nombre de domaines
+    décroissant et coupe à `limit`.
+    """
+    available = clusters
+    multi_source = [c for c in available if len(c.source_domains) >= 2]
+    pool = multi_source if len(multi_source) >= count else available
+    return sorted(pool, key=lambda c: len(c.source_domains), reverse=True)[:limit]
+
+
+async def _load_contents(hours: int) -> list[Content]:
+    since = datetime.now(UTC) - timedelta(hours=hours)
+    stmt = (
+        select(Content)
+        .join(Content.source)
+        .options(selectinload(Content.source))
+        .where(
+            Content.published_at >= since,
+            Source.is_active.is_(True),
+        )
+        .order_by(Content.published_at.desc())
+    )
+    async with async_session_maker() as session:
+        result = await session.execute(stmt)
+        return list(result.scalars().all())
+
+
+def _build_clusters(contents: list[Content], fold_enabled: bool) -> list[TopicCluster]:
+    if fold_enabled:
+        os.environ["EDITORIAL_COVERAGE_FOLD_ENABLED"] = "true"
+    else:
+        os.environ["EDITORIAL_COVERAGE_FOLD_ENABLED"] = "false"
+    detector = ImportanceDetector()
+    return detector.build_topic_clusters(contents)
+
+
+def _domain_histogram(clusters: list[TopicCluster]) -> dict[str, int]:
+    hist: Counter[int] = Counter(len(c.source_domains) for c in clusters)
+    # buckets lisibles : 1, 2, 3, 4+
+    out = {"1": 0, "2": 0, "3": 0, "4+": 0}
+    for n, cnt in hist.items():
+        if n <= 1:
+            out["1"] += cnt
+        elif n == 2:
+            out["2"] += cnt
+        elif n == 3:
+            out["3"] += cnt
+        else:
+            out["4+"] += cnt
+    return out
+
+
+def _theme_counter(clusters: list[TopicCluster]) -> dict[str, int]:
+    return dict(Counter((c.theme or "null") for c in clusters))
+
+
+def _label_for(key: ClusterKey, by_key: dict[ClusterKey, TopicCluster]) -> str:
+    c = by_key.get(key)
+    if c is None:
+        return "?"
+    return (c.label or (c.contents[0].title if c.contents else ""))[:70]
+
+
+async def run() -> int:
+    config = load_editorial_config()
+    count = config.pipeline.subjects_count
+    limit = config.pipeline.cluster_input_limit
+
+    contents = await _load_contents(args.hours)
+    if not contents:
+        print("⚠ Aucun contenu chargé — vérifier DATABASE_URL et --hours.")
+        return 2
+
+    clusters_off = _build_clusters(contents, fold_enabled=False)
+    clusters_on = _build_clusters(contents, fold_enabled=True)
+
+    by_key_off = {_cluster_key(c): c for c in clusters_off}
+    by_key_on = {_cluster_key(c): c for c in clusters_on}
+
+    top_off = _select_top_clusters(clusters_off, count, limit)
+    top_on = _select_top_clusters(clusters_on, count, limit)
+    keys_off = [_cluster_key(c) for c in top_off]
+    keys_on = [_cluster_key(c) for c in top_on]
+    set_off, set_on = set(keys_off), set(keys_on)
+
+    leaving = set_off - set_on  # dans le top-15 baseline, plus après fold
+    entering = set_on - set_off  # nouveaux dans le top-15 après fold
+
+    denom = max(len(set_off), 1)
+    pct_changed = len(leaving) / denom
+
+    # Franchissements de gate, sur les clusters appariés.
+    crossings_2_1 = 0
+    crossings_3_2 = 0
+    for key, c_off in by_key_off.items():
+        c_on = by_key_on.get(key)
+        if c_on is None:
+            continue
+        d_off, d_on = len(c_off.source_domains), len(c_on.source_domains)
+        if d_off >= 2 and d_on < 2:
+            crossings_2_1 += 1
+        if d_off >= 3 and d_on == 2:
+            crossings_3_2 += 1
+
+    # Répartition par thème des clusters entrants / sortants (garde-fou politics).
+    leaving_themes = Counter(_label_theme(k, by_key_off) for k in leaving)
+    entering_themes = Counter(_label_theme(k, by_key_on) for k in entering)
+    theme_net: dict[str, int] = {}
+    for t in set(leaving_themes) | set(entering_themes):
+        theme_net[t] = entering_themes.get(t, 0) - leaving_themes.get(t, 0)
+    politics_net = theme_net.get("politics", 0)
+
+    payload = {
+        "tag": args.tag,
+        "hours": args.hours,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "contents_loaded": len(contents),
+        "clusters_total_off": len(clusters_off),
+        "clusters_total_on": len(clusters_on),
+        "top_limit": limit,
+        "subjects_count": count,
+        "top15_size_off": len(top_off),
+        "top15_size_on": len(top_on),
+        "top15_leaving": len(leaving),
+        "top15_entering": len(entering),
+        "top15_pct_changed": round(pct_changed, 4),
+        "crossings_2_to_1": crossings_2_1,
+        "crossings_3_to_2": crossings_3_2,
+        "domain_hist_off": _domain_histogram(clusters_off),
+        "domain_hist_on": _domain_histogram(clusters_on),
+        "leaving_themes": dict(leaving_themes),
+        "entering_themes": dict(entering_themes),
+        "theme_net_entering_minus_leaving": theme_net,
+        "politics_net": politics_net,
+        "churn_abort_threshold": CHURN_ABORT_THRESHOLD,
+        "aborted": pct_changed > CHURN_ABORT_THRESHOLD,
+        "leaving_labels": [_label_for(k, by_key_off) for k in leaving],
+        "entering_labels": [_label_for(k, by_key_on) for k in entering],
+    }
+
+    CONTEXT_DIR.mkdir(parents=True, exist_ok=True)
+    json_path = CONTEXT_DIR / f"dryrun_coverage_fold_{args.tag}.json"
+    md_path = CONTEXT_DIR / f"dryrun_coverage_fold_{args.tag}.md"
+    json_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    md_path.write_text(_render_md(payload), encoding="utf-8")
+
+    _print_summary(payload, by_key_off, by_key_on, leaving, entering)
+
+    if payload["aborted"]:
+        print(
+            f"\n❌ ABORT : {pct_changed:.0%} du top-15 change "
+            f"(> {CHURN_ABORT_THRESHOLD:.0%}). Revoir le critère avant de merger."
+        )
+        return 1
+    if politics_net < 0:
+        print(
+            f"\n⚠ politics net-sortant du top-15 ({politics_net}). "
+            "À examiner, mais non bloquant."
+        )
+    print(f"\n✅ OK : {pct_changed:.0%} du top-15 change (≤ {CHURN_ABORT_THRESHOLD:.0%}).")
+    print(f"   JSON : {json_path}")
+    print(f"   MD   : {md_path}")
+    return 0
+
+
+def _label_theme(key: ClusterKey, by_key: dict[ClusterKey, TopicCluster]) -> str:
+    c = by_key.get(key)
+    return (c.theme or "null") if c is not None else "null"
+
+
+def _render_md(p: dict) -> str:
+    lines = [
+        f"# Dry-run fold couverture B-2 — `{p['tag']}`",
+        "",
+        f"- Généré : {p['generated_at']}",
+        f"- Fenêtre : {p['hours']}h — {p['contents_loaded']} contenus",
+        f"- Clusters : {p['clusters_total_off']} (off) / {p['clusters_total_on']} (on)",
+        "",
+        "## Top-15 soumis au LLM (entrée)",
+        "",
+        f"- Sortants : **{p['top15_leaving']}** / {p['top15_size_off']}",
+        f"- Entrants : **{p['top15_entering']}**",
+        f"- % changé : **{p['top15_pct_changed']:.0%}** "
+        f"(seuil abort {p['churn_abort_threshold']:.0%})",
+        f"- Franchissements 2→1 : {p['crossings_2_to_1']} · 3→2 : {p['crossings_3_to_2']}",
+        "",
+        "## Distribution source_count (tous clusters)",
+        "",
+        "| domaines | off | on |",
+        "|---|---|---|",
+    ]
+    for bucket in ("1", "2", "3", "4+"):
+        lines.append(
+            f"| {bucket} | {p['domain_hist_off'][bucket]} | {p['domain_hist_on'][bucket]} |"
+        )
+    lines += [
+        "",
+        "## Thèmes (entrants − sortants, garde-fou politics)",
+        "",
+        "| thème | entrants | sortants | net |",
+        "|---|---|---|---|",
+    ]
+    net = p["theme_net_entering_minus_leaving"]
+    for t in sorted(net, key=lambda k: net[k]):
+        lines.append(
+            f"| {t} | {p['entering_themes'].get(t, 0)} | "
+            f"{p['leaving_themes'].get(t, 0)} | {net[t]:+d} |"
+        )
+    lines += [
+        "",
+        f"**politics net = {p['politics_net']:+d}** "
+        f"({'net-sortant ⚠' if p['politics_net'] < 0 else 'ok'})",
+        "",
+        f"**Verdict : {'ABORT ❌' if p['aborted'] else 'OK ✅'}**",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _print_summary(p, by_key_off, by_key_on, leaving, entering) -> None:
+    print("=" * 66)
+    print(f"  DRY-RUN FOLD COUVERTURE B-2 — tag={p['tag']} hours={p['hours']}")
+    print("=" * 66)
+    print(f"  Contenus         : {p['contents_loaded']}")
+    print(f"  Clusters off/on  : {p['clusters_total_off']} / {p['clusters_total_on']}")
+    print(
+        f"  Top-15 sortants  : {p['top15_leaving']} / {p['top15_size_off']} "
+        f"({p['top15_pct_changed']:.0%})"
+    )
+    print(f"  Top-15 entrants  : {p['top15_entering']}")
+    print(f"  2→1 / 3→2        : {p['crossings_2_to_1']} / {p['crossings_3_to_2']}")
+    print(f"  politics net     : {p['politics_net']:+d}")
+    if args.compare:
+        print("-" * 66)
+        print("  SORTANTS (dans le top-15 baseline, foldés hors ensuite) :")
+        for k in leaving:
+            c = by_key_off.get(k)
+            print(
+                f"    [{c.theme or 'null':<13}] {len(c.source_domains)}→? "
+                f"{_label_for(k, by_key_off)}"
+            )
+        print("  ENTRANTS :")
+        for k in entering:
+            c = by_key_on.get(k)
+            print(
+                f"    [{c.theme or 'null':<13}] {len(c.source_domains)} dom. "
+                f"{_label_for(k, by_key_on)}"
+            )
+
+
+async def _main() -> int:
+    try:
+        return await run()
+    finally:
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/packages/api/tests/alembic/test_cq01_subtopics_uniq_muted.py
+++ b/packages/api/tests/alembic/test_cq01_subtopics_uniq_muted.py
@@ -1,0 +1,171 @@
+"""Test la *logique* de la migration cq01_subtopics_uniq_muted (C-1).
+
+Comme `test_interest_state_migration.py`, on ne re-joue pas Alembic : on insère
+un état pré-migration puis on exécute les blocs SQL data-fix de la migration et
+on vérifie le résultat. La création du schéma (contrainte + index) est couverte
+en bout-en-bout par `alembic upgrade head`.
+
+Les constantes SQL ci-dessous DOIVENT rester synchronisées avec
+`alembic/versions/cq01_subtopics_uniq_muted.py` (le dossier `tests/alembic/`
+shadow le package `alembic` → on ne peut pas importer le module migration).
+"""
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+
+from app.models.user import UserInterest, UserProfile, UserSubtopic
+from app.models.user_personalization import UserPersonalization
+
+# --- COPIE de alembic/versions/cq01_subtopics_uniq_muted.py ---
+DEDUP_SUBTOPICS_SQL = """
+DELETE FROM user_subtopics
+WHERE id IN (
+  SELECT id FROM (
+    SELECT id, ROW_NUMBER() OVER (
+      PARTITION BY user_id, topic_slug
+      ORDER BY weight DESC, created_at DESC
+    ) AS rn
+    FROM user_subtopics
+  ) t WHERE rn > 1
+)
+"""
+
+DELETE_MUTED_INTERESTS_SQL = """
+DELETE FROM user_interests ui
+USING user_personalization up
+WHERE up.user_id = ui.user_id
+  AND ui.interest_slug = ANY(COALESCE(up.muted_themes, '{}'))
+"""
+
+
+@pytest.mark.asyncio
+async def test_dedupe_keeps_max_weight_subtopic(db_session):
+    """Le dédup garde la ligne de plus grand weight par (user_id, topic_slug)."""
+    user_id = uuid4()
+    db_session.add(UserProfile(user_id=user_id, onboarding_completed=True))
+    await db_session.commit()
+
+    # Reproduit l'état pré-migration : la contrainte d'unicité n'existait pas.
+    await db_session.execute(
+        text(
+            "ALTER TABLE user_subtopics "
+            "DROP CONSTRAINT uq_user_subtopics_user_topic"
+        )
+    )
+    await db_session.commit()
+
+    db_session.add_all(
+        [
+            UserSubtopic(user_id=user_id, topic_slug="ai", weight=0.3),
+            UserSubtopic(user_id=user_id, topic_slug="ai", weight=1.8),  # gagnant
+            UserSubtopic(user_id=user_id, topic_slug="crypto", weight=1.0),
+        ]
+    )
+    await db_session.commit()
+
+    await db_session.execute(text(DEDUP_SUBTOPICS_SQL))
+    await db_session.commit()
+
+    rows = (
+        await db_session.execute(
+            text(
+                "SELECT topic_slug, weight FROM user_subtopics "
+                "WHERE user_id = :uid ORDER BY topic_slug"
+            ),
+            {"uid": user_id},
+        )
+    ).all()
+    assert len(rows) == 2
+    by_slug = {r[0]: r[1] for r in rows}
+    assert by_slug["ai"] == 1.8
+    assert by_slug["crypto"] == 1.0
+
+    # Idempotence : 2ᵉ passage ne supprime plus rien.
+    result = await db_session.execute(text(DEDUP_SUBTOPICS_SQL))
+    await db_session.commit()
+    assert result.rowcount == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_muted_interests_removes_only_muted(db_session):
+    """Le DELETE retire les intérêts sur un thème muté, garde les autres."""
+    user_id = uuid4()
+    db_session.add(UserProfile(user_id=user_id, onboarding_completed=True))
+    await db_session.commit()
+
+    db_session.add(
+        UserPersonalization(user_id=user_id, muted_themes=["tech", "sport"])
+    )
+    db_session.add_all(
+        [
+            UserInterest(user_id=user_id, interest_slug="tech", weight=1.05),
+            UserInterest(user_id=user_id, interest_slug="politics", weight=1.2),
+        ]
+    )
+    await db_session.commit()
+
+    result = await db_session.execute(text(DELETE_MUTED_INTERESTS_SQL))
+    await db_session.commit()
+    assert result.rowcount == 1  # seul "tech" (muté) supprimé
+
+    rows = (
+        await db_session.execute(
+            text(
+                "SELECT interest_slug FROM user_interests "
+                "WHERE user_id = :uid ORDER BY interest_slug"
+            ),
+            {"uid": user_id},
+        )
+    ).all()
+    assert [r[0] for r in rows] == ["politics"]
+
+    # Idempotence : 2ᵉ passage = 0 ligne supprimée.
+    result = await db_session.execute(text(DELETE_MUTED_INTERESTS_SQL))
+    await db_session.commit()
+    assert result.rowcount == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_muted_keeps_redeclared_theme(db_session):
+    """Un thème muté PUIS re-déclaré (retiré de muted_themes) n'est pas supprimé."""
+    user_id = uuid4()
+    db_session.add(UserProfile(user_id=user_id, onboarding_completed=True))
+    await db_session.commit()
+
+    # L'utilisateur a re-déclaré "tech" → il n'est plus dans muted_themes.
+    db_session.add(UserPersonalization(user_id=user_id, muted_themes=["sport"]))
+    db_session.add(
+        UserInterest(user_id=user_id, interest_slug="tech", weight=1.3)
+    )
+    await db_session.commit()
+
+    result = await db_session.execute(text(DELETE_MUTED_INTERESTS_SQL))
+    await db_session.commit()
+    assert result.rowcount == 0
+
+    row = await db_session.scalar(
+        text(
+            "SELECT interest_slug FROM user_interests WHERE user_id = :uid"
+        ),
+        {"uid": user_id},
+    )
+    assert row == "tech"
+
+
+@pytest.mark.asyncio
+async def test_delete_muted_noop_when_no_mutes(db_session):
+    """Aucun mute (muted_themes vide) → aucun intérêt supprimé."""
+    user_id = uuid4()
+    db_session.add(UserProfile(user_id=user_id, onboarding_completed=True))
+    await db_session.commit()
+    db_session.add(UserPersonalization(user_id=user_id, muted_themes=[]))
+    db_session.add(
+        UserInterest(user_id=user_id, interest_slug="tech", weight=1.1)
+    )
+    await db_session.commit()
+
+    result = await db_session.execute(text(DELETE_MUTED_INTERESTS_SQL))
+    await db_session.commit()
+    assert result.rowcount == 0

--- a/packages/api/tests/test_digest_per_user_projection.py
+++ b/packages/api/tests/test_digest_per_user_projection.py
@@ -14,13 +14,12 @@ from uuid import uuid4
 
 import pytest
 
-from app.services.digest_selector import DigestSelector, DigestContext
+from app.services.digest_selector import DigestContext, DigestSelector
 from app.services.editorial.schemas import (
     EditorialPipelineResult,
     EditorialSubject,
     MatchedActuArticle,
 )
-
 
 # ─── Factories ────────────────────────────────────────────────────────────────
 
@@ -214,6 +213,49 @@ async def test_rehydrate_clusters_from_cluster_data():
     assert clusters[0].cluster_id == "cl-1"
     assert {c.id for c in clusters[0].contents} == {c1.id, c2.id}
     assert clusters[0].source_ids == {src}
+
+
+@pytest.mark.asyncio
+async def test_rehydrated_clusters_do_not_depend_on_source_domains():
+    """Invariant B-2 : `cluster_data` ne sérialise PAS `source_domains`.
+
+    Le fold couverture (importance_detector) agit sur `source_ids` en phase
+    globale ; les clusters réhydratés per-user en héritent via `source_ids` et
+    ont `source_domains == set()`. Ce test verrouille l'invariant pour que la
+    projection per-user (et une future PR de tri) ne s'appuie jamais sur
+    `source_domains` d'un cluster réhydraté — sinon tout compte multi-sources
+    per-user retomberait à 0. Cf. bug-curation-essentiel-personnalisation §2.
+    """
+    src_a = uuid4()
+    src_b = uuid4()
+    c1 = _make_content(src_a, title="A")
+    c2 = _make_content(src_b, title="B")
+    selector = _make_selector(session_maker=_FakeSessionMaker([c1, c2]))
+
+    global_ctx = types.SimpleNamespace(
+        cluster_data=[
+            {
+                "cluster_id": "cl-1",
+                "label": "Cluster 1",
+                "content_ids": [str(c1.id), str(c2.id)],
+                "source_ids": [str(src_a), str(src_b)],
+                "theme": "tech",
+            }
+        ],
+        subjects=[],
+    )
+
+    clusters = await selector._rehydrate_editorial_clusters(global_ctx)
+    assert len(clusters) == 1
+    # source_ids (déjà foldé en global) porte le décompte multi-sources.
+    assert clusters[0].source_ids == {src_a, src_b}
+    assert len(clusters[0].source_ids) >= 2
+    # source_domains reste vide : aucune dépendance per-user dessus. Piège
+    # verrouillé : la propriété `is_multi_source` lit `source_domains`, donc
+    # elle vaut False sur un cluster réhydraté — le per-user DOIT compter via
+    # `source_ids`, jamais via `is_multi_source`/`source_domains`.
+    assert clusters[0].source_domains == set()
+    assert clusters[0].is_multi_source is False
 
 
 @pytest.mark.asyncio

--- a/packages/api/tests/test_importance_detector.py
+++ b/packages/api/tests/test_importance_detector.py
@@ -430,3 +430,202 @@ class TestAggregatorFold:
         assert len(clusters) == 1
         assert clusters[0].source_ids == {r1, r2}
         assert clusters[0].is_multi_source is True
+
+
+class TestReliabilityFold:
+    """Fold couverture par fiabilité (B-2).
+
+    Une rédaction non curée à faible fiabilité (`low`/`mixed`) — BFMTV « Home
+    Fil actu », CNEWS — apporte du volume sans jugement éditorial : elle ne doit
+    pas gonfler `source_count`. `unknown` (jamais évaluée, ex. Libération -
+    Politique) reste comptée. Cf. bug-curation-essentiel-personnalisation §1.2.
+    """
+
+    def _make_content(
+        self,
+        title,
+        *,
+        is_curated,
+        reliability_score,
+        source_id=None,
+        source_type=None,
+    ):
+        from datetime import UTC
+        from datetime import datetime as dt
+
+        from app.models.enums import SourceType
+
+        c = MagicMock()
+        c.title = title
+        c.id = uuid.uuid4()
+        c.source_id = source_id or uuid.uuid4()
+        c.published_at = dt.now(UTC)
+        c.entities = None
+        c.theme = None
+        c.url = f"https://source-{c.source_id}.fr/article"
+        c.source = MagicMock()
+        c.source.type = source_type or SourceType.ARTICLE
+        c.source.theme = "politics"
+        c.source.is_curated = is_curated
+        c.source.reliability_score = reliability_score
+        return c
+
+    def test_low_reliability_uncurated_does_not_inflate_source_count(self):
+        from app.models.enums import ReliabilityScore
+
+        counted_id = uuid.uuid4()
+        folded_id = uuid.uuid4()
+        contents = [
+            self._make_content(
+                "Budget 2027 débat Assemblée nationale motion",
+                is_curated=True,
+                reliability_score=ReliabilityScore.HIGH,
+                source_id=counted_id,
+            ),
+            self._make_content(
+                "Budget 2027 débat Assemblée nationale motion",
+                is_curated=False,
+                reliability_score=ReliabilityScore.LOW,
+                source_id=folded_id,
+            ),
+        ]
+        det = ImportanceDetector(similarity_threshold=0.4)
+        clusters = det.build_topic_clusters(contents)
+        assert len(clusters) == 1
+        # La source low non curée est foldée sur source_ids ET source_domains.
+        assert clusters[0].source_ids == {counted_id}
+        assert clusters[0].source_domains == {f"source-{counted_id}.fr"}
+        assert clusters[0].is_multi_source is False
+
+    def test_folded_only_cluster_keeps_its_count(self):
+        """Repli : un cluster composé UNIQUEMENT de sources foldées les garde."""
+        from app.models.enums import ReliabilityScore
+
+        f1 = uuid.uuid4()
+        f2 = uuid.uuid4()
+        contents = [
+            self._make_content(
+                "Fait divers agression centre-ville caméra",
+                is_curated=False,
+                reliability_score=ReliabilityScore.LOW,
+                source_id=f1,
+            ),
+            self._make_content(
+                "Fait divers agression centre-ville caméra",
+                is_curated=False,
+                reliability_score=ReliabilityScore.MIXED,
+                source_id=f2,
+            ),
+        ]
+        det = ImportanceDetector(similarity_threshold=0.4)
+        clusters = det.build_topic_clusters(contents)
+        assert len(clusters) == 1
+        assert clusters[0].source_ids == {f1, f2}
+        assert clusters[0].is_multi_source is True
+
+    def test_curated_medium_source_still_counts(self):
+        """Europe 1 (curée, medium) compte toujours : le fold vise low/mixed non curées."""
+        from app.models.enums import ReliabilityScore
+
+        europe1_id = uuid.uuid4()
+        folded_id = uuid.uuid4()
+        contents = [
+            self._make_content(
+                "Réforme retraites concertation syndicats calendrier",
+                is_curated=True,
+                reliability_score=ReliabilityScore.MEDIUM,
+                source_id=europe1_id,
+            ),
+            self._make_content(
+                "Réforme retraites concertation syndicats calendrier",
+                is_curated=False,
+                reliability_score=ReliabilityScore.LOW,
+                source_id=folded_id,
+            ),
+        ]
+        det = ImportanceDetector(similarity_threshold=0.4)
+        clusters = det.build_topic_clusters(contents)
+        assert len(clusters) == 1
+        assert clusters[0].source_ids == {europe1_id}
+
+    def test_unknown_reliability_still_counts(self):
+        """Non-régression : Libération - Politique (unknown, non curée) compte."""
+        from app.models.enums import ReliabilityScore
+
+        libe_id = uuid.uuid4()
+        high_id = uuid.uuid4()
+        contents = [
+            self._make_content(
+                "Élection législative partielle résultat second tour",
+                is_curated=False,
+                reliability_score=ReliabilityScore.UNKNOWN,
+                source_id=libe_id,
+            ),
+            self._make_content(
+                "Élection législative partielle résultat second tour",
+                is_curated=True,
+                reliability_score=ReliabilityScore.HIGH,
+                source_id=high_id,
+            ),
+        ]
+        det = ImportanceDetector(similarity_threshold=0.4)
+        clusters = det.build_topic_clusters(contents)
+        assert len(clusters) == 1
+        assert clusters[0].source_ids == {libe_id, high_id}
+        assert clusters[0].is_multi_source is True
+
+    def test_kill_switch_restores_aggregator_only_fold(self, monkeypatch):
+        """EDITORIAL_COVERAGE_FOLD_ENABLED=false : la source low non curée recompte."""
+        from app.models.enums import ReliabilityScore
+
+        monkeypatch.setenv("EDITORIAL_COVERAGE_FOLD_ENABLED", "false")
+
+        counted_id = uuid.uuid4()
+        low_id = uuid.uuid4()
+        contents = [
+            self._make_content(
+                "Sommet climat annonce financement pays sud",
+                is_curated=True,
+                reliability_score=ReliabilityScore.HIGH,
+                source_id=counted_id,
+            ),
+            self._make_content(
+                "Sommet climat annonce financement pays sud",
+                is_curated=False,
+                reliability_score=ReliabilityScore.LOW,
+                source_id=low_id,
+            ),
+        ]
+        det = ImportanceDetector(similarity_threshold=0.4)
+        clusters = det.build_topic_clusters(contents)
+        assert len(clusters) == 1
+        assert clusters[0].source_ids == {counted_id, low_id}
+        assert clusters[0].is_multi_source is True
+
+    def test_custom_reliability_csv_env(self, monkeypatch):
+        """EDITORIAL_COVERAGE_FOLD_RELIABILITY=low : mixed recompte, low toujours foldée."""
+        from app.models.enums import ReliabilityScore
+
+        monkeypatch.setenv("EDITORIAL_COVERAGE_FOLD_RELIABILITY", "low")
+
+        mixed_id = uuid.uuid4()
+        low_id = uuid.uuid4()
+        contents = [
+            self._make_content(
+                "Procès affaire corruption marché public verdict",
+                is_curated=False,
+                reliability_score=ReliabilityScore.MIXED,
+                source_id=mixed_id,
+            ),
+            self._make_content(
+                "Procès affaire corruption marché public verdict",
+                is_curated=False,
+                reliability_score=ReliabilityScore.LOW,
+                source_id=low_id,
+            ),
+        ]
+        det = ImportanceDetector(similarity_threshold=0.4)
+        clusters = det.build_topic_clusters(contents)
+        assert len(clusters) == 1
+        # `low` reste foldée ; `mixed` n'est plus dans le critère → recompte.
+        assert clusters[0].source_ids == {mixed_id}

--- a/packages/api/tests/test_interest_weight_concurrency.py
+++ b/packages/api/tests/test_interest_weight_concurrency.py
@@ -1,19 +1,18 @@
-"""Régression Sentry PYTHON-4P — race condition user_interests_user_slug_uniq.
+"""Re-pondération des intérêts sur lecture — comportement C-1 (UPDATE-only).
 
-L'ancien code de re-pondération des intérêts faisait un check-then-insert
-(SELECT UserInterest ; si absent → add()). Sous concurrence (SEEN au scroll +
-CONSUMED au retour WebView quasi-simultanés pour le même thème), les deux
-requêtes voyaient "absent" et inséraient → IntegrityError sur
-user_interests_user_slug_uniq → 500, et le commit de lecture était perdu.
+Contexte historique (PYTHON-4P) : l'ancien code faisait un check-then-insert
+puis un upsert `ON CONFLICT` pour éviter la race SEEN/CONSUMED.
 
-Le fix remplace l'insertion par un upsert Postgres atomique
-(INSERT ... ON CONFLICT (user_id, interest_slug) DO UPDATE). La requête
-"perdante" d'une course emprunte la branche DO UPDATE — c'est exactement ce
-qu'exerce ici un second appel séquentiel sur le même (user, thème).
+C-1 (bug-curation-essentiel-personnalisation §3.1) va plus loin : une **lecture
+est un signal passif** et ne doit plus **fabriquer** d'intérêt. Fabriquer une
+ligne `state='followed'` sur le thème de la SOURCE empoisonnait la perso et
+contredisait les `muted_themes`. `_adjust_interest_weight` fait donc désormais
+un **UPDATE seul** (no-op si la ligne n'existe pas) : plus aucune création sur
+lecture, la course d'insertion disparaît de fait (plus d'INSERT). La création
+reste réservée aux signaux explicites (like/save/note).
 
 NB : la fixture `db_session` isole chaque test dans une connexion unique +
-savepoints (cf. conftest), donc une vraie concurrence 2-connexions n'est pas
-reproductible ici ; on valide le chemin ON CONFLICT de façon déterministe.
+savepoints (cf. conftest).
 """
 
 from datetime import datetime
@@ -53,31 +52,42 @@ async def _make_content(db_session, source, *, duration_seconds=None):
 
 
 @pytest.mark.asyncio
-async def test_adjust_interest_weight_creates_then_increments(db_session, test_source):
-    """1er appel crée l'intérêt (1.0 + boost, FOLLOWED) ; 2e appel incrémente."""
+async def test_read_does_not_create_interest(db_session, test_source):
+    """C-1 : une lecture sur un thème inconnu ne FABRIQUE plus d'intérêt."""
     service = ContentService(db_session)
     user_id = await _make_user(db_session)
     content = await _make_content(db_session, test_source)
-    content_id = content.id  # capturé avant expunge_all (évite un reload sync)
+    content_id = content.id
     theme = test_source.theme  # "society"
 
-    # 1er appel : création
     await service._adjust_interest_weight(user_id, content_id, time_spent=None)
     await db_session.commit()
 
-    db_session.expunge_all()  # l'upsert Core bypass l'ORM → vider l'identity map
+    db_session.expunge_all()
     row = await db_session.scalar(
         select(UserInterest).where(
             UserInterest.user_id == user_id,
             UserInterest.interest_slug == theme,
         )
     )
-    assert row is not None
-    # engagement_factor=1.0 (pas de time_spent), learning_rate=0.05
-    assert row.weight == pytest.approx(1.0 + 0.05)
-    assert row.state == InterestState.FOLLOWED
+    assert row is None, "la lecture ne doit créer aucun UserInterest (C-1)"
 
-    # 2e appel : branche ON CONFLICT DO UPDATE → incrément, une seule ligne
+
+@pytest.mark.asyncio
+async def test_read_increments_existing_interest(db_session, test_source):
+    """Une lecture RENFORCE un intérêt déjà déclaré (UPDATE), sans doublon."""
+    service = ContentService(db_session)
+    user_id = await _make_user(db_session)
+    content = await _make_content(db_session, test_source)
+    content_id = content.id
+    theme = test_source.theme
+
+    # Intérêt déclaré préexistant (ex. onboarding), weight 1.0.
+    db_session.add(
+        UserInterest(user_id=user_id, interest_slug=theme, weight=1.0)
+    )
+    await db_session.commit()
+
     await service._adjust_interest_weight(user_id, content_id, time_spent=None)
     await db_session.commit()
 
@@ -90,8 +100,9 @@ async def test_adjust_interest_weight_creates_then_increments(db_session, test_s
             )
         )
     ).all()
-    assert len(rows) == 1, "pas de doublon : la contrainte unique tient"
-    assert rows[0].weight == pytest.approx(1.0 + 0.05 + 0.05)
+    assert len(rows) == 1
+    # engagement_factor=1.0 (pas de time_spent), learning_rate=0.05
+    assert rows[0].weight == pytest.approx(1.0 + 0.05)
 
 
 @pytest.mark.asyncio

--- a/packages/api/tests/test_like_feature.py
+++ b/packages/api/tests/test_like_feature.py
@@ -1,12 +1,12 @@
 """Tests for like feature: set_like_status, subtopic weight adjustments."""
 
-import pytest
-from unittest.mock import MagicMock, AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
-from datetime import datetime
 
-from app.services.content_service import ContentService
+import pytest
+
 from app.models.content import UserContentStatus
+from app.services.content_service import ContentService
 
 
 @pytest.mark.asyncio
@@ -78,7 +78,10 @@ async def test_like_adjusts_subtopic_weights():
         service, "_adjust_subtopic_weights", new_callable=AsyncMock
     ) as mock_adjust:
         await service.set_like_status(user_id, content_id, True)
-        mock_adjust.assert_called_once_with(user_id, content_id, 0.15)
+        # Like = signal explicite → allow_create=True (C-1).
+        mock_adjust.assert_called_once_with(
+            user_id, content_id, 0.15, allow_create=True
+        )
 
 
 @pytest.mark.asyncio
@@ -101,41 +104,18 @@ async def test_unlike_reverses_subtopic_weights():
         service, "_adjust_subtopic_weights", new_callable=AsyncMock
     ) as mock_adjust:
         await service.set_like_status(user_id, content_id, False)
-        mock_adjust.assert_called_once_with(user_id, content_id, -0.15)
+        # Unlike (delta < 0) : allow_create=True mais la branche update-only
+        # s'applique de toute façon (pas de création sur signal négatif).
+        mock_adjust.assert_called_once_with(
+            user_id, content_id, -0.15, allow_create=True
+        )
 
 
-@pytest.mark.asyncio
-async def test_like_weight_cap():
-    """Verify weight doesn't exceed 3.0 after subtopic adjustment."""
-    from app.models.user import UserSubtopic
-    from app.models.content import Content
-    from app.models.source import Source
-
-    session = AsyncMock()
-    service = ContentService(session)
-
-    user_id = uuid4()
-    content_id = uuid4()
-
-    # Mock content with topics
-    mock_source = MagicMock(spec=Source)
-    mock_source.theme = "tech"
-    mock_content = MagicMock(spec=Content)
-    mock_content.topics = ["ai"]
-    mock_content.source = mock_source
-
-    # Subtopic near cap
-    mock_subtopic = UserSubtopic(
-        user_id=user_id, topic_slug="ai", weight=2.95
-    )
-
-    session.get.return_value = mock_content
-    session.scalar.side_effect = [mock_subtopic, None]  # subtopic, then interest
-
-    await service._adjust_subtopic_weights(user_id, content_id, 0.15)
-
-    # Weight should be capped at 3.0
-    assert mock_subtopic.weight == 3.0
+# NB : le cap 3.0, le clamp 0.1, la création sur like et le "no-create" sur
+# lecture de `_adjust_subtopic_weights` sont désormais couverts contre une vraie
+# DB (l'implémentation est passée d'une mutation ORM à un upsert Postgres Core,
+# non observable via un mock de session) — cf.
+# `tests/test_subtopic_weight_concurrency.py`.
 
 
 @pytest.mark.asyncio
@@ -158,42 +138,7 @@ async def test_bookmark_adjusts_subtopic_weights():
         service, "_adjust_subtopic_weights", new_callable=AsyncMock
     ) as mock_adjust:
         await service.set_save_status(user_id, content_id, True)
-        mock_adjust.assert_called_once_with(user_id, content_id, 0.05)
-
-
-@pytest.mark.asyncio
-async def test_like_creates_new_subtopic():
-    """Verify liking creates subtopic if none exists."""
-    from app.models.content import Content
-    from app.models.source import Source
-
-    session = AsyncMock()
-    service = ContentService(session)
-
-    user_id = uuid4()
-    content_id = uuid4()
-
-    mock_source = MagicMock(spec=Source)
-    mock_source.theme = "tech"
-    mock_content = MagicMock(spec=Content)
-    mock_content.topics = ["quantum_computing"]
-    mock_content.source = mock_source
-
-    session.get.return_value = mock_content
-    # No existing subtopic or interest
-    session.scalar.return_value = None
-
-    await service._adjust_subtopic_weights(user_id, content_id, 0.15)
-
-    # Le sous-thème est créé via add() ; l'intérêt de thème passe désormais par
-    # un upsert atomique (execute) — un seul add() (le sous-thème).
-    assert session.add.call_count == 1
-    # L'intérêt est upserté sur user_interests via execute().
-    interest_inserts = [
-        call.args[0]
-        for call in session.execute.call_args_list
-        if getattr(call.args[0], "is_insert", False)
-        and getattr(call.args[0], "table", None) is not None
-        and call.args[0].table.name == "user_interests"
-    ]
-    assert len(interest_inserts) == 1
+        # Bookmark = signal explicite → allow_create=True (C-1).
+        mock_adjust.assert_called_once_with(
+            user_id, content_id, 0.05, allow_create=True
+        )

--- a/packages/api/tests/test_subtopic_weight_concurrency.py
+++ b/packages/api/tests/test_subtopic_weight_concurrency.py
@@ -1,0 +1,176 @@
+"""Re-pondération des sous-thèmes — comportement C-1 (`allow_create`).
+
+Calqué sur `test_interest_weight_concurrency.py`. C-1
+(bug-curation-essentiel-personnalisation §3.1) : une lecture (signal passif) ne
+FABRIQUE plus de ligne `user_subtopics` — seuls les signaux **explicites**
+(like/save/note, `allow_create=True`) peuvent en créer une. L'upsert Postgres
+(`ON CONFLICT (user_id, topic_slug)` → `uq_user_subtopics_user_topic`) borne le
+poids [0.1, 3.0].
+"""
+
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+
+from app.models.content import Content
+from app.models.enums import ContentType
+from app.models.user import UserProfile, UserSubtopic
+from app.services.content_service import ContentService
+from app.services.recommendation.scoring_config import ScoringWeights
+
+
+async def _make_user(db_session):
+    user_id = uuid4()
+    db_session.add(UserProfile(user_id=user_id, display_name="Test User"))
+    await db_session.commit()
+    return user_id
+
+
+async def _make_content(db_session, source, *, topics):
+    content = Content(
+        id=uuid4(),
+        source_id=source.id,
+        title="Article test",
+        url=f"https://example.com/{uuid4()}",
+        guid=str(uuid4()),
+        published_at=datetime.utcnow(),
+        content_type=ContentType.ARTICLE,
+        topics=topics,
+    )
+    db_session.add(content)
+    await db_session.commit()
+    return content
+
+
+@pytest.mark.asyncio
+async def test_read_does_not_create_subtopic(db_session, test_source):
+    """C-1 : une lecture sur un topic inconnu ne crée AUCUN user_subtopics."""
+    service = ContentService(db_session)
+    user_id = await _make_user(db_session)
+    content = await _make_content(db_session, test_source, topics=["ai"])
+    content_id = content.id
+
+    # Lecture : allow_create par défaut False.
+    await service._adjust_subtopic_weights(
+        user_id, content_id, ScoringWeights.READ_TOPIC_BOOST
+    )
+    await db_session.commit()
+
+    db_session.expunge_all()
+    row = await db_session.scalar(
+        select(UserSubtopic).where(
+            UserSubtopic.user_id == user_id,
+            UserSubtopic.topic_slug == "ai",
+        )
+    )
+    assert row is None, "la lecture ne doit créer aucun sous-thème (C-1)"
+
+
+@pytest.mark.asyncio
+async def test_like_creates_subtopic(db_session, test_source):
+    """Un like (signal explicite, allow_create=True) crée le sous-thème."""
+    service = ContentService(db_session)
+    user_id = await _make_user(db_session)
+    content = await _make_content(db_session, test_source, topics=["ai"])
+    content_id = content.id
+
+    await service._adjust_subtopic_weights(
+        user_id, content_id, ScoringWeights.LIKE_TOPIC_BOOST, allow_create=True
+    )
+    await db_session.commit()
+
+    db_session.expunge_all()
+    row = await db_session.scalar(
+        select(UserSubtopic).where(
+            UserSubtopic.user_id == user_id,
+            UserSubtopic.topic_slug == "ai",
+        )
+    )
+    assert row is not None
+    assert row.weight == pytest.approx(1.0 + ScoringWeights.LIKE_TOPIC_BOOST)
+
+
+@pytest.mark.asyncio
+async def test_read_increments_existing_subtopic(db_session, test_source):
+    """Une lecture RENFORCE un sous-thème existant (UPDATE), sans doublon."""
+    service = ContentService(db_session)
+    user_id = await _make_user(db_session)
+    content = await _make_content(db_session, test_source, topics=["ai"])
+    content_id = content.id
+
+    db_session.add(UserSubtopic(user_id=user_id, topic_slug="ai", weight=1.0))
+    await db_session.commit()
+
+    await service._adjust_subtopic_weights(
+        user_id, content_id, ScoringWeights.READ_TOPIC_BOOST
+    )
+    await db_session.commit()
+
+    db_session.expunge_all()
+    rows = (
+        await db_session.scalars(
+            select(UserSubtopic).where(
+                UserSubtopic.user_id == user_id,
+                UserSubtopic.topic_slug == "ai",
+            )
+        )
+    ).all()
+    assert len(rows) == 1
+    assert rows[0].weight == pytest.approx(1.0 + ScoringWeights.READ_TOPIC_BOOST)
+
+
+@pytest.mark.asyncio
+async def test_upsert_caps_at_3(db_session, test_source):
+    """Le DO UPDATE de l'upsert préserve le cap métier à 3.0."""
+    service = ContentService(db_session)
+    user_id = await _make_user(db_session)
+    content = await _make_content(db_session, test_source, topics=["ai"])
+
+    db_session.add(UserSubtopic(user_id=user_id, topic_slug="ai", weight=2.95))
+    await db_session.commit()
+
+    for _ in range(5):
+        await service._adjust_subtopic_weights(
+            user_id,
+            content.id,
+            ScoringWeights.LIKE_TOPIC_BOOST,
+            allow_create=True,
+        )
+    await db_session.commit()
+
+    db_session.expunge_all()
+    row = await db_session.scalar(
+        select(UserSubtopic).where(
+            UserSubtopic.user_id == user_id,
+            UserSubtopic.topic_slug == "ai",
+        )
+    )
+    assert row.weight == pytest.approx(3.0)
+
+
+@pytest.mark.asyncio
+async def test_negative_delta_clamps_at_floor(db_session, test_source):
+    """Un signal négatif (dismiss) borne le poids à 0.1 sans créer de ligne."""
+    service = ContentService(db_session)
+    user_id = await _make_user(db_session)
+    content = await _make_content(db_session, test_source, topics=["ai"])
+
+    db_session.add(UserSubtopic(user_id=user_id, topic_slug="ai", weight=0.15))
+    await db_session.commit()
+
+    # DISMISS_TOPIC_PENALTY = -0.15 → 0.15 - 0.15 = 0.0 → clamp plancher 0.1.
+    await service._adjust_subtopic_weights(
+        user_id, content.id, ScoringWeights.DISMISS_TOPIC_PENALTY
+    )
+    await db_session.commit()
+
+    db_session.expunge_all()
+    row = await db_session.scalar(
+        select(UserSubtopic).where(
+            UserSubtopic.user_id == user_id,
+            UserSubtopic.topic_slug == "ai",
+        )
+    )
+    assert row.weight == pytest.approx(0.1)

--- a/packages/api/tests/test_user_service_persist.py
+++ b/packages/api/tests/test_user_service_persist.py
@@ -1,9 +1,12 @@
-import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
-from app.services.user_service import UserService
+
+import pytest
+
+from app.models.user import UserPreference
 from app.schemas.user import OnboardingAnswers
-from app.models.user import UserPreference, UserSubtopic
+from app.services.user_service import UserService
+
 
 @pytest.mark.asyncio
 async def test_save_onboarding_persists_subtopics():
@@ -11,19 +14,19 @@ async def test_save_onboarding_persists_subtopics():
     mock_db = AsyncMock()
     # Mock get_or_create_profile to return a mock profile
     mock_profile = MagicMock()
-    
+
     service = UserService(mock_db)
-    
+
     # Mock internal calls
     # db.add is synchronous in SQLAlchemy sessions generally, but if we use AsyncSession it might behave differently in tests.
     # The warning said 'coroutine was never awaited'. This means our mock IS async but we called it without await.
-    # UserSubtopic creation calls self.db.add(). 
+    # UserSubtopic creation calls self.db.add().
     # If mock_db is an AsyncMock, then mock_db.add matches as AsyncMock which expects await.
     # We should configure add to be a MagicMock (synchronous).
     mock_db.add = MagicMock()
-    
+
     service.get_or_create_profile = AsyncMock(return_value=mock_profile)
-    
+
     user_id = str(uuid4())
     answers = OnboardingAnswers(
         objective="learn",
@@ -35,24 +38,36 @@ async def test_save_onboarding_persists_subtopics():
         themes=["tech"],
         subtopics=["ai", "crypto"] # 2 subtopics
     )
-    
+
     # Execute
     result = await service.save_onboarding(user_id, answers)
-    
+
     # Verify subtopics created count in response
     assert result["subtopics_created"] == 2
-    
-    # Verify db.add was called for UserSubtopic
-    # gathered all calls to db.add
-    added_objects = [call.args[0] for call in mock_db.add.call_args_list]
-    
-    subtopics_added = [obj for obj in added_objects if isinstance(obj, UserSubtopic)]
-    
-    assert len(subtopics_added) == 2
-    slugs = [s.topic_slug for s in subtopics_added]
-    assert "ai" in slugs
-    assert "crypto" in slugs
-    
+
+    # C-1 : l'onboarding passe désormais par un upsert Postgres
+    # (pg_insert ... on_conflict_do_nothing) au lieu d'un db.add brut, pour ne
+    # pas échouer sur la nouvelle contrainte uq_user_subtopics_user_topic en
+    # cas de double soumission. On inspecte donc les statements execute().
+    from sqlalchemy.dialects import postgresql
+
+    subtopic_slugs = []
+    for call in mock_db.execute.call_args_list:
+        stmt = call.args[0]
+        # INSERT seulement (l'onboarding fait aussi un DELETE préalable sur la
+        # même table pour repartir d'un état propre).
+        if (
+            getattr(stmt, "is_insert", False)
+            and getattr(stmt, "table", None) is not None
+            and stmt.table.name == "user_subtopics"
+        ):
+            params = stmt.compile(dialect=postgresql.dialect()).params
+            subtopic_slugs.append(params.get("topic_slug"))
+
+    assert len(subtopic_slugs) == 2
+    assert "ai" in subtopic_slugs
+    assert "crypto" in subtopic_slugs
+
     # Verify flush called
     assert mock_db.flush.called
 


### PR DESCRIPTION
# fix(curation): fold couverture (B-2) + arrêt de la fabrication d'intérêts (C-1)

Base `main`. **Une migration Alembic** (`cq01_subtopics_uniq_muted`).
Backend-only (0 fichier mobile).

## Contexte

Deuxième livrable du lot « qualité de la curation », après PR 1 (B-1
métadonnées, #1047). La cible du lot est
`score = w_imp · norm(importance) + w_perso · norm(perso)` (PR 4-5). Les deux
termes sont aujourd'hui faux : `importance` compte de la redondance (B), `perso`
est un signal plat et fabriqué (C). **Cette PR répare les deux termes avant que
PR 4 ne les mélange.** Elle ne change volontairement **pas** le tri.

Diagnostic complet : `docs/bugs/bug-curation-essentiel-personnalisation.md`.

## PR 2 — B-2 : ne compter que les rédactions qui portent un jugement

`importance_detector.py` : `_is_aggregator` → `_counts_toward_coverage`, appliqué
aux **deux** collections (`source_ids` **et** `source_domains`).

- **Critère** : `SourceType.REDDIT` **OU** (`is_curated` falsy **ET**
  `reliability_score ∈ {low, mixed}`). Réglable sans déploiement :
  `EDITORIAL_COVERAGE_FOLD_RELIABILITY` (défaut `low,mixed`),
  `EDITORIAL_COVERAGE_FOLD_ENABLED` (kill switch, défaut `true`).
- **`unknown` volontairement exclu** : « jamais évaluée » ≠ « peu fiable » ;
  l'inclure folderait 39,5 % du corpus `politics` (déjà à 1,3 % du top-5).

### Dry-run comparatif (prod, lecture seule, 24 h) — livrable bloquant

`scripts/dryrun_coverage_fold.py --hours 24 --tag b2-fold` (read-only, sans LLM,
exit ≠ 0 si > 50 % du top-15 change). Résultat sur 1 565 contenus / 1 086
clusters :

- **top-15 (entrée LLM) change de 13 %** (2 sortants, 2 entrants) ;
- **18 clusters franchissent `2→1`**, 9 franchissent `3→2` ; `4+ domaines` :
  22 → 13 ;
- **`politics` net = +0** (non enterré ; sortants = 1 environment, 1 culture ;
  entrants = 1 science, 1 sport).

Artefacts : `.context/dryrun_coverage_fold_b2-fold.{json,md}`.

## PR 3 — C-1 : arrêter de fabriquer des intérêts

Correctif **au moment de l'écriture** (une fois la ligne créée, rien ne distingue
un intérêt déclaré d'un intérêt fabriqué) :

- `_adjust_interest_weight` (lecture) → **UPDATE seul** (no-op si absent).
- `_adjust_subtopic_weights` → paramètre `allow_create` (défaut `False`). Créent
  seulement les signaux **explicites** : like/save/note (`content_service`),
  feedback (`routers/contents.py`), actions digest **SAVE/LIKE**
  (`digest_service`). Lecture (READ) et signaux négatifs = update seul.
- **Double-comptage confirmé (§3.1)** : le tail « interest par thème source » de
  `_adjust_subtopic_weights` fabriquait **aussi** un `user_interests` sur lecture
  (en plus de `_adjust_interest_weight`). Il est désormais gardé par le même
  `allow_create` → plus aucune fabrication d'intérêt sur lecture. La magnitude du
  renforcement d'un intérêt *existant* sur lecture (0,05 + 0,03) est inchangée
  (hors périmètre C-1, relève de PR 4).
- Onboarding (`user_service.py`) : `db.add(UserSubtopic)` → upsert
  `on_conflict_do_nothing` (ne casse pas sur la nouvelle contrainte).

### Migration `cq01_subtopics_uniq_muted` (down_revision `sa02_alerts_v2`)

1. **Dédup** `user_subtopics` sur `(user_id, topic_slug)` (garde le plus grand
   weight) — la contrainte d'origine avait été droppée par accident
   (`4d497ce7bcc2`).
2. **`UNIQUE uq_user_subtopics_user_topic`** + **`INDEX ix_user_subtopics_user_id`**
   (la table n'avait aucun index → seq scan à chaque lecture feed/digest).
3. **`DELETE`** idempotent des `user_interests` contredisant un `muted_themes`.

Idempotente, `__table_args__` posé sur le modèle. Testée : `alembic upgrade head`
sur DB vide (chaîne complète), downgrade/re-upgrade, exactement **1 head**.

**Risque expand-contract assumé** (DB partagée staging/prod) : pendant ≤ 1
semaine, le backend `production` (ancien code) fait encore du check-then-insert ;
une course produira une `IntegrityError` ponctuelle (mesuré **5×** sur toute la
vie de la table) au lieu d'un doublon silencieux. Décision PO §5 : contrainte
dans cette PR.

## Tests

- `test_importance_detector.py::TestReliabilityFold` — 7 cas (fold low/mixed,
  repli cluster 100 % foldé, curée medium compte, **`unknown` compte** — non-rég
  Libération, `source_ids` **et** `source_domains`, kill switch, CSV env).
- `test_digest_per_user_projection.py::test_rehydrated_clusters_do_not_depend_on_source_domains`
  — invariant : cluster réhydraté n'a pas de `source_domains`, le décompte passe
  par `source_ids` (déjà foldé en global).
- `test_subtopic_weight_concurrency.py` (nouveau) — read n'crée pas / like crée /
  cap 3.0 / clamp 0.1.
- `test_interest_weight_concurrency.py` — réécrit : read n'crée pas / read
  incrémente un existant.
- `tests/alembic/test_cq01_subtopics_uniq_muted.py` (nouveau) — dédup garde
  max-weight + idempotence, DELETE muté (seulement muté, idempotent, thème
  re-déclaré préservé, no-op sans mute).
- Non-régression `test_like_feature.py` / `test_user_service_persist.py` mis à
  jour (`allow_create`, upsert onboarding).
- **Suite backend complète : 2862 passed, 18 skipped, 2 xfailed.** `ruff check` OK.

## Vérification C-1 (avant/après)

Bloc « C-1 » ajouté à `docs/qa/scripts/baseline_curation.sql` (M8-M11). À lancer
via le rôle service (`claude_analytics_ro` n'a pas le `SELECT` sur
`user_interests`/`user_subtopics`). Valeurs live prod (via MCP Supabase) :

| # | Métrique | Avant (live 02/08) | Après |
|---|---|---|---|
| M8 | `user_interests` sur un thème muté | **42** (27 comptes) | **0** après migration |
| M11 | Doublons `(user_id, topic_slug)` | **5** | **0**, impossible |

(M8 = 53 au snapshot 02/08 ; le chiffre dérive tant que `production` fabrique
encore — d'où le rejeu post-release ci-dessous.)

## Après merge

1. `alembic upgrade head` rejoué automatiquement au boot Railway (staging + prod).
2. **Après la release hebdo suivante** : rejouer une fois le `DELETE` des thèmes
   mutés (le temps que `production` prenne le correctif de code) :

   ```sql
   DELETE FROM user_interests ui USING user_personalization up
   WHERE up.user_id = ui.user_id
     AND ui.interest_slug = ANY(COALESCE(up.muted_themes, '{}'));
   ```

## Ce que cette PR ne fait pas

- Ne change pas le tri (`is_multi`, `subject_rank_key`) — **PR 4**.
- Ne rebranche pas le pool personnalisé (« l'IA » qui remonte) — **PR 5**.
- N'atteint pas les cibles M1-M4 seule : elle rend les deux termes du futur score
  honnêtes, le mélange c'est PR 4-5.
