### PR TITLE
feat(mesure+reco): impression Tournée+Essentiel (PR-1) + SCORING_OVERRIDES/sweep (PR-2) — lot reco

### DIFF
--- a/apps/mobile/lib/core/services/analytics_service.dart
+++ b/apps/mobile/lib/core/services/analytics_service.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -53,12 +55,19 @@ class AnalyticsService {
     _sessionId = const Uuid().v4();
     _sessionStartTime = DateTime.now();
     final localDate = _sessionStartTime!.toIso8601String().split('T').first;
+    // Sonde de périmètre : « ce compte a-t-il personnalisé l'ordre de sa
+    // Tournée ? ». C'est du SharedPreferences **local**, donc invisible en DB —
+    // c'est la seule façon de savoir combien de comptes sont concernés par une
+    // règle d'ordonnancement qui recouvre l'ordre manuel.
+    final prefs = await SharedPreferences.getInstance();
+    final tourneeCustomized = prefs.getBool(_kTourneeCustomizedPrefKey) ?? false;
 
     await _logEvent('session_start', {
       'session_id': _sessionId,
       'is_organic': isOrganic,
       'platform': defaultTargetPlatform.toString(),
       'local_date': localDate,
+      'tournee_customized': tourneeCustomized,
       if (_appVersion != null) 'app_version': _appVersion,
     });
     // Story 14.1 — PostHog uses `app_open` as the conventional event name
@@ -83,6 +92,11 @@ class AnalyticsService {
     // pause→resume cycle can start a fresh session immediately.
     _sessionId = null;
     _sessionStartTime = null;
+
+    // Vide le buffer d'impressions AVANT `session_end` : `endSession` est
+    // appelée sur `AppLifecycleState.paused` (cf. `app.dart`), c'est le dernier
+    // moment garanti où le process tourne encore.
+    await flushPendingEvents();
 
     await _logEvent('session_end', {
       'session_id': sessionId,
@@ -404,6 +418,92 @@ class AnalyticsService {
       'position': position,
     };
     await _logEvent('digest_item_viewed', props);
+  }
+
+  // ──────────────────────────────────────────────────────────────
+  // Impressions d'article — dénominateur du CTR (Tournée + Essentiel)
+  // ──────────────────────────────────────────────────────────────
+
+  /// Clé SharedPreferences de dédup des impressions d'article : une entrée
+  /// `'$dayKey|$sectionKey|$contentId'` par carte déjà comptée aujourd'hui,
+  /// purgée des jours passés à chaque écriture (même pattern que
+  /// [_kSuggestionImpressionsKey]).
+  static const _kArticleImpressionsKey = 'article_impressions_v1';
+
+  /// Miroir de `tournee_customized_v1` (cf. `tournee_order_prefs_provider`).
+  /// Dupliqué ici plutôt qu'importé : `core/services` ne doit pas dépendre
+  /// d'un feature.
+  static const _kTourneeCustomizedPrefKey = 'tournee_customized_v1';
+
+  /// Garde-fou mémoire : les clés déjà comptées **dans ce process**, pour ne
+  /// pas relire SharedPreferences à chaque re-montage de carte au scroll (une
+  /// carte recyclée par le viewport paresseux re-déclenche son tracker).
+  final Set<String> _impressedArticleKeys = <String>{};
+
+  /// Impression d'un article rendu dans la Tournée ou l'Essentiel — le
+  /// **dénominateur** du CTR, dont le numérateur reste
+  /// `user_content_status.status = 'consumed'` côté backend.
+  ///
+  /// Dédupliquée **1×/(contentId, sectionKey, jour)** : un article vu trois
+  /// fois dans la même section le même jour compte une impression. Le même
+  /// article vu dans deux sections différentes en compte deux — c'est voulu,
+  /// la position dans une section est justement ce qu'on mesure.
+  ///
+  /// Backend-only, **pas de miroir PostHog** : le dénominateur doit se joindre
+  /// à `user_content_status` × `contents` en Postgres, et le pipeline PostHog
+  /// ne couvre qu'une fraction des clics réels (`article_read` ≈ 15 % des
+  /// `consumed`). Un miroir donnerait deux chiffres divergents pour la même
+  /// métrique.
+  ///
+  /// `algo_version` est estampillé **côté serveur** (cf.
+  /// `routers/analytics.py`) : le client ne connaît pas la configuration de
+  /// scoring.
+  Future<void> trackArticleImpression({
+    required String contentId,
+    required String sectionKey,
+    required String sectionFamily,
+    required String surface,
+    required String dayKey,
+    required int sectionIndex,
+    required int positionInSection,
+    required int globalPosition,
+    double? scoreTotal,
+    double? blockScore,
+    String? theme,
+    String? sourceId,
+    bool isSerene = false,
+    bool underfilled = false,
+  }) async {
+    if (_apiClient == null) return;
+    final entry = '$dayKey|$sectionKey|$contentId';
+    if (!_impressedArticleKeys.add(entry)) return;
+
+    final prefs = await SharedPreferences.getInstance();
+    // Purge des jours passés : on ne conserve que les entrées du jour courant.
+    final kept = (prefs.getStringList(_kArticleImpressionsKey) ?? const [])
+        .where((e) => e.startsWith('$dayKey|'))
+        .toList();
+    if (kept.contains(entry)) return; // déjà comptée aujourd'hui (relance)
+    kept.add(entry);
+    await prefs.setStringList(_kArticleImpressionsKey, kept);
+
+    await _logEventBuffered('article_impression', {
+      'session_id': _sessionId,
+      'content_id': contentId,
+      'section_key': sectionKey,
+      'section_family': sectionFamily,
+      'surface': surface,
+      'day_key': dayKey,
+      'section_index': sectionIndex,
+      'position_in_section': positionInSection,
+      'global_position': globalPosition,
+      'score_total': scoreTotal,
+      'block_score': blockScore,
+      'theme': theme,
+      'source_id': sourceId,
+      'is_serene': isSerene,
+      'underfilled': underfilled,
+    });
   }
 
   Future<void> trackPerspectiveComparisonOpened({
@@ -1130,6 +1230,71 @@ class AnalyticsService {
     await _logEvent('grille_revealed', props);
     await _capturePostHog('grille_revealed', props);
   }
+
+  // ──────────────────────────────────────────────────────────────
+  // Buffer d'events — POST groupé
+  // ──────────────────────────────────────────────────────────────
+
+  /// Taille de lot déclenchant un flush immédiat. Aligné sur le plafond serveur
+  /// (`MAX_BATCH_EVENTS = 100`) avec une marge large : un flush ne doit jamais
+  /// se faire refuser pour cause de lot trop grand.
+  static const int _kBatchFlushSize = 25;
+
+  /// Inactivité au bout de laquelle un lot partiel part quand même — sinon les
+  /// impressions d'une session courte n'arrivent qu'à la mise en arrière-plan.
+  static const Duration _kBatchIdleFlush = Duration(seconds: 10);
+
+  final List<Map<String, dynamic>> _pendingEvents = [];
+  Timer? _flushTimer;
+
+  /// Empile un event pour envoi **groupé**. Réservé à la télémétrie à haut
+  /// volume (impressions) : `_logEvent` reste le chemin unitaire de tout event
+  /// porteur d'un effet de bord serveur (`session_start` → streak, version).
+  ///
+  /// Motif : `_logEvent` fait un POST HTTP par event. ~30 impressions par
+  /// session, c'est 30 POST fire-and-forget sur réseau mobile.
+  Future<void> _logEventBuffered(
+    String eventType,
+    Map<String, dynamic> eventData,
+  ) async {
+    if (_apiClient == null) return;
+    if (_deviceId == null) await init();
+    _pendingEvents.add({
+      'event_type': eventType,
+      'event_data': eventData,
+      'device_id': _deviceId,
+    });
+    if (_pendingEvents.length >= _kBatchFlushSize) {
+      await flushPendingEvents();
+      return;
+    }
+    _flushTimer?.cancel();
+    _flushTimer = Timer(_kBatchIdleFlush, () => unawaited(flushPendingEvents()));
+  }
+
+  /// Pousse le buffer vers `POST /analytics/events/batch`. Appelée sur seuil,
+  /// sur inactivité et par [endSession] (donc sur `AppLifecycleState.paused`).
+  ///
+  /// Un lot qui échoue est **abandonné**, jamais ré-empilé : de l'analytics
+  /// best-effort qui se remettrait en file grossirait sans borne hors ligne, et
+  /// finirait par rejouer un lot au-delà du plafond serveur.
+  Future<void> flushPendingEvents() async {
+    _flushTimer?.cancel();
+    _flushTimer = null;
+    final client = _apiClient;
+    if (client == null || _pendingEvents.isEmpty) return;
+    final batch = List<Map<String, dynamic>>.from(_pendingEvents);
+    _pendingEvents.clear();
+    try {
+      await client.dio.post<dynamic>('analytics/events/batch', data: batch);
+    } catch (e) {
+      debugPrint('Analytics batch error (${batch.length} events): $e');
+    }
+  }
+
+  /// Nombre d'events en attente de flush — sonde de test.
+  @visibleForTesting
+  int get pendingEventCount => _pendingEvents.length;
 
   Future<void> _logEvent(
     String eventType,

--- a/apps/mobile/lib/core/services/analytics_service.dart
+++ b/apps/mobile/lib/core/services/analytics_service.dart
@@ -440,6 +440,26 @@ class AnalyticsService {
   /// carte recyclée par le viewport paresseux re-déclenche son tracker).
   final Set<String> _impressedArticleKeys = <String>{};
 
+  /// Dédup persistante scindée par jour, partagée par les impressions d'article
+  /// et de suggestion. Range [entry] dans la liste SharedPreferences [prefsKey]
+  /// en purgeant les jours passés (on ne garde que les entrées préfixées par
+  /// `'$dayKey|'`). Retourne `true` si l'entrée est neuve — l'événement doit
+  /// alors partir —, `false` si elle a déjà été comptée aujourd'hui.
+  Future<bool> _recordDailyOnce(
+    String prefsKey,
+    String entry,
+    String dayKey,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    final kept = (prefs.getStringList(prefsKey) ?? const [])
+        .where((e) => e.startsWith('$dayKey|'))
+        .toList();
+    if (kept.contains(entry)) return false;
+    kept.add(entry);
+    await prefs.setStringList(prefsKey, kept);
+    return true;
+  }
+
   /// Impression d'un article rendu dans la Tournée ou l'Essentiel — le
   /// **dénominateur** du CTR, dont le numérateur reste
   /// `user_content_status.status = 'consumed'` côté backend.
@@ -478,14 +498,9 @@ class AnalyticsService {
     final entry = '$dayKey|$sectionKey|$contentId';
     if (!_impressedArticleKeys.add(entry)) return;
 
-    final prefs = await SharedPreferences.getInstance();
-    // Purge des jours passés : on ne conserve que les entrées du jour courant.
-    final kept = (prefs.getStringList(_kArticleImpressionsKey) ?? const [])
-        .where((e) => e.startsWith('$dayKey|'))
-        .toList();
-    if (kept.contains(entry)) return; // déjà comptée aujourd'hui (relance)
-    kept.add(entry);
-    await prefs.setStringList(_kArticleImpressionsKey, kept);
+    if (!await _recordDailyOnce(_kArticleImpressionsKey, entry, dayKey)) {
+      return; // déjà comptée aujourd'hui (relance)
+    }
 
     await _logEventBuffered('article_impression', {
       'session_id': _sessionId,
@@ -1084,15 +1099,10 @@ class AnalyticsService {
     required String kind,
     required String dayKey,
   }) async {
-    final prefs = await SharedPreferences.getInstance();
     final entry = '$dayKey|$sectionKey';
-    // Purge des jours passés : on ne conserve que les entrées du jour courant.
-    final kept = (prefs.getStringList(_kSuggestionImpressionsKey) ?? const [])
-        .where((e) => e.startsWith('$dayKey|'))
-        .toList();
-    if (kept.contains(entry)) return; // déjà comptée aujourd'hui
-    kept.add(entry);
-    await prefs.setStringList(_kSuggestionImpressionsKey, kept);
+    if (!await _recordDailyOnce(_kSuggestionImpressionsKey, entry, dayKey)) {
+      return; // déjà comptée aujourd'hui
+    }
     final props = {
       'session_id': _sessionId,
       'section_key': sectionKey,

--- a/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
+++ b/apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart
@@ -116,6 +116,38 @@ String sectionKey(FluxSection section) {
   };
 }
 
+/// Famille d'une section pour la mesure : `theme | source | veille |
+/// editorial`. Découpe principale de la jauge CTR de la Tournée — un CTR
+/// agrégé toutes familles confondues ne dit rien, un bloc source et un bloc
+/// éditorial ne se comparent pas.
+///
+/// `editorial` regroupe les blocs **épinglés** (héros Essentiel, Actus du jour,
+/// Bonnes Nouvelles, alertes, carrousel) : ils ne concourent pas au classement
+/// des blocs personnalisés.
+String sectionFamily(FluxSection section) {
+  if (section is! FeedThemeSection) return 'editorial';
+  return switch (section.kind) {
+    SectionKind.source => 'source',
+    SectionKind.veille => 'veille',
+    _ => 'theme',
+  };
+}
+
+/// Nombre de cartes d'article qu'une section rend réellement — le pas dont
+/// avance le rang absolu d'une carte dans la page (`global_position`).
+///
+/// Les blocs sans carte d'article (alertes, carrousel) valent 0 : ils
+/// n'occupent pas de rang de lecture. Le carrousel est un scroller horizontal,
+/// ses items ne se lisent pas comme une pile verticale.
+int renderedCardCount(FluxSection section) => switch (section) {
+      EssentielSection(:final articles) => articles.length,
+      DigestTopicSection(:final topics, :final coreVisibleCount) =>
+        topics.take(coreVisibleCount).length,
+      FeedThemeSection(:final items, :final coreVisibleCount) =>
+        items.take(coreVisibleCount).length,
+      AlertsSection() || CarouselSection() => 0,
+    };
+
 /// One section of the Flux Continu V1.8 home screen.
 ///
 /// Each section renders the same visual shell (banner + cards + optional
@@ -160,6 +192,11 @@ class EssentielArticle {
   final String? thumbnailUrl;
   final DateTime publishedAt;
   final String sourceName;
+
+  /// UUID de la source. Servi par `/api/essentiel` (`source.id`) et jusqu'ici
+  /// jeté au parse : il porte la découpe « CTR par source » de la mesure.
+  final String? sourceId;
+
   final String sourceLetter;
   final SectionKind kind;
   final String? theme;
@@ -201,6 +238,7 @@ class EssentielArticle {
     required this.sourceLetter,
     required this.sectionLabel,
     required this.rank,
+    this.sourceId,
     this.description,
     this.thumbnailUrl,
     this.kind = SectionKind.theme,
@@ -251,6 +289,7 @@ class EssentielArticle {
           DateTime.tryParse(json['published_at'] as String? ?? '') ??
           DateTime.now(),
       sourceName: sourceName,
+      sourceId: source['id'] as String?,
       sourceLetter: (json['source_letter'] as String?) ?? _initial(sourceName),
       kind: _parseKind(json['kind'] as String?),
       theme: json['theme'] as String?,
@@ -281,7 +320,7 @@ class EssentielArticle {
     'description': description,
     'thumbnail_url': thumbnailUrl,
     'published_at': publishedAt.toIso8601String(),
-    'source': {'name': sourceName},
+    'source': {'name': sourceName, if (sourceId != null) 'id': sourceId},
     'source_letter': sourceLetter,
     'kind': kind.name,
     'theme': theme,

--- a/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
+++ b/apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart
@@ -1940,12 +1940,21 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
       (s) => s is FeedThemeSection && s.isPlaceholder,
     );
 
+    // Rang absolu de la prochaine carte dans la page — avancé section par
+    // section (cf. [renderedCardCount]). C'est lui qui porte l'effet de
+    // position dans la mesure : `position_in_section` seul confond la 1ʳᵉ carte
+    // du haut de page avec la 1ʳᵉ carte du 9ᵉ bloc.
+    var globalPosition = 0;
+    final impressionDayKey = TourneeProgressService.dayKey(DateTime.now());
+
     final slivers = <SliverToBoxAdapter>[];
     for (var i = 0; i < state.sections.length; i++) {
       if (state.grilleSlotIndex == i) {
         slivers.add(_grilleSliver(followedByNormalSection: true));
       }
       final section = state.sections[i];
+      final sectionGlobalOffset = globalPosition;
+      globalPosition += renderedCardCount(section);
       final isFavorite = _isFavoriteSection(section);
       // Story 22.3 — une section suggérée ne porte pas l'étoile « favori »
       // (elle se gère via son badge « Choisie pour vous » + sheet), pour ne pas
@@ -1993,6 +2002,11 @@ class _FluxContinuScreenState extends ConsumerState<FluxContinuScreen>
                     child: SectionBlock(
                       section: section,
                       showPreparingLabel: i == firstPreparingIndex,
+                      // Mesure d'impression — dénominateur du CTR de la Tournée.
+                      impressionDayKey: impressionDayKey,
+                      sectionIndex: i,
+                      globalPositionOffset: sectionGlobalOffset,
+                      isSerene: state.isSerene,
                       onTapArticle: (a) => _openArticle(context, a),
                       onDismissArticle: _onSwipeDismiss,
                       pendingFeedbackIds: _pendingFeedback,

--- a/apps/mobile/lib/features/flux_continu/widgets/article_impression_tracker.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/article_impression_tracker.dart
@@ -1,0 +1,178 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:visibility_detector/visibility_detector.dart';
+
+import '../../../core/providers/analytics_provider.dart';
+
+/// Fraction visible minimale d'une carte pour qu'elle compte comme vue.
+/// Standard MRC de viewabilité display (50 % de pixels), transposé à une carte
+/// d'article : au-delà, une carte à moitié coupée par le bas de l'écran ne
+/// serait jamais comptée alors qu'elle est lisible.
+const double kImpressionMinVisibleFraction = 0.5;
+
+/// Durée pendant laquelle la carte doit rester au-dessus du seuil. Standard MRC
+/// (1 s pour du display). Filtre le scroll rapide : traverser la Tournée d'un
+/// coup de pouce ne doit pas gonfler le dénominateur du CTR de cartes que
+/// personne n'a lues.
+const Duration kImpressionMinVisibleDuration = Duration(milliseconds: 1000);
+
+/// Métadonnées d'une carte au moment de son impression — tout ce dont la jauge
+/// CTR a besoin pour découper le taux (par famille de section, par rang, par
+/// bande de score). Assemblées au rendu, jamais reconstruites a posteriori :
+/// l'ordre des sections change d'un jour à l'autre.
+@immutable
+class ArticleImpressionInfo {
+  final String contentId;
+  final String sectionKey;
+
+  /// `theme | source | veille | editorial`. `editorial` couvre les blocs non
+  /// personnalisés (Essentiel, Actus du jour, Bonnes Nouvelles) : ils sont
+  /// épinglés et ne concourent pas au classement des blocs.
+  final String sectionFamily;
+
+  /// `tournee | essentiel`. Flâner est **hors périmètre** (flux chronologique
+  /// assumé — mesurer un CTR par rang n'y voudrait rien dire).
+  final String surface;
+
+  /// Rang de la section dans la Tournée du jour (0 = héros Essentiel).
+  final int sectionIndex;
+
+  /// Rang de la carte dans sa section.
+  final int positionInSection;
+
+  /// Rang de la carte dans la page entière — c'est lui qui porte l'effet de
+  /// position, `positionInSection` seul ne distingue pas la 1ʳᵉ carte du haut
+  /// de page de la 1ʳᵉ carte du 9ᵉ bloc.
+  final int globalPosition;
+
+  /// Score de recommandation de l'article. `null` sur les blocs éditoriaux, qui
+  /// ne passent pas par le moteur de scoring personnalisé.
+  final double? scoreTotal;
+
+  /// Score du bloc qui a décidé de son rang. `null` tant que l'ordonnancement
+  /// par score n'est pas branché — c'est ce champ qui reliera « ordre des
+  /// blocs » et « CTR mesuré ».
+  final double? blockScore;
+
+  final String? theme;
+  final String? sourceId;
+  final bool isSerene;
+
+  /// La section est **maigre** (≤1 survivant après dédup). Découpe utile : un
+  /// CTR bas sur un bloc maigre ne se lit pas comme un CTR bas sur un bloc plein.
+  final bool underfilled;
+
+  const ArticleImpressionInfo({
+    required this.contentId,
+    required this.sectionKey,
+    required this.sectionFamily,
+    required this.surface,
+    required this.sectionIndex,
+    required this.positionInSection,
+    required this.globalPosition,
+    this.scoreTotal,
+    this.blockScore,
+    this.theme,
+    this.sourceId,
+    this.isSerene = false,
+    this.underfilled = false,
+  });
+}
+
+/// Enveloppe une carte de la Tournée ou de l'Essentiel pour compter son
+/// **impression** : ≥ [kImpressionMinVisibleFraction] visible pendant
+/// ≥ [kImpressionMinVisibleDuration], une fois par
+/// `(contentId, sectionKey, jour)`.
+///
+/// Frère de `AutoGrowCandidate`, délibérément **pas** une extension de
+/// celui-ci : son seuil est 0,9, il exclut les articles lus (or un article lu
+/// *a été* impressionné, c'est même le numérateur du CTR) et son contrat de
+/// `dispose` en microtask sert un tout autre besoin. Les deux
+/// `VisibilityDetector` s'imbriquent sans conflit — chacun a sa propre clé.
+class ArticleImpressionTracker extends ConsumerStatefulWidget {
+  const ArticleImpressionTracker({
+    super.key,
+    required this.info,
+    required this.dayKey,
+    required this.child,
+  });
+
+  final ArticleImpressionInfo info;
+
+  /// Jour Tournée (frontière 4 h Paris, cf. `TourneeProgressService.dayKey`) —
+  /// passé plutôt que calculé ici pour que le widget reste pur et testable.
+  final String dayKey;
+
+  final Widget child;
+
+  @override
+  ConsumerState<ArticleImpressionTracker> createState() =>
+      _ArticleImpressionTrackerState();
+}
+
+class _ArticleImpressionTrackerState
+    extends ConsumerState<ArticleImpressionTracker> {
+  Timer? _dwell;
+  bool _fired = false;
+
+  void _onVisibility(VisibilityInfo visibility) {
+    if (!mounted || _fired) return;
+    if (visibility.visibleFraction >= kImpressionMinVisibleFraction) {
+      // `??=` : une carte qui reste visible émet plusieurs notifications
+      // (scroll continu) ; réarmer le timer à chaque fois le repousserait
+      // indéfiniment et aucune impression ne partirait jamais.
+      _dwell ??= Timer(kImpressionMinVisibleDuration, _fire);
+    } else {
+      _dwell?.cancel();
+      _dwell = null;
+    }
+  }
+
+  void _fire() {
+    _dwell = null;
+    if (!mounted || _fired) return;
+    _fired = true;
+    final info = widget.info;
+    unawaited(
+      ref.read(analyticsServiceProvider).trackArticleImpression(
+            contentId: info.contentId,
+            sectionKey: info.sectionKey,
+            sectionFamily: info.sectionFamily,
+            surface: info.surface,
+            dayKey: widget.dayKey,
+            sectionIndex: info.sectionIndex,
+            positionInSection: info.positionInSection,
+            globalPosition: info.globalPosition,
+            scoreTotal: info.scoreTotal,
+            blockScore: info.blockScore,
+            theme: info.theme,
+            sourceId: info.sourceId,
+            isSerene: info.isSerene,
+            underfilled: info.underfilled,
+          ),
+    );
+  }
+
+  @override
+  void dispose() {
+    // Le seul état à nettoyer est le timer : rien n'est muté hors de ce widget
+    // avant qu'il ne se déclenche, donc pas de contrat `dispose` fragile ici.
+    _dwell?.cancel();
+    _dwell = null;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return VisibilityDetector(
+      key: Key(
+        'impression_${widget.info.surface}_'
+        '${widget.info.sectionKey}_${widget.info.contentId}',
+      ),
+      onVisibilityChanged: _onVisibility,
+      child: widget.child,
+    );
+  }
+}

--- a/apps/mobile/lib/features/flux_continu/widgets/article_impression_tracker.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/article_impression_tracker.dart
@@ -133,7 +133,11 @@ class _ArticleImpressionTrackerState
   void _fire() {
     _dwell = null;
     if (!mounted || _fired) return;
-    _fired = true;
+    // `setState` retire le `VisibilityDetector` du sous-arbre (cf. `build`) :
+    // une carte ne compte qu'une fois, la garder branchée ferait recalculer sa
+    // géométrie à chaque tick de scroll pour le reste de la session. ~30 cartes
+    // sur la Tournée → autant de détecteurs qui s'éteignent dès qu'ils ont tiré.
+    setState(() => _fired = true);
     final info = widget.info;
     unawaited(
       ref.read(analyticsServiceProvider).trackArticleImpression(
@@ -166,6 +170,9 @@ class _ArticleImpressionTrackerState
 
   @override
   Widget build(BuildContext context) {
+    // Une fois l'impression comptée, plus rien à observer : on sort du pipeline
+    // de `visibility_detector` en rendant l'enfant nu.
+    if (_fired) return widget.child;
     return VisibilityDetector(
       key: Key(
         'impression_${widget.info.surface}_'

--- a/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart
@@ -22,6 +22,7 @@ import '../providers/selected_edition_date_provider.dart';
 import '../providers/weather_provider.dart';
 import '../services/tournee_progress_service.dart';
 import '../utils/theme_color_mapping.dart';
+import 'article_impression_tracker.dart';
 import 'auto_grow_candidate.dart';
 import 'coverage_chip.dart';
 import 'edition_timeline_sheet.dart';
@@ -44,12 +45,57 @@ class EssentielHiFiCard extends ConsumerWidget {
   /// masquée à `0`. Alimente « L'Essentiel vivant » (surface dynamique).
   final int newSinceMorning;
 
+  /// Jour Tournée courant. Non-null ⇒ chaque tuile compte une impression
+  /// (`surface: essentiel`). `null` sur les éditions passées en lecture seule.
+  final String? impressionDayKey;
+
+  /// Rang du héros dans la page et nombre de cartes rendues avant lui —
+  /// toujours 0/0 aujourd'hui (le héros ouvre la Tournée), mais portés en
+  /// paramètre pour que la mesure ne dépende pas de cette hypothèse.
+  final int sectionIndex;
+  final int globalPositionOffset;
+  final bool isSerene;
+
   const EssentielHiFiCard({
     super.key,
     required this.articles,
     required this.onTapArticle,
     this.newSinceMorning = 0,
+    this.impressionDayKey,
+    this.sectionIndex = 0,
+    this.globalPositionOffset = 0,
+    this.isSerene = false,
   });
+
+  /// Enveloppe une tuile dans son compteur d'impression ; passe-plat quand la
+  /// mesure n'est pas câblée (lecture seule).
+  Widget _tracked({
+    required EssentielArticle article,
+    required int position,
+    required Widget child,
+  }) {
+    final dayKey = impressionDayKey;
+    if (dayKey == null) return child;
+    return ArticleImpressionTracker(
+      dayKey: dayKey,
+      info: ArticleImpressionInfo(
+        contentId: article.contentId,
+        sectionKey: 'essentiel_v3',
+        sectionFamily: 'editorial',
+        surface: 'essentiel',
+        sectionIndex: sectionIndex,
+        positionInSection: position,
+        globalPosition: globalPositionOffset + position,
+        // Le héros ne passe pas par le moteur de scoring personnalisé
+        // (`recommendation_reason` est nul sur le chemin editorial_v3) : pas de
+        // score à porter, et c'est une propriété du produit, pas un trou.
+        theme: article.theme,
+        sourceId: article.sourceId,
+        isSerene: isSerene,
+      ),
+      child: child,
+    );
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -144,24 +190,33 @@ class EssentielHiFiCard extends ConsumerWidget {
             // header→lead 8→6 (le fond teinté du lead rétablit la séparation).
             const SizedBox(height: 6),
             if (lead != null)
-              _LeadTile(
+              _tracked(
                 article: lead,
-                accent: accent,
-                spec: spec,
-                readState: readStateFor(lead),
-                onTap: () => onTapArticle(lead),
+                position: 0,
+                child: _LeadTile(
+                  article: lead,
+                  accent: accent,
+                  spec: spec,
+                  readState: readStateFor(lead),
+                  onTap: () => onTapArticle(lead),
+                ),
               ),
-            for (final a in remaining) ...[
+            for (var i = 0; i < remaining.length; i++) ...[
               // Séparateur de tuiles medium 8→6 de part et d'autre du hairline
               // (poste le plus rentable : ×4, hairline 0.6px conserve le « moat »).
               const SizedBox(height: 6),
               const _Hairline(),
               const SizedBox(height: 6),
-              _MediumTile(
-                article: a,
-                spec: spec,
-                readState: readStateFor(a),
-                onTap: () => onTapArticle(a),
+              _tracked(
+                article: remaining[i],
+                // +1 : le lead occupe le rang 0.
+                position: i + 1,
+                child: _MediumTile(
+                  article: remaining[i],
+                  spec: spec,
+                  readState: readStateFor(remaining[i]),
+                  onTap: () => onTapArticle(remaining[i]),
+                ),
               ),
             ],
           ],

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -317,45 +317,37 @@ class SectionBlock extends StatelessWidget {
         return const [];
       case DigestTopicSection(:final topics, :final coreVisibleCount):
         final visible = topics.take(coreVisibleCount).toList();
-        final firstSwipeableIndex = visible.indexWhere(
-          (topic) =>
-              !pendingFeedbackIds.contains(pickTopicLead(topic).contentId),
+        // `pickTopicLead` scanne les articles du topic ; on le résout une fois
+        // par topic ici plutôt qu'à chaque référence (≈6×/carte/frame de scroll).
+        final leads = [for (final topic in visible) pickTopicLead(topic)];
+        final firstSwipeableIndex = leads.indexWhere(
+          (lead) => !pendingFeedbackIds.contains(lead.contentId),
         );
         final imageAllowed = _imageAllowedIds([
-          for (final topic in visible)
-            (
-              id: pickTopicLead(topic).contentId,
-              thumb: pickTopicLead(topic).thumbnailUrl,
-            ),
+          for (final lead in leads)
+            (id: lead.contentId, thumb: lead.thumbnailUrl),
         ]);
         return [
           for (var i = 0; i < visible.length; i++)
-            if (pendingFeedbackIds.contains(
-              pickTopicLead(visible[i]).contentId,
-            ))
-              _feedbackInlineFor(pickTopicLead(visible[i]).contentId)
+            if (pendingFeedbackIds.contains(leads[i].contentId))
+              _feedbackInlineFor(leads[i].contentId)
             else
               _tracked(
                 position: i,
-                contentId: pickTopicLead(visible[i]).contentId,
-                scoreTotal:
-                    pickTopicLead(visible[i]).recommendationReason?.scoreTotal,
+                contentId: leads[i].contentId,
+                scoreTotal: leads[i].recommendationReason?.scoreTotal,
                 theme: visible[i].theme,
-                sourceId: pickTopicLead(visible[i]).source?.id,
+                sourceId: leads[i].source?.id,
                 child: FluxContinuArticleCard(
-                  article: pickTopicLead(visible[i]),
-                  allowImageOnTop: imageAllowed.contains(
-                    pickTopicLead(visible[i]).contentId,
-                  ),
+                  article: leads[i],
+                  allowImageOnTop: imageAllowed.contains(leads[i].contentId),
                   sourceCount: visible[i].coverageCount,
                   perspectiveSources: visible[i].perspectiveSources,
                   divergenceLevel: visible[i].divergenceLevel,
-                  onTap: () => onTapArticle(pickTopicLead(visible[i])),
+                  onTap: () => onTapArticle(leads[i]),
                   onSwipeDismiss: onDismissArticle == null
                       ? null
-                      : () => onDismissArticle!(
-                          pickTopicLead(visible[i]).contentId,
-                        ),
+                      : () => onDismissArticle!(leads[i].contentId),
                   enableSwipeHint:
                       enableSwipeHintOnFirstCard && i == firstSwipeableIndex,
                   onSwipeHintComplete:

--- a/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
+++ b/apps/mobile/lib/features/flux_continu/widgets/section_block.dart
@@ -6,6 +6,7 @@ import '../../feed/widgets/feed_carousel.dart';
 import '../../feed/widgets/feedback_inline.dart';
 import '../models/flux_continu_models.dart';
 import 'alerts_section_card.dart';
+import 'article_impression_tracker.dart';
 import 'essentiel_hi_fi_card.dart';
 import 'etoffer_theme_footer.dart';
 import 'flux_continu_article_card.dart';
@@ -80,6 +81,28 @@ class SectionBlock extends StatelessWidget {
   /// toute la Tournée, comme le veut le minimalisme du design system.
   final bool showPreparingLabel;
 
+  /// Jour Tournée courant. **Non-null ⇒ les cartes comptent une impression**
+  /// (dénominateur du CTR). Laissé `null` sur les chemins de **lecture seule** —
+  /// les éditions passées de `/edition`, qui sont de la consultation d'archive
+  /// et pas une Tournée servie par l'algo : les y compter fausserait le taux.
+  final String? impressionDayKey;
+
+  /// Rang de la section dans la page (0 = héros). Ignoré sans
+  /// [impressionDayKey].
+  final int sectionIndex;
+
+  /// Nombre de cartes rendues **avant** cette section, pour que chaque carte
+  /// porte son rang absolu dans la page.
+  final int globalPositionOffset;
+
+  /// Somme des meilleurs scores du bloc, quand l'ordonnancement par score est
+  /// branché. `null` = ordre non piloté par le score.
+  final double? blockScore;
+
+  /// Jour « serein » (mode Bonnes Nouvelles) — un CTR de jour serein ne se
+  /// compare pas à un CTR de jour normal.
+  final bool isSerene;
+
   const SectionBlock({
     super.key,
     required this.section,
@@ -101,7 +124,47 @@ class SectionBlock extends StatelessWidget {
     this.onTapSuggestionInfo,
     this.onPromoteSuggestion,
     this.showPreparingLabel = false,
+    this.impressionDayKey,
+    this.sectionIndex = 0,
+    this.globalPositionOffset = 0,
+    this.blockScore,
+    this.isSerene = false,
   });
+
+  /// Enveloppe une carte d'article dans son compteur d'impression. Passe-plat
+  /// quand [impressionDayKey] est `null` (lecture seule) : zéro widget de plus
+  /// dans l'arbre sur ces chemins.
+  Widget _tracked({
+    required int position,
+    required String contentId,
+    required Widget child,
+    double? scoreTotal,
+    String? theme,
+    String? sourceId,
+  }) {
+    final dayKey = impressionDayKey;
+    if (dayKey == null) return child;
+    final section = this.section;
+    return ArticleImpressionTracker(
+      dayKey: dayKey,
+      info: ArticleImpressionInfo(
+        contentId: contentId,
+        sectionKey: sectionKey(section),
+        sectionFamily: sectionFamily(section),
+        surface: 'tournee',
+        sectionIndex: sectionIndex,
+        positionInSection: position,
+        globalPosition: globalPositionOffset + position,
+        scoreTotal: scoreTotal,
+        blockScore: blockScore,
+        theme: theme,
+        sourceId: sourceId,
+        isSerene: isSerene,
+        underfilled: section is FeedThemeSection && section.underfilled,
+      ),
+      child: child,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -120,6 +183,10 @@ class SectionBlock extends StatelessWidget {
               articles: section.articles,
               newSinceMorning: section.newSinceMorning,
               onTapArticle: (a) => onTapArticle(a),
+              impressionDayKey: impressionDayKey,
+              sectionIndex: sectionIndex,
+              globalPositionOffset: globalPositionOffset,
+              isSerene: isSerene,
             ),
             const SizedBox(height: 16),
           ],
@@ -268,31 +335,39 @@ class SectionBlock extends StatelessWidget {
             ))
               _feedbackInlineFor(pickTopicLead(visible[i]).contentId)
             else
-              FluxContinuArticleCard(
-                article: pickTopicLead(visible[i]),
-                allowImageOnTop: imageAllowed.contains(
-                  pickTopicLead(visible[i]).contentId,
+              _tracked(
+                position: i,
+                contentId: pickTopicLead(visible[i]).contentId,
+                scoreTotal:
+                    pickTopicLead(visible[i]).recommendationReason?.scoreTotal,
+                theme: visible[i].theme,
+                sourceId: pickTopicLead(visible[i]).source?.id,
+                child: FluxContinuArticleCard(
+                  article: pickTopicLead(visible[i]),
+                  allowImageOnTop: imageAllowed.contains(
+                    pickTopicLead(visible[i]).contentId,
+                  ),
+                  sourceCount: visible[i].coverageCount,
+                  perspectiveSources: visible[i].perspectiveSources,
+                  divergenceLevel: visible[i].divergenceLevel,
+                  onTap: () => onTapArticle(pickTopicLead(visible[i])),
+                  onSwipeDismiss: onDismissArticle == null
+                      ? null
+                      : () => onDismissArticle!(
+                          pickTopicLead(visible[i]).contentId,
+                        ),
+                  enableSwipeHint:
+                      enableSwipeHintOnFirstCard && i == firstSwipeableIndex,
+                  onSwipeHintComplete:
+                      enableSwipeHintOnFirstCard && i == firstSwipeableIndex
+                      ? onSwipeHintComplete
+                      : null,
+                  nudgeAnchor: i == firstSwipeableIndex
+                      ? firstSwipeableCardAnchor
+                      : null,
+                  onSwipeConversion: onSwipeConversion,
+                  onLongPressConversion: onLongPressConversion,
                 ),
-                sourceCount: visible[i].coverageCount,
-                perspectiveSources: visible[i].perspectiveSources,
-                divergenceLevel: visible[i].divergenceLevel,
-                onTap: () => onTapArticle(pickTopicLead(visible[i])),
-                onSwipeDismiss: onDismissArticle == null
-                    ? null
-                    : () => onDismissArticle!(
-                        pickTopicLead(visible[i]).contentId,
-                      ),
-                enableSwipeHint:
-                    enableSwipeHintOnFirstCard && i == firstSwipeableIndex,
-                onSwipeHintComplete:
-                    enableSwipeHintOnFirstCard && i == firstSwipeableIndex
-                    ? onSwipeHintComplete
-                    : null,
-                nudgeAnchor: i == firstSwipeableIndex
-                    ? firstSwipeableCardAnchor
-                    : null,
-                onSwipeConversion: onSwipeConversion,
-                onLongPressConversion: onLongPressConversion,
               ),
           // Actus du jour — pas de footer d'ajout de sources → on re-signale
           // l'ouverture de la section par un « Tout lire › » discret cliquable.
@@ -376,25 +451,33 @@ class SectionBlock extends StatelessWidget {
                 VeilleArticleRow(:final content, :final index) =>
                   pendingFeedbackIds.contains(content.id)
                       ? _feedbackInlineFor(content.id)
-                      : FluxContinuArticleCard(
-                          article: content,
-                          onTap: () => onTapArticle(content),
-                          onSwipeDismiss: onDismissArticle == null
-                              ? null
-                              : () => onDismissArticle!(content.id),
-                          enableSwipeHint:
-                              enableSwipeHintOnFirstCard &&
-                              index == firstSwipeableIndex,
-                          onSwipeHintComplete:
-                              enableSwipeHintOnFirstCard &&
-                                  index == firstSwipeableIndex
-                              ? onSwipeHintComplete
-                              : null,
-                          nudgeAnchor: index == firstSwipeableIndex
-                              ? firstSwipeableCardAnchor
-                              : null,
-                          onSwipeConversion: onSwipeConversion,
-                          onLongPressConversion: onLongPressConversion,
+                      : _tracked(
+                          position: index,
+                          contentId: content.id,
+                          scoreTotal:
+                              content.recommendationReason?.scoreTotal,
+                          theme: content.source.theme,
+                          sourceId: content.source.id,
+                          child: FluxContinuArticleCard(
+                            article: content,
+                            onTap: () => onTapArticle(content),
+                            onSwipeDismiss: onDismissArticle == null
+                                ? null
+                                : () => onDismissArticle!(content.id),
+                            enableSwipeHint:
+                                enableSwipeHintOnFirstCard &&
+                                index == firstSwipeableIndex,
+                            onSwipeHintComplete:
+                                enableSwipeHintOnFirstCard &&
+                                    index == firstSwipeableIndex
+                                ? onSwipeHintComplete
+                                : null,
+                            nudgeAnchor: index == firstSwipeableIndex
+                                ? firstSwipeableCardAnchor
+                                : null,
+                            onSwipeConversion: onSwipeConversion,
+                            onLongPressConversion: onLongPressConversion,
+                          ),
                         ),
               },
           ];
@@ -411,24 +494,31 @@ class SectionBlock extends StatelessWidget {
             if (pendingFeedbackIds.contains(visible[i].id))
               _feedbackInlineFor(visible[i].id)
             else
-              FluxContinuArticleCard(
-                article: visible[i],
-                allowImageOnTop: imageAllowed.contains(visible[i].id),
-                onTap: () => onTapArticle(visible[i]),
-                onSwipeDismiss: onDismissArticle == null
-                    ? null
-                    : () => onDismissArticle!(visible[i].id),
-                enableSwipeHint:
-                    enableSwipeHintOnFirstCard && i == firstSwipeableIndex,
-                onSwipeHintComplete:
-                    enableSwipeHintOnFirstCard && i == firstSwipeableIndex
-                    ? onSwipeHintComplete
-                    : null,
-                nudgeAnchor: i == firstSwipeableIndex
-                    ? firstSwipeableCardAnchor
-                    : null,
-                onSwipeConversion: onSwipeConversion,
-                onLongPressConversion: onLongPressConversion,
+              _tracked(
+                position: i,
+                contentId: visible[i].id,
+                scoreTotal: visible[i].recommendationReason?.scoreTotal,
+                theme: themeSlug ?? visible[i].source.theme,
+                sourceId: visible[i].source.id,
+                child: FluxContinuArticleCard(
+                  article: visible[i],
+                  allowImageOnTop: imageAllowed.contains(visible[i].id),
+                  onTap: () => onTapArticle(visible[i]),
+                  onSwipeDismiss: onDismissArticle == null
+                      ? null
+                      : () => onDismissArticle!(visible[i].id),
+                  enableSwipeHint:
+                      enableSwipeHintOnFirstCard && i == firstSwipeableIndex,
+                  onSwipeHintComplete:
+                      enableSwipeHintOnFirstCard && i == firstSwipeableIndex
+                      ? onSwipeHintComplete
+                      : null,
+                  nudgeAnchor: i == firstSwipeableIndex
+                      ? firstSwipeableCardAnchor
+                      : null,
+                  onSwipeConversion: onSwipeConversion,
+                  onLongPressConversion: onLongPressConversion,
+                ),
               ),
           // Cohérence Tournée — un thème **maigre affiché** (≤1 survivant après
           // dédup, enrichi par réinjection) porte en pied le footer « Étoffer »

--- a/apps/mobile/test/core/services/analytics_service_impressions_test.dart
+++ b/apps/mobile/test/core/services/analytics_service_impressions_test.dart
@@ -1,0 +1,279 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:facteur/core/api/api_client.dart';
+import 'package:facteur/core/services/analytics_service.dart';
+import 'package:facteur/core/services/posthog_service.dart';
+
+class _MockApiClient extends Mock implements ApiClient {}
+
+class _MockDio extends Mock implements Dio {}
+
+class _RecordingPostHog extends PostHogService {
+  final List<String> captured = [];
+
+  @override
+  bool get isEnabled => true;
+
+  @override
+  Future<void> capture({
+    required String event,
+    Map<String, Object>? properties,
+  }) async {
+    captured.add(event);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _MockApiClient api;
+  late _MockDio dio;
+  late _RecordingPostHog posthog;
+
+  setUpAll(() {
+    registerFallbackValue(<String, dynamic>{});
+  });
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    api = _MockApiClient();
+    dio = _MockDio();
+    when(() => api.dio).thenReturn(dio);
+    when(() => dio.post<dynamic>(any(), data: any(named: 'data'))).thenAnswer(
+      (_) async =>
+          Response(requestOptions: RequestOptions(path: ''), statusCode: 201),
+    );
+    posthog = _RecordingPostHog();
+  });
+
+  Future<void> impress(
+    AnalyticsService service, {
+    required String contentId,
+    String sectionKey = 'theme:politique',
+    String dayKey = '2026-08-02',
+    int position = 0,
+    double? scoreTotal,
+  }) {
+    return service.trackArticleImpression(
+      contentId: contentId,
+      sectionKey: sectionKey,
+      sectionFamily: 'theme',
+      surface: 'tournee',
+      dayKey: dayKey,
+      sectionIndex: 1,
+      positionInSection: position,
+      globalPosition: 5 + position,
+      scoreTotal: scoreTotal,
+      theme: 'politique',
+      sourceId: 'source-1',
+    );
+  }
+
+  List<Map<String, dynamic>> batchesPosted() {
+    final calls = verify(
+      () => dio.post<dynamic>(
+        'analytics/events/batch',
+        data: captureAny(named: 'data'),
+      ),
+    ).captured;
+    return [
+      for (final call in calls)
+        for (final event in call as List) event as Map<String, dynamic>,
+    ];
+  }
+
+  test('une impression est bufferisée, pas postée unitairement', () async {
+    final service = AnalyticsService(api, posthog: posthog);
+
+    await impress(service, contentId: 'a');
+
+    expect(service.pendingEventCount, 1);
+    verifyNever(
+      () => dio.post<dynamic>('analytics/events', data: any(named: 'data')),
+    );
+    verifyNever(
+      () =>
+          dio.post<dynamic>('analytics/events/batch', data: any(named: 'data')),
+    );
+  });
+
+  test('le buffer part en un seul POST batch au 25e event', () async {
+    final service = AnalyticsService(api, posthog: posthog);
+
+    for (var i = 0; i < 25; i++) {
+      await impress(service, contentId: 'content-$i', position: i);
+    }
+
+    expect(service.pendingEventCount, 0);
+    final posted = batchesPosted();
+    expect(posted, hasLength(25));
+    expect(
+      posted.map((e) => e['event_type']).toSet(),
+      {'article_impression'},
+    );
+  });
+
+  test('flushPendingEvents vide un lot partiel', () async {
+    final service = AnalyticsService(api, posthog: posthog);
+    await impress(service, contentId: 'a');
+    await impress(service, contentId: 'b');
+
+    await service.flushPendingEvents();
+
+    expect(service.pendingEventCount, 0);
+    expect(batchesPosted(), hasLength(2));
+  });
+
+  test('flushPendingEvents sur buffer vide ne poste rien', () async {
+    final service = AnalyticsService(api, posthog: posthog);
+
+    await service.flushPendingEvents();
+
+    verifyNever(
+      () =>
+          dio.post<dynamic>('analytics/events/batch', data: any(named: 'data')),
+    );
+  });
+
+  test('dédup 1×/(contentId, sectionKey, jour)', () async {
+    final service = AnalyticsService(api, posthog: posthog);
+
+    await impress(service, contentId: 'a');
+    await impress(service, contentId: 'a');
+    await impress(service, contentId: 'a');
+    await service.flushPendingEvents();
+
+    expect(batchesPosted(), hasLength(1));
+  });
+
+  test('le même article dans deux sections compte deux impressions', () async {
+    final service = AnalyticsService(api, posthog: posthog);
+
+    await impress(service, contentId: 'a', sectionKey: 'theme:politique');
+    await impress(service, contentId: 'a', sectionKey: 'source:lemonde');
+    await service.flushPendingEvents();
+
+    expect(batchesPosted(), hasLength(2));
+  });
+
+  test('la dédup survit à une relance dans la journée', () async {
+    await AnalyticsService(api, posthog: posthog).trackArticleImpression(
+      contentId: 'a',
+      sectionKey: 'theme:politique',
+      sectionFamily: 'theme',
+      surface: 'tournee',
+      dayKey: '2026-08-02',
+      sectionIndex: 0,
+      positionInSection: 0,
+      globalPosition: 0,
+    );
+
+    // Nouveau process : le garde-fou mémoire est vide, seul SharedPreferences
+    // se souvient.
+    final afterRestart = AnalyticsService(api, posthog: posthog);
+    await impress(afterRestart, contentId: 'a');
+    await afterRestart.flushPendingEvents();
+
+    expect(afterRestart.pendingEventCount, 0);
+    verifyNever(
+      () =>
+          dio.post<dynamic>('analytics/events/batch', data: any(named: 'data')),
+    );
+  });
+
+  test('le changement de jour purge la dédup de la veille', () async {
+    final service = AnalyticsService(api, posthog: posthog);
+
+    await impress(service, contentId: 'a', dayKey: '2026-08-01');
+    await impress(service, contentId: 'a', dayKey: '2026-08-02');
+    await service.flushPendingEvents();
+
+    expect(batchesPosted(), hasLength(2));
+
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getStringList('article_impressions_v1')!;
+    expect(stored, ['2026-08-02|theme:politique|a']);
+  });
+
+  test('aucun miroir PostHog — la mesure est backend-only', () async {
+    final service = AnalyticsService(api, posthog: posthog);
+
+    await impress(service, contentId: 'a');
+    await service.flushPendingEvents();
+
+    expect(posthog.captured, isEmpty);
+  });
+
+  test('les propriétés de découpe de la jauge sont portées', () async {
+    final service = AnalyticsService(api, posthog: posthog);
+
+    await impress(service, contentId: 'a', position: 2, scoreTotal: 61.5);
+    await service.flushPendingEvents();
+
+    final data = batchesPosted().single['event_data'] as Map<String, dynamic>;
+    expect(data['content_id'], 'a');
+    expect(data['section_key'], 'theme:politique');
+    expect(data['section_family'], 'theme');
+    expect(data['surface'], 'tournee');
+    expect(data['section_index'], 1);
+    expect(data['position_in_section'], 2);
+    expect(data['global_position'], 7);
+    expect(data['score_total'], 61.5);
+    expect(data['theme'], 'politique');
+    expect(data['source_id'], 'source-1');
+    expect(data['day_key'], '2026-08-02');
+    // `algo_version` est estampillé côté serveur : le client ne le pose pas.
+    expect(data.containsKey('algo_version'), isFalse);
+  });
+
+  test('un score absent passe en null sans faire échouer l\'event', () async {
+    final service = AnalyticsService(api, posthog: posthog);
+
+    await impress(service, contentId: 'a');
+    await service.flushPendingEvents();
+
+    final data = batchesPosted().single['event_data'] as Map<String, dynamic>;
+    expect(data['score_total'], isNull);
+    expect(data['block_score'], isNull);
+  });
+
+  test('endSession flush le buffer avant de poster session_end', () async {
+    final service = AnalyticsService(api, posthog: posthog);
+    await service.startSession();
+    await impress(service, contentId: 'a');
+
+    await service.endSession();
+
+    expect(service.pendingEventCount, 0);
+    expect(batchesPosted(), hasLength(1));
+  });
+
+  test('session_start porte la sonde tournee_customized', () async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      'tournee_customized_v1': true,
+    });
+    final service = AnalyticsService(api, posthog: posthog);
+
+    await service.startSession();
+
+    final calls = verify(
+      () => dio.post<dynamic>(
+        'analytics/events',
+        data: captureAny(named: 'data'),
+      ),
+    ).captured;
+    final payload = calls.single as Map<String, dynamic>;
+    expect(payload['event_data']['tournee_customized'], isTrue);
+  });
+
+  test('AnalyticsService.disabled ne bufferise rien', () async {
+    final service = AnalyticsService.disabled();
+
+    await impress(service, contentId: 'a');
+
+    expect(service.pendingEventCount, 0);
+  });
+}

--- a/apps/mobile/test/features/flux_continu/widgets/article_impression_tracker_test.dart
+++ b/apps/mobile/test/features/flux_continu/widgets/article_impression_tracker_test.dart
@@ -1,0 +1,198 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:visibility_detector/visibility_detector.dart';
+
+import 'package:facteur/core/providers/analytics_provider.dart';
+import 'package:facteur/core/services/analytics_service.dart';
+import 'package:facteur/features/flux_continu/widgets/article_impression_tracker.dart';
+
+/// Enregistre les impressions au lieu de les poster. `super.disabled()` :
+/// aucune dépendance réseau ni SharedPreferences dans ce test — on mesure le
+/// **déclencheur** (seuil de visibilité), pas la dédup (couverte par
+/// `analytics_service_impressions_test.dart`).
+class _RecordingAnalytics extends AnalyticsService {
+  _RecordingAnalytics() : super.disabled();
+
+  final List<Map<String, Object?>> impressions = [];
+
+  @override
+  Future<void> trackArticleImpression({
+    required String contentId,
+    required String sectionKey,
+    required String sectionFamily,
+    required String surface,
+    required String dayKey,
+    required int sectionIndex,
+    required int positionInSection,
+    required int globalPosition,
+    double? scoreTotal,
+    double? blockScore,
+    String? theme,
+    String? sourceId,
+    bool isSerene = false,
+    bool underfilled = false,
+  }) async {
+    impressions.add({
+      'content_id': contentId,
+      'section_key': sectionKey,
+      'day_key': dayKey,
+      'position_in_section': positionInSection,
+      'global_position': globalPosition,
+      'score_total': scoreTotal,
+    });
+  }
+}
+
+/// Hauteur du viewport de test (défaut `flutter_test`).
+const double _viewportHeight = 600;
+
+/// Hauteur de la carte suivie — la fraction visible se lit directement en
+/// pixels : 100 px visibles sur 200 = 50 %.
+const double _cardHeight = 200;
+
+void main() {
+  late _RecordingAnalytics analytics;
+  late ScrollController controller;
+
+  setUp(() {
+    // Sans intervalle nul, le timer interne du VisibilityDetector reste pendant
+    // au teardown et le test échoue sur un timer non purgé.
+    VisibilityDetectorController.instance.updateInterval = Duration.zero;
+    analytics = _RecordingAnalytics();
+    controller = ScrollController();
+  });
+
+  tearDown(() => controller.dispose());
+
+  /// Pose la carte suivie sous le pli : à l'offset 0 elle est hors écran, et
+  /// `jumpTo(n)` la fait entrer de `n` pixels.
+  Future<void> pumpTracked(
+    WidgetTester tester, {
+    ArticleImpressionInfo? info,
+    bool mounted = true,
+  }) {
+    return tester.pumpWidget(
+      ProviderScope(
+        overrides: [analyticsServiceProvider.overrideWithValue(analytics)],
+        child: MaterialApp(
+          home: Scaffold(
+            body: ListView(
+              controller: controller,
+              children: [
+                const SizedBox(height: _viewportHeight),
+                if (mounted)
+                  SizedBox(
+                    height: _cardHeight,
+                    child: ArticleImpressionTracker(
+                      dayKey: '2026-08-02',
+                      info: info ??
+                          const ArticleImpressionInfo(
+                            contentId: 'content-1',
+                            sectionKey: 'theme:politique',
+                            sectionFamily: 'theme',
+                            surface: 'tournee',
+                            sectionIndex: 2,
+                            positionInSection: 1,
+                            globalPosition: 7,
+                            scoreTotal: 61.5,
+                          ),
+                      child: const Text('carte'),
+                    ),
+                  ),
+                const SizedBox(height: 1000),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('une carte sous le pli ne compte aucune impression',
+      (tester) async {
+    await pumpTracked(tester);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 3));
+
+    expect(analytics.impressions, isEmpty);
+  });
+
+  testWidgets('une carte visible à 25 % ne compte pas, même après 3 s',
+      (tester) async {
+    await pumpTracked(tester);
+    controller.jumpTo(50); // 50 px sur 200 = 25 %
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 3));
+
+    expect(analytics.impressions, isEmpty);
+  });
+
+  testWidgets('50 % pendant 1 s compte exactement une impression',
+      (tester) async {
+    await pumpTracked(tester);
+    controller.jumpTo(100); // 100 px sur 200 = 50 %
+    await tester.pump();
+
+    await tester.pump(const Duration(milliseconds: 999));
+    expect(
+      analytics.impressions,
+      isEmpty,
+      reason: 'le seuil de durée est 1 s, pas 999 ms',
+    );
+
+    await tester.pump(const Duration(milliseconds: 2));
+    expect(analytics.impressions, hasLength(1));
+    expect(analytics.impressions.single['content_id'], 'content-1');
+    expect(analytics.impressions.single['section_key'], 'theme:politique');
+    expect(analytics.impressions.single['global_position'], 7);
+    expect(analytics.impressions.single['score_total'], 61.5);
+  });
+
+  testWidgets('un scroll rapide qui traverse la carte ne compte rien',
+      (tester) async {
+    await pumpTracked(tester);
+    controller.jumpTo(150); // pleinement visible
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    controller.jumpTo(0); // repartie sous le pli avant le seuil de durée
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 3));
+
+    expect(analytics.impressions, isEmpty);
+  });
+
+  testWidgets('rester visible plus longtemps ne compte pas deux fois',
+      (tester) async {
+    await pumpTracked(tester);
+    controller.jumpTo(150);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    expect(analytics.impressions, hasLength(1));
+
+    // Aller-retour au-dessus/en-dessous du seuil : la carte a déjà été comptée.
+    controller.jumpTo(0);
+    await tester.pump();
+    controller.jumpTo(150);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 3));
+
+    expect(analytics.impressions, hasLength(1));
+  });
+
+  testWidgets('démonter la carte avant le seuil ne laisse aucun timer pendant',
+      (tester) async {
+    await pumpTracked(tester);
+    controller.jumpTo(150);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    // Retire la carte de l'arbre : le timer de dwell est encore armé.
+    await pumpTracked(tester, mounted: false);
+    await tester.pump(const Duration(seconds: 3));
+
+    expect(analytics.impressions, isEmpty);
+    // Le test échouerait au teardown sur un timer non annulé.
+  });
+}

--- a/docs/maintenance/maintenance-reco-optimisation-lot2.md
+++ b/docs/maintenance/maintenance-reco-optimisation-lot2.md
@@ -1,0 +1,280 @@
+# Maintenance — Optimisation des recos, lot 2 : tuning, ordre des blocs, mesure
+
+> **Date d'ouverture** : 2026-08-02
+> **Branche** : `boujonlaurin-dotcom/tuning-seuils-et-ranking-tournee`
+> **PRs ciblées** : `main`
+> **Type** : lot séquencé (6 PRs)
+> **Prolonge** : [`maintenance-reco-quality-step-up.md`](./maintenance-reco-quality-step-up.md)
+> **Ne le refait pas** — les constats de PR0/PR1/PR2 y restent la référence.
+
+## Cadre
+
+Quatre axes demandés par le PO : (1) affiner les seuils/constantes contre un jeu
+de données et de faux profils, (2) réordonner les blocs de la Tournée par la
+somme de recommandabilité de leur top-3, (3) câbler de la mesure objective, (4)
+faire apprendre l'algo sur des taux de clics.
+
+Trois faits vérifiés cadrent le lot.
+
+**L'A/B est hors de portée.** DAU moyen 16,1 (78 users distincts / 30 j).
+Détecter +0,3 pp sur un CTR de base de 1,41 % demande ~27 000 slots/bras *avant*
+clustering ; avec un ICC de 0,03-0,10 par user le facteur de design passe à
+×17-×55, soit **1,5 à 5 ans par bras**. Les décisions de tuning se prennent
+**offline**. La mesure online est une jauge de garde-fou, pas un arbitre.
+
+**Il n'existait aucun tracking d'impression.** `trackDigestItemViewed` n'a aucun
+call site en prod ; `last_impressed_at` n'est écrit qu'au pull-to-refresh. Le
+dénominateur du CTR était reconstruit depuis `daily_digest.items`, ce qui ne
+couvre que le digest — pas les sections de la Tournée. C'est le blocage dur de
+l'axe 4, et l'objet de PR-1.
+
+**La prémisse de l'axe 2 sur la comparabilité était inversée.**
+`recommendation_service.py:2455-2470` restreint les sections thème de la Tournée
+aux **sources suivies** (chemin two-phase, repli curated si 0 source suivie).
+Blocs thème et blocs source encaissent donc le même `TRUSTED_SOURCE = 35` : un
+tri global au score ne remonte pas mécaniquement les sources. Le tri global
+demandé est sûr.
+
+**Décisions PO au cadrage** : lot complet séquencé · tri **global** (familles
+mélangées) · le tri s'applique **aussi aux comptes ayant personnalisé leur
+ordre** (l'ordre manuel devient une base, pas une autorité) · méthodo
+**sensibilité d'abord**, gold en garde-fou seulement.
+
+**Zéro migration Alembic sur tout le lot** — conséquence de deux propriétés de
+l'existant : `analytics_events.event_data` est en JSONB, et `ScoringWeights`
+n'expose que des attributs de classe. Si une migration apparaît dans une PR de
+ce lot, c'est un signal d'erreur de conception à réexaminer.
+
+## Séquence
+
+| PR | Objet | Axe | État |
+|---|---|---|---|
+| PR-1 | Instrumentation d'impression | 3 | **livrée** |
+| PR-2 | `SCORING_OVERRIDES` + contexte de sweep | 1 (outillage) | à faire |
+| PR-3 | Personas, corpus gelé, harnais de sensibilité | 1 | à faire |
+| PR-4 | Ordre des blocs par score top-3 | 2 | à faire |
+| PR-5 | Shrinkage affinité source + `DIGEST_SPORT_PENALTY` | 4 (amorce) | à faire, gated sur PR-3 |
+| PR-6 | `evaluate_tournee_ctr.py` | 3 | à faire, ≈2 semaines après PR-1 |
+
+PR-1 passe en premier parce que sa valeur est fonction du **temps calendaire
+écoulé** : chaque jour non shippé est un jour de données perdu.
+
+---
+
+## PR-1 — Instrumentation d'impression
+
+### Ce qui est posé
+
+**Event `article_impression`** dans `analytics_events` (`event_type`), aucune
+table, aucune migration : la colonne `event_data` est déjà en JSONB et les trois
+colonnes utiles (`user_id`, `event_type`, `created_at`) sont déjà indexées.
+
+Propriétés portées :
+
+| Propriété | Source | Note |
+|---|---|---|
+| `content_id` | carte | |
+| `section_key` | `sectionKey(section)` | |
+| `section_family` | `sectionFamily(section)` | `theme \| source \| veille \| editorial` |
+| `surface` | rendu | `tournee \| essentiel` |
+| `section_index` | rang de la section | |
+| `position_in_section` | rang de la carte | |
+| `global_position` | compteur de page | porte l'effet de position |
+| `score_total` | `recommendation_reason.score_total` | `null` sur les blocs éditoriaux |
+| `block_score` | — | `null` **jusqu'à PR-4** : c'est ce champ qui reliera « ordre des blocs » et « CTR mesuré » |
+| `theme`, `source_id` | carte | |
+| `is_serene`, `underfilled` | état | découpes de lecture |
+| `day_key` | `TourneeProgressService.dayKey` | frontière 4 h Paris |
+| `session_id` | `AnalyticsService` | |
+| `algo_version` | **serveur** | cf. ci-dessous |
+
+### Décisions et leurs raisons
+
+**Seuil de viewabilité : ≥ 50 % pendant ≥ 1 000 ms** (standard MRC display).
+Au-dessus de 50 %, une carte à moitié coupée par le bas de l'écran ne serait
+jamais comptée alors qu'elle est lisible ; sans seuil de durée, traverser la
+Tournée d'un coup de pouce gonflerait le dénominateur de cartes que personne
+n'a lues.
+
+**Nouveau widget, pas une extension d'`AutoGrowCandidate`.** Celui-ci a un
+seuil de 0,9, exclut les articles lus (`_visible && !_read` — or un article lu
+*a été* impressionné, c'est même le numérateur du CTR) et porte un contrat
+`dispose`/microtask qui sert un tout autre besoin. Les deux `VisibilityDetector`
+s'imbriquent sans conflit, chacun ayant sa clé.
+
+**Périmètre : Tournée + Essentiel.** Pas Flâner — le flux chronologique est
+voulu, un CTR par rang n'y voudrait rien dire. Pas les **éditions passées**
+(`/edition`) : c'est de la consultation d'archive, pas une Tournée servie par
+l'algo ; les y compter fausserait le taux. Techniquement, `SectionBlock` ne
+compte que si `impressionDayKey` est non-null, et les chemins archive le
+laissent nul.
+
+**Dédup 1×/(`content_id`, `section_key`, `day_key`)**, sur le pattern exact de
+`trackSuggestionImpression` : liste SharedPreferences purgée au changement de
+jour + garde-fou mémoire dans le process (une carte recyclée par le viewport
+paresseux re-déclenche son tracker au scroll). Le **même** article vu dans deux
+sections compte deux impressions : la position dans une section est justement ce
+qu'on mesure.
+
+**Batching obligatoire.** `_logEvent` fait un POST HTTP par event ; ~30
+impressions par session, c'est 30 POST fire-and-forget sur réseau mobile.
+Nouveau `POST /api/analytics/events/batch` (**additif** — `POST /events` reste
+intact pour les binaires en circulation), buffer client flushé à 25 events / 10 s
+d'inactivité / `endSession` (donc `AppLifecycleState.paused`, cf. `app.dart`).
+Un lot qui échoue est **abandonné**, jamais ré-empilé : de l'analytics
+best-effort qui se remettrait en file grossirait sans borne hors ligne.
+
+Le batch **n'exécute aucun effet de bord** de `/events` (streak sur
+`session_start`, mise à jour d'`app_version`) : `session_start` reste sur le
+chemin unitaire. C'est écrit dans la docstring de l'endpoint.
+
+**`algo_version` estampillé côté serveur.** Le mobile ne connaît pas la
+configuration de scoring, et la faire redescendre dans `/api/feed` +
+`/api/essentiel` puis remonter dans l'event serait trois surfaces de plumbing
+pour la même valeur. Limite assumée et documentée : un redeploy entre le scoring
+d'un flux et l'impression de ses cartes estampille la nouvelle version sur des
+cartes scorées par l'ancienne — quelques minutes de données par déploiement.
+`scoring_algo_version()` vit dans `scoring_config.py`, exactement là où PR-2
+ajoutera le hash des overrides actifs.
+
+**Backend-only, pas de miroir PostHog.** Le dénominateur doit se joindre à
+`user_content_status` × `contents` × `daily_digest`, et cette jointure n'existe
+qu'en Postgres. La divergence est déjà mesurable : `article_read` = 200 events /
+12 users sur 30 j contre **1 312 `consumed` / 50 users** — le pipeline PostHog
+couvre ~15 % des clics réels. Un miroir donnerait deux chiffres divergents pour
+la même métrique.
+
+**Sonde `tournee_customized` sur `session_start`.** C'est du SharedPreferences
+local, invisible en DB : c'est la seule façon de savoir combien de comptes PR-4
+concerne réellement.
+
+**`EssentielArticle.sourceId`** : `/api/essentiel` servait déjà `source.id`, le
+parse mobile le jetait. Ajouté (additif, round-trip par le cache) — il porte la
+découpe « CTR par source » sur la surface héros.
+
+### Volume et coût
+
+~30 impressions uniques/user/jour × 16,1 DAU ≈ **480/jour, 14 500/mois**.
+`analytics_events` fait 385/j aujourd'hui → on triple, non-problème Postgres.
+
+Index partiel `CREATE INDEX CONCURRENTLY … WHERE event_type='article_impression'`
+→ **différé** jusqu'à >100k lignes (≈ 7 mois au volume estimé).
+
+### Fichiers
+
+| Fichier | Nature |
+|---|---|
+| `packages/api/app/routers/analytics.py` | `POST /events/batch`, `_stamp_algo_version` |
+| `packages/api/app/services/analytics_service.py` | `log_events` (bulk, 1 commit) |
+| `packages/api/app/services/recommendation/scoring_config.py` | `scoring_algo_version()` |
+| `packages/api/tests/routers/test_analytics_events_batch.py` | nouveau |
+| `apps/mobile/lib/features/flux_continu/widgets/article_impression_tracker.dart` | nouveau |
+| `apps/mobile/lib/core/services/analytics_service.dart` | `trackArticleImpression`, buffer, sonde |
+| `apps/mobile/lib/features/flux_continu/widgets/section_block.dart` | câblage Tournée |
+| `apps/mobile/lib/features/flux_continu/widgets/essentiel_hi_fi_card.dart` | câblage Essentiel |
+| `apps/mobile/lib/features/flux_continu/models/flux_continu_models.dart` | `sectionFamily`, `renderedCardCount`, `sourceId` |
+| `apps/mobile/lib/features/flux_continu/screens/flux_continu_screen.dart` | rang absolu + `dayKey` |
+| `apps/mobile/test/core/services/analytics_service_impressions_test.dart` | nouveau |
+| `apps/mobile/test/features/flux_continu/widgets/article_impression_tracker_test.dart` | nouveau |
+
+### Vérification post-merge (à faire, J+2 après déploiement)
+
+```sql
+SELECT count(*), count(DISTINCT user_id)
+FROM analytics_events
+WHERE event_type = 'article_impression'
+  AND created_at > now() - interval '2 days';
+```
+
+Attendu ≈ 960 lignes / ~16 users/jour. **< 200 ou > 5 000 ⇒ seuil ou dédup
+faux** — ne pas commencer PR-6 sans avoir tranché.
+
+**Gate de couverture** : ≥ 80 % des `consumed` du jour ont une impression
+appariée sous 24 h. C'est exactement le test qui aurait attrapé le trou
+d'`article_read`.
+
+```sql
+WITH consumed AS (
+  SELECT user_id, content_id, updated_at
+  FROM user_content_status
+  WHERE status = 'consumed'
+    AND updated_at > now() - interval '2 days'
+),
+impressed AS (
+  SELECT user_id,
+         event_data->>'content_id' AS content_id,
+         created_at
+  FROM analytics_events
+  WHERE event_type = 'article_impression'
+    AND created_at > now() - interval '3 days'
+)
+SELECT round(100.0 * count(i.content_id) / nullif(count(*), 0), 1) AS pct_apparie
+FROM consumed c
+LEFT JOIN impressed i
+  ON i.user_id = c.user_id
+ AND i.content_id = c.content_id::text
+ AND i.created_at BETWEEN c.updated_at - interval '24 hours' AND c.updated_at;
+```
+
+Un taux durablement bas signale une **surface non instrumentée**, pas un bug de
+seuil : le premier réflexe est de chercher d'où viennent les `consumed` non
+appariés (Flâner et le reader sont hors périmètre par construction — les en
+exclure avant de conclure).
+
+---
+
+## Journal des constantes modifiées
+
+Une ligne par constante touchée par le lot : valeur avant/après, quel objectif a
+bougé, de combien, sur quel fichier corpus. Vide tant que PR-3 n'a pas livré le
+harnais — **aucune constante ne bouge sans mesure**.
+
+| Date | Constante | Avant | Après | Objectif déplacé | Corpus |
+|---|---|---|---|---|---|
+| — | — | — | — | — | — |
+
+---
+
+## Différé — apprentissage par CTR (cœur de l'axe 4)
+
+Impossible aujourd'hui : `user_content_status` ne compte que 1 395 lignes
+`unseen` contre 4 188 `consumed` — les lignes sont créées à l'interaction, pas à
+la livraison. Il n'existait aucun dénominateur honnête hors du digest ; PR-1 le
+crée, il faut maintenant le laisser se remplir.
+
+**Critères de ré-entrée, les cinq simultanément :**
+
+| Signal | Seuil | Justification |
+|---|---|---|
+| Impressions collectées | ≥ 60 000 lignes `article_impression` | à 480/j = **125 jours** ; ≥ 1 200 impressions/user sur les 50 récurrents |
+| Cellules (user, source) à n ≥ 30 impressions | ≥ 300 | en-dessous, un CTR rétréci est à 90 % le prior — on apprendrait le prior |
+| Cellules (user, thème) à n ≥ 50 impressions | ≥ 150 | ~3 thèmes × 50 users |
+| Stabilité du CTR d'impression | ±1 pp semaine-sur-semaine sur 4 semaines | si le taux de base dérive, tout poids appris court après une tendance |
+| Couverture du numérateur | ≥ 80 % des `consumed` appariés sous 24 h | prouve que l'instrumentation ne rate pas une surface |
+
+Date attendue au DAU actuel : **~2027-02**. Réévaluer plus tôt si le **DAU
+dépasse 33** (→ > 30 000 impressions/mois, portes atteintes en ~2 mois).
+
+**Ce qu'il ne faut PAS construire maintenant** : un job hebdo matérialisant
+`user_source_ctr` / `user_theme_ctr` dès le jour 1. `analytics_events` conserve
+tout, l'agrégat est calculable rétroactivement. Construire le tuyau avant la
+porte, c'est le prototype de la chose qu'on ship et qu'on n'utilise jamais.
+
+---
+
+## Points à vérifier avant d'attaquer les PRs suivantes
+
+1. `essentiel_service.py` passe-t-il par `PillarScoringEngine` ? (décide du coût
+   réel de l'option « faire remonter un score » écartée en PR-4 — non ouvert).
+2. Le repli two-phase de `personalized_theme_mode` quand le pool de sources
+   suivies est maigre : tombe-t-il sur du curated non suivi ? Si oui la
+   comparabilité inter-familles varie *par bloc et par jour*
+   (`recommendation_service.py:2455-2470`).
+3. **`content_interaction` = 0 event sur 30 jours** alors que
+   `digest_provider.dart:729-790` est censé l'émettre. Chemin mort ou call site
+   plus atteint — possible régression silencieuse **indépendante de ce lot**, à
+   investiguer à part.
+4. `_capSectionsToFit` (`flux_continu_provider.dart` L1180-1259) applique un
+   plancher dur « jamais 1 seul article dès que 2 sont disponibles » — vérifier
+   qu'il ne rend pas le tri de PR-4 partiellement inopérant sur les blocs qu'il
+   vise.

--- a/docs/maintenance/maintenance-reco-optimisation-lot2.md
+++ b/docs/maintenance/maintenance-reco-optimisation-lot2.md
@@ -50,7 +50,7 @@ ce lot, c'est un signal d'erreur de conception à réexaminer.
 | PR | Objet | Axe | État |
 |---|---|---|---|
 | PR-1 | Instrumentation d'impression | 3 | **livrée** |
-| PR-2 | `SCORING_OVERRIDES` + contexte de sweep | 1 (outillage) | à faire |
+| PR-2 | `SCORING_OVERRIDES` + contexte de sweep | 1 (outillage) | **livrée** |
 | PR-3 | Personas, corpus gelé, harnais de sensibilité | 1 | à faire |
 | PR-4 | Ordre des blocs par score top-3 | 2 | à faire |
 | PR-5 | Shrinkage affinité source + `DIGEST_SPORT_PENALTY` | 4 (amorce) | à faire, gated sur PR-3 |
@@ -220,6 +220,80 @@ Un taux durablement bas signale une **surface non instrumentée**, pas un bug de
 seuil : le premier réflexe est de chercher d'où viennent les `consumed` non
 appariés (Flâner et le reader sont hors périmètre par construction — les en
 exclure avant de conclure).
+
+---
+
+## PR-2 — `SCORING_OVERRIDES` + contexte de sweep
+
+Pas pour l'A/B (impossible), **pour la latence de rollback** : aujourd'hui,
+changer une constante de scoring = commit + redeploy Railway sur une DB partagée
+main-staging / production. Cette PR pose deux surfaces de surcharge de
+`ScoringWeights`, une déployée et une offline.
+
+### Surcharge d'environnement `SCORING_OVERRIDES` (déployée)
+
+Une seule variable d'env portant du JSON `{"CONSTANTE": valeur, …}`, parsée
+**une fois** au premier import, appliquée par `setattr` sur `ScoringWeights`.
+Rollback = vider la variable Railway + restart (~30 s). Précédent : les env vars
+ad hoc déjà en place (`EDITORIAL_SOLO_SUBJECT_MIN_SCORE`,
+`EDITORIAL_COVERAGE_FOLD_ENABLED`…).
+
+- **Placement critique** : appliquée **en bas de `scoring_config.py`**, donc au
+  premier import de `ScoringWeights`, AVANT que tout autre module ne fige une
+  valeur en argument par défaut (`scheduler.decayed_subtopic_weight`) ou en copie
+  de niveau module (`essentiel_service._W_TRENDING`). Ces call sites lisent donc
+  la valeur **surchargée** — l'env override est effectif partout.
+- **Robustesse** : JSON invalide → erreur loggée, **rien appliqué** (fail-closed
+  sur la config) ; clé inconnue → WARN + ignorée ; chaque override → INFO.
+  `PILLAR_WEIGHTS` n'est accepté que si la somme fait 1.0.
+- **`algo_version`** : `scoring_algo_version()` suffixe désormais un hash court,
+  déterministe et stable des overrides actifs (`pillars_v1+ovr.<hash>`). Sans
+  override actif, la version reste nue (`pillars_v1`) — inchangé pour les
+  binaires sans la variable. C'est ce qui rend deux semaines de CTR mesurées sous
+  deux jeux de constantes comparables : l'event `article_impression` porte de
+  quelle config il relève (cf. PR-1).
+
+### Contexte de sweep offline `weights_override` (tuning)
+
+`scripts/_scoring_overrides.py::weights_override(**kwargs)` — généralisation
+directe du `_threshold_override` de `evaluate_veille_curation.py` (qui ne patchait
+que `VEILLE_RELEVANCE_THRESHOLD`, et **délègue désormais** à cette mécanique
+partagée). Patche N attributs le temps d'un `with`, restaure en `finally`.
+Consommé par les harnais de sensibilité/sweep de PR-3.
+
+### Deux pièges traités
+
+1. **Constantes liées au chargement du module (non patchables à chaud).**
+   `scheduler.decayed_subtopic_weight(decay=ScoringWeights.SUBTOPIC_DECAY)` fige
+   la valeur à l'import : un `setattr` runtime serait un **no-op silencieux**.
+   `weights_override` **lève** si on cible un nom de `NON_PATCHABLE_AT_RUNTIME`
+   (= `{SUBTOPIC_DECAY}`). Garde anti-drift :
+   `test_scoring_overrides.py::test_no_new_module_bound_defaults` parse l'AST de
+   tout `app/`, recense les défauts `def … = ScoringWeights.X` et échoue si la
+   liste s'allonge sans que la garde soit mise à jour. *(L'env override, lui,
+   atteint ces call sites car il court avant leur import — seul le sweep runtime
+   est concerné.)*
+2. **`PILLAR_WEIGHTS` est un dict mutable de classe** : deep-copié avant patch,
+   restauré après, et l'invariant `sum == 1.0` réasserté une fois tous les patchs
+   posés (les deux surfaces).
+
+### Règle de discipline (non négociable)
+
+L'override env est un outil de **tuning et de rollback, pas une surface de
+configuration**. Tout override qui survit plus d'un cycle est **promu dans
+`scoring_config.py` et la variable vidée** — sinon la source de vérité dérive,
+ce qui est le problème même qu'on cherche à résoudre.
+
+### Fichiers
+
+| Fichier | Nature |
+|---|---|
+| `packages/api/app/services/recommendation/scoring_config.py` | `_apply_env_scoring_overrides`, `_ACTIVE_OVERRIDES`, hash dans `scoring_algo_version()` |
+| `packages/api/scripts/_scoring_overrides.py` | nouveau — `weights_override`, `NON_PATCHABLE_AT_RUNTIME` |
+| `packages/api/scripts/evaluate_veille_curation.py` | `_threshold_override` délègue à `weights_override` |
+| `packages/api/tests/scripts/test_scoring_overrides.py` | nouveau — sweep, env, garde AST |
+
+Aucune migration Alembic (`ScoringWeights` n'expose que des attributs de classe).
 
 ---
 

--- a/packages/api/app/routers/analytics.py
+++ b/packages/api/app/routers/analytics.py
@@ -3,7 +3,7 @@
 from datetime import UTC, date, datetime
 from uuid import UUID
 
-from fastapi import APIRouter, BackgroundTasks, Depends, Header
+from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException
 from pydantic import BaseModel, Field
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -11,9 +11,20 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import get_db, safe_async_session
 from app.dependencies import get_current_user_id
 from app.services.analytics_service import AnalyticsService
+from app.services.recommendation.scoring_config import scoring_algo_version
 from app.services.streak_service import StreakService
 
 router = APIRouter(tags=["Analytics"])
+
+#: Taille maximale d'un lot accepté par `POST /events/batch`. Le client flush
+#: tous les 25 events : la marge absorbe un flush de fin de session sans jamais
+#: laisser un lot pathologique ouvrir un commit de plusieurs milliers de lignes.
+MAX_BATCH_EVENTS = 100
+
+#: Impression d'un article dans la Tournée ou l'Essentiel — le **dénominateur**
+#: du CTR. Le seul type d'event que le backend estampille (cf.
+#: [_stamp_algo_version]).
+IMPRESSION_EVENT_TYPE = "article_impression"
 
 
 class EventCreate(BaseModel):
@@ -85,6 +96,55 @@ async def log_event(
         background_tasks.add_task(_update_app_version, user_id, app_version)
 
     return {"status": "ok"}
+
+
+def _stamp_algo_version(event: EventCreate) -> dict:
+    """Estampille la version de scoring active sur une impression.
+
+    Côté **serveur** et pas client : le mobile ne connaît pas la configuration
+    de scoring, et la faire redescendre dans `/api/feed` + `/api/essentiel`
+    puis remonter dans l'event serait trois surfaces de plumbing pour la même
+    valeur. Limite assumée : un redeploy entre le scoring d'un flux et
+    l'impression de ses cartes estampille la nouvelle version sur des cartes
+    scorées par l'ancienne — quelques minutes de données par déploiement.
+
+    Un `algo_version` déjà posé par le client n'est jamais écrasé.
+    """
+    if event.event_type != IMPRESSION_EVENT_TYPE:
+        return event.event_data
+    if event.event_data.get("algo_version"):
+        return event.event_data
+    return {**event.event_data, "algo_version": scoring_algo_version()}
+
+
+@router.post("/events/batch", status_code=201)
+async def log_events_batch(
+    events: list[EventCreate],
+    user_id: UUID = Depends(get_current_user_id),
+    db: AsyncSession = Depends(get_db),
+):
+    """Enregistre un **lot** d'événements analytiques en un seul commit.
+
+    Additif : `POST /events` reste le chemin unitaire et n'est pas touché — les
+    binaires en circulation continuent de l'utiliser. Ce lot est réservé à la
+    télémétrie fire-and-forget (impressions) : il n'exécute **aucun** des effets
+    de bord de `/events` (streak sur `session_start`, mise à jour d'app_version).
+    Un `session_start` doit donc rester sur le chemin unitaire.
+    """
+    if len(events) > MAX_BATCH_EVENTS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Lot trop grand ({len(events)} > {MAX_BATCH_EVENTS} events)",
+        )
+
+    accepted = await AnalyticsService(db).log_events(
+        user_id=user_id,
+        events=[
+            (event.event_type, _stamp_algo_version(event), event.device_id)
+            for event in events
+        ],
+    )
+    return {"status": "ok", "accepted": accepted}
 
 
 @router.get("/digest-metrics")

--- a/packages/api/app/services/analytics_service.py
+++ b/packages/api/app/services/analytics_service.py
@@ -42,6 +42,36 @@ class AnalyticsService:
         await self.session.commit()
         return event
 
+    async def log_events(
+        self,
+        user_id: UUID,
+        events: list[tuple[str, dict[str, Any], str | None]],
+    ) -> int:
+        """Log un lot d'événements en **un seul commit**.
+
+        Pendant bulk de [log_event], pour le buffer client d'impressions : une
+        session de lecture produit ~30 `article_impression`, soit 30 POST et
+        30 commits si on repassait par le chemin unitaire.
+
+        [events] = liste de `(event_type, event_data, device_id)`. Retourne le
+        nombre de lignes insérées.
+        """
+        if not events:
+            return 0
+        self.session.add_all(
+            [
+                AnalyticsEvent(
+                    user_id=user_id,
+                    event_type=event_type,
+                    event_data=event_data,
+                    device_id=device_id,
+                )
+                for event_type, event_data, device_id in events
+            ]
+        )
+        await self.session.commit()
+        return len(events)
+
     async def get_dau(self, target_date: date = None) -> int:
         """Récupère le nombre d'utilisateurs actifs journaliers (DAU)."""
         if target_date is None:

--- a/packages/api/app/services/recommendation/scoring_config.py
+++ b/packages/api/app/services/recommendation/scoring_config.py
@@ -566,3 +566,18 @@ class ScoringWeights:
     # Fenêtre de récence (jours) du comptage d'articles par candidat (aligné
     # sur le filtre 14 j du fallback `get_top_themes`).
     TOURNEE_SUGGEST_RECENCY_DAYS = 14
+
+
+def scoring_algo_version() -> str:
+    """Identifiant de la configuration de scoring **effectivement active**.
+
+    Estampillé sur chaque `article_impression` (cf. `routers/analytics.py`) :
+    sans lui, aucune comparaison avant/après d'un cycle de tuning n'est
+    possible — deux semaines de CTR mesurées sous deux jeux de constantes
+    différents ne sont pas comparables et rien dans la donnée ne le dirait.
+
+    Aujourd'hui = la seule version du moteur. Le lot « tuning » ajoutera ici le
+    hash des overrides d'environnement actifs (`SCORING_OVERRIDES`), de sorte
+    qu'un tuning appliqué sans redeploy change quand même la version.
+    """
+    return ScoringWeights.SCORING_VERSION

--- a/packages/api/app/services/recommendation/scoring_config.py
+++ b/packages/api/app/services/recommendation/scoring_config.py
@@ -1,3 +1,11 @@
+import hashlib
+import json
+import logging
+import os
+
+_logger = logging.getLogger(__name__)
+
+
 class ScoringWeights:
     """
     Configuration centralisée des poids de l'algorithme de recommandation.
@@ -568,6 +576,110 @@ class ScoringWeights:
     TOURNEE_SUGGEST_RECENCY_DAYS = 14
 
 
+# ---------------------------------------------------------------------------
+# SCORING_OVERRIDES — surcharge d'environnement (outil de tuning / rollback)
+# ---------------------------------------------------------------------------
+# Une seule variable d'env portant du JSON `{"CONSTANTE": valeur, …}`, parsée
+# **une fois** ici et appliquée par `setattr` sur `ScoringWeights`. But : la
+# **latence de rollback**. Aujourd'hui changer une constante = commit + redeploy
+# Railway sur une DB partagée main-staging / production ; ici, rollback = vider
+# la variable Railway + restart (~30 s). Précédent : les env vars ad hoc déjà en
+# place (`EDITORIAL_SOLO_SUBJECT_MIN_SCORE`, `EDITORIAL_COVERAGE_FOLD_ENABLED`…).
+#
+# Placement critique : **en bas de ce module**, donc appliqué au premier import
+# de `ScoringWeights`, AVANT que tout autre module ne lie une valeur en argument
+# par défaut (`scheduler.decayed_subtopic_weight`) ou en copie de niveau module
+# (`essentiel_service._W_TRENDING`). Ces call sites picoreront donc la valeur
+# **surchargée** — l'env override est effectif partout, contrairement au sweep
+# runtime (`scripts/_scoring_overrides.py`, cf. `NON_PATCHABLE_AT_RUNTIME`).
+#
+# DISCIPLINE (runbook `maintenance-reco-optimisation-lot2.md`) : l'override env
+# est un outil de tuning et de rollback, **pas une surface de configuration**.
+# Tout override qui survit plus d'un cycle est promu dans ce fichier et la
+# variable vidée — sinon la source de vérité dérive, le problème même qu'on
+# cherche à résoudre.
+
+# Constantes actives surchargées (nom → valeur appliquée). Alimente le hash de
+# `scoring_algo_version()` : deux semaines de CTR sous deux jeux de constantes
+# ne sont comparables que si l'event porte de quelle config il relève.
+_ACTIVE_OVERRIDES: dict[str, object] = {}
+
+
+def is_overridable_scoring_key(name: str) -> bool:
+    """Un nom surchargeable de `ScoringWeights` : attribut **public existant**.
+    Partagé par les deux surfaces de surcharge (env ici, sweep runtime dans
+    `scripts/_scoring_overrides.py`) pour qu'elles jugent « clé valide » pareil.
+    """
+    return not name.startswith("_") and hasattr(ScoringWeights, name)
+
+
+def pillar_weights_sum_ok(weights: dict[str, float]) -> bool:
+    """Invariant `PILLAR_WEIGHTS` : la somme des poids fait 1.0 (tolérance 1e-6).
+    Source unique de la règle et de la tolérance pour les deux surfaces.
+    """
+    return abs(sum(weights.values()) - 1.0) <= 1e-6
+
+
+def _coerce_override(name: str, value: object) -> object:
+    """Aligne le type JSON sur celui de la constante (int JSON → float attendu)."""
+    current = getattr(ScoringWeights, name)
+    if isinstance(current, bool):
+        return bool(value)
+    if (
+        isinstance(current, float)
+        and isinstance(value, int)
+        and not isinstance(value, bool)
+    ):
+        return float(value)
+    return value
+
+
+def _apply_env_scoring_overrides() -> None:
+    """Parse `SCORING_OVERRIDES` et patche `ScoringWeights`. Best-effort :
+    un JSON invalide log une erreur et **n'applique rien** (fail-closed sur la
+    config), une clé inconnue est WARN et ignorée, chaque override est loggé INFO.
+    """
+    raw = os.environ.get("SCORING_OVERRIDES", "").strip()
+    if not raw:
+        return
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        _logger.error("SCORING_OVERRIDES ignoré (JSON invalide) : %s", exc)
+        return
+    if not isinstance(parsed, dict):
+        _logger.error(
+            "SCORING_OVERRIDES ignoré : objet JSON attendu, reçu %s",
+            type(parsed).__name__,
+        )
+        return
+
+    for name, value in parsed.items():
+        if not is_overridable_scoring_key(name):
+            _logger.warning("SCORING_OVERRIDES : clé inconnue ignorée « %s »", name)
+            continue
+        if name == "PILLAR_WEIGHTS":
+            if not isinstance(value, dict):
+                _logger.warning(
+                    "SCORING_OVERRIDES : PILLAR_WEIGHTS attend un objet, ignoré"
+                )
+                continue
+            if not pillar_weights_sum_ok(value):
+                _logger.error(
+                    "SCORING_OVERRIDES : PILLAR_WEIGHTS somme %s != 1.0, ignoré",
+                    sum(value.values()),
+                )
+                continue
+        coerced = _coerce_override(name, value)
+        old = getattr(ScoringWeights, name)
+        setattr(ScoringWeights, name, coerced)
+        _ACTIVE_OVERRIDES[name] = coerced
+        _logger.info("SCORING_OVERRIDES : %s %r → %r", name, old, coerced)
+
+
+_apply_env_scoring_overrides()
+
+
 def scoring_algo_version() -> str:
     """Identifiant de la configuration de scoring **effectivement active**.
 
@@ -576,8 +688,13 @@ def scoring_algo_version() -> str:
     possible — deux semaines de CTR mesurées sous deux jeux de constantes
     différents ne sont pas comparables et rien dans la donnée ne le dirait.
 
-    Aujourd'hui = la seule version du moteur. Le lot « tuning » ajoutera ici le
-    hash des overrides d'environnement actifs (`SCORING_OVERRIDES`), de sorte
-    qu'un tuning appliqué sans redeploy change quand même la version.
+    Sans override actif = la seule version du moteur (`SCORING_VERSION`), donc
+    inchangé pour les binaires sans `SCORING_OVERRIDES`. Avec overrides, on
+    suffixe un hash court, déterministe et stable des overrides appliqués : un
+    tuning poussé sans redeploy change quand même la version estampillée.
     """
-    return ScoringWeights.SCORING_VERSION
+    if not _ACTIVE_OVERRIDES:
+        return ScoringWeights.SCORING_VERSION
+    payload = json.dumps(_ACTIVE_OVERRIDES, sort_keys=True, default=str)
+    digest = hashlib.sha1(payload.encode()).hexdigest()[:8]
+    return f"{ScoringWeights.SCORING_VERSION}+ovr.{digest}"

--- a/packages/api/scripts/_scoring_overrides.py
+++ b/packages/api/scripts/_scoring_overrides.py
@@ -1,0 +1,93 @@
+"""Contexte de sweep partagé pour les harnais de tuning du scoring.
+
+Généralisation directe du `_threshold_override` de `evaluate_veille_curation.py`
+(qui ne patchait que `VEILLE_RELEVANCE_THRESHOLD`) : `weights_override(**kwargs)`
+patche N attributs de `ScoringWeights` le temps d'un `with`, puis restaure.
+
+Pourquoi ça marche : les ~212 lectures de constantes en prod sont toutes de la
+forme `ScoringWeights.X` **évaluée à l'appel**, jamais liée à l'avance — un
+`setattr` runtime les atteint donc toutes... **sauf** celles copiées au
+chargement d'un module (argument par défaut de `def`). Celles-là sont dans
+`NON_PATCHABLE_AT_RUNTIME` et un sweep qui les cible **échoue bruyamment** plutôt
+que de mentir par un no-op silencieux.
+
+Miroir runtime de la surcharge d'environnement `SCORING_OVERRIDES`
+(`scoring_config.py`) : même cible (`ScoringWeights`), même invariant piliers.
+L'env sert le tuning/rollback *déployé* ; ce contexte sert le sweep *offline*.
+"""
+
+from __future__ import annotations
+
+import copy
+from contextlib import contextmanager
+
+from app.services.recommendation.scoring_config import (
+    ScoringWeights,
+    is_overridable_scoring_key,
+    pillar_weights_sum_ok,
+)
+
+# Constantes liées à une valeur **au chargement du module** (argument par défaut
+# d'un `def`), donc invisibles à un `setattr` runtime : `decayed_subtopic_weight`
+# (`workers/scheduler.py`) fige `decay=ScoringWeights.SUBTOPIC_DECAY` à l'import.
+# Un sweep qui les cible serait un no-op silencieux → on lève.
+#
+# Tenu synchrone avec le code par
+# `tests/scripts/test_scoring_overrides.py::test_no_new_module_bound_defaults`
+# (grep AST des signatures `def … = ScoringWeights.X`). Si ce test rougit, soit
+# refactorer le call site pour lire la constante à l'appel, soit ajouter le nom
+# ici en connaissance de cause.
+NON_PATCHABLE_AT_RUNTIME = frozenset({"SUBTOPIC_DECAY"})
+
+
+def _assert_pillars_sum_to_one() -> None:
+    if not pillar_weights_sum_ok(ScoringWeights.PILLAR_WEIGHTS):
+        total = sum(ScoringWeights.PILLAR_WEIGHTS.values())
+        raise ValueError(
+            f"PILLAR_WEIGHTS doit sommer à 1.0 (reçu {total}) — override invalide."
+        )
+
+
+@contextmanager
+def weights_override(**overrides: object):
+    """Patche temporairement des attributs de `ScoringWeights`.
+
+    - Clé inconnue (ou privée `_…`) → `ValueError` (faute de frappe = échec dur).
+    - Clé dans `NON_PATCHABLE_AT_RUNTIME` → `ValueError` (le patch serait inerte).
+    - `PILLAR_WEIGHTS` (dict mutable de classe) : deep-copié avant, restauré
+      après, et l'invariant `sum == 1.0` est réasserté une fois tous les patchs
+      posés.
+    - Restauration garantie en `finally`, même si l'invariant échoue.
+    """
+    if not overrides:
+        yield
+        return
+
+    unknown = [name for name in overrides if not is_overridable_scoring_key(name)]
+    if unknown:
+        raise ValueError(
+            f"weights_override : constante(s) inconnue(s) de ScoringWeights {unknown}"
+        )
+
+    blocked = [name for name in overrides if name in NON_PATCHABLE_AT_RUNTIME]
+    if blocked:
+        raise ValueError(
+            f"weights_override : {blocked} est liée au chargement du module "
+            "(argument par défaut) — un setattr runtime serait un no-op silencieux. "
+            "Refactorer le call site pour lire la constante à l'appel, ou promouvoir "
+            "la valeur dans scoring_config.py."
+        )
+
+    originals: dict[str, object] = {}
+    try:
+        for name, value in overrides.items():
+            current = getattr(ScoringWeights, name)
+            originals[name] = (
+                copy.deepcopy(current) if isinstance(current, dict) else current
+            )
+            setattr(ScoringWeights, name, value)
+        _assert_pillars_sum_to_one()
+        yield
+    finally:
+        for name, value in originals.items():
+            setattr(ScoringWeights, name, value)

--- a/packages/api/scripts/evaluate_veille_curation.py
+++ b/packages/api/scripts/evaluate_veille_curation.py
@@ -83,6 +83,7 @@ from app.services.veille.feed_filter import (  # noqa: E402
 from app.services.veille.scoring_context import (  # noqa: E402
     build_veille_scoring_context,
 )
+from scripts._scoring_overrides import weights_override  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 CONTEXT_DIR = REPO_ROOT / ".context"
@@ -111,17 +112,15 @@ def _threshold_override(value: float | None):
 
     ``_score_block`` lit l'attribut de classe ; on le patche pour le sweep
     plutôt que de forker la porte (anti-drift). S'applique globalement (Bloc A
-    **et** Bloc B) le temps de l'évaluation.
+    **et** Bloc B) le temps de l'évaluation. Délègue au contexte de sweep
+    partagé ``weights_override`` (`scripts/_scoring_overrides.py`) — une seule
+    mécanique de patch/restore pour tous les harnais.
     """
     if value is None:
         yield
         return
-    original = ScoringWeights.VEILLE_RELEVANCE_THRESHOLD
-    ScoringWeights.VEILLE_RELEVANCE_THRESHOLD = value
-    try:
+    with weights_override(VEILLE_RELEVANCE_THRESHOLD=value):
         yield
-    finally:
-        ScoringWeights.VEILLE_RELEVANCE_THRESHOLD = original
 
 
 # ---------------------------------------------------------------------------

--- a/packages/api/tests/routers/test_analytics_events_batch.py
+++ b/packages/api/tests/routers/test_analytics_events_batch.py
@@ -1,0 +1,174 @@
+"""`POST /api/analytics/events/batch` — lot d'events en un seul commit.
+
+Chemin d'ingestion du dénominateur du CTR (`article_impression`) : une session
+de lecture en produit ~30, que le client bufferise puis pousse en un POST.
+"""
+
+from uuid import uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from app.database import get_db
+from app.dependencies import get_current_user_id
+from app.main import app
+from app.models.analytics import AnalyticsEvent
+from app.routers.analytics import MAX_BATCH_EVENTS
+from app.services.recommendation.scoring_config import scoring_algo_version
+
+
+def _override_db(session):
+    async def _fake_db():
+        yield session
+
+    return _fake_db
+
+
+def _override_user(user_id: str):
+    async def _fake_user():
+        return user_id
+
+    return _fake_user
+
+
+def _impression(index: int) -> dict:
+    return {
+        "event_type": "article_impression",
+        "event_data": {
+            "content_id": f"content-{index}",
+            "section_key": "theme:politique",
+            "section_family": "theme",
+            "position_in_section": index,
+        },
+        "device_id": "device-1",
+    }
+
+
+async def _post_batch(db_session, user_id, payload):
+    app.dependency_overrides[get_current_user_id] = _override_user(str(user_id))
+    app.dependency_overrides[get_db] = _override_db(db_session)
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            return await ac.post("/api/analytics/events/batch", json=payload)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_batch_persists_every_event(db_session):
+    user_id = uuid4()
+
+    response = await _post_batch(
+        db_session, user_id, [_impression(i) for i in range(25)]
+    )
+
+    assert response.status_code == 201
+    assert response.json()["accepted"] == 25
+
+    rows = (
+        (
+            await db_session.execute(
+                select(AnalyticsEvent).where(AnalyticsEvent.user_id == user_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 25
+    assert {row.event_type for row in rows} == {"article_impression"}
+    assert {row.device_id for row in rows} == {"device-1"}
+
+
+@pytest.mark.asyncio
+async def test_batch_at_cap_is_accepted_and_over_cap_is_rejected(db_session):
+    user_id = uuid4()
+
+    at_cap = await _post_batch(
+        db_session, user_id, [_impression(i) for i in range(MAX_BATCH_EVENTS)]
+    )
+    assert at_cap.status_code == 201
+    assert at_cap.json()["accepted"] == MAX_BATCH_EVENTS
+
+    over_cap = await _post_batch(
+        db_session, user_id, [_impression(i) for i in range(MAX_BATCH_EVENTS + 1)]
+    )
+    assert over_cap.status_code == 422
+
+    # Le lot refusé n'a rien écrit : seul le lot au cap est en base.
+    count = (
+        (
+            await db_session.execute(
+                select(AnalyticsEvent).where(AnalyticsEvent.user_id == user_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(count) == MAX_BATCH_EVENTS
+
+
+@pytest.mark.asyncio
+async def test_partial_event_data_does_not_fail_the_batch(db_session):
+    """Un event aux propriétés incomplètes passe : `event_data` est un JSONB
+    libre, une carte sans score ne doit pas faire tomber les 24 autres."""
+    user_id = uuid4()
+
+    response = await _post_batch(
+        db_session,
+        user_id,
+        [
+            {"event_type": "article_impression", "event_data": {}},
+            _impression(1),
+            {"event_type": "article_impression", "event_data": {"content_id": "x"}},
+        ],
+    )
+
+    assert response.status_code == 201
+    assert response.json()["accepted"] == 3
+
+
+@pytest.mark.asyncio
+async def test_impressions_are_stamped_with_the_active_algo_version(db_session):
+    user_id = uuid4()
+
+    await _post_batch(
+        db_session,
+        user_id,
+        [
+            _impression(0),
+            # Version déjà posée par le client → jamais écrasée.
+            {
+                "event_type": "article_impression",
+                "event_data": {"content_id": "c", "algo_version": "pinned_by_client"},
+            },
+            # Event non-impression → pas d'estampille (l'algo ne le concerne pas).
+            {"event_type": "feed_scroll", "event_data": {"depth": 3}},
+        ],
+    )
+
+    rows = (
+        (
+            await db_session.execute(
+                select(AnalyticsEvent).where(AnalyticsEvent.user_id == user_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    by_content = {row.event_data.get("content_id"): row for row in rows}
+
+    assert by_content["content-0"].event_data["algo_version"] == scoring_algo_version()
+    assert by_content["c"].event_data["algo_version"] == "pinned_by_client"
+    assert "algo_version" not in by_content[None].event_data
+
+
+@pytest.mark.asyncio
+async def test_empty_batch_is_a_noop(db_session):
+    user_id = uuid4()
+
+    response = await _post_batch(db_session, user_id, [])
+
+    assert response.status_code == 201
+    assert response.json()["accepted"] == 0

--- a/packages/api/tests/scripts/test_scoring_overrides.py
+++ b/packages/api/tests/scripts/test_scoring_overrides.py
@@ -1,0 +1,221 @@
+"""Tests pour l'outillage de tuning du scoring (lot reco PR-2).
+
+Couvre les deux surfaces de surcharge de `ScoringWeights` :
+
+- **Sweep runtime** (`scripts/_scoring_overrides.py::weights_override`) :
+  patch/restore, restauration sur exception, invariant piliers, garde
+  `NON_PATCHABLE_AT_RUNTIME`, clé inconnue, deep-copy de `PILLAR_WEIGHTS`.
+- **Surcharge d'environnement** (`scoring_config.py::_apply_env_scoring_overrides`
+  + `scoring_algo_version`) : application, coercition de type, hash de version.
+- **Garde anti-drift AST** : la liste des constantes liées en argument par
+  défaut de `def` n'a pas grandi sans qu'on mette `NON_PATCHABLE_AT_RUNTIME` à
+  jour (sinon un sweep les patcherait dans le vide).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from app.services.recommendation import scoring_config as sc
+from app.services.recommendation.scoring_config import (
+    ScoringWeights,
+    scoring_algo_version,
+)
+from scripts._scoring_overrides import (
+    NON_PATCHABLE_AT_RUNTIME,
+    weights_override,
+)
+
+APP_ROOT = Path(__file__).resolve().parents[2] / "app"
+
+
+# ---------------------------------------------------------------------------
+# weights_override — sweep runtime
+# ---------------------------------------------------------------------------
+
+
+def test_patches_then_restores():
+    original = ScoringWeights.THEME_MATCH
+    with weights_override(THEME_MATCH=999.0):
+        assert ScoringWeights.THEME_MATCH == 999.0
+    assert original == ScoringWeights.THEME_MATCH
+
+
+def test_restores_on_exception():
+    original = ScoringWeights.THEME_MATCH
+    with pytest.raises(RuntimeError), weights_override(THEME_MATCH=999.0):
+        raise RuntimeError("boom")
+    assert original == ScoringWeights.THEME_MATCH
+
+
+def test_empty_override_is_noop():
+    original = ScoringWeights.THEME_MATCH
+    with weights_override():
+        assert original == ScoringWeights.THEME_MATCH
+    assert original == ScoringWeights.THEME_MATCH
+
+
+def test_unknown_constant_raises():
+    with (
+        pytest.raises(ValueError, match="inconnue"),
+        weights_override(NOT_A_REAL_CONSTANT=1.0),
+    ):
+        pass
+
+
+def test_private_attr_rejected():
+    with (
+        pytest.raises(ValueError, match="inconnue"),
+        weights_override(_ACTIVE_OVERRIDES={}),
+    ):
+        pass
+
+
+def test_non_patchable_constant_raises_loudly():
+    # SUBTOPIC_DECAY est figé en argument par défaut de `decayed_subtopic_weight`
+    # au chargement du module : un setattr runtime serait un no-op silencieux.
+    with (
+        pytest.raises(ValueError, match="no-op silencieux"),
+        weights_override(SUBTOPIC_DECAY=0.5),
+    ):
+        pass
+
+
+def test_pillar_weights_deep_copied_and_restored():
+    original = dict(ScoringWeights.PILLAR_WEIGHTS)
+    new = {"pertinence": 0.5, "source": 0.2, "fraicheur": 0.2, "qualite": 0.1}
+    with weights_override(PILLAR_WEIGHTS=new):
+        assert new == ScoringWeights.PILLAR_WEIGHTS
+        # Muter le dict actif ne doit pas contaminer la copie de restauration.
+        ScoringWeights.PILLAR_WEIGHTS["pertinence"] = 0.99
+    assert original == ScoringWeights.PILLAR_WEIGHTS
+
+
+def test_pillar_weights_sum_invariant_enforced():
+    original = dict(ScoringWeights.PILLAR_WEIGHTS)
+    bad = {"pertinence": 0.9, "source": 0.9, "fraicheur": 0.0, "qualite": 0.0}
+    with (
+        pytest.raises(ValueError, match="sommer à 1.0"),
+        weights_override(PILLAR_WEIGHTS=bad),
+    ):
+        pass
+    # Restauration garantie malgré l'échec d'invariant.
+    assert original == ScoringWeights.PILLAR_WEIGHTS
+
+
+def test_multiple_constants_at_once():
+    o_theme, o_trusted = ScoringWeights.THEME_MATCH, ScoringWeights.TRUSTED_SOURCE
+    with weights_override(THEME_MATCH=1.0, TRUSTED_SOURCE=2.0):
+        assert ScoringWeights.THEME_MATCH == 1.0
+        assert ScoringWeights.TRUSTED_SOURCE == 2.0
+    assert o_theme == ScoringWeights.THEME_MATCH
+    assert o_trusted == ScoringWeights.TRUSTED_SOURCE
+
+
+# ---------------------------------------------------------------------------
+# SCORING_OVERRIDES — surcharge d'environnement + version
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def restore_scoring_state():
+    """Snapshot/restore de l'état global patché par l'env override."""
+    snapshot_active = dict(sc._ACTIVE_OVERRIDES)
+    snapshot_theme = ScoringWeights.THEME_MATCH
+    snapshot_pillars = dict(ScoringWeights.PILLAR_WEIGHTS)
+    yield
+    sc._ACTIVE_OVERRIDES.clear()
+    sc._ACTIVE_OVERRIDES.update(snapshot_active)
+    ScoringWeights.THEME_MATCH = snapshot_theme
+    ScoringWeights.PILLAR_WEIGHTS = snapshot_pillars
+
+
+def test_algo_version_plain_without_overrides():
+    # Suite lancée sans SCORING_OVERRIDES : version nue, pas de suffixe.
+    if not sc._ACTIVE_OVERRIDES:
+        assert scoring_algo_version() == ScoringWeights.SCORING_VERSION
+
+
+def test_env_override_applies_and_stamps_version(monkeypatch, restore_scoring_state):
+    monkeypatch.setenv("SCORING_OVERRIDES", '{"THEME_MATCH": 42}')
+    sc._ACTIVE_OVERRIDES.clear()
+    sc._apply_env_scoring_overrides()
+
+    # int JSON coercé vers float (type de la constante).
+    assert ScoringWeights.THEME_MATCH == 42.0
+    assert isinstance(ScoringWeights.THEME_MATCH, float)
+    assert sc._ACTIVE_OVERRIDES == {"THEME_MATCH": 42.0}
+
+    version = scoring_algo_version()
+    assert version.startswith(f"{ScoringWeights.SCORING_VERSION}+ovr.")
+    # Déterministe : même config → même hash.
+    assert version == scoring_algo_version()
+
+
+def test_env_override_unknown_key_warns_and_skips(monkeypatch, restore_scoring_state):
+    monkeypatch.setenv("SCORING_OVERRIDES", '{"NOPE": 1, "THEME_MATCH": 7}')
+    sc._ACTIVE_OVERRIDES.clear()
+    sc._apply_env_scoring_overrides()
+    assert "NOPE" not in sc._ACTIVE_OVERRIDES
+    assert sc._ACTIVE_OVERRIDES == {"THEME_MATCH": 7.0}
+
+
+def test_env_override_invalid_json_applies_nothing(monkeypatch, restore_scoring_state):
+    original = ScoringWeights.THEME_MATCH
+    monkeypatch.setenv("SCORING_OVERRIDES", "{not json")
+    sc._ACTIVE_OVERRIDES.clear()
+    sc._apply_env_scoring_overrides()
+    assert sc._ACTIVE_OVERRIDES == {}
+    assert original == ScoringWeights.THEME_MATCH
+
+
+def test_env_override_pillar_bad_sum_rejected(monkeypatch, restore_scoring_state):
+    original = dict(ScoringWeights.PILLAR_WEIGHTS)
+    monkeypatch.setenv(
+        "SCORING_OVERRIDES",
+        '{"PILLAR_WEIGHTS": {"pertinence": 0.9, "source": 0.9, '
+        '"fraicheur": 0.0, "qualite": 0.0}}',
+    )
+    sc._ACTIVE_OVERRIDES.clear()
+    sc._apply_env_scoring_overrides()
+    assert "PILLAR_WEIGHTS" not in sc._ACTIVE_OVERRIDES
+    assert original == ScoringWeights.PILLAR_WEIGHTS
+
+
+# ---------------------------------------------------------------------------
+# Garde anti-drift : arguments par défaut liés à `ScoringWeights.X`
+# ---------------------------------------------------------------------------
+
+
+def _module_bound_default_constants() -> set[str]:
+    """Grep AST : constantes `ScoringWeights.X` liées en **argument par défaut**
+    d'un `def` (donc figées au chargement du module, invisibles au sweep runtime).
+    """
+    found: set[str] = set()
+    for path in APP_ROOT.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            defaults = list(node.args.defaults) + [
+                d for d in node.args.kw_defaults if d is not None
+            ]
+            for default in defaults:
+                if (
+                    isinstance(default, ast.Attribute)
+                    and isinstance(default.value, ast.Name)
+                    and default.value.id == "ScoringWeights"
+                ):
+                    found.add(default.attr)
+    return found
+
+
+def test_no_new_module_bound_defaults():
+    """Si cette liste grandit, un sweep sur la nouvelle constante serait un
+    no-op silencieux : soit refactorer le call site (lire à l'appel), soit
+    ajouter le nom à `NON_PATCHABLE_AT_RUNTIME` en connaissance de cause.
+    """
+    assert _module_bound_default_constants() == set(NON_PATCHABLE_AT_RUNTIME)


### PR DESCRIPTION
> **Ce PR porte deux tranches du lot reco : PR-1 (instrumentation d'impression) et PR-2 (outillage de tuning). Les deux sont backend/mobile additifs, sans migration.**

---

# PR-1 — Instrumentation d'impression Tournée + Essentiel

## Quoi

Instrumentation d'**impression** d'article (Tournée + Essentiel) — le **dénominateur** du CTR, qui n'existait pas. Nouvel event `article_impression` dans `analytics_events` : **zéro table, zéro migration** (`event_data` est déjà en JSONB, 1 head Alembic).

Décisions notables (toutes documentées dans le code) :
- **Seuil MRC ≥ 50 % / ≥ 1 s** dans un `ArticleImpressionTracker` neuf — pas une extension d'`AutoGrowCandidate` (seuil 0,9 + exclusion des articles lus incompatibles : un article lu *est* le numérateur).
- **`algo_version` estampillé côté serveur** (`scoring_algo_version()`), pas client — le mobile ne connaît pas la config de scoring. Posé exactement là où le lot tuning ajoute le hash des overrides (→ livré en PR-2).
- **Éditions passées exclues** du comptage (archive ≠ Tournée servie par l'algo).
- **`block_score` plumbé mais `null`** jusqu'au lot d'ordonnancement par score — le schéma de l'event est stable dès maintenant.
- Bonus : `/api/essentiel` servait déjà `source.id`, le parse mobile le jetait — ajouté (découpe « CTR par source » sur la surface héros).

Second commit = passe **simplify** : le tracker se démonte du pipeline `visibility_detector` après tir (~30 cartes qui ne recalculent plus leur géométrie à chaque tick de scroll), dédup jour extraite en helper partagé, `pickTopicLead` résolu une fois par topic.

## Pourquoi

Sans dénominateur, aucun ratio de clic mesurable, donc aucun cycle de tuning du ranking Tournée n'est évaluable. Valeur fonction du temps calendaire : la porte de collecte de l'axe 4 est à ~125 jours — d'où l'intérêt de partir vite.

---

# PR-2 — `SCORING_OVERRIDES` + contexte de sweep

## Quoi

Deux surfaces de surcharge de `ScoringWeights`, une déployée et une offline — pour la **latence de rollback** (aujourd'hui, changer une constante de scoring = commit + redeploy Railway sur la DB partagée main-staging / production).

- **`SCORING_OVERRIDES` (déployée)** : une var d'env JSON `{"CONSTANTE": valeur, …}` parsée **une fois** au premier import de `scoring_config`, appliquée par `setattr`. Appliquée **en bas du module** → effective avant tout call site qui fige une valeur en argument par défaut. **Fail-closed** (JSON invalide → rien appliqué), WARN + skip sur clé inconnue, invariant piliers `sum == 1.0`. Rollback = vider la var Railway + restart (~30 s).
- **`scoring_algo_version()`** suffixe désormais un hash court, déterministe et stable des overrides actifs (`pillars_v1+ovr.<hash>`) ; version nue sans override. C'est ce qui rend deux fenêtres de CTR sous deux jeux de constantes comparables — l'event `article_impression` (PR-1) porte de quelle config il relève.
- **`scripts/_scoring_overrides.py::weights_override` (offline)** : contexte de sweep partagé, généralise l'ancien `_threshold_override` d'`evaluate_veille_curation` (qui **délègue** désormais). Garde `NON_PATCHABLE_AT_RUNTIME` (constantes figées à l'import → un `setattr` runtime serait un no-op silencieux, donc on **lève**) + test **AST anti-drift** qui échoue si un nouveau `def … = ScoringWeights.X` apparaît sans mise à jour de la garde.

Passe **simplify** intégrée : invariant piliers et prédicat « clé surchargeable » extraits en helpers partagés `pillar_weights_sum_ok` / `is_overridable_scoring_key` dans `scoring_config.py` — une seule source de la règle et de la tolérance pour les deux surfaces.

## Pourquoi

Débloque le tuning et le rollback du scoring sans cycle commit+redeploy, et fournit à PR-3 (harnais de sensibilité) le contexte de sweep. Discipline non négociable (runbook `maintenance-reco-optimisation-lot2.md`) : l'override env est un outil de tuning/rollback, **pas une surface de config** — tout override qui survit plus d'un cycle est promu dans `scoring_config.py` et la var vidée.

---

## Comment ça a été vérifié

- [x] Backend `pytest` complet — **2911 passed**, 18 skipped, 2 xfailed, 0 failed (15 nouveaux tests scoring overrides : sweep, env, garde AST)
- [x] Mobile `flutter test` complet (PR-1) — **1993 passed**, 28 failed = baseline `origin/main` (aucun dans les zones touchées ; 20 nouveaux tests verts)
- [x] `flutter analyze` fichiers touchés — aucun problème
- [x] Endpoint live `POST /api/analytics/events/batch` — 403 sans auth, 401 token invalide (PR-1)
- [x] `ruff check` + `ruff format --check` sur les 4 fichiers backend touchés — clean
- [x] Alembic — 1 head, **aucune migration** (`ScoringWeights` = attributs de classe)
- [x] Passe `simplify` (4 agents) sur chaque tranche — fixes appliqués, re-verify vert

## Zones à risque

- **Analytics** (PR-1 : nouvel endpoint batch **additif** ; `POST /events` unitaire inchangé, side-effects streak/app_version préservés).
- **Scoring** (PR-2 : `_apply_env_scoring_overrides()` court au premier import de `scoring_config` — sans la var `SCORING_OVERRIDES`, no-op total et `scoring_algo_version()` reste nue ; comportement inchangé pour les binaires sans la var).
- Perceptuel (PR-1) : ~30 `VisibilityDetector` de plus sur la Tournée, chacun se démonte après avoir tiré. À sentir au scroll sur un check manuel avant merge.
