### PR TITLE
fix(mobile): mot du jour manqué affiché correctement dans la carte de l'essentiel

### DIFF
--- a/apps/mobile/lib/features/grille/widgets/carte_cta.dart
+++ b/apps/mobile/lib/features/grille/widgets/carte_cta.dart
@@ -129,6 +129,7 @@ class CarteCta extends StatelessWidget {
   final VoidCallback onOpen;
 
   bool get _deja => state == CarteCtaState.deja;
+  bool get _dejaRate => _deja && !today.isSolved;
 
   @override
   Widget build(BuildContext context) {
@@ -156,7 +157,9 @@ class CarteCta extends StatelessWidget {
           ),
           const SizedBox(height: 14),
           Text(
-            _deja ? 'Bien joué !' : 'Trouve le mot du jour',
+            _deja
+                ? (_dejaRate ? 'Loupé de peu !' : 'Bien joué !')
+                : 'Trouve le mot du jour',
             textAlign: TextAlign.center,
             style: GoogleFonts.fraunces(
               fontSize: 25,
@@ -192,6 +195,10 @@ class CarteCta extends StatelessWidget {
 
   String _intro() {
     if (_deja) {
+      if (_dejaRate) {
+        return '« Pas trouvé cette fois, mais tu y étais presque. '
+            'Reviens demain matin pour un mot tout neuf. »';
+      }
       final n = today.nbEssais;
       return '« Trouvé en $n essai${n > 1 ? 's' : ''} — bien joué !. '
           'Un nouveau mot arrivera demain matin. »';
@@ -202,12 +209,13 @@ class CarteCta extends StatelessWidget {
 
   Widget _stamp(BuildContext context) {
     final c = context.facteurColors;
-    final color = _deja ? c.success : c.textStamp;
+    final dejaSolved = _deja && !_dejaRate;
+    final color = dejaSolved ? c.success : c.textStamp;
     return Transform.rotate(
       angle: -2 * math.pi / 180,
       child: Container(
         decoration: BoxDecoration(
-          color: color.withValues(alpha: _deja ? 0.07 : 0.06),
+          color: color.withValues(alpha: dejaSolved ? 0.07 : 0.06),
           borderRadius: BorderRadius.circular(4),
           border: Border.all(color: color, width: 1.5),
         ),

--- a/apps/mobile/test/features/grille/widgets/grille_cta_card_test.dart
+++ b/apps/mobile/test/features/grille/widgets/grille_cta_card_test.dart
@@ -62,6 +62,26 @@ GrilleTodayResponse _todayInProgress() => const GrilleTodayResponse(
       prochainMotDansSec: 1000,
     );
 
+GrilleTodayResponse _todaySolved() => const GrilleTodayResponse(
+      date: '2026-05-31',
+      dateAffichee: 'Dimanche 31 mai',
+      dateCourt: 'Dim. 31 mai',
+      numero: 'N°144',
+      longueur: 6,
+      essaisMax: 6,
+      premiereLettre: 'B',
+      indice: 'indice',
+      theme: 'theme',
+      statut: 'solved',
+      essais: [],
+      nbEssais: 3,
+      streak: 2,
+      prochainMotDansSec: 1000,
+      mot: 'BATEAU',
+    );
+
+GrilleTodayResponse _todayFailed() => _todaySolved().copyWith(statut: 'failed');
+
 Widget _wrap(_FakeGrilleRepository repo) {
   return ProviderScope(
     overrides: [
@@ -110,4 +130,20 @@ void main() {
     await t.pumpAndSettle();
     expect(find.byType(CarteCta), findsOneWidget);
   });
+
+  testWidgets('mot trouvé → carte "Bien joué !"', (t) async {
+    await t.pumpWidget(_wrap(_FakeGrilleRepository(today: _todaySolved())));
+    await t.pumpAndSettle();
+    expect(find.text('Bien joué !'), findsOneWidget);
+  });
+
+  testWidgets(
+    'mot manqué → carte "Loupé de peu !" et pas "Bien joué !"',
+    (t) async {
+      await t.pumpWidget(_wrap(_FakeGrilleRepository(today: _todayFailed())));
+      await t.pumpAndSettle();
+      expect(find.text('Loupé de peu !'), findsOneWidget);
+      expect(find.text('Bien joué !'), findsNothing);
+    },
+  );
 }


### PR DESCRIPTION
## What

Dans la carte « La Grille du jour » (`CarteCta`, affichée dans l'essentiel), le message de preview affichait toujours "Bien joué !" / "Trouvé en N essai(s) — bien joué !", même quand le mot du jour n'avait **pas** été trouvé (statut `failed`/`revealed`).

Ajoute une distinction sur `today.isSolved` :
- **Trouvé** : "Bien joué !" + "Trouvé en N essai(s)..." (inchangé)
- **Manqué** : "Loupé de peu !" + "Pas trouvé cette fois, mais tu y étais presque. Reviens demain matin pour un mot tout neuf."

Le tampon "DÉJÀ JOUÉE" repasse aussi en couleur neutre (`textStamp`) au lieu du vert `success` quand le mot est manqué.

## Why

L'écran "Mot du jour manqué" (`GrilleDejaJoueView`) affichait déjà correctement la distinction trouvé/manqué, mais la carte preview dans l'essentiel ne la reprenait pas — un utilisateur qui loupait le mot du jour se voyait féliciter à tort dans l'essentiel.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Maintenance / Refactor

## Checklist

- [x] Tests ajoutés (`apps/mobile/test/features/grille/widgets/grille_cta_card_test.dart`) couvrant les cas trouvé/manqué
- [ ] `flutter test` / `flutter analyze` — n'a pas pu être exécuté dans cet environnement (SDK Flutter non installé) ; à valider en CI
- [ ] N/A backend — aucun changement Python/Alembic
- [ ] N/A auth/DB

## Staging

- [ ] Déployé sur staging
- [ ] Smoke test passé
- [x] N/A (changement UI mobile uniquement, pas de backend)


---
_Generated by [Claude Code](https://claude.ai/code/session_014tumu5MoTKvyHyLTGSKP9m)_