### PR TITLE
fix(digest): garde-fou rollback avant le commit final (PYTHON-4R)

### DIFF
--- a/docs/bugs/bug-python-4r.md
+++ b/docs/bugs/bug-python-4r.md
@@ -1,0 +1,80 @@
+# Bug — `PendingRollbackError` au commit final du job digest (PYTHON-4R)
+
+> **Élevé** — remonté par le triage Sentry nocturne du 2026-08-01.
+> Issue Sentry : `PYTHON-4R`, culprit `run_digest_generation`.
+
+## Symptôme
+
+Le job `daily_digest` remonte en échec sur Sentry avec un `PendingRollbackError`
+levé par le `await session.commit()` final de `run_digest_generation`
+(`packages/api/app/jobs/digest_generation_job.py`).
+
+C'est un **faux échec** : tous les digests ont bien été générés et committés en
+amont. Seule la clôture de la transaction de lecture partagée plante. Conséquences
+réelles : bruit Sentry, run marqué en échec, et le watchdog de 08h15 peut relancer
+une génération inutile.
+
+## Cause racine
+
+`job.run()` est correctement isolé — chaque utilisateur, le mot du jour et la
+couverture tournent dans leur propre session fille, avec leur propre commit. Mais
+plusieurs étapes best-effort touchent la **session batch partagée** avec ce motif,
+introduit par les patches PYTHON-5G / PYTHON-5M :
+
+```python
+with contextlib.suppress(Exception):
+    await session.rollback()
+    await apply_session_timeouts(session)   # ré-ouvre une tx via SET LOCAL
+```
+
+`apply_session_timeouts` (`packages/api/app/database.py:174`) **avale sa propre
+exception** (log `debug`, pas de rollback). Si le `SET LOCAL statement_timeout`
+échoue — scénario documenté de pression pool matinale / connexion Supavisor
+flaky — la nouvelle transaction reste en `PENDING_ROLLBACK`, l'erreur est
+silencieusement avalée, et rien ne rollback avant la fin. Le `commit()` final
+explose alors.
+
+Le span `http.client GET europe1.fr` visible dans la trace Sentry est ambiant
+(travail éditorial concurrent), pas la cause.
+
+## Correctif
+
+Un seul fichier touché, périmètre strict du job digest. Avant le commit final :
+
+```python
+if session.in_transaction() and not session.is_active:
+    await session.rollback()
+try:
+    await session.commit()
+except PendingRollbackError:
+    logger.warning("digest_generation_final_commit_pending_rollback")
+    await session.rollback()
+```
+
+- `in_transaction() and not is_active` est la détection publique et exacte d'une
+  transaction « invalide / needs rollback » en SQLAlchemy 2.0 — on la nettoie
+  *avant* de committer.
+- Le `except PendingRollbackError` est une ceinture-bretelles : si l'état de
+  transaction nous échappe, on rollback au lieu de crasher, et on retourne quand
+  même le résultat (le travail réel est déjà persisté).
+
+Le commit final est le point de convergence de toutes les étapes amont : on ferme
+la classe entière de bug quelle que soit l'étape qui a sali la session, sans jouer
+au whack-a-mole. Aucun autre chemin (`except: rollback(); raise`) n'est modifié.
+
+## Vérification
+
+- `pytest tests/test_digest_generation_job.py` — vérifier qu'aucun test n'assertait
+  un raise sur ce commit final.
+- En staging : lancer un run digest, confirmer que les digests sont générés et
+  qu'aucun `PendingRollbackError` ne remonte.
+- Surveiller le log `digest_generation_final_commit_pending_rollback` : s'il
+  apparaît, le garde-fou a joué — cela confirme la cause et signale une pression
+  pool à regarder.
+
+## Suivi hors périmètre
+
+La racine partagée est `apply_session_timeouts`, qui avale son erreur sans
+rollback. La corriger là (rollback dans son `except`) protègerait **tous** les
+appelants, pas seulement le digest. C'est de l'infra partagée
+(`packages/api/app/database.py`) → ticket séparé.

--- a/packages/api/app/jobs/digest_generation_job.py
+++ b/packages/api/app/jobs/digest_generation_job.py
@@ -23,6 +23,7 @@ from uuid import UUID
 import sentry_sdk
 import structlog
 from sqlalchemy import func, select
+from sqlalchemy.exc import PendingRollbackError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import apply_session_timeouts, safe_async_session
@@ -1185,7 +1186,35 @@ async def run_digest_generation(
     async with safe_async_session() as session:
         try:
             result = await job.run(session, target_date)
-            await session.commit()
+            # Le travail réel du run est déjà committé dans des sessions filles
+            # ISOLÉES : seeding de l'état (commit intra-`run`), prune historique,
+            # génération par utilisateur (`_process_batch`), mot du jour
+            # (`_match_grille_featured_article`). La session batch partagée ne
+            # porte plus, au mieux, qu'une tx de LECTURE ouverte au retour.
+            #
+            # Mais une étape best-effort amont a pu la laisser en
+            # PENDING_ROLLBACK : les blocs `with contextlib.suppress(...):
+            # rollback(); apply_session_timeouts(session)` re-poussent des
+            # `SET LOCAL` juste après le rollback ; sous pression pool matinale
+            # ce SET LOCAL peut échouer, et `apply_session_timeouts` AVALE son
+            # erreur en interne (log debug) sans rollback → la nouvelle tx reste
+            # invalide. Le `commit()` final planterait alors en
+            # PendingRollbackError (Sentry PYTHON-4R) — un FAUX échec, puisque
+            # tous les digests ont bien été générés et committés en amont.
+            #
+            # Garde-fou : si la tx partagée est invalide, on la rollback AVANT
+            # de committer. Le commit final ne sert qu'à clôturer proprement la
+            # tx de lecture ; il ne doit jamais faire échouer un run réussi.
+            if session.in_transaction() and not session.is_active:
+                await session.rollback()
+            try:
+                await session.commit()
+            except PendingRollbackError:
+                # Ceinture + bretelles : si l'état de tx nous a échappé, un
+                # commit sur tx invalide se solde par un rollback plutôt qu'un
+                # crash. Le travail réel est déjà persisté en sessions filles.
+                logger.warning("digest_generation_final_commit_pending_rollback")
+                await session.rollback()
             return result
         except Exception:
             await session.rollback()


### PR DESCRIPTION
# Note de review — PYTHON-4R (PendingRollbackError, job `daily_digest`)

## Cause racine (confirmée par le code)
Le crash tombe sur le **`await session.commit()` final** de `run_digest_generation`
(`packages/api/app/jobs/digest_generation_job.py`). Contrairement à ce que suggère
la trace, ce n'est PAS un `except` oublié : la fonction a déjà un `try/except:
rollback(); raise` autour du commit. Le vrai problème est en amont, dans `job.run()`.

`run()` est déjà bien isolé (chaque user, le mot du jour, la couverture tournent
dans leur propre session fille). Mais plusieurs étapes best-effort qui touchent la
**session batch partagée** ont ce motif, ajouté par les patches PYTHON-5G/5M :

```python
with contextlib.suppress(Exception):
    await session.rollback()
    await apply_session_timeouts(session)   # ré-ouvre une tx via SET LOCAL
```

`apply_session_timeouts` (dans `app/database.py`) **avale sa propre exception** en
interne (log `debug`, pas de rollback). Donc si le `SET LOCAL statement_timeout`
échoue — exactement le scénario documenté de pression pool le matin / statement
timeout / connexion Supavisor flaky — la nouvelle tx reste en **PENDING_ROLLBACK**,
l'erreur est silencieusement avalée, et rien ne rollback avant la fin. Le
`commit()` final explose alors en `PendingRollbackError`.

C'est un **faux échec** : tous les digests ont bien été générés et committés dans
les sessions filles. Seule la clôture de la tx de lecture partagée plante → bruit
Sentry + run marqué en échec (le watchdog 08h15 peut relancer inutilement). Le span
`http.client GET europe1.fr` de la trace est ambiant (travail éditorial/feed
concurrent), pas la cause directe — d'où mon écart assumé avec l'hypothèse de trace.

## Ce que change le patch
Un seul fichier touché, périmètre strict du job digest. Avant le commit final :

```python
if session.in_transaction() and not session.is_active:
    await session.rollback()
try:
    await session.commit()
except PendingRollbackError:
    logger.warning("digest_generation_final_commit_pending_rollback")
    await session.rollback()
```

- `in_transaction() and not is_active` = détection publique et exacte d'une tx
  "invalide / needs rollback" (SQLAlchemy 2.0). On la nettoie AVANT de committer.
- Le `except PendingRollbackError` est une ceinture-bretelles : même si l'état de
  tx nous échappe, on rollback au lieu de crasher, et on **retourne quand même le
  résultat** (le travail réel est déjà persisté).
- Ajout de l'import `from sqlalchemy.exc import PendingRollbackError`.

## Pourquoi c'est propre
- Minimal : ~1 import + le garde-fou sur le commit final, pas de refactor des
  nombreux blocs `suppress` existants.
- Cohérent avec le style du repo (rollback défensif + log structuré déjà partout).
- Corrige au bon endroit : le commit final est le point de convergence de TOUTES
  les étapes amont, donc on ferme la classe entière de bug quelle que soit celle
  qui a sali la session, sans jouer au whack-a-mole étape par étape.
- Ne masque pas de vraie perte de données : les writes critiques sont committés en
  sessions filles ; la session batch ne porte plus qu'une tx de lecture.

## Risque de régression
Très faible. Le seul changement de comportement : un run qui aurait levé
`PendingRollbackError` au commit final termine désormais en **succès** (avec un
`warning` loggé) au lieu de remonter en erreur. C'est l'intention. Aucun autre
chemin (`except: rollback(); raise`) n'est modifié. Pas d'impact feed/routers.

## À tester avant merge
1. `python -m py_compile` OK (fait). Faire tourner la suite `tests/` du job digest
   (`pytest packages/api -k digest`) — vérifier qu'aucun test n'assertait un raise
   sur ce commit final.
2. Test ciblé : simuler une session batch en PENDING_ROLLBACK avant le commit final
   (mock `session.is_active=False` + `in_transaction()=True`) et vérifier que
   `run_digest_generation` retourne le résultat sans lever.
3. Prod/staging : lancer un run digest et confirmer que les digests sont générés,
   qu'aucun `PendingRollbackError` ne remonte, et surveiller le log
   `digest_generation_final_commit_pending_rollback` (indicateur que le garde-fou
   a joué → confirme la cause et à surveiller côté pool).

## Piste de fond (hors périmètre, à noter pour plus tard)
La vraie racine partagée est `apply_session_timeouts` qui avale son erreur sans
rollback. Le fixer là (rollback dans son `except`) protègerait TOUS les appelants,
pas seulement le digest — mais c'est dans `app/database.py` (infra partagée), hors
périmètre de ce ticket. À traiter séparément.

---

Doc bug : `docs/bugs/bug-python-4r.md`

Fixes PYTHON-4R
