### PR TITLE
perf(feed): supprime le N+1 d'upsert impressions (PYTHON-5Q)

### DIFF
--- a/docs/bugs/bug-python-5q.md
+++ b/docs/bugs/bug-python-5q.md
@@ -1,0 +1,73 @@
+# Bug — N+1 d'upsert sur les impressions du feed (PYTHON-5Q)
+
+> **Élevé** — remonté par le triage Sentry nocturne du 2026-08-01.
+> Issue Sentry : `PYTHON-5Q`, culprit annoncé `get_personalized_feed`.
+
+## Symptôme
+
+Requêtes répétées / `SET LOCAL` en rafale sur le chemin feed, remontés comme un
+N+1 par le monitoring. Sous charge, ça consomme le pool de connexions pendant que
+l'utilisateur parcourt son flux.
+
+## Cause racine
+
+**Le culprit nommé par Sentry est trompeur.** Le chemin de *lecture*
+`get_personalized_feed` → `_compute_feed` → `RecommendationService.get_feed` est
+déjà entièrement batché : `_get_candidates` fait un `selectinload(Content.source)`,
+`_hydrate_user_status` charge les statuts en un seul `IN (...)`, `_build_carousels`
+passe par le catalogue unifié `build_phase_b`, et le contexte utilisateur est
+chargé via `asyncio.gather` sur des short sessions. Plusieurs vagues de fixes N+1
+antérieures y sont déjà documentées (Round 3/4/5, PYTHON-1C, PYTHON-37).
+
+Le vrai N+1 est une **boucle d'écriture**, adjacente au culprit :
+
+- `refresh_feed` (`packages/api/app/routers/feed.py`) : un `await db.execute(insert(...).on_conflict_do_update(...))` **par `content_id`** ;
+- `undo_refresh` : le même motif, une requête par entrée à restaurer.
+
+Ce sont les endpoints d'impressions que l'app tire pendant l'usage du feed — donc
+N requêtes par rafraîchissement, plus un `SET LOCAL` par itération sous le wrapper
+de session qui arme les timeouts par statement.
+
+## Correctif
+
+Les deux boucles sont collapsées en un seul `INSERT ... ON CONFLICT DO UPDATE`
+multi-lignes.
+
+Côté `undo_refresh`, la sémantique per-row est préservée via la pseudo-table
+`EXCLUDED` : `stmt.excluded.last_impressed_at` restaure la valeur propre à chaque
+ligne (y compris `NULL`), là où la boucle passait une valeur littérale différente
+à chaque itération.
+
+### La déduplication est load-bearing
+
+Postgres refuse qu'un `ON CONFLICT DO UPDATE` vise deux fois la même ligne cible
+dans un même statement (`cannot affect row a second time`). La boucle d'origine
+n'avait pas ce problème — chaque `execute()` n'affectait qu'une ligne. Le passage
+au bulk **introduit** donc un crash latent si le payload contient un `content_id`
+en double. D'où :
+
+- `refresh_feed` : `dict.fromkeys(...)` — dédup en gardant l'ordre ; toutes les
+  valeurs sont identiques (`now`), l'ordre de gain est indifférent ;
+- `undo_refresh` : `{e.content_id: e for e in ...}` — **last-write-wins**, ce qui
+  reproduit exactement la sémantique de la boucle.
+
+Effet de bord assumé : `refreshed` / `restored` comptent désormais les
+`content_id` **uniques** et non les entrées reçues.
+
+## Vérification
+
+`pytest tests/test_feed_refresh_undo.py` — 9 tests verts contre un vrai Postgres
+(pas un mock), dont deux ajoutés par ce correctif :
+
+- `test_refresh_with_duplicate_content_ids`
+- `test_undo_with_duplicate_content_ids`
+
+Ces deux tests ont été validés en négatif : en désactivant temporairement la
+déduplication, ils échouent tous les deux avec le `ProgrammingError` Postgres
+« ON CONFLICT DO UPDATE command cannot affect row a second time ». Ils gardent donc
+réellement l'invariant, ils ne font pas que passer.
+
+Le cas « tous les `previous_last_impressed_at` à NULL » est couvert par le test
+préexistant `test_undo_after_first_refresh_restores_null`, également vert contre
+Postgres — ce qui écarte un souci d'inférence de type sur la colonne all-NULL du
+bulk insert.

--- a/packages/api/app/routers/feed.py
+++ b/packages/api/app/routers/feed.py
@@ -574,18 +574,30 @@ async def refresh_feed(
         for cid in body.content_ids
     ]
 
-    # 2. UPSERT last_impressed_at = now()
+    # 2. UPSERT last_impressed_at = now() — fix N+1 (famille Sentry PYTHON-5Q).
+    # Avant : un `db.execute()` par content_id dans une boucle → N requêtes
+    # (et, sous le wrapper de session qui arme les timeouts par statement, un
+    # `SET LOCAL` répété par itération). Désormais un seul `INSERT ... ON
+    # CONFLICT DO UPDATE` multi-lignes. `dict.fromkeys` dédoublonne en gardant
+    # l'ordre : un `ON CONFLICT DO UPDATE` ne peut pas viser deux fois la même
+    # ligne cible dans un même statement.
+    unique_content_ids = list(dict.fromkeys(body.content_ids))
     refreshed = 0
-    for content_id in body.content_ids:
+    if unique_content_ids:
         stmt = (
             insert(UserContentStatus)
             .values(
-                user_id=user_uuid,
-                content_id=content_id,
-                status=ContentStatus.UNSEEN.value,
-                last_impressed_at=now,
-                created_at=now,
-                updated_at=now,
+                [
+                    {
+                        "user_id": user_uuid,
+                        "content_id": content_id,
+                        "status": ContentStatus.UNSEEN.value,
+                        "last_impressed_at": now,
+                        "created_at": now,
+                        "updated_at": now,
+                    }
+                    for content_id in unique_content_ids
+                ]
             )
             .on_conflict_do_update(
                 index_elements=["user_id", "content_id"],
@@ -593,7 +605,7 @@ async def refresh_feed(
             )
         )
         await db.execute(stmt)
-        refreshed += 1
+        refreshed = len(unique_content_ids)
 
     await db.commit()
     FEED_CACHE.invalidate(user_uuid)
@@ -627,29 +639,39 @@ async def undo_refresh(
 
     user_uuid = UUID(current_user_id)
     now = datetime.now(UTC)
-    restored = 0
 
-    for entry in body.previous_impressions:
-        stmt = (
-            insert(UserContentStatus)
-            .values(
-                user_id=user_uuid,
-                content_id=entry.content_id,
-                status=ContentStatus.UNSEEN.value,
-                last_impressed_at=entry.previous_last_impressed_at,
-                created_at=now,
-                updated_at=now,
-            )
-            .on_conflict_do_update(
-                index_elements=["user_id", "content_id"],
-                set_={
+    # Fix N+1 (famille Sentry PYTHON-5Q) : upsert bulk au lieu d'un
+    # `db.execute()` par entrée. `stmt.excluded.last_impressed_at` restaure la
+    # valeur propre à chaque ligne (y compris NULL) via la pseudo-table
+    # EXCLUDED, ce qui préserve la sémantique per-row de la boucle. Dédup en
+    # gardant la DERNIÈRE valeur par content_id (comme la boucle : last write
+    # wins) — nécessaire pour que le `ON CONFLICT DO UPDATE` reste valide sur
+    # une cible unique.
+    dedup = {e.content_id: e for e in body.previous_impressions}
+    restored = 0
+    if dedup:
+        stmt = insert(UserContentStatus).values(
+            [
+                {
+                    "user_id": user_uuid,
+                    "content_id": entry.content_id,
+                    "status": ContentStatus.UNSEEN.value,
                     "last_impressed_at": entry.previous_last_impressed_at,
+                    "created_at": now,
                     "updated_at": now,
-                },
-            )
+                }
+                for entry in dedup.values()
+            ]
+        )
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["user_id", "content_id"],
+            set_={
+                "last_impressed_at": stmt.excluded.last_impressed_at,
+                "updated_at": now,
+            },
         )
         await db.execute(stmt)
-        restored += 1
+        restored = len(dedup)
 
     await db.commit()
     FEED_CACHE.invalidate(user_uuid)

--- a/packages/api/tests/test_feed_refresh_undo.py
+++ b/packages/api/tests/test_feed_refresh_undo.py
@@ -118,6 +118,61 @@ class TestRefreshFeedBackup:
         for entry in second.previous_impressions:
             assert entry.previous_last_impressed_at is not None
 
+    async def test_refresh_with_duplicate_content_ids(
+        self, db_session, test_contents, fake_user_id
+    ):
+        """Un content_id en double ne fait pas planter l'upsert bulk (PYTHON-5Q).
+
+        L'upsert est passé d'une boucle `db.execute()` par id à un seul
+        `INSERT ... ON CONFLICT DO UPDATE` multi-lignes. Postgres refuse qu'un
+        `ON CONFLICT DO UPDATE` vise deux fois la même ligne cible dans un même
+        statement ("cannot affect row a second time") : la déduplication est
+        donc load-bearing, pas cosmétique.
+        """
+        ids = [c.id for c in test_contents]
+        # Le premier id est envoyé deux fois.
+        body = FeedRefreshRequest(content_ids=[ids[0], *ids])
+
+        response = await refresh_feed(
+            body=body, db=db_session, current_user_id=fake_user_id
+        )
+
+        # `refreshed` compte les ids UNIQUES.
+        assert response.refreshed == 3
+        # Toutes les lignes ont bien été impressionnées.
+        for cid in ids:
+            assert await _get_last_impressed(db_session, fake_user_id, cid) is not None
+
+    async def test_undo_with_duplicate_content_ids(
+        self, db_session, test_contents, fake_user_id
+    ):
+        """Idem côté undo : dédup last-write-wins, comme la boucle d'origine."""
+        ids = [c.id for c in test_contents]
+        await refresh_feed(
+            body=FeedRefreshRequest(content_ids=ids),
+            db=db_session,
+            current_user_id=fake_user_id,
+        )
+
+        older = datetime(2026, 1, 1, tzinfo=UTC)
+        newer = datetime(2026, 2, 2, tzinfo=UTC)
+        # Deux entrées pour le même content_id : la DERNIÈRE doit gagner.
+        body = FeedRefreshUndoRequest(
+            previous_impressions=[
+                PreviousImpression(content_id=ids[0], previous_last_impressed_at=older),
+                PreviousImpression(content_id=ids[0], previous_last_impressed_at=newer),
+            ]
+        )
+
+        resp = await undo_refresh(
+            body=body, db=db_session, current_user_id=fake_user_id
+        )
+
+        assert resp == {"restored": 1}
+        restored = await _get_last_impressed(db_session, fake_user_id, ids[0])
+        assert restored is not None
+        assert abs((restored - newer).total_seconds()) < 0.001
+
 
 class TestUndoRefresh:
     """undo_refresh should restore previous last_impressed_at values."""
@@ -194,9 +249,7 @@ class TestUndoRefresh:
             # Restored timestamp should match the one captured after first refresh
             assert abs((restored_ts - first_ts[cid]).total_seconds()) < 0.001
 
-    async def test_undo_is_idempotent(
-        self, db_session, test_contents, fake_user_id
-    ):
+    async def test_undo_is_idempotent(self, db_session, test_contents, fake_user_id):
         """Running undo twice with the same backup is safe (no-op on 2nd run)."""
         ids = [c.id for c in test_contents]
 


### PR DESCRIPTION
# Review — Fix N+1 famille PYTHON-5Q (feed router)

## TL;DR
Le N+1 signalé (`SET LOCAL` / requêtes répétées dans une boucle) n'est **pas**
dans le chemin de lecture de `get_personalized_feed` : ce pipeline est déjà
entièrement batché. Le vrai N+1 restant dans `feed.py` est une **boucle
d'UPSERT** (un `db.execute()` par `content_id`) dans `refresh_feed` et
`undo_refresh` — les endpoints d'impressions que l'app tire pendant l'usage du
feed. Je les collapse en **un seul `INSERT ... ON CONFLICT` bulk**.

## Où était le N+1 (et où il n'était pas)
- **Chemin de lecture `get_personalized_feed` → `_compute_feed` →
  `RecommendationService.get_feed` : déjà batché.** Vérifié fonction par
  fonction : `_get_candidates` fait un `selectinload(Content.source)` (pas de
  lazy `.source` par item), `_hydrate_user_status` charge les statuts en un seul
  `IN (...)`, `_build_carousels` passe par un catalogue unifié (`build_phase_b`),
  et le contexte utilisateur / scoring est chargé via `asyncio.gather` sur des
  short sessions. Aucune boucle de fetch par item. Le code **contredit**
  l'hypothèse « la boucle de fetch n'est pas batchée » côté lecture — les
  commentaires du fichier documentent d'ailleurs plusieurs vagues de fixes N+1 /
  pool antérieures (Round 3/4/5, PYTHON-1C, PYTHON-37).
- **Vrai N+1 = boucle d'écriture.**
  - `refresh_feed` (`feed.py`, ~l. 578-596 avant patch) : `for content_id in
    body.content_ids: await db.execute(insert(...).on_conflict_do_update(...))`.
  - `undo_refresh` (~l. 632-652 avant patch) : même motif sur
    `body.previous_impressions`.
  Chaque itération = un aller-retour SQL ; sous le wrapper de session qui arme
  les timeouts par statement, chaque `execute` traîne aussi son `SET LOCAL` →
  exactement le motif « SET LOCAL répétés dans une boucle » de la famille 5Q.
  Ces endpoints sont tirés au chargement / rafraîchissement du feed (ils
  invalident aussi `FEED_CACHE`), d'où leur rattachement à la transaction feed.

## Ce que change le patch (feed.py uniquement)
- `refresh_feed` : une seule requête `insert(UserContentStatus).values([...]).
  on_conflict_do_update(set_={last_impressed_at: now, updated_at: now})` pour
  tous les `content_id`. `dict.fromkeys(body.content_ids)` dédoublonne en
  gardant l'ordre (un `ON CONFLICT DO UPDATE` ne peut pas viser 2× la même ligne
  cible dans un statement).
- `undo_refresh` : idem, mais chaque ligne restaure **sa** valeur précédente via
  `stmt.excluded.last_impressed_at` (pseudo-table EXCLUDED) → sémantique per-row
  identique à la boucle, NULL inclus. Dédup `{content_id: entry}` en gardant la
  dernière valeur (comme la boucle : last write wins).
- Aucune modif du chemin de lecture ni du service (respect du périmètre :
  digest / get_perspectives / contents.py non touchés).

## Gain attendu
- `refresh_feed` / `undo_refresh` : **N requêtes → 1** (typiquement ~20 items
  affichés = 20 executes → 1 statement), et N `SET LOCAL` → 1. Une seule
  round-trip réseau + un seul upsert planifié par Postgres.

## Risque de régression — faible
- Contrat des réponses préservé : `previous_impressions` (calculé avant, via un
  `select ... IN` déjà batché) est inchangé ; l'undo reste idempotent.
- Micro-changement documenté : `refreshed` / `restored` comptent désormais les
  `content_id` **uniques** (avant : doublons comptés en double). Un batch de
  refresh = les items visibles à l'écran, les doublons ne sont pas attendus.
- La dédup est nécessaire, sinon un même `content_id` deux fois dans un batch
  ferait échouer le `ON CONFLICT DO UPDATE` (« cannot affect row a second time »).

## À tester
- `POST /feed/refresh` avec N `content_ids` (mélange lignes existantes / neuves) :
  toutes reçoivent `last_impressed_at = now`, `status` UNSEEN préservé, un seul
  statement en log SQL. Vérifier que `FEED_CACHE.invalidate` est toujours appelé.
- Batch avec `content_ids` en doublon → pas d'erreur, upsert unique.
- `POST /feed/refresh/undo` : chaque ligne retrouve exactement sa
  `previous_last_impressed_at` (dont NULL). Rejouer l'undo = no-op (idempotent).
- Non-régression lecture : le feed renvoie les mêmes items dans le même ordre
  (aucun code de lecture modifié).

---

## Ajouts par rapport à la note d'origine

- **2 tests de régression** sur la déduplication, qui est load-bearing : Postgres
  refuse qu'un `ON CONFLICT DO UPDATE` vise deux fois la même ligne cible
  (« cannot affect row a second time »). La boucle d'origine n'avait pas ce
  problème — le passage au bulk *introduit* le crash latent, la dédup le referme.
  `test_refresh_with_duplicate_content_ids` + `test_undo_with_duplicate_content_ids`.
- Ces 2 tests ont été **validés en négatif** : dédup désactivée temporairement,
  ils échouent tous les deux avec le `ProgrammingError` Postgres attendu. Ils
  gardent donc réellement l'invariant.
- Suite `tests/test_feed_refresh_undo.py` : **9 passed** contre un vrai Postgres.
  Le cas all-NULL (`test_undo_after_first_refresh_restores_null`) est vert, ce qui
  écarte un souci d'inférence de type sur la colonne all-NULL du bulk insert.

Doc bug : `docs/bugs/bug-python-5q.md`

Fixes PYTHON-5Q
