### PR TITLE
perf(perspectives): précharge les attributs source en 1 requête (PYTHON-50)

### DIFF
--- a/docs/bugs/bug-python-50.md
+++ b/docs/bugs/bug-python-50.md
@@ -1,0 +1,79 @@
+# Bug — N+1 sur les attributs source du flux RSS perspectives (PYTHON-50)
+
+> **Élevé** — remonté par le triage Sentry nocturne du 2026-08-01.
+> Issue Sentry : `PYTHON-50`, culprit annoncé `get_perspectives`.
+
+## Symptôme
+
+Rafale de `SELECT sources ... WHERE url ILIKE '%domaine%'` sur le chemin
+perspectives, proportionnelle au nombre d'items du flux RSS Google News.
+
+## Cause racine
+
+**Le culprit nommé par Sentry est trompeur**, comme pour PYTHON-5Q. L'endpoint
+`get_perspectives` programme un refresh en arrière-plan qui passe par
+`PerspectiveService._parse_rss`.
+
+Dans `_parse_rss`, chaque item RSS appelle `resolve_bias(domain)` puis
+`resolve_reliability(domain)`. Les deux passent par `_resolve_source_column`, qui
+fait un `SELECT` sur `Source` avec un predicate `url ILIKE %domaine%`. Résultat :
+**jusqu'à 2 requêtes par item RSS**.
+
+Ce chemin est **distinct** de celui déjà corrigé par la PR #806
+(`search_internal_perspectives` / `build_cluster_perspectives`). Là-bas, le fix
+était un `selectinload(Content.source)` : la source est atteignable par une
+relation ORM. Ici, la résolution se fait **par domaine**, sur des items RSS
+externes sans lien ORM — le `selectinload` ne s'applique pas.
+
+## Correctif
+
+Ajout de `PerspectiveService._prefetch_source_attributes(domains)`, appelé une
+fois en tête de `_parse_rss` avec les domaines de tous les items. Il collapse les
+lookups en **une seule requête** (`or_(*[Source.url.ilike(...)])`) puis pré-remplit
+`_bias_cache` / `_reliability_cache`, que `resolve_bias` / `resolve_reliability`
+consultent déjà en premier.
+
+Le patch est **purement additif** : aucune ligne existante n'est modifiée.
+
+### Préservation stricte de la sémantique
+
+Le préchargement duplique la logique de `_resolve_source_column`, donc il en
+reproduit les cas limites à l'identique :
+
+- **1 seule source active matchée, valeur ≠ `unknown`** → on pré-remplit ;
+- **>1 source matchée** → `scalar_one_or_none()` lèverait, l'exception est
+  attrapée et `_resolve_source_column` retombe sur `"unknown"` **sans essayer le
+  fallback par nom**. Le préchargement écrit donc `"unknown"`, et surtout ne
+  pioche pas l'une des deux sources au hasard ;
+- **0 match, ou match unique à `unknown`** → on ne pré-remplit rien, et l'appel
+  per-item d'origine gère le fallback par nom, inchangé.
+
+`resolve_bias` consulte `DOMAIN_BIAS_MAP` *avant* le cache : précharger un domaine
+présent dans la map est donc sans effet. Le préchargement est best-effort — toute
+erreur est loggée et laisse le chemin per-item intact.
+
+## Vérification
+
+`pytest tests/test_perspective_service_n1.py` — 2 tests ajoutés :
+
+- `test_parse_rss_prefetches_source_attributes_in_one_query` : 5 items RSS, mesure
+  les requêtes émises via le `_QueryCounter` existant. **Validé en négatif** : en
+  désactivant l'appel au préchargement, le test échoue en mesurant exactement
+  **10 requêtes** (5 items × 2 lookups) contre ≤ 2 après fix. Le gain est donc
+  mesuré, pas supposé.
+- `test_prefetch_preserves_resolve_semantics` : compare, domaine par domaine, le
+  résultat de `resolve_bias`/`resolve_reliability` **avec** et **sans**
+  préchargement, sur les trois cas qui divergent le plus (match unique, double
+  match, domaine absent). C'est l'invariant qui rend le fix sûr.
+
+Les domaines de test sont volontairement absents de `DOMAIN_BIAS_MAP` : la map en
+dur court-circuite `resolve_bias` avant tout accès DB et masquerait le N+1.
+
+Suite complète perspectives : **42 tests verts** contre un vrai Postgres.
+
+## Suivi hors périmètre
+
+`_parse_rss` est **partagé** avec le pipeline du job digest (`pipeline.py`). Le
+correctif étant purement additif (un préchargement de cache, aucune modification
+de la logique existante), il est sans risque pour le digest. Mais ce couplage est
+à garder en tête pour toute évolution future de `_parse_rss`.

--- a/packages/api/app/services/perspective_service.py
+++ b/packages/api/app/services/perspective_service.py
@@ -378,6 +378,71 @@ class PerspectiveService:
             source_name,
         )
 
+    async def _prefetch_source_attributes(self, domains: list[str]) -> None:
+        """Batch-warm ``_bias_cache``/``_reliability_cache`` in a single query.
+
+        Sans ça, chaque item RSS Google News déclenche 1-2 SELECT ``Source``
+        via ``resolve_bias``/``resolve_reliability`` (predicate ``url ILIKE
+        %domaine%``) → N+1 remonté par Sentry (PYTHON-50, culprit
+        ``get_perspectives`` : le endpoint programme un refresh en background
+        qui passe par ``_parse_rss``). On collapse les lookups par-domaine en
+        UNE requête, puis on pré-remplit les caches que ``resolve_*`` consulte
+        déjà. La sémantique est préservée à l'identique :
+
+        - on ne pré-remplit QUE ce que le predicate ``url`` par-domaine aurait
+          renvoyé (1 seule source active matchée, valeur ≠ "unknown") ;
+        - >1 source matchée → ``scalar_one_or_none`` lèverait, et
+          ``_resolve_source_column`` retombe sur "unknown" : on reproduit ce
+          "unknown" ;
+        - 0 match, ou match unique à valeur "unknown" → on ne pré-remplit rien,
+          et l'appel per-item d'origine gère le fallback par nom inchangé.
+
+        Best-effort : toute erreur laisse le chemin per-item d'origine intact.
+        """
+        if not self._has_db():
+            return
+        uniq = {d for d in domains if d}
+        uniq = {
+            d
+            for d in uniq
+            if d not in self._bias_cache or d not in self._reliability_cache
+        }
+        if not uniq:
+            return
+        try:
+            from app.models.source import Source
+
+            async with self._short_session() as session:
+                if session is None:
+                    return
+                stmt = select(Source).where(
+                    Source.is_active.is_(True),
+                    or_(*[Source.url.ilike(f"%{d}%") for d in uniq]),
+                )
+                rows = (await session.execute(stmt)).scalars().all()
+        except Exception as e:  # pragma: no cover - best-effort prefetch
+            logger.warning("prefetch_source_attributes_error", error=str(e))
+            return
+
+        for d in uniq:
+            matches = [s for s in rows if d.lower() in (s.url or "").lower()]
+            if len(matches) == 1:
+                s = matches[0]
+                if d not in self._bias_cache:
+                    b = s.bias_stance
+                    if b and getattr(b, "value", b) != "unknown":
+                        # normalize = identité pour le biais (cf. resolve_bias)
+                        self._bias_cache[d] = b
+                if d not in self._reliability_cache:
+                    r = s.reliability_score
+                    if r and getattr(r, "value", r) != "unknown":
+                        self._reliability_cache[d] = str(getattr(r, "value", r))
+            elif len(matches) > 1:
+                # scalar_one_or_none lèverait → _resolve_source_column = "unknown"
+                self._bias_cache.setdefault(d, "unknown")
+                self._reliability_cache.setdefault(d, "unknown")
+            # len(matches) == 0 → laissé au fallback per-item (predicate nom)
+
     async def analyze_divergences(
         self,
         article_title: str,
@@ -1050,6 +1115,19 @@ class PerspectiveService:
                 "perspectives_parse_rss",
                 total_items=len(items),
             )
+
+            # N+1 fix (Sentry PYTHON-50) : pré-charge en UNE requête le biais /
+            # la fiabilité de tous les domaines candidats, pour que les appels
+            # resolve_bias / resolve_reliability de la boucle ci-dessous tapent
+            # le cache mémoire au lieu d'un SELECT Source par item RSS.
+            # Sur-préchargement inoffensif : un domaine finalement filtré ne
+            # fait que remplir un cache jamais lu (sortie inchangée).
+            prefetch_domains = [
+                self._extract_domain(el.get("url", "") or "")
+                for el in (item.find("source") for item in items)
+                if el is not None
+            ]
+            await self._prefetch_source_attributes(prefetch_domains)
 
             perspectives = []
             seen_domains = set()

--- a/packages/api/tests/test_perspective_service_n1.py
+++ b/packages/api/tests/test_perspective_service_n1.py
@@ -20,7 +20,7 @@ from sqlalchemy import event
 from sqlalchemy.orm import selectinload
 
 from app.models.content import Content
-from app.models.enums import BiasStance, ContentType, SourceType
+from app.models.enums import BiasStance, ContentType, ReliabilityScore, SourceType
 from app.models.source import Source
 from app.services.perspective_service import PerspectiveService
 
@@ -57,6 +57,37 @@ async def _make_source(db_session, *, name: str, url: str, bias: BiasStance) -> 
         is_active=True,
         is_curated=False,
         bias_stance=bias,
+    )
+    db_session.add(src)
+    await db_session.commit()
+    return src
+
+
+async def _make_source_full(
+    db_session,
+    *,
+    name: str,
+    url: str,
+    bias: BiasStance,
+    reliability: ReliabilityScore,
+) -> Source:
+    """Comme [_make_source] mais avec `reliability_score` explicite.
+
+    `_parse_rss` résout biais ET fiabilité : laisser la fiabilité à "unknown"
+    ferait retomber `resolve_reliability` sur une requête par domaine et
+    masquerait l'effet du préchargement.
+    """
+    src = Source(
+        id=uuid4(),
+        name=name,
+        url=url,
+        feed_url=f"https://feed.example/{uuid4()}.xml",
+        type=SourceType.ARTICLE,
+        theme="society",
+        is_active=True,
+        is_curated=False,
+        bias_stance=bias,
+        reliability_score=reliability,
     )
     db_session.add(src)
     await db_session.commit()
@@ -170,10 +201,16 @@ async def test_build_cluster_perspectives_no_db_hit_when_source_preloaded(
     est déjà eager-loadée par l'appelant (cas réel : pipeline éditorial +
     _load_cluster_articles_for_representative)."""
     src_a = await _make_source(
-        db_session, name="Le Monde", url="https://lemonde.fr", bias=BiasStance.CENTER_LEFT
+        db_session,
+        name="Le Monde",
+        url="https://lemonde.fr",
+        bias=BiasStance.CENTER_LEFT,
     )
     src_b = await _make_source(
-        db_session, name="Le Figaro", url="https://lefigaro.fr", bias=BiasStance.CENTER_RIGHT
+        db_session,
+        name="Le Figaro",
+        url="https://lefigaro.fr",
+        bias=BiasStance.CENTER_RIGHT,
     )
     c_a = await _make_content(
         db_session, src_a, title="Titre A", url="https://lemonde.fr/a", entity_name="X"
@@ -213,3 +250,134 @@ async def test_build_cluster_perspectives_no_db_hit_when_source_preloaded(
         f"N+1 régression: build_cluster_perspectives a émis {counter.count} requêtes "
         "alors que Content.source était pré-chargé."
     )
+
+
+# --- PYTHON-50 : N+1 sur le parsing du flux RSS Google News --------------------
+#
+# Chemin DISTINCT de celui couvert plus haut (#806, perspectives internes) :
+# `_parse_rss` résout le biais / la fiabilité par DOMAINE, pas via une relation
+# `Content.source` eager-loadable. Sans préchargement, chaque item RSS émet 1-2
+# SELECT ILIKE sur `sources`.
+
+# Domaines volontairement absents de DOMAIN_BIAS_MAP : la map en dur court-circuite
+# `resolve_bias` avant tout accès DB et masquerait le N+1 qu'on veut mesurer.
+_RSS_DOMAINS = [
+    "journal-alpha.example",
+    "journal-bravo.example",
+    "journal-charlie.example",
+    "journal-delta.example",
+    "journal-echo.example",
+]
+
+
+def _rss_with_sources(domains: list[str]) -> bytes:
+    items = "".join(
+        f"""
+        <item>
+          <title>Titre {i} - Journal {i}</title>
+          <link>https://{d}/article-{i}</link>
+          <source url="https://{d}/">Journal {i}</source>
+          <pubDate>Tue, 04 Aug 2026 10:00:00 GMT</pubDate>
+        </item>"""
+        for i, d in enumerate(domains)
+    )
+    return f"<rss><channel>{items}</channel></rss>".encode()
+
+
+@pytest.mark.asyncio
+async def test_parse_rss_prefetches_source_attributes_in_one_query(db_session):
+    """`_parse_rss` ne doit pas émettre 1-2 SELECT Source par item RSS.
+
+    Avant fix : 5 items → jusqu'à 10 requêtes ILIKE (resolve_bias +
+    resolve_reliability par domaine). Après : 1 requête de préchargement,
+    puis tout est servi depuis `_bias_cache` / `_reliability_cache`.
+    """
+    for i, domain in enumerate(_RSS_DOMAINS):
+        await _make_source_full(
+            db_session,
+            name=f"Journal {i}",
+            url=f"https://{domain}/",
+            bias=BiasStance.CENTER,
+            reliability=ReliabilityScore.HIGH,
+        )
+
+    service = PerspectiveService(db=db_session)
+    content = _rss_with_sources(_RSS_DOMAINS)
+
+    counter = _QueryCounter()
+    sync_conn = await db_session.connection()
+    raw_conn = sync_conn.sync_connection
+    counter.attach(raw_conn)
+    try:
+        perspectives = await service._parse_rss(content)
+    finally:
+        counter.detach(raw_conn)
+
+    assert len(perspectives) == 5
+    assert {p.bias_stance for p in perspectives} == {"center"}
+
+    # 1 requête de préchargement attendue. On tolère 2 (BEGIN du savepoint) ;
+    # l'ancien code en émettait jusqu'à 10.
+    assert counter.count <= 2, (
+        f"N+1 régression: _parse_rss a émis {counter.count} requêtes pour 5 items "
+        "(attendu ≤ 2 — le préchargement doit éviter les ILIKE par item)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_prefetch_preserves_resolve_semantics(db_session):
+    """Le préchargement doit donner EXACTEMENT ce que `resolve_*` aurait renvoyé.
+
+    C'est l'invariant qui rend le fix sûr : il duplique la logique de
+    `_resolve_source_column` (lookup par URL sur source active), donc on compare
+    les deux chemins domaine par domaine sur les cas qui divergent le plus.
+    """
+    # 1 seule source active → le préchargement doit remplir le cache.
+    await _make_source_full(
+        db_session,
+        name="Unique",
+        url="https://unique-match.example/",
+        bias=BiasStance.LEFT,
+        reliability=ReliabilityScore.HIGH,
+    )
+    # 2 sources actives matchent le même domaine → `scalar_one_or_none` lèverait,
+    # et `_resolve_source_column` retombe sur "unknown". Le préchargement doit
+    # reproduire ce "unknown" (et NON piocher l'une des deux au hasard).
+    for suffix in ("a", "b"):
+        await _make_source_full(
+            db_session,
+            name=f"Double {suffix}",
+            url=f"https://double-match.example/{suffix}",
+            bias=BiasStance.RIGHT,
+            reliability=ReliabilityScore.LOW,
+        )
+
+    cases = ["unique-match.example", "double-match.example", "absent.example"]
+
+    # Chemin de référence : resolve_* sans préchargement, un service par cas
+    # pour repartir d'un cache vide.
+    expected = {}
+    for domain in cases:
+        ref = PerspectiveService(db=db_session)
+        expected[domain] = (
+            await ref.resolve_bias(domain),
+            await ref.resolve_reliability(domain),
+        )
+
+    # Chemin préchargé.
+    warmed = PerspectiveService(db=db_session)
+    await warmed._prefetch_source_attributes(cases)
+    actual = {
+        domain: (
+            await warmed.resolve_bias(domain),
+            await warmed.resolve_reliability(domain),
+        )
+        for domain in cases
+    }
+
+    assert actual == expected, (
+        f"Le préchargement diverge de resolve_* : attendu {expected}, obtenu {actual}"
+    )
+    # Garde-fou explicite sur les deux cas limites.
+    assert expected["double-match.example"] == ("unknown", "unknown")
+    assert expected["absent.example"] == ("unknown", "unknown")


### PR DESCRIPTION
# PYTHON-50 — N+1 sur `get_perspectives` (perspectives d'un contenu)

## TL;DR
Le culprit Sentry est `app.routers.contents.get_perspectives`, mais **le chemin
synchrone de la requête est déjà propre** (déjà batché via `selectinload`, avec
des commentaires qui documentent un fix N+1 antérieur). Le vrai N+1 restant vit
un cran plus bas, dans `PerspectiveService._parse_rss`, et il est rattaché à la
transaction `get_perspectives` parce que l'endpoint programme un **refresh en
background** (`BackgroundTasks`) qui repasse par ce code. J'ai donc adapté (comme
prévu quand le code contredit l'hypothèse) et corrigé la vraie boucle.

## Où était le N+1
Fichier : `packages/api/app/services/perspective_service.py`, méthode
`_parse_rss` (la boucle `for item in items:`, autour des lignes ~1105-1108 avant
patch) :

```python
bias = await self.resolve_bias(domain, source_name=source_name)
reliability = await self.resolve_reliability(domain, source_name=source_name)
```

Pour **chaque** résultat Google News, `resolve_bias` puis `resolve_reliability`
partent en base (`_resolve_source_column` -> `SELECT ... FROM sources WHERE url
ILIKE '%domaine%'`). Résultat : jusqu'à ~2 requêtes `Source` par item (une par
domaine unique non couvert par le `DOMAIN_BIAS_MAP` en dur), donc le classique
N+1 « une requête par itération de boucle ».

Chaîne d'appel côté endpoint :
`get_perspectives` -> `background_tasks.add_task(_refresh_perspectives_cache_background)`
-> `get_perspectives_hybrid` -> `search_perspectives` -> `_parse_rss`.

Le chemin **live** (non-background) de `get_perspectives`, lui, n'appelle que
`search_internal_perspectives` et `build_cluster_perspectives`, tous deux déjà en
`selectinload(Content.source)` + lecture du biais en mémoire : **rien à corriger
côté `contents.py`** (0 requête dans une boucle, vérifié).

## Ce que change le patch
Purement additif (74 lignes, 0 suppression), dans `perspective_service.py` :

1. Nouvelle méthode `_prefetch_source_attributes(domains)` : **une seule**
   requête `SELECT * FROM sources WHERE is_active AND (url ILIKE %d1% OR ...)`
   pour tous les domaines candidats, puis pré-remplit les caches existants
   `_bias_cache` / `_reliability_cache` que `resolve_*` consulte déjà.
2. Un pré-passage dans `_parse_rss` qui collecte les domaines des items et
   appelle ce prefetch **avant** la boucle.

La boucle et les appels `resolve_bias`/`resolve_reliability` restent en place :
ils deviennent des **cache hits**. Belt-and-suspenders -> aucune modif du
contrat, mêmes données, même ordre.

**Sémantique préservée à l'identique** : on ne pré-remplit un domaine que si le
predicate `url` par-domaine aurait renvoyé exactement la même valeur (1 seule
source active matchée, valeur != "unknown"). Cas `>1` match -> on reproduit le
"unknown" que `scalar_one_or_none` provoque aujourd'hui. Cas `0` match ou match
unique "unknown" -> on ne touche à rien, le fallback per-item par **nom** de
source joue comme avant.

## Gain attendu
De ~O(N) requêtes `Source` (N = domaines Google News uniques, typiquement 6-10)
à **1 requête** batchée. Restent seulement les rares fallbacks par nom de source
(url non matchée). Sur l'endpoint chargé, ça retire la grappe de requêtes que
Sentry flag et allège le refresh background.

## Risque de régression
Faible. Changement additif, `py_compile` OK, sortie identique par construction.
Point de vigilance principal : `_parse_rss` est **partagé** avec le job digest
(`editorial/pipeline.py` -> `get_perspectives_hybrid` -> `_parse_rss`), qui est
hors de mon périmètre et traité par un autre agent. Mon patch **améliore** aussi
ce chemin sans changer sa sortie, mais **il touche un fichier que l'agent
"digest" est susceptible d'éditer** -> risque de conflit de merge à coordonner.
Je n'ai touché ni `feed.py` ni `editorial/pipeline.py`.

## À tester
- `/contents/{id}/perspectives` sur un article **non-digest** (chemin live +
  refresh background live) : compter les requêtes `sources` (une seule attendue
  pour la partie Google News) et vérifier biais/fiabilité/ordre inchangés.
- Un domaine **présent** en base (biais + fiabilité renseignés) -> valeurs
  identiques à avant.
- Un domaine **absent** de la table + une source qui matche par **nom** ->
  vérifier que le fallback par nom fonctionne toujours.
- Un domaine matchant **plusieurs** sources actives -> toujours "unknown"
  (comportement historique).
- Non-régression du digest (`pipeline.py`) puisque `_parse_rss` est partagé.

---

## Ajouts par rapport à la note d'origine

Le chemin ajouté (`_prefetch_source_attributes`) n'était couvert par **aucun** test :
les tests existants de `_parse_rss` construisent le service sans DB, donc
`_has_db()` est faux et le préchargement était un no-op. Deux tests ajoutés dans
`tests/test_perspective_service_n1.py` :

- `test_parse_rss_prefetches_source_attributes_in_one_query` — **validé en négatif** :
  préchargement désactivé, le test échoue en mesurant exactement **10 requêtes**
  (5 items × 2 lookups) contre ≤ 2 après fix. Le gain est mesuré, pas supposé.
- `test_prefetch_preserves_resolve_semantics` — compare `resolve_bias` /
  `resolve_reliability` **avec** et **sans** préchargement sur les 3 cas limites
  (match unique, double match → `unknown`, domaine absent). C'est l'invariant qui
  rend sûre la duplication de logique de `_resolve_source_column`.

Les domaines de test sont volontairement hors `DOMAIN_BIAS_MAP` : la map en dur
court-circuite `resolve_bias` avant tout accès DB et masquerait le N+1.

Diff `app/services/perspective_service.py` : **purement additif** (0 ligne
supprimée) — ce qui borne le risque pour `pipeline.py`, qui partage `_parse_rss`.

Suite perspectives complète : **42 passed** contre un vrai Postgres.

Doc bug : `docs/bugs/bug-python-50.md`

Fixes PYTHON-50
