### PR TITLE
feat(onboarding): amorce notif précoce + relance abandons J+0/J+1

### DIFF
--- a/apps/mobile/lib/core/services/analytics_service.dart
+++ b/apps/mobile/lib/core/services/analytics_service.dart
@@ -380,6 +380,33 @@ class AnalyticsService {
     });
   }
 
+  /// Écran d'amorce notif (étape 3/4) affiché.
+  Future<void> trackOnboardingNotifPrimingShown({required int step}) async {
+    await _capturePostHog('onboarding_notif_priming_shown', {
+      'session_id': _sessionId,
+      'step': step,
+    });
+  }
+
+  /// L'utilisateur a accepté l'amorce ; [registered] = device enregistré côté
+  /// serveur (donc joignable par une relance J+0/J+1).
+  Future<void> trackOnboardingNotifPrimingAccepted({
+    required bool registered,
+  }) async {
+    await _capturePostHog('onboarding_notif_priming_accepted', {
+      'session_id': _sessionId,
+      'registered': registered,
+    });
+  }
+
+  /// L'utilisateur a repoussé l'amorce (« Plus tard ») — aucune demande OS
+  /// déclenchée, la modale d'activation quotidienne reste disponible.
+  Future<void> trackOnboardingNotifPrimingRefused() async {
+    await _capturePostHog('onboarding_notif_priming_refused', {
+      'session_id': _sessionId,
+    });
+  }
+
   // ──────────────────────────────────────────────────────────────
   // Sprint 2 — feature-by-feature events (PR1)
   // ──────────────────────────────────────────────────────────────

--- a/apps/mobile/lib/core/services/push_notification_service.dart
+++ b/apps/mobile/lib/core/services/push_notification_service.dart
@@ -77,10 +77,15 @@ class PushNotificationService {
     const androidSettings =
         AndroidInitializationSettings('@drawable/ic_stat_facteur');
 
+    // Permission iOS demandée explicitement (cf. requestPermission), JAMAIS au
+    // boot : le pop-up système ne s'affiche qu'une fois par install, et
+    // `init()` tourne pendant l'onboarding. Le déclencher ici brûlerait
+    // l'unique demande avant l'écran d'amorce (étape 3/4) et avant la modale
+    // d'activation quotidienne. On garde donc les 3 flags à `false`.
     const iosSettings = DarwinInitializationSettings(
-      requestAlertPermission: true,
-      requestBadgePermission: true,
-      requestSoundPermission: true,
+      requestAlertPermission: false,
+      requestBadgePermission: false,
+      requestSoundPermission: false,
     );
 
     const settings = InitializationSettings(
@@ -105,6 +110,22 @@ class PushNotificationService {
           await androidPlugin.requestNotificationsPermission() ?? false;
       debugPrint(
           'PushNotificationService: Android notification permission: $granted');
+      return granted;
+    }
+    // iOS : la demande n'est plus faite au boot (cf. DarwinInitializationSettings
+    // à `false`). On déclenche donc explicitement le pop-up système ici — il ne
+    // s'affiche qu'une fois, l'appel est un no-op idempotent si déjà décidé.
+    final iosPlugin = _plugin.resolvePlatformSpecificImplementation<
+        IOSFlutterLocalNotificationsPlugin>();
+    if (iosPlugin != null) {
+      final granted = await iosPlugin.requestPermissions(
+            alert: true,
+            badge: true,
+            sound: true,
+          ) ??
+          false;
+      debugPrint(
+          'PushNotificationService: iOS notification permission: $granted');
       return granted;
     }
     return true;

--- a/apps/mobile/lib/features/onboarding/screens/onboarding_screen.dart
+++ b/apps/mobile/lib/features/onboarding/screens/onboarding_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../config/theme.dart';
@@ -5,6 +7,8 @@ import '../../../core/auth/auth_state.dart';
 import '../../../core/providers/analytics_provider.dart';
 import '../providers/onboarding_analytics.dart';
 import '../providers/onboarding_provider.dart';
+import '../services/onboarding_push_priming.dart';
+import '../widgets/onboarding_notif_priming.dart';
 import '../widgets/onboarding_progress_bar.dart';
 import '../widgets/reaction_screen.dart';
 import '../onboarding_strings.dart';
@@ -34,12 +38,57 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   /// provider : celui-ci est aussi lu hors onboarding.
   late final OnboardingStepTracker _stepTracker;
 
+  /// Amorce notif précoce (étape 3/4) : planifiée une seule fois, quelques
+  /// secondes après avoir atteint l'étape, pour capter tôt la permission.
+  Timer? _primingTimer;
+  bool _primingScheduled = false;
+
   @override
   void initState() {
     super.initState();
     _stepTracker = OnboardingStepTracker(ref.read(analyticsServiceProvider));
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) _stepTracker.onState(ref.read(onboardingProvider));
+      if (!mounted) return;
+      final state = ref.read(onboardingProvider);
+      _stepTracker.onState(state);
+      unawaited(_maybeSchedulePriming(state));
+    });
+  }
+
+  @override
+  void dispose() {
+    _primingTimer?.cancel();
+    super.dispose();
+  }
+
+  /// Arme (une seule fois) l'écran d'amorce ~4 s après avoir atteint l'étape
+  /// `objective` (ou au-delà), pour une session anonyme qui ne l'a pas encore
+  /// vu. `objective` est un écran de « dwell » : le délai atterrit de façon
+  /// fiable pendant que l'utilisateur est présent. Le seuil est ancré sur
+  /// l'index de l'enum (pas un littéral) pour survivre à un réordonnancement
+  /// des questions.
+  ///
+  /// `_primingScheduled` passe à `true` de façon synchrone avant le premier
+  /// `await` : la garde de ré-entrance tient donc même si `ref.listen` rappelle
+  /// pendant l'ouverture de la box Hive.
+  Future<void> _maybeSchedulePriming(OnboardingState state) async {
+    if (_primingScheduled) return;
+    if (state.globalQuestionIndex < Section1Question.objective.index) return;
+    if (!ref.read(authStateProvider).isAnonymous) return;
+    _primingScheduled = true;
+    if (await ref.read(onboardingPushPrimingProvider).hasSeenPriming()) return;
+    _primingTimer = Timer(const Duration(seconds: 4), () {
+      if (!mounted) return;
+      final current = ref.read(onboardingProvider);
+      // Ne pas tirer pendant la transition de conclusion (finalize).
+      if (current.isReadyToFinalize) return;
+      unawaited(
+        showOnboardingNotifPriming(
+          context,
+          ref,
+          step: current.globalQuestionIndex,
+        ),
+      );
     });
   }
 
@@ -48,7 +97,10 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     final state = ref.watch(onboardingProvider);
     ref.listen<OnboardingState>(
       onboardingProvider,
-      (_, next) => _stepTracker.onState(next),
+      (_, next) {
+        _stepTracker.onState(next);
+        unawaited(_maybeSchedulePriming(next));
+      },
     );
 
     return Scaffold(

--- a/apps/mobile/lib/features/onboarding/services/onboarding_push_priming.dart
+++ b/apps/mobile/lib/features/onboarding/services/onboarding_push_priming.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../../../core/services/server_push_service.dart';
+
+/// Coordinateur de l'amorce notif précoce (écran « Activer les rappels ? »
+/// affiché à l'étape 3/4 de l'onboarding).
+///
+/// Séparé du widget pour être testable (le widget lit une instance via
+/// [onboardingPushPrimingProvider], surchargeable en test).
+///
+/// Point CLÉ : accepter déclenche l'UNIQUE pop-up système et enregistre le
+/// device (même sur session anonyme, avant la fin de l'onboarding) pour rendre
+/// l'utilisateur joignable par une relance. Refuser ne déclenche AUCUNE demande
+/// OS et ne touche JAMAIS `notif_modal_seen` (le gate de la modale d'activation
+/// quotidienne) : le flag one-shot [seenKey] est distinct, si bien qu'un refus
+/// ici ne consomme rien pour la demande quotidienne ultérieure.
+class OnboardingPushPriming {
+  const OnboardingPushPriming();
+
+  /// Clé Hive (box `settings`) : amorce précoce vue une fois. DISTINCTE de
+  /// `notif_modal_seen` — ne jamais fusionner les deux.
+  static const seenKey = 'notif_early_priming_seen';
+
+  Future<Box<dynamic>> _box() => Hive.openBox<dynamic>('settings');
+
+  Future<bool> hasSeenPriming() async {
+    final box = await _box();
+    return box.get(seenKey, defaultValue: false) as bool;
+  }
+
+  Future<void> _markSeen() async {
+    final box = await _box();
+    await box.put(seenKey, true);
+  }
+
+  /// Accepte : déclenche la demande OS + enregistre le device. Renvoie `true`
+  /// si le device est enregistré côté serveur (relance possible).
+  Future<bool> acceptAndRegister() async {
+    final registered = await ServerPushService.instance.initAndRegister();
+    await _markSeen();
+    return registered;
+  }
+
+  /// Refuse : marque l'amorce vue, sans aucun appel OS.
+  Future<void> refuse() => _markSeen();
+}
+
+final onboardingPushPrimingProvider = Provider<OnboardingPushPriming>(
+  (ref) => const OnboardingPushPriming(),
+);

--- a/apps/mobile/lib/features/onboarding/widgets/onboarding_notif_priming.dart
+++ b/apps/mobile/lib/features/onboarding/widgets/onboarding_notif_priming.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../config/theme.dart';
+import '../../../core/providers/analytics_provider.dart';
+import '../../../core/web/web_perf.dart';
+import '../services/onboarding_push_priming.dart';
+
+/// Écran d'amorce interne affiché ~quelques secondes après l'étape 3/4.
+///
+/// Volontairement plus léger que `NotificationActivationModal` (pas de créneau,
+/// pas de bonnes nouvelles, pas d'aperçu) : un seul but, capter tôt la
+/// permission pour pouvoir relancer un abandon. Seul « Activer » déclenche la
+/// vraie pop-up système ; « Plus tard » ne consomme rien.
+Future<void> showOnboardingNotifPriming(
+  BuildContext context,
+  WidgetRef ref, {
+  required int step,
+}) async {
+  // Push local indispo sur Web — no-op (comme showNotificationActivationModal).
+  if (!kSupportsPushNotifications) return;
+  return showDialog<void>(
+    context: context,
+    barrierDismissible: false,
+    barrierColor: context.facteurColors.scrim,
+    useRootNavigator: true,
+    builder: (_) => Dialog(
+      insetPadding: const EdgeInsets.symmetric(
+        horizontal: FacteurSpacing.space4,
+        vertical: FacteurSpacing.space6,
+      ),
+      backgroundColor: Colors.transparent,
+      elevation: 0,
+      child: _OnboardingNotifPriming(step: step),
+    ),
+  );
+}
+
+class _OnboardingNotifPriming extends ConsumerStatefulWidget {
+  final int step;
+
+  const _OnboardingNotifPriming({required this.step});
+
+  @override
+  ConsumerState<_OnboardingNotifPriming> createState() =>
+      _OnboardingNotifPrimingState();
+}
+
+class _OnboardingNotifPrimingState
+    extends ConsumerState<_OnboardingNotifPriming> {
+  bool _busy = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      // Garde anti-« ref après dispose » (cf. NotificationActivationModal).
+      if (!mounted) return;
+      ref
+          .read(analyticsServiceProvider)
+          .trackOnboardingNotifPrimingShown(step: widget.step);
+    });
+  }
+
+  Future<void> _onAccept() async {
+    if (_busy) return;
+    setState(() => _busy = true);
+
+    final priming = ref.read(onboardingPushPrimingProvider);
+    final analytics = ref.read(analyticsServiceProvider);
+    final registered = await priming.acceptAndRegister();
+    await analytics.trackOnboardingNotifPrimingAccepted(registered: registered);
+
+    if (!mounted) return;
+    Navigator.of(context).pop();
+  }
+
+  Future<void> _onSkip() async {
+    if (_busy) return;
+    setState(() => _busy = true);
+
+    await ref.read(onboardingPushPrimingProvider).refuse();
+    await ref.read(analyticsServiceProvider).trackOnboardingNotifPrimingRefused();
+
+    if (!mounted) return;
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.facteurColors;
+    final theme = Theme.of(context);
+
+    return Material(
+      color: colors.backgroundPrimary,
+      borderRadius: BorderRadius.circular(FacteurRadius.xl),
+      clipBehavior: Clip.antiAlias,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          FacteurSpacing.space4,
+          FacteurSpacing.space6,
+          FacteurSpacing.space4,
+          FacteurSpacing.space4,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // TODO(PO): valider copy — FR sobre, pas d'em-dash, pas de fausse
+            // métaphore facteur/lettre.
+            Text(
+              'Activer les rappels ?',
+              style: theme.textTheme.displaySmall
+                  ?.copyWith(fontWeight: FontWeight.bold),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: FacteurSpacing.space3),
+            Text(
+              'Reçois un rappel pour reprendre ta configuration et la '
+              'terminer en une minute.',
+              style: theme.textTheme.bodyMedium
+                  ?.copyWith(color: colors.textSecondary),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: FacteurSpacing.space6),
+            FilledButton(
+              onPressed: _busy ? null : _onAccept,
+              child: const Text('Activer les rappels'),
+            ),
+            const SizedBox(height: FacteurSpacing.space2),
+            TextButton(
+              onPressed: _busy ? null : _onSkip,
+              child: const Text('Plus tard'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/test/features/onboarding/widgets/onboarding_notif_priming_test.dart
+++ b/apps/mobile/test/features/onboarding/widgets/onboarding_notif_priming_test.dart
@@ -1,0 +1,153 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import 'package:facteur/core/providers/analytics_provider.dart';
+import 'package:facteur/core/services/analytics_service.dart';
+import 'package:facteur/features/onboarding/services/onboarding_push_priming.dart';
+import 'package:facteur/features/onboarding/widgets/onboarding_notif_priming.dart';
+
+class _RecordingAnalytics implements AnalyticsService {
+  final List<String> calls = [];
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) async {
+    calls.add(invocation.memberName.toString());
+  }
+}
+
+/// Fake du seam d'amorce : enregistre les appels sans toucher Firebase/Hive.
+class _FakePriming implements OnboardingPushPriming {
+  bool acceptCalled = false;
+  bool refuseCalled = false;
+
+  @override
+  Future<bool> hasSeenPriming() async => false;
+
+  @override
+  Future<bool> acceptAndRegister() async {
+    acceptCalled = true;
+    return true;
+  }
+
+  @override
+  Future<void> refuse() async {
+    refuseCalled = true;
+  }
+}
+
+Widget _host({
+  required OnboardingPushPriming priming,
+  required AnalyticsService analytics,
+}) {
+  return ProviderScope(
+    overrides: [
+      onboardingPushPrimingProvider.overrideWithValue(priming),
+      analyticsServiceProvider.overrideWithValue(analytics),
+    ],
+    child: MaterialApp(
+      home: Scaffold(
+        body: Consumer(
+          builder: (context, ref, _) => Center(
+            child: ElevatedButton(
+              onPressed: () =>
+                  showOnboardingNotifPriming(context, ref, step: 3),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('hive_priming_test_');
+    Hive.init(tempDir.path);
+  });
+
+  tearDown(() async {
+    if (Hive.isBoxOpen('settings')) {
+      await Hive.box<dynamic>('settings').clear();
+    }
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    await tempDir.delete(recursive: true);
+  });
+
+  testWidgets('affiche le titre + les deux CTA', (tester) async {
+    await tester.pumpWidget(
+      _host(priming: _FakePriming(), analytics: _RecordingAnalytics()),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Activer les rappels ?'), findsOneWidget);
+    expect(find.text('Activer les rappels'), findsOneWidget);
+    expect(find.text('Plus tard'), findsOneWidget);
+  });
+
+  testWidgets('accept → acceptAndRegister appelé + event accepted + fermeture',
+      (tester) async {
+    final priming = _FakePriming();
+    final analytics = _RecordingAnalytics();
+    await tester.pumpWidget(_host(priming: priming, analytics: analytics));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Activer les rappels'));
+    await tester.pumpAndSettle();
+
+    expect(priming.acceptCalled, isTrue);
+    expect(
+      analytics.calls.any((c) => c.contains('PrimingAccepted')),
+      isTrue,
+    );
+    // Dialog fermé.
+    expect(find.text('Activer les rappels ?'), findsNothing);
+  });
+
+  testWidgets(
+    'refus (« Plus tard ») appelle refuse() + event refused, sans accept',
+    (tester) async {
+      final priming = _FakePriming();
+      final analytics = _RecordingAnalytics();
+      await tester.pumpWidget(_host(priming: priming, analytics: analytics));
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Plus tard'));
+      await tester.pumpAndSettle();
+
+      expect(priming.refuseCalled, isTrue);
+      expect(priming.acceptCalled, isFalse);
+      expect(
+        analytics.calls.any((c) => c.contains('PrimingRefused')),
+        isTrue,
+      );
+      // Dialog fermé.
+      expect(find.text('Activer les rappels ?'), findsNothing);
+    },
+  );
+
+  // Le contrat Hive du seam se teste hors widget : `refuse()` fait de l'I/O
+  // fichier réelle, or la lancer dans un callback pompé sous fake-async
+  // (`pumpAndSettle`) provoque un deadlock d'`openBox` concurrent. Ici, en
+  // async réel, l'I/O aboutit normalement.
+  test('refuse() pose notif_early_priming_seen SANS notif_modal_seen', () async {
+    await const OnboardingPushPriming().refuse();
+
+    final box = await Hive.openBox<dynamic>('settings');
+    expect(box.get('notif_early_priming_seen'), isTrue);
+    // Le gate de la modale d'activation quotidienne NE doit PAS être posé.
+    expect(box.get('notif_modal_seen'), isNull);
+  });
+}

--- a/docs/stories/core/onboarding.relance-abandons-push.md
+++ b/docs/stories/core/onboarding.relance-abandons-push.md
@@ -1,0 +1,71 @@
+# Story — Relance des abandons d'onboarding par push (amorce précoce + J+0/J+1)
+
+**Type** : Feature
+**Statut** : CODE terminé, VERIFY en cours
+**Branche** : `boujonlaurin-dotcom/san-salvador`
+
+## Problème / objectif
+
+Beaucoup d'utilisateurs démarrent l'onboarding puis l'abandonnent. On veut les
+relancer par une notification push. Cela suppose de **capter la permission de
+notification tôt** (dès l'étape 3/4) et d'**enregistrer le device** pendant que
+l'utilisateur est encore anonyme (le compte email n'est créé qu'à la dernière
+étape → la vraie population d'abandon est anonyme).
+
+### Contrainte de plateforme centrale
+La pop-up système de permission ne s'affiche **qu'une fois** (iOS + Android 13+).
+Exigence PO : un refus de l'ask précoce ne doit **pas** brûler la pop-up de la
+notif quotidienne. → **écran d'amorce interne** : seul un OUI déclenche la vraie
+pop-up ; un refus ne consomme rien. Flag one-shot dédié
+`notif_early_priming_seen`, **distinct** du gate `notif_modal_seen` de la modale
+quotidienne.
+
+### Décisions PO
+1. Écran d'amorce interne (pas la vraie pop-up directe).
+2. Cible = tous les abandons d'onboarding, anonymes inclus.
+3. Relances J+0 (~1h) puis J+1 (~24h).
+
+## Implémentation
+
+### Mobile
+- `core/services/push_notification_service.dart` — iOS ne demande plus la
+  permission au boot (`DarwinInitializationSettings(request*: false)`) ; branche
+  iOS explicite ajoutée à `requestPermission()`.
+- `features/onboarding/services/onboarding_push_priming.dart` (NOUVEAU) — seam
+  testable : `hasSeenPriming` / `acceptAndRegister` (→ `initAndRegister`, unique
+  pop-up OS + enregistrement anonyme) / `refuse` (aucun appel OS). Provider
+  `onboardingPushPrimingProvider`.
+- `features/onboarding/widgets/onboarding_notif_priming.dart` (NOUVEAU) — écran
+  léger « Activer les rappels ? », gardé par `kSupportsPushNotifications`.
+- `features/onboarding/screens/onboarding_screen.dart` — `_maybeSchedulePriming`
+  arme un `Timer(4s)` une fois, à `globalQuestionIndex >= 3`, session anonyme,
+  amorce non vue ; annulé au dispose et non tiré pendant `isReadyToFinalize`.
+- `core/services/analytics_service.dart` — 3 events :
+  `onboarding_notif_priming_shown|accepted|refused`.
+
+### Backend
+- `app/services/onboarding_reengagement_dispatcher.py` (NOUVEAU) — sélectionne
+  les `push_devices` non révoqués dont `user_profiles.onboarding_completed =
+  False`, ancre = `device.created_at`, envoie D0 (≥1h) puis D1 (≥24h), heures
+  calmes locales respectées (report au prochain 08:00), idempotent via
+  `push_deliveries` kinds `onboarding_reengagement_d0`/`_d1`. Budget gouverneur
+  bypassé (2 envois à vie / device). Deep link `/onboarding`.
+- `app/workers/scheduler.py` — job `IntervalTrigger(minutes=5)`.
+- **Aucune migration** (kinds = chaînes dans la colonne `String(32)` existante ;
+  head Alembic `mg06_merge_cq01_st02` inchangé).
+
+## Tests
+- Backend : `tests/services/test_onboarding_reengagement_dispatcher.py` (9 cas :
+  D0/D1 timing, idempotence, stop-on-complete, quiet hours, token invalide,
+  stale). ✅ 9/9.
+- Mobile : `test/features/onboarding/widgets/onboarding_notif_priming_test.dart`
+  (titre + CTA ; accept → register + event ; refus n'écrit PAS `notif_modal_seen`).
+
+## Copy — `// TODO(PO): valider`
+- Amorce : « Activer les rappels ? » / « Reçois un rappel pour reprendre ta
+  configuration et la terminer en une minute. » / « Activer les rappels » /
+  « Plus tard ».
+- J+0 : « Tu y étais presque » / « Ta configuration n'est pas terminée. Reprends
+  en une minute. »
+- J+1 : « On termine ta configuration ? » / « Quelques réponses suffisent pour
+  recevoir ton premier récap. »

--- a/packages/api/app/services/onboarding_reengagement_dispatcher.py
+++ b/packages/api/app/services/onboarding_reengagement_dispatcher.py
@@ -1,0 +1,221 @@
+"""Relance des abandons d'onboarding par push (J+0 ~1h puis J+1 ~24h).
+
+Cible : les devices enregistrés tôt (écran d'amorce à l'étape 3/4) dont
+l'utilisateur n'a PAS terminé l'onboarding (`user_profiles.onboarding_completed
+= False`). L'ancre temporelle est `push_devices.created_at` (stable à travers
+les ré-enregistrements) = moment de l'opt-in précoce / abandon.
+
+Réutilise le transport et l'insertion idempotente de `push_dispatcher`
+(`firebase_configured`, `send_fcm`, `get_or_create_delivery`,
+`is_invalid_token_error`). Deux `kind` distincts (`onboarding_reengagement_d0` /
+`_d1`) → deux lignes `push_deliveries` one-shot par device sur la contrainte
+d'unicité `(device_id, target_date, kind)`. Aucune migration : `kind` est déjà
+une colonne `String(32)`.
+
+Le gouverneur de budget (`check_push_budget`) est volontairement bypassé : ce
+budget arbitre la piste digest quotidien. Ici le tunnel est naturellement
+plafonné à 2 envois à vie par device (deux kinds, chacun one-shot).
+"""
+
+import asyncio
+from datetime import UTC, datetime, time, timedelta
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+import structlog
+from sqlalchemy import select
+
+from app.database import safe_async_session
+from app.models.analytics import AnalyticsEvent
+from app.models.push_notification import PushDevice
+from app.models.user import UserProfile
+from app.services.posthog_client import get_posthog_client
+from app.services.push_dispatcher import (
+    PushSender,
+    firebase_configured,
+    get_or_create_delivery,
+    is_invalid_token_error,
+    send_fcm,
+)
+
+logger = structlog.get_logger()
+
+KIND_D0 = "onboarding_reengagement_d0"
+KIND_D1 = "onboarding_reengagement_d1"
+
+# Fenêtre de sélection : on ignore les devices trop vieux (l'abandon n'est plus
+# « chaud » et le purge anonyme finira le ménage à J+30). Couvre largement J+1.
+STALE_AFTER = timedelta(days=3)
+D0_AFTER = timedelta(hours=1)
+D1_AFTER = timedelta(hours=24)
+RETRY_DELAY = timedelta(minutes=5)
+
+# Heures calmes locales : pas d'envoi avant 08:00 ni à partir de 21:00.
+QUIET_START = time(21, 0)
+QUIET_END = time(8, 0)
+
+FALLBACK_TIMEZONE = "Europe/Paris"
+
+# TODO(PO): valider copy — FR sobre, pas d'em-dash, pas de métaphore facteur/lettre.
+_COPY: dict[str, tuple[str, str]] = {
+    KIND_D0: (
+        "Tu y étais presque",
+        "Ta configuration n'est pas terminée. Reprends en une minute.",
+    ),
+    KIND_D1: (
+        "On termine ta configuration ?",
+        "Quelques réponses suffisent pour recevoir ton premier récap.",
+    ),
+}
+
+
+def _resolve_zone(timezone: str) -> ZoneInfo:
+    try:
+        return ZoneInfo(timezone)
+    except ZoneInfoNotFoundError:
+        return ZoneInfo(FALLBACK_TIMEZONE)
+
+
+def _next_active_utc(local_now: datetime) -> datetime:
+    """Prochain 08:00 local (en UTC) après une fenêtre calme."""
+    if local_now.time() >= QUIET_START:
+        base = (local_now + timedelta(days=1)).replace(
+            hour=QUIET_END.hour, minute=QUIET_END.minute, second=0, microsecond=0
+        )
+    else:  # avant QUIET_END
+        base = local_now.replace(
+            hour=QUIET_END.hour, minute=QUIET_END.minute, second=0, microsecond=0
+        )
+    return base.astimezone(UTC)
+
+
+def _is_quiet(local_now: datetime) -> bool:
+    local_time = local_now.time()
+    return local_time < QUIET_END or local_time >= QUIET_START
+
+
+async def dispatch_onboarding_reengagement_pushes(
+    *,
+    now: datetime | None = None,
+    sender: PushSender = send_fcm,
+) -> dict[str, int]:
+    """Envoie les relances J+0 puis J+1 aux abandons d'onboarding."""
+    metrics = {
+        "sent": 0,
+        "deferred": 0,
+        "retried": 0,
+        "invalid_tokens": 0,
+    }
+    if sender is send_fcm and not firebase_configured():
+        logger.info(
+            "onboarding_reengagement_disabled", reason="firebase_not_configured"
+        )
+        return metrics
+
+    utc_now = (now or datetime.now(UTC)).astimezone(UTC)
+
+    async with safe_async_session() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(PushDevice)
+                    .join(UserProfile, UserProfile.user_id == PushDevice.user_id)
+                    .where(
+                        PushDevice.revoked_at.is_(None),
+                        UserProfile.onboarding_completed.is_(False),
+                        PushDevice.created_at > utc_now - STALE_AFTER,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        for device in rows:
+            created_at = device.created_at
+            if created_at.tzinfo is None:
+                created_at = created_at.replace(tzinfo=UTC)
+            elapsed = utc_now - created_at
+
+            zone = _resolve_zone(device.timezone)
+            local_now = utc_now.astimezone(zone)
+
+            for kind, threshold in ((KIND_D0, D0_AFTER), (KIND_D1, D1_AFTER)):
+                if elapsed < threshold:
+                    continue
+
+                delivery = await get_or_create_delivery(
+                    session,
+                    device_id=device.device_id,
+                    target_date=created_at.date(),
+                    now=utc_now,
+                    kind=kind,
+                )
+                if delivery.status in {"sent", "skipped"}:
+                    continue
+                if delivery.next_attempt_at and delivery.next_attempt_at > utc_now:
+                    continue
+
+                if _is_quiet(local_now):
+                    delivery.status = "pending"
+                    delivery.next_attempt_at = _next_active_utc(local_now)
+                    delivery.error_code = "quiet_hours"
+                    metrics["deferred"] += 1
+                    continue
+
+                title, body = _COPY[kind]
+                delivery.attempt_count += 1
+                delivery.last_attempt_at = utc_now
+                try:
+                    await asyncio.to_thread(
+                        sender,
+                        device.fcm_token,
+                        title,
+                        body,
+                        {
+                            "kind": kind,
+                            "route": "/onboarding",
+                            "sent_at": utc_now.isoformat(),
+                        },
+                    )
+                except Exception as exc:
+                    delivery.status = "failed"
+                    delivery.next_attempt_at = utc_now + RETRY_DELAY
+                    delivery.error_code = type(exc).__name__
+                    delivery.error_message = str(exc)[:1000]
+                    if is_invalid_token_error(exc):
+                        device.revoked_at = utc_now
+                        metrics["invalid_tokens"] += 1
+                    else:
+                        metrics["retried"] += 1
+                    logger.warning(
+                        "onboarding_reengagement_failed",
+                        device_id=str(device.device_id),
+                        kind=kind,
+                        error=type(exc).__name__,
+                    )
+                else:
+                    delivery.status = "sent"
+                    delivery.sent_at = utc_now
+                    delivery.next_attempt_at = None
+                    delivery.error_code = None
+                    delivery.error_message = None
+                    metrics["sent"] += 1
+                    # Ajout direct (pas de commit mid-loop qui expirerait les
+                    # objets ORM) : persisté par le commit final.
+                    session.add(
+                        AnalyticsEvent(
+                            user_id=device.user_id,
+                            event_type="push_sent",
+                            event_data={"kind": kind},
+                        )
+                    )
+                    get_posthog_client().capture(
+                        device.user_id,
+                        "push_sent",
+                        {"kind": kind},
+                    )
+
+        await session.commit()
+
+    logger.info("onboarding_reengagement_completed", **metrics)
+    return metrics

--- a/packages/api/app/workers/scheduler.py
+++ b/packages/api/app/workers/scheduler.py
@@ -21,6 +21,9 @@ from app.jobs.recompute_source_coverage_themes import (
 from app.jobs.recompute_source_language import recompute_source_language
 from app.jobs.rescue_failed_sources_job import run_rescue_failed_sources
 from app.services.observability.cost_budget import log_budget_projection
+from app.services.onboarding_reengagement_dispatcher import (
+    dispatch_onboarding_reengagement_pushes,
+)
 from app.services.push_alert_dispatcher import (
     dispatch_source_alerts,
     dispatch_topic_alerts,
@@ -759,6 +762,19 @@ def start_scheduler() -> None:
         max_instances=1,
     )
 
+    # Relance des abandons d'onboarding (Epic onboarding) — même cadence. Cible
+    # les devices enregistrés tôt (amorce étape 3/4) dont l'onboarding n'est pas
+    # terminé : J+0 (~1h) puis J+1 (~24h), 2 envois à vie max par device.
+    scheduler.add_job(
+        dispatch_onboarding_reengagement_pushes,
+        trigger=IntervalTrigger(minutes=5),
+        id="onboarding_reengagement_push_dispatch",
+        name="Onboarding re-engagement push dispatcher",
+        replace_existing=True,
+        coalesce=True,
+        max_instances=1,
+    )
+
     # Garde-fou file de classification (30 min) — alerte Sentry si le plus
     # vieux pending dépasse le seuil (défaut 12 h). 2e couche par-dessus le
     # superviseur `_on_task_done` du worker : détecte l'angle-mort même si la
@@ -792,6 +808,7 @@ def start_scheduler() -> None:
             "daily_essentiel_push_dispatch",
             "source_alert_push_dispatch",
             "topic_alert_push_dispatch",
+            "onboarding_reengagement_push_dispatch",
             "classification_queue_health_check",
         ],
         rss_interval_minutes=settings.rss_sync_interval_minutes,

--- a/packages/api/tests/services/test_onboarding_reengagement_dispatcher.py
+++ b/packages/api/tests/services/test_onboarding_reengagement_dispatcher.py
@@ -1,0 +1,297 @@
+"""Tests du dispatcher de relance des abandons d'onboarding (J+0 / J+1)."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import Mock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+
+from app.models.analytics import AnalyticsEvent
+from app.models.push_notification import PushDelivery, PushDevice
+from app.models.user import UserProfile
+from app.services.onboarding_reengagement_dispatcher import (
+    KIND_D0,
+    KIND_D1,
+    dispatch_onboarding_reengagement_pushes,
+)
+
+
+async def _seed_abandoner(
+    db_session,
+    *,
+    created_at: datetime,
+    timezone: str = "Europe/Paris",
+    onboarding_completed: bool = False,
+):
+    user_id = uuid4()
+    device_id = uuid4()
+    db_session.add(
+        UserProfile(
+            user_id=user_id,
+            display_name="Abandoner",
+            onboarding_completed=onboarding_completed,
+        )
+    )
+    await db_session.flush()
+    db_session.add(
+        PushDevice(
+            device_id=device_id,
+            user_id=user_id,
+            fcm_token="reengage-token",
+            platform="android",
+            timezone=timezone,
+            created_at=created_at,
+            last_active_at=created_at,
+        )
+    )
+    await db_session.commit()
+    return user_id, device_id
+
+
+def _sync(sender: Mock):
+    def _call(*args):
+        return sender(*args)
+
+    return _call
+
+
+# 11:00 Paris (heure active, hors quiet hours) le 15/06/2026 = 09:00 UTC.
+_ACTIVE_NOW = datetime(2026, 6, 15, 9, 0, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_d0_sent_after_one_hour_when_incomplete(db_session, fake_session_maker):
+    _, device_id = await _seed_abandoner(
+        db_session, created_at=_ACTIVE_NOW - timedelta(minutes=90)
+    )
+    sender = Mock(return_value="message-id")
+
+    with patch(
+        "app.services.onboarding_reengagement_dispatcher.safe_async_session",
+        fake_session_maker,
+    ):
+        metrics = await dispatch_onboarding_reengagement_pushes(
+            now=_ACTIVE_NOW, sender=_sync(sender)
+        )
+
+    assert metrics["sent"] == 1
+    assert sender.call_count == 1
+    _, title, _, data = sender.call_args.args
+    assert data["kind"] == KIND_D0
+    assert data["route"] == "/onboarding"
+    delivery = await db_session.scalar(
+        select(PushDelivery).where(
+            PushDelivery.device_id == device_id, PushDelivery.kind == KIND_D0
+        )
+    )
+    assert delivery is not None
+    assert delivery.status == "sent"
+
+
+@pytest.mark.asyncio
+async def test_nothing_before_one_hour(db_session, fake_session_maker):
+    await _seed_abandoner(db_session, created_at=_ACTIVE_NOW - timedelta(minutes=30))
+    sender = Mock(return_value="message-id")
+
+    with patch(
+        "app.services.onboarding_reengagement_dispatcher.safe_async_session",
+        fake_session_maker,
+    ):
+        metrics = await dispatch_onboarding_reengagement_pushes(
+            now=_ACTIVE_NOW, sender=_sync(sender)
+        )
+
+    assert metrics["sent"] == 0
+    assert sender.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_idempotent_across_runs(db_session, fake_session_maker):
+    await _seed_abandoner(db_session, created_at=_ACTIVE_NOW - timedelta(minutes=90))
+    sender = Mock(return_value="message-id")
+
+    with patch(
+        "app.services.onboarding_reengagement_dispatcher.safe_async_session",
+        fake_session_maker,
+    ):
+        first = await dispatch_onboarding_reengagement_pushes(
+            now=_ACTIVE_NOW, sender=_sync(sender)
+        )
+        second = await dispatch_onboarding_reengagement_pushes(
+            now=_ACTIVE_NOW + timedelta(minutes=5), sender=_sync(sender)
+        )
+
+    assert first["sent"] == 1
+    assert second["sent"] == 0
+    assert sender.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_completed_user_excluded(db_session, fake_session_maker):
+    await _seed_abandoner(
+        db_session,
+        created_at=_ACTIVE_NOW - timedelta(minutes=90),
+        onboarding_completed=True,
+    )
+    sender = Mock(return_value="message-id")
+
+    with patch(
+        "app.services.onboarding_reengagement_dispatcher.safe_async_session",
+        fake_session_maker,
+    ):
+        metrics = await dispatch_onboarding_reengagement_pushes(
+            now=_ACTIVE_NOW, sender=_sync(sender)
+        )
+
+    assert metrics["sent"] == 0
+    assert sender.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_stop_on_complete_no_d1(db_session, fake_session_maker):
+    """Une fois l'onboarding terminé, aucune relance J+1 (filtre structurel)."""
+    user_id, _ = await _seed_abandoner(
+        db_session, created_at=_ACTIVE_NOW - timedelta(hours=25)
+    )
+    # L'utilisateur revient et termine l'onboarding.
+    profile = await db_session.scalar(
+        select(UserProfile).where(UserProfile.user_id == user_id)
+    )
+    profile.onboarding_completed = True
+    await db_session.commit()
+
+    sender = Mock(return_value="message-id")
+    with patch(
+        "app.services.onboarding_reengagement_dispatcher.safe_async_session",
+        fake_session_maker,
+    ):
+        metrics = await dispatch_onboarding_reengagement_pushes(
+            now=_ACTIVE_NOW, sender=_sync(sender)
+        )
+
+    assert metrics["sent"] == 0
+    assert sender.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_d1_after_24h_sends_both_relances(db_session, fake_session_maker):
+    user_id, device_id = await _seed_abandoner(
+        db_session, created_at=_ACTIVE_NOW - timedelta(hours=25)
+    )
+    sender = Mock(return_value="message-id")
+
+    with patch(
+        "app.services.onboarding_reengagement_dispatcher.safe_async_session",
+        fake_session_maker,
+    ):
+        metrics = await dispatch_onboarding_reengagement_pushes(
+            now=_ACTIVE_NOW, sender=_sync(sender)
+        )
+
+    # created_at > 24h → D0 (jamais envoyé) ET D1 partent dans le même run.
+    assert metrics["sent"] == 2
+    kinds = {call.args[3]["kind"] for call in sender.call_args_list}
+    assert kinds == {KIND_D0, KIND_D1}
+    deliveries = (
+        (
+            await db_session.execute(
+                select(PushDelivery).where(PushDelivery.device_id == device_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {d.kind for d in deliveries} == {KIND_D0, KIND_D1}
+    assert all(d.status == "sent" for d in deliveries)
+    events = (
+        (
+            await db_session.execute(
+                select(AnalyticsEvent).where(
+                    AnalyticsEvent.user_id == user_id,
+                    AnalyticsEvent.event_type == "push_sent",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {e.event_data["kind"] for e in events} == {KIND_D0, KIND_D1}
+
+
+@pytest.mark.asyncio
+async def test_quiet_hours_defer(db_session, fake_session_maker):
+    # 03:00 Paris = 01:00 UTC ; device créé 90 min avant → D0 dû mais heure calme.
+    quiet_now = datetime(2026, 6, 15, 1, 0, tzinfo=UTC)
+    _, device_id = await _seed_abandoner(
+        db_session, created_at=quiet_now - timedelta(minutes=90)
+    )
+    sender = Mock(return_value="message-id")
+
+    with patch(
+        "app.services.onboarding_reengagement_dispatcher.safe_async_session",
+        fake_session_maker,
+    ):
+        metrics = await dispatch_onboarding_reengagement_pushes(
+            now=quiet_now, sender=_sync(sender)
+        )
+
+    assert metrics["sent"] == 0
+    assert metrics["deferred"] == 1
+    assert sender.call_count == 0
+    delivery = await db_session.scalar(
+        select(PushDelivery).where(
+            PushDelivery.device_id == device_id, PushDelivery.kind == KIND_D0
+        )
+    )
+    assert delivery is not None
+    assert delivery.status == "pending"
+    assert delivery.error_code == "quiet_hours"
+    # Reporté au prochain 08:00 Paris (06:00 UTC le même jour).
+    assert delivery.next_attempt_at == datetime(2026, 6, 15, 6, 0, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_invalid_token_revokes_device(db_session, fake_session_maker):
+    _, device_id = await _seed_abandoner(
+        db_session, created_at=_ACTIVE_NOW - timedelta(minutes=90)
+    )
+
+    class UnregisteredError(Exception):
+        pass
+
+    def invalid_sender(*_args):
+        raise UnregisteredError("token is no longer valid")
+
+    with patch(
+        "app.services.onboarding_reengagement_dispatcher.safe_async_session",
+        fake_session_maker,
+    ):
+        metrics = await dispatch_onboarding_reengagement_pushes(
+            now=_ACTIVE_NOW, sender=invalid_sender
+        )
+
+    assert metrics["invalid_tokens"] == 1
+    device = await db_session.scalar(
+        select(PushDevice).where(PushDevice.device_id == device_id)
+    )
+    assert device is not None
+    assert device.revoked_at is not None
+
+
+@pytest.mark.asyncio
+async def test_stale_device_excluded(db_session, fake_session_maker):
+    # Device créé il y a 4 jours → hors fenêtre (STALE_AFTER = 3 j).
+    await _seed_abandoner(db_session, created_at=_ACTIVE_NOW - timedelta(days=4))
+    sender = Mock(return_value="message-id")
+
+    with patch(
+        "app.services.onboarding_reengagement_dispatcher.safe_async_session",
+        fake_session_maker,
+    ):
+        metrics = await dispatch_onboarding_reengagement_pushes(
+            now=_ACTIVE_NOW, sender=_sync(sender)
+        )
+
+    assert metrics["sent"] == 0
+    assert sender.call_count == 0


### PR DESCRIPTION
## Quoi

Relance des abandons d'onboarding par push. Deux briques :
1. **Amorce notif précoce** (mobile) : un écran interne « Activer les rappels ? » s'ouvre ~4 s après avoir atteint l'étape `objective` (3/4) pour une session **anonyme**. Seul un OUI déclenche la vraie pop-up OS et enregistre le device ; un « Plus tard » ne consomme **rien** (gate one-shot `notif_early_priming_seen`, distinct de `notif_modal_seen` de la modale quotidienne).
2. **Dispatcher de relance** (backend) : un job scheduler (5 min) envoie J+0 (~1 h) puis J+1 (~24 h) aux devices enregistrés dont l'onboarding n'est pas terminé.

## Pourquoi

La vraie population d'abandon est **anonyme** (le compte n'est créé qu'à la dernière étape). Pour la relancer, il faut capter la permission notif **tôt** et enregistrer le device avant la fin. Contrainte plateforme : la pop-up OS ne s'affiche qu'une fois → un ask précoce refusé ne doit pas la brûler, d'où l'écran d'amorce interne.

## Détails d'implémentation

**Mobile**
- `OnboardingPushPriming` (seam testable) + écran d'amorce léger ; `Timer(4s)` armé **une seule fois** à `globalQuestionIndex >= Section1Question.objective.index` (seuil ancré sur l'enum, pas un littéral → stable au réordonnancement), annulé au `dispose`, non tiré pendant `isReadyToFinalize`.
- iOS : la permission n'est **plus** demandée au boot (`DarwinInitializationSettings(request* : false)`) ; elle est déplacée sur l'action utilisateur explicite dans `requestPermission()`.
- 3 events analytics : `onboarding_notif_priming_shown|accepted|refused`.
- Gardé par `kSupportsPushNotifications` → **no-op sur web**.

**Backend**
- `onboarding_reengagement_dispatcher` : devices non révoqués + `onboarding_completed = False`, ancre `created_at`, heures calmes locales (report au prochain 08:00), idempotent via `push_deliveries` (kinds `onboarding_reengagement_d0`/`_d1`), gouverneur de budget bypassé (2 envois à vie / device). Deep link `/onboarding`.
- **Aucune migration** (kinds = chaînes dans la colonne `String(32)` existante ; head Alembic `mg06_merge_cq01_st02` inchangé).

## Comment ça a été vérifié

- [x] Backend : `pytest` complet — **2920 passed, 18 skipped, 2 xfailed** ; dispatcher **9/9** ; `ruff check` OK ; **1 head Alembic**, 0 migration.
- [x] Mobile : widget priming **4/4** ; `flutter analyze` sur les fichiers touchés — **0 nouvelle issue**.
- [x] `/simplify` passé : aplatissement de l'IIFE async, seuil ancré sur l'enum (fin du magic number), `ORDER BY` inutile retiré, `QUIET_END.hour` au lieu du littéral.
- [ ] QA device réel (iOS/Android) : scénarios de `.context/qa-handoff.md` (apparition, refus ne brûle rien, accept → pop-up OS, one-shot, web = pas d'amorce). Push local indispo sur web → hors scope automatisé.

## Zones à risque

- `push_notification_service.dart` : déplacement de la demande de permission iOS hors du boot (impacte aussi la modale d'activation quotidienne).
- `scheduler.py` : nouveau job périodique.
- Session anonyme + `push_devices` enregistrés avant création de compte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)