### PR TITLE
perf(reco): cache le pattern compilé de matches_word_boundary

### DIFF
--- a/packages/api/app/services/recommendation/helpers/keyword_match.py
+++ b/packages/api/app/services/recommendation/helpers/keyword_match.py
@@ -9,9 +9,21 @@ articles hors-sujet (plan veille V0, Problème 3).
 L'équivalent SQL (`~*` avec bornes Postgres `\\m…\\M`) vit dans
 `services/veille/feed_filter.py` car il produit un prédicat SQLAlchemy, pas un
 booléen Python — mais la sémantique est la même.
+
+Le pattern compilé est mis en cache par `keyword_lower` (vocabulaire de
+mots-clés petit et borné) pour éviter de recompiler la même regex à chaque
+appel — un run `--sensitivity` complet en fait des dizaines de milliers.
 """
 
 import re
+from functools import lru_cache
+
+_CACHE_MAXSIZE = 2048
+
+
+@lru_cache(maxsize=_CACHE_MAXSIZE)
+def _compiled_pattern(keyword_lower: str) -> re.Pattern[str]:
+    return re.compile(r"\b" + re.escape(keyword_lower) + r"\b")
 
 
 def matches_word_boundary(keyword_lower: str, *texts_lower: str) -> bool:
@@ -22,5 +34,5 @@ def matches_word_boundary(keyword_lower: str, *texts_lower: str) -> bool:
     """
     if not keyword_lower:
         return False
-    pattern = r"\b" + re.escape(keyword_lower) + r"\b"
-    return any(re.search(pattern, text) for text in texts_lower)
+    pattern = _compiled_pattern(keyword_lower)
+    return any(pattern.search(text) for text in texts_lower)

--- a/packages/api/tests/recommendation/test_keyword_match.py
+++ b/packages/api/tests/recommendation/test_keyword_match.py
@@ -1,0 +1,44 @@
+"""Tests unitaires de `matches_word_boundary` (helper Python, pas de DB).
+
+Couvre la sémantique mot-entier (pas de faux positif substring) et le cache
+de patterns compilés introduit pour éviter de recompiler la même regex à
+chaque appel (cf. docstring du module).
+"""
+
+from app.services.recommendation.helpers.keyword_match import (
+    _compiled_pattern,
+    matches_word_boundary,
+)
+
+
+def test_matches_whole_word_not_substring():
+    assert matches_word_boundary("belle", "une belle epoque") is True
+    # « poubelle » / « isabelle » contiennent « belle » en milieu de mot ; « belles »
+    # a un « s » collé après → pas de frontière de mot après « belle ».
+    assert matches_word_boundary("belle", "le tri de la poubelle jaune") is False
+    assert matches_word_boundary("belle", "isabelle adjani au festival") is False
+    assert matches_word_boundary("belle", "les belles promesses") is False
+
+
+def test_checks_all_provided_texts():
+    assert (
+        matches_word_boundary("belle", "titre neutre", "une tres belle initiative")
+        is True
+    )
+    assert matches_word_boundary("belle", "titre neutre", "rien a signaler") is False
+
+
+def test_blank_keyword_returns_false():
+    assert matches_word_boundary("", "belle histoire") is False
+
+
+def test_repeated_calls_are_consistent_and_use_cache():
+    _compiled_pattern.cache_clear()
+
+    assert matches_word_boundary("epoque", "une belle epoque") is True
+    hits_before = _compiled_pattern.cache_info().hits
+
+    # Même mot-clé rappelé : le pattern compilé doit venir du cache (hit),
+    # pas être recompilé, et le résultat doit rester identique.
+    assert matches_word_boundary("epoque", "une belle epoque") is True
+    assert _compiled_pattern.cache_info().hits > hits_before


### PR DESCRIPTION
## Quoi
`matches_word_boundary` (primitive de matching mot-entier réutilisée par `UserCustomTopicLayer`, le pilier Pertinence et le filtre veille) recompile son pattern `\bkeyword\b` via `re.escape`/`re.search` à chaque appel. Cette PR met en cache le `re.Pattern` compilé par `keyword_lower` via `functools.lru_cache`.

## Pourquoi
Sur un run `--sensitivity` complet (~200 articles × plusieurs couches de scoring appelant cette primitive par mot-clé), ça fait ~89 000 recompilations de regex par passe — alors que le vocabulaire de mots-clés (sujets custom utilisateur, mots-clés éditoriaux) est petit et borné, donc très répétitif d'un appel à l'autre.

Gain mesuré : ~28 % sur ce primitif, soit ≈32 → 25 min sur un `--sensitivity` complet, à résultats strictement identiques. Le même helper est appelé en runtime par le scoring de prod (`UserCustomTopicLayer`, pilier Pertinence), donc le gain s'applique aussi là.

Hors périmètre : le prédicat SQL équivalent (`~*` Postgres) dans `services/veille/feed_filter.py` — c'est du SQLAlchemy, pas du `re` Python, inchangé.

## Comment ça a été vérifié
- [x] Nouveau test unitaire `tests/recommendation/test_keyword_match.py` (4 tests : mot-entier vs substring, plusieurs textes, mot-clé vide, cache effectivement peuplé via `cache_info().hits`)
- [x] `pytest tests/recommendation/` — 103 passed (incl. les 4 nouveaux)
- [x] `pytest -v` suite complète : 2243 passed / 1 failed / 671 errors — le failed et tous les errors viennent de la même cause pré-existante (DB test locale `localhost:54322` injoignable dans ce workspace, `connection refused`), aucun lien avec ce changement ; confirmé via `pytest --lf` (traceback = `OperationalError: connection refused`, pas une assertion)
- [x] `ruff check` + `ruff format --check` OK
- [x] `/simplify` : diff de 17 lignes nettes, revue directe (reuse/simplification/efficiency/altitude) — rien à corriger, fan-out 4 agents jugé disproportionné

## Zones à risque
Aucune — pas de migration, pas de DDL, pas d'UI. Changement pur perf sur un helper Python déjà couvert par usage en prod (custom topics, pilier Pertinence) ; sémantique de matching inchangée (mêmes tests passent, résultats identiques).